### PR TITLE
Attempt to add auto-publishing.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,22 @@
+name: publish
+on:
+  push:
+    tags:
+    - 'v.*'
+
+jobs:
+  # Publishes mtrack to crates.io.
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update apt
+      run: sudo apt update
+    - name: Install alsa
+      run: sudo apt-get install -y libasound2-dev
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Run publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.1.1
+
+Removal of unneeded ringbuffer dependency.
+
+# 0.1.0
+
+Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.1.0"
+version = "0.1.1"
+authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"
 readme = "README.md"


### PR DESCRIPTION
This should (hopefully) add in auto-publishing. We'll need to test by seeing if the action works, however. The version has been bumped to 0.1.1 to both test this and publish a new version with the removed ringbuffer dependency.