### PR TITLE
Fix playback for audio only.

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -162,10 +162,15 @@ impl Player {
     ) {
         let song = song.clone();
         let cancel_handle = cancel_handle.clone();
-        let barrier = Arc::new(match midi_device {
-            Some(_) => Barrier::new(2),
-            None => Barrier::new(1),
-        });
+
+        // Set up the play barrier, which will synchronize the two calls to play.
+        let barrier = Arc::new(Barrier::new(
+            if midi_device.is_some() && song.midi_file.is_some() {
+                2
+            } else {
+                1
+            },
+        ));
 
         let audio_join_handle = {
             let device = device.clone();

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -39,7 +39,7 @@ pub struct Song {
     /// The MIDI event to play when the song is selected in a playlist.
     pub midi_event: Option<LiveEvent<'static>>,
     /// The MIDI file to play along with the audio tracks.
-    midi_file: Option<PathBuf>,
+    pub midi_file: Option<PathBuf>,
     /// The number of channels required to play this song.
     pub num_channels: u16,
     /// The sample rate of this song.


### PR DESCRIPTION
Audio only playback would wait for the new play barrier to hit the wait if a MIDI device was configured. This has been fixed.