### PR TITLE
Use channel mappings instead of a per-track mappings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,28 +122,23 @@ tracks:
 # we want directly.
 - name: click
   file: click.wav # File paths are relative to the song.yaml file.
-  channel: 7
 # Similarly, our cue only has one channel.
 - name: cue
   file: /mnt/song-storage/cue.wav # Or file paths can be absolute.
-  channel: 8
 # Our backing track file has two channels, so we have to specify `file_channel` to let
 # mtrack know which channel from the file to use.
 - name: backing-track-l
   file: Backing Tracks.wav
   file_channel: 1
-  channel: 9
 # We can re-use our backing track file and specify the other channel if we'd like to do
 # stereo.
 - name: backing-track-r
   file: Backing Tracks.wav
   file_channel: 2
-  channel: 10
 # Our keys file has two channels, but we're only interested in one.
 - name: keys
   file: Keys.wav
   file_channel: 1
-  channel: 11
 ---
 # We can define multiple songs in one file.
 name: The Song Name (alternate version)
@@ -169,7 +164,7 @@ Songs (count: 23):
 You can play individual songs by using `mtrack play`:
 
 ```
-$ mtrack play -m my-midi-device my-audio-device /mnt/song-storage "My cool song"
+$ mtrack play -m my-midi-device my-audio-device click=1,cue=2 /mnt/song-storage "My cool song"
 2024-03-22T21:24:25.588828Z  INFO emit (midir): mtrack::midi::midir: Emitting event. device="my-midi-device:my-midi-device MIDI 1 28:0" event="Midi { channel: u4(15), message: ProgramChange { program: u7(3) } }"
 2024-03-22T21:24:25.589420Z  INFO player: mtrack::player: Waiting for song to finish. song="My cool song"
 2024-03-22T21:24:25.589992Z  INFO play song (rodio): mtrack::audio::rodio: Playing song. device="my-audio-device" song="My cool song" duration="4:14"
@@ -265,6 +260,14 @@ controller:
     channel: 16
     controller: 100
     value: 5
+
+# Mappings of track names to output channels.
+track_mappings:
+  click: 1
+  cue: 2
+  backing-track-l: 3
+  backing-track-r: 4
+  keys: 5
 ```
 
 You can start `mtrack` as a process with `mtrack start /path/to/player.yaml /path/to/playlist.yaml`.

--- a/assets/songs/songs.yaml
+++ b/assets/songs/songs.yaml
@@ -3,7 +3,6 @@ midi_file: ../song.mid
 tracks:
 - name: track 1
   file: ../1Channel22.05k.wav
-  channel: 1
 ---
 name: Song 2
 midi_event:
@@ -13,7 +12,6 @@ midi_event:
 tracks:
 - name: track 1
   file: ../1Channel44.1k.wav
-  channel: 1
 ---
 name: Song 3
 midi_file: ../song.mid
@@ -21,11 +19,9 @@ tracks:
 - name: track 1
   file: ../2Channel44.1k.wav
   file_channel: 1
-  channel: 1
 - name: track 2
   file: ../2Channel44.1k.wav
   file_channel: 2
-  channel: 2
 ---
 name: Song 4
 midi_file: ../song.mid
@@ -33,31 +29,27 @@ tracks:
 - name: track 1
   file: ../8Channel44.1k.wav
   file_channel: 1
-  channel: 1
 - name: track 2
   file: ../8Channel44.1k.wav
   file_channel: 2
-  channel: 2
 - name: track 3
   file: ../8Channel44.1k.wav
   file_channel: 3
-  channel: 3
 - name: track 4
   file: ../8Channel44.1k.wav
   file_channel: 4
-  channel: 4
+- name: track 5
+  file: ../8Channel44.1k.wav
+  file_channel: 5
 - name: track 6
   file: ../8Channel44.1k.wav
   file_channel: 6
-  channel: 6
 - name: track 7
   file: ../8Channel44.1k.wav
   file_channel: 7
-  channel: 7
 - name: track 8
   file: ../8Channel44.1k.wav
   file_channel: 8
-  channel: 8
 ---
 name: Song 5
 midi_event:
@@ -69,14 +61,12 @@ tracks:
 - name: track 1
   file: ../20-sec-long.wav
   file_channel: 1
-  channel: 1
 ---
 name: Song 6
 midi_file: ../song.mid
 tracks:
 - name: track 1
   file: ../1Channel22.05k.wav
-  channel: 1
 ---
 name: Song 7
 midi_file: ../song.mid
