### PR TITLE
Use duration as default when subtracting duration in accurate timer.

### DIFF
--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -317,9 +317,11 @@ impl<T: Timer> Timer for AccurateTimer<T> {
         match self.last_instant {
             Some(last_instant) => {
                 self.last_instant = Some(last_instant.add(duration));
+
+                // Subtract the duration unless it would be an overflow. If so, use the original duration.
                 duration = duration
                     .checked_sub(Instant::now().duration_since(last_instant))
-                    .expect("duration should not be less during subtraction")
+                    .unwrap_or(duration);
             }
             None => self.last_instant = Some(time::Instant::now()),
         };


### PR DESCRIPTION
If the duration subtraction in the accurate timer results in an overflow, just use the original duration instead of expecting an error.