### PR TITLE
Remove unused ringbuffer dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,6 @@ dependencies = [
  "nodi",
  "regex",
  "ringbuf",
- "ringbuffer",
  "serde",
  "serde_yaml",
  "shh",
@@ -958,12 +957,6 @@ checksum = "79abed428d1fd2a128201cec72c5f6938e2da607c6f3745f769fabea399d950a"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "ringbuffer"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ midly = "0.5.3"
 nodi = { version = "1.0.0", features = ["hybrid-sleep", "midir"] }
 regex = "1.10.3"
 ringbuf = "0.3.3"
-ringbuffer = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 shh = "1.0.1"


### PR DESCRIPTION
The ringbuffer dependency has been removed, as ringbuf is used instead.