### PR TITLE
Use a more accurate MIDI timer, move play barrier.

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 // Copyright (C) 2024 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
@@ -16,6 +15,8 @@ use std::{error::Error, fmt, sync::Arc};
 
 use crate::playsync::CancelHandle;
 use crate::songs::Song;
+use std::collections::HashMap;
+use std::sync::Barrier;
 
 mod cpal;
 mod mock;
@@ -31,6 +32,7 @@ pub trait Device: fmt::Display + std::marker::Send + std::marker::Sync {
         song: Arc<Song>,
         mappings: &HashMap<String, u16>,
         cancel_handle: CancelHandle,
+        play_barrier: Arc<Barrier>,
     ) -> Result<(), Box<dyn Error>>;
 }
 

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -17,7 +17,7 @@ use std::{
     fmt,
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc, Arc,
+        mpsc, Arc, Barrier,
     },
     thread,
 };
@@ -60,6 +60,7 @@ impl super::Device for Device {
         song: Arc<Song>,
         _: &HashMap<String, u16>,
         cancel_handle: CancelHandle,
+        play_barrier: Arc<Barrier>,
     ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();
@@ -78,6 +79,8 @@ impl super::Device for Device {
             let cancel_handle = cancel_handle.clone();
             // Wait until the song is cancelled or until the song is done.
             thread::spawn(move || {
+                play_barrier.wait();
+
                 // Wait for a signal or until we hit cancellation.
                 let _ = sleep_rx.recv_timeout(song.duration);
 

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -11,7 +11,11 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::{error::Error, fmt, sync::Arc};
+use std::{
+    error::Error,
+    fmt,
+    sync::{Arc, Barrier},
+};
 
 use tokio::sync::mpsc::Sender;
 
@@ -32,7 +36,12 @@ pub trait Device: fmt::Display + std::marker::Send + std::marker::Sync {
     fn stop_watch_events(&self);
 
     /// Plays the given song through the MIDI interface.
-    fn play(&self, song: Arc<Song>, cancel_handle: CancelHandle) -> Result<(), Box<dyn Error>>;
+    fn play(
+        &self,
+        song: Arc<Song>,
+        cancel_handle: CancelHandle,
+        play_barrier: Arc<Barrier>,
+    ) -> Result<(), Box<dyn Error>>;
 
     /// Emits an event.
     fn emit(&self, song: Arc<Song>) -> Result<(), Box<dyn Error>>;

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -128,7 +128,12 @@ impl super::Device for Device {
     }
 
     /// Plays the given song through the MIDI interface.
-    fn play(&self, song: Arc<Song>, cancel_handle: CancelHandle) -> Result<(), Box<dyn Error>> {
+    fn play(
+        &self,
+        song: Arc<Song>,
+        cancel_handle: CancelHandle,
+        play_barrier: Arc<Barrier>,
+    ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();
 
@@ -145,6 +150,7 @@ impl super::Device for Device {
             let cancel_handle = cancel_handle.clone();
             // Wait until the song is cancelled or until the song is done.
             thread::spawn(move || {
+                play_barrier.wait();
                 // Wait for a signal or until we hit cancellation.
                 let _ = sleep_rx.recv_timeout(song.duration);
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -176,8 +176,7 @@ impl Player {
             thread::spawn(move || {
                 let song_name = song.name.to_string();
 
-                barrier.wait();
-                if let Err(e) = device.play(song, &mappings, cancel_handle) {
+                if let Err(e) = device.play(song, &mappings, cancel_handle, barrier) {
                     error!(
                         err = e.as_ref(),
                         song = song_name,
@@ -196,8 +195,7 @@ impl Player {
             let midi_join_handle = thread::spawn(move || {
                 let song_name = song.name.to_string();
 
-                barrier.wait();
-                if let Err(e) = midi_device.play(song, cancel_handle) {
+                if let Err(e) = midi_device.play(song, cancel_handle, barrier) {
                     error!(
                         err = e.as_ref(),
                         song = song_name,


### PR DESCRIPTION
The MIDI timer is now more accurate by using the intended next elapsed time based on the last instant. This helps stop drift in between the playing of MIDI notes. Additionally, the play barrier has been moved closer to the MIDI and audio play, which ensures that the audio and MIDI are closer aligned during playback.

Closes https://github.com/mdwn/mtrack/issues/31