@@ -84,25 +74,21 @@ tracks:
 - name: track 1
   file: ../20-sec-long.wav
   file_channel: 1
-  channel: 1
 ---
 name: Song 8
 midi_file: ../song.mid
 tracks:
 - name: track 1
   file: ../1Channel22.05k.wav
-  channel: 1
 ---
 name: Song 9
 midi_file: ../song.mid
 tracks:
 - name: track 1
   file: ../1Channel22.05k.wav
-  channel: 1
 ---
 name: Song 10
 midi_file: ../song.mid
 tracks:
 - name: track 1
   file: ../1Channel22.05k.wav
-  channel: 1

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -62,3 +62,11 @@ controller:
     channel: 16
     controller: 100
     value: 5
+
+# Mappings of track names to output channels.
+track_mappings:
+  click: 1
+  cue: 2
+  backing-track-l: 3
+  backing-track-r: 4
+  keys: 5

--- a/examples/songs/a-really-cool-song/song.yaml
+++ b/examples/songs/a-really-cool-song/song.yaml
@@ -8,12 +8,9 @@ midi_event:
 tracks:
 - name: click
   file: click.wav
-  channel: 7
 - name: backing-track-l
   file: backing-track.wav
   file_channel: 1
-  channel: 9
 - name: backing-track-r
   file: backing-track.wav
   file_channel: 2
-  channel: 10

--- a/examples/songs/a-really-fast-one/song.yaml
+++ b/examples/songs/a-really-fast-one/song.yaml
@@ -8,12 +8,9 @@ midi_event:
 tracks:
 - name: click
   file: click.wav
-  channel: 7
 - name: backing-track-l
   file: backing-track.wav
   file_channel: 1
-  channel: 9
 - name: backing-track-r
   file: backing-track.wav
   file_channel: 2
-  channel: 10

--- a/examples/songs/another-cool-song/song.yaml
+++ b/examples/songs/another-cool-song/song.yaml
@@ -10,12 +10,9 @@ midi_file: song.mid
 tracks:
 - name: click
   file: click.wav
-  channel: 7
 - name: backing-track-l
   file: backing-track.wav
   file_channel: 1
-  channel: 9
 - name: backing-track-r
   file: backing-track.wav
   file_channel: 2
-  channel: 10

--- a/examples/songs/outro-tape/song.yaml
+++ b/examples/songs/outro-tape/song.yaml
@@ -9,8 +9,6 @@ tracks:
 - name: backing-track-l
   file: backing-track.wav
   file_channel: 1
-  channel: 9
 - name: backing-track-r
   file: backing-track.wav
   file_channel: 2
-  channel: 10

--- a/examples/songs/sound-check/song.yaml
+++ b/examples/songs/sound-check/song.yaml
@@ -9,8 +9,6 @@ tracks:
 - name: backing-track-l
   file: backing-track.wav
   file_channel: 1
-  channel: 9
 - name: backing-track-r
   file: backing-track.wav
   file_channel: 2
-  channel: 10

--- a/examples/songs/the-slow-one/song.yaml
+++ b/examples/songs/the-slow-one/song.yaml
@@ -8,12 +8,9 @@ midi_event:
 tracks:
 - name: click
   file: click.wav
-  channel: 7
 - name: backing-track-l
   file: backing-track.wav
   file_channel: 1
-  channel: 9
 - name: backing-track-r
   file: backing-track.wav
   file_channel: 2
