### PR TITLE
Bump version to v0.1.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - Player level channel mapping, merging of channels.
+
+Channel mappings have been removed from individual song files and will now be
+maintained as part of the player configuration.
+
+Channels can now be merged. That is, tracks can target the same output channel.
+
 ## [0.1.1] - Minor dependency update.
 
 Removal of unneeded ringbuffer dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "alsa 0.8.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"


### PR DESCRIPTION
The version of mtrack has been bumped to v0.1.2.