### PR TITLE
Correct the publish job to glob syntax instead of regex syntax.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: publish
 on:
   push:
     tags:
-    - 'v.*'
+    - 'v*'
 
 jobs:
   # Publishes mtrack to crates.io.


### PR DESCRIPTION
The publish job now uses glob syntax instead of regex syntax.