-  channel: 10

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 // Copyright (C) 2024 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
@@ -25,7 +26,12 @@ pub trait Device: fmt::Display + std::marker::Send + std::marker::Sync {
     fn name(&self) -> String;
 
     /// Plays the given song through the audio interface.
-    fn play(&self, song: Arc<Song>, cancel_handle: CancelHandle) -> Result<(), Box<dyn Error>>;
+    fn play(
+        &self,
+        song: Arc<Song>,
+        mappings: &HashMap<String, u16>,
+        cancel_handle: CancelHandle,
+    ) -> Result<(), Box<dyn Error>>;
 }
 
 /// Lists devices known to cpal.

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use std::{
+    collections::HashMap,
     error::Error,
     fmt,
     sync::{
@@ -54,7 +55,12 @@ impl super::Device for Device {
     }
 
     /// A mock device that will sleep for the length of the song duration.
-    fn play(&self, song: Arc<Song>, cancel_handle: CancelHandle) -> Result<(), Box<dyn Error>> {
+    fn play(
+        &self,
+        song: Arc<Song>,
+        _: &HashMap<String, u16>,
+        cancel_handle: CancelHandle,
+    ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ mod player;
 mod playlist;
 mod song;
 mod track;
+mod trackmappings;
 
 /// Parses songs from a YAML file.
 pub fn parse_songs(file: &PathBuf) -> Result<Vec<crate::songs::Song>, Box<dyn Error>> {
@@ -95,6 +96,7 @@ pub fn init_player_and_controller(
     let playlist = parse_playlist(&PathBuf::from(playlist_path), Arc::clone(&songs))?;
     let player = crate::player::Player::new(
         device,
+        player_config.mappings.track_mappings,
         midi_device.clone(),
         playlist,
         crate::playlist::Playlist::from_songs(songs)?,

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use super::controller::Controller;
+use super::trackmappings::TrackMappings;
 
 /// The configuration for the multitrack player.
 #[derive(Deserialize)]
@@ -22,6 +23,7 @@ pub(super) struct Player {
     pub controller: Controller,
     /// The audio device to use.
     pub audio_device: String,
+    pub mappings: TrackMappings,
     /// The MIDI device to use.
     pub midi_device: Option<String>,
     /// The path to the song definitions.

--- a/src/config/trackmappings.rs
+++ b/src/config/trackmappings.rs
@@ -11,28 +11,14 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::{error::Error, path::Path};
+use std::collections::HashMap;
 
 use serde::Deserialize;
 
-/// A YAML representation of a track.
+/// The mappings of tracks to output channels.
 #[derive(Deserialize)]
-pub(super) struct Track {
-    /// The name of the track.
-    name: String,
-    /// The file associated with the track.
-    file: String,
-    /// The file channel of the track to use.
-    file_channel: Option<u16>,
-}
-
-impl Track {
-    /// Converts this track configuration into a Track object.
-    pub(super) fn to_track(&self, song_path: &Path) -> Result<crate::songs::Track, Box<dyn Error>> {
-        crate::songs::Track::new(
-            self.name.clone(),
-            Path::join(song_path, self.file.clone()),
-            self.file_channel,
-        )
-    }
+pub(super) struct TrackMappings {
+    // The individual track mappings.
+    #[serde(flatten)]
+    pub track_mappings: HashMap<String, u16>,
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -124,6 +124,7 @@ impl Controller {
 #[cfg(test)]
 mod test {
     use std::{
+        collections::HashMap,
         error::Error,
         io,
         path::PathBuf,
@@ -220,6 +221,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_controller() -> Result<(), Box<dyn Error>> {
         let driver = Arc::new(TestDriver::new(TestEvent::Unset));
+        let mappings: HashMap<String, u16> = HashMap::new();
         let device = Arc::new(audio::test::Device::get("mock-device"));
         let songs = config::get_all_songs(&PathBuf::from("assets/songs"))?;
         let playlist =
@@ -227,6 +229,7 @@ mod test {
         let all_songs_playlist = Playlist::from_songs(songs.clone())?;
         let player = Player::new(
             device.clone(),
+            mappings,
             None,
             playlist.clone(),
             all_songs_playlist.clone(),

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -130,7 +130,7 @@ impl Drop for Driver {
 
 #[cfg(test)]
 mod test {
-    use std::{error::Error, path::PathBuf, sync::Arc};
+    use std::{collections::HashMap, error::Error, path::PathBuf, sync::Arc};
 
     use crate::{
         audio, config, controller::Controller, midi, player::Player, playlist::Playlist,
@@ -208,12 +208,14 @@ mod test {
         playlist_event.write(&mut playlist_buf)?;
 
         let device = Arc::new(audio::test::Device::get("mock-device"));
+        let mappings: HashMap<String, u16> = HashMap::new();
         let songs = config::get_all_songs(&PathBuf::from("assets/songs"))?;
         let playlist =
             config::parse_playlist(&PathBuf::from("assets/playlist.yaml"), songs.clone())?;
         let all_songs_playlist = Playlist::from_songs(songs.clone())?;
         let player = Player::new(
             device.clone(),
+            mappings,
             None,
             playlist.clone(),
             all_songs_playlist.clone(),


### PR DESCRIPTION
A channel mapping at the player config level has been introduced and per-track mappings within a song has been removed. This is way less redundant than the previous method. It is breaking, but given that this repo only has 2 stars, I think it's reasonable to introduce this now before the original method has more time to propagate.