### PR TITLE
Add a CPAL playback test.

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -132,7 +132,7 @@ mod test {
 
     use tokio::{sync::mpsc::Sender, task::JoinHandle};
 
-    use crate::{audio, config, player::Player, playlist::Playlist, test::test::eventually};
+    use crate::{audio, config, player::Player, playlist::Playlist, test::eventually};
 
     use super::{Driver, Event};
 

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -134,7 +134,7 @@ mod test {
 
     use crate::{
         audio, config, controller::Controller, midi, player::Player, playlist::Playlist,
-        test::test::eventually,
+        test::eventually,
     };
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/player.rs
+++ b/src/player.rs
@@ -370,7 +370,7 @@ impl Player {
 mod test {
     use std::{error::Error, path::PathBuf, sync::Arc};
 
-    use crate::{audio, config, midi, playlist::Playlist, test::test::eventually};
+    use crate::{audio, config, midi, playlist::Playlist, test::eventually};
 
     use super::Player;
 

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -549,11 +549,9 @@ impl Songs {
 
 #[cfg(test)]
 mod test {
-    use std::{error::Error, fs::File, path::PathBuf};
+    use std::{error::Error, path::PathBuf};
 
-    use hound::{SampleFormat, WavSpec, WavWriter};
-
-    use crate::config;
+    use crate::{config, test::write_wav};
 
     use super::{Sample, SongSource};
 
@@ -636,34 +634,6 @@ mod test {
 
         let song = super::Song::new("song name".into(), None, None, vec![track1, track2])?;
         song.source(4)
-    }
-
-    fn write_wav<S: Sample>(path: PathBuf, samples: Vec<S>) -> Result<(), Box<dyn Error>> {
-        let tempwav = File::create(path)?;
-        let sample_format = if S::FORMAT.is_int() || S::FORMAT.is_uint() {
-            SampleFormat::Int
-        } else if S::FORMAT.is_float() {
-            SampleFormat::Float
-        } else {
-            return Err("Unsupported sample format".into());
-        };
-
-        let mut writer = WavWriter::new(
-            tempwav,
-            WavSpec {
-                channels: 1,
-                sample_rate: 44100,
-                bits_per_sample: 32,
-                sample_format: sample_format,
-            },
-        )?;
-
-        // Write a simple set of samples to the wav file.
-        for sample in samples {
-            writer.write_sample(sample)?;
-        }
-
-        Ok(())
     }
 
     fn get_frame<S: Sample>(

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,37 +11,70 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-#[cfg(test)]
-pub mod test {
-    use std::{
-        thread,
-        time::{Duration, SystemTime},
+
+use std::{
+    error::Error,
+    fs::File,
+    path::PathBuf,
+    thread,
+    time::{Duration, SystemTime},
+};
+
+use hound::{SampleFormat, WavSpec, WavWriter};
+
+use crate::songs::Sample;
+
+/// Wait for the given predicate to return true or fail.
+#[inline]
+pub fn eventually<F>(predicate: F, error_msg: &str)
+where
+    F: Fn() -> bool,
+{
+    let start = SystemTime::now();
+    let tick = Duration::from_millis(10);
+    let timeout = Duration::from_secs(3);
+
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed.is_err() {
+            assert!(false, "System time error");
+        }
+        let elapsed = elapsed.unwrap();
+
+        if elapsed > timeout {
+            assert!(false, "{}", error_msg);
+        }
+        if predicate() {
+            return;
+        }
+        thread::sleep(tick);
+    }
+}
+
+pub fn write_wav<S: Sample>(path: PathBuf, samples: Vec<S>) -> Result<(), Box<dyn Error>> {
+    let tempwav = File::create(path)?;
+    let sample_format = if S::FORMAT.is_int() || S::FORMAT.is_uint() {
+        SampleFormat::Int
+    } else if S::FORMAT.is_float() {
+        SampleFormat::Float
+    } else {
+        return Err("Unsupported sample format".into());
     };
 
-    /// Wait for the given predicate to return true or fail.
-    #[inline]
-    pub fn eventually<F>(predicate: F, error_msg: &str)
-    where
-        F: Fn() -> bool,
-    {
-        let start = SystemTime::now();
-        let tick = Duration::from_millis(10);
-        let timeout = Duration::from_secs(3);
+    let mut writer = WavWriter::new(
+        tempwav,
+        WavSpec {
+            channels: 1,
+            sample_rate: 44100,
+            bits_per_sample: 32,
+            sample_format: sample_format,
+        },
+    )?;
 
-        loop {
-            let elapsed = start.elapsed();
-            if elapsed.is_err() {
-                assert!(false, "System time error");
-            }
-            let elapsed = elapsed.unwrap();
-
-            if elapsed > timeout {
-                assert!(false, "{}", error_msg);
-            }
-            if predicate() {
-                return;
-            }
-            thread::sleep(tick);
-        }
+    // Write a simple set of samples to the wav file.
+    for sample in samples {
+        writer.write_sample(sample)?;
     }
+
+    Ok(())
 }


### PR DESCRIPTION
A test has been added to the CPAL playback function. It's difficult to test this in its entirety due to its dependence on actual audio hardware, but we can at least verify that the output callback does what we expect. Some light refactoring was done as part of this.