### PR TITLE
Add create Github release for tags.

### DIFF
--- a/.github/workflows/mtrack.yaml
+++ b/.github/workflows/mtrack.yaml
@@ -8,8 +8,32 @@ on:
     - main
 
 jobs:
+  # Build the code and verify that Cargo.lock is up to date.
+  build:
+    name: Build mtrack
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update apt
+      run: sudo apt update
+    - name: Install alsa
+      run: sudo apt-get install -y libasound2-dev
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Build mtrack
+      run: cargo build
+    - name: Check of Cargo.lock is up to date
+      run: |
+        if git diff --exit-code Cargo.lock; then
+          echo "Cargo.lock is up to date."
+        else
+          echo "Cargo.lock needs to be updated."
+          exit 1
+        fi
+
   # Clippy effectively lints the code.
   clippy:
+    name: Lint mtrack
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -26,6 +50,7 @@ jobs:
 
   # Make sure the code is properly formatted.
   rustfmt-check:
+    name: Run rustfmt
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -42,6 +67,7 @@ jobs:
 
   # Make sure the tests pass.
   test:
+    name: Run tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -62,6 +88,7 @@ jobs:
 
   # Make sure all code has an appropriate license header.
   licensure:
+    name: Ensure license headers
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -71,3 +98,19 @@ jobs:
       run: cargo install licensure
     - name: Check for licenses
       run: licensure --check -p
+
+  # Verify changelog is in keep-a-changelog format.
+  verify-changelog:
+    name: Verify changelog format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # We'll run the extract release notes action and drop the results on the floor.
+      # If extract-release-notes can successfully extract release notes, we'll
+      # consider this success for now.
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v2
+      - name: Current release notes
+        run: echo '${{ steps.extract-release-notes.outputs.release_notes }}'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,11 +2,12 @@ name: publish
 on:
   push:
     tags:
-    - 'v*'
+    - 'v*.*.*'
 
 jobs:
   # Publishes mtrack to crates.io.
   publish:
+    name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -20,3 +21,18 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: cargo publish
+
+  # Creates a release on Github.
+  release:
+    name: Create a GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extract release notes
+        id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v2
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create --notes '${{ steps.extract-release-notes.outputs.release_notes }}' --title ${{ github.ref_name }} ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
-# 0.1.1
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - Minor dependency update.
 
 Removal of unneeded ringbuffer dependency.
 
-# 0.1.0
+## [0.1.0] - Initial release.
 
-Initial release.
+### Added
+
+- Initial release.


### PR DESCRIPTION
A Github release will be created for tags now. Additionally, a check has been added that will ensure that Cargo.lock is up to date. The CHANGELOG has been adjusted into keepachangelog format to aide in automatically publishing release notes.