### PR TITLE
Add in a status reporting feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Breaking Change) Track mappings now support mapping to multiple channels.
 
+Status reporting is now configurable.
+
 ## [0.1.3] - MIDI tuning, accuracy.
 
 MIDI playback is now more accurate and has been tuned to be more in time with audio

--- a/README.md
+++ b/README.md
@@ -208,6 +208,37 @@ midi_device: UltraLite-mk5
 # If the path is not absolute, it will be relative to the location of this file.
 songs: /mnt/song-storage
 
+# Status events are emitted to the controller while mtrack is running. This is largely done
+# in order to confirm that mtrack is connected to the controller and operating properly.
+# The statuses are emitted periodically in the following timeline:
+# - Off (1 second)
+# - On (250 milliseconds, either idling or playing)
+# - Off (1 second)
+# - On (250 milliseconds, either idling or playing)
+# - ...
+status_events:
+  # Off events are emitted, in order, when trying to return the status indicator to "normal."
+  # If your MIDI controller has LEDs, for example, this would be to turn the LED off.
+  off_events:
+  - type: control_change
+    channel: 16
+    controller: 3
+    value: 2
+  # Idling events are emitted, in order, when trying to indicate that the player is connected,
+  # but not currently doing anything.
+  idling_events:
+  - type: control_change
+    channel: 16
+    controller: 2
+    value: 2
+  # Playing events are emitted, in order, when trying to indicate that the player is connected,
+  # and actively playing.
+  playing_events:
+  - type: control_change
+    channel: 16
+    controller: 2
+    value: 2
+
 # The controller definition. As of now, the valid kinds of controllers are:
 # - keyboard
 # - midi

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -166,8 +166,7 @@ impl Device {
 
         let num_channels = *mappings
             .iter()
-            .map(|entry| entry.1)
-            .flatten()
+            .flat_map(|entry| entry.1)
             .max()
             .ok_or("no max channel found")?;
 

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -14,6 +14,7 @@
 use serde::Deserialize;
 
 use super::controller::Controller;
+use super::midi;
 use super::trackmappings::TrackMappings;
 
 /// The configuration for the multitrack player.
@@ -27,6 +28,19 @@ pub(super) struct Player {
     pub track_mappings: TrackMappings,
     /// The MIDI device to use.
     pub midi_device: Option<String>,
+    /// Events to emit to report status out via MIDI.
+    pub status_events: Option<StatusEvents>,
     /// The path to the song definitions.
     pub songs: String,
+}
+
+/// The configuration for emitting status events.
+#[derive(Deserialize)]
+pub(super) struct StatusEvents {
+    /// The events to emit to clear the status.
+    pub off_events: Vec<midi::Event>,
+    /// The events to emit to indicate that the player is idling and waiting for input.
+    pub idling_events: Vec<midi::Event>,
+    /// The events to emit to indicate that the player is currently playing.
+    pub playing_events: Vec<midi::Event>,
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -233,6 +233,7 @@ mod test {
             None,
             playlist.clone(),
             all_songs_playlist.clone(),
+            None,
         );
         let mut controller = super::Controller::new(player, driver.clone())?;
 

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -193,12 +193,18 @@ mod test {
             playlist_event,
         ));
 
+        let unrecognized_event = midly::live::LiveEvent::Midi {
+            channel: 15.into(),
+            message: midly::MidiMessage::ProgramChange { program: 27.into() },
+        };
+
         let mut play_buf: Vec<u8> = Vec::with_capacity(8);
         let mut prev_buf: Vec<u8> = Vec::with_capacity(8);
         let mut next_buf: Vec<u8> = Vec::with_capacity(8);
         let mut stop_buf: Vec<u8> = Vec::with_capacity(8);
         let mut all_songs_buf: Vec<u8> = Vec::with_capacity(8);
         let mut playlist_buf: Vec<u8> = Vec::with_capacity(8);
+        let mut unrecognized_buf: Vec<u8> = Vec::with_capacity(8);
 
         play_event.write(&mut play_buf)?;
         prev_event.write(&mut prev_buf)?;
@@ -206,6 +212,7 @@ mod test {
         stop_event.write(&mut stop_buf)?;
         all_songs_event.write(&mut all_songs_buf)?;
         playlist_event.write(&mut playlist_buf)?;
+        unrecognized_event.write(&mut unrecognized_buf)?;
 
         let device = Arc::new(audio::test::Device::get("mock-device"));
         let mappings: HashMap<String, Vec<u16>> = HashMap::new();
@@ -219,36 +226,42 @@ mod test {
             None,
             playlist.clone(),
             all_songs_playlist.clone(),
+            None,
         );
         let _controller = Controller::new(player, driver)?;
 
         println!("Playlist: {}", playlist);
         println!("AllSongs: {}", all_songs_playlist);
 
-        // Test the controller directing the player.
+        // Test the controller directing the player. Make sure we put
+        // unrecognized events in between to make sure that they're ignored.
         println!("Playlist -> Song 1");
         eventually(
             || playlist.current().name == "Song 1",
             "Playlist never became Song 1",
         );
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         println!("Playlist -> Song 3");
         eventually(
             || playlist.current().name == "Song 3",
             "Playlist never became Song 3",
         );
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         println!("Playlist -> Song 5");
         eventually(
             || playlist.current().name == "Song 5",
             "Playlist never became Song 5",
         );
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         println!("Playlist -> Song 7");
         eventually(
             || playlist.current().name == "Song 7",
             "Playlist never became Song 7",
         );
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&prev_buf);
         println!("Playlist -> Song 5");
         eventually(
@@ -256,43 +269,51 @@ mod test {
             "Playlist never became Song 5",
         );
         println!("Switch to AllSongs");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&all_songs_buf);
         eventually(
             || all_songs_playlist.current().name == "Song 1",
             "All Songs Playlist never became Song 1",
         );
         println!("AllSongs -> Song 10");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         eventually(
             || all_songs_playlist.current().name == "Song 10",
             "All Songs Playlist never became Song 10",
         );
         println!("AllSongs -> Song 2");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         eventually(
             || all_songs_playlist.current().name == "Song 2",
             "All Songs Playlist never became Song 2",
         );
         println!("AllSongs -> Song 10");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&prev_buf);
         eventually(
             || all_songs_playlist.current().name == "Song 10",
             "All Songs Playlist never became Song 10",
         );
         println!("Switch to Playlist");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&playlist_buf);
         eventually(
             || playlist.current().name == "Song 5",
             "Playlist never became Song 5",
         );
         println!("Playlist -> Song 7");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         eventually(
             || playlist.current().name == "Song 7",
             "Playlist never became Song 7",
         );
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&play_buf);
         eventually(|| device.is_playing(), "Song never started playing");
+        midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&stop_buf);
         eventually(|| !device.is_playing(), "Song never stopped playing");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,11 +181,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 };
                 let track = track_and_channel[0];
                 let channel = track_and_channel[1].parse::<u16>()?;
-                if !converted_mappings.contains_key(track.into()) {
+                if !converted_mappings.contains_key(track) {
                     converted_mappings.insert(track.into(), vec![]);
                 }
                 converted_mappings
-                    .get_mut(track.into())
+                    .get_mut(track)
                     .expect("expected mapping")
                     .push(channel);
             }
@@ -203,6 +203,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 midi_device,
                 playlist,
                 Playlist::from_songs(songs)?,
+                None,
             );
 
             player.play().await?;

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -17,6 +17,7 @@ use std::{
     sync::{Arc, Barrier},
 };
 
+use midly::live::LiveEvent;
 use tokio::sync::mpsc::Sender;
 
 use crate::{playsync::CancelHandle, songs::Song};
@@ -41,7 +42,7 @@ pub trait Device: fmt::Display + std::marker::Send + std::marker::Sync {
     ) -> Result<(), Box<dyn Error>>;
 
     /// Emits an event.
-    fn emit(&self, song: Arc<Song>) -> Result<(), Box<dyn Error>>;
+    fn emit(&self, midi_event: Option<LiveEvent<'static>>) -> Result<(), Box<dyn Error>>;
 }
 
 /// Lists devices known to midir.

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -21,6 +21,7 @@ use std::{
     thread,
 };
 
+use midly::live::LiveEvent;
 use tokio::{sync::mpsc::Sender, task::JoinHandle};
 use tracing::{info, span, Level};
 
@@ -164,8 +165,8 @@ impl super::Device for Device {
     }
 
     /// Emits an event.
-    fn emit(&self, song: Arc<Song>) -> Result<(), Box<dyn Error>> {
-        if let Some(midi_event) = song.midi_event {
+    fn emit(&self, midi_event: Option<LiveEvent<'static>>) -> Result<(), Box<dyn Error>> {
+        if let Some(midi_event) = midi_event {
             let mut emit_called = self
                 .emit_called
                 .lock()

--- a/src/player.rs
+++ b/src/player.rs
@@ -120,11 +120,13 @@ impl Player {
                     let emit_result: Result<(), Box<dyn Error>> = if join.is_none() {
                         status_events
                             .idling_events
-                            .iter().try_for_each(|event| midi_device.emit(Some(*event)))
+                            .iter()
+                            .try_for_each(|event| midi_device.emit(Some(*event)))
                     } else {
                         status_events
                             .playing_events
-                            .iter().try_for_each(|event| midi_device.emit(Some(*event)))
+                            .iter()
+                            .try_for_each(|event| midi_device.emit(Some(*event)))
                     };
 
                     if let Err(err) = emit_result {
@@ -137,7 +139,8 @@ impl Player {
                 {
                     let status_event_emit_result: Result<(), Box<dyn Error>> = status_events
                         .off_events
-                        .iter().try_for_each(|event| midi_device.emit(Some(*event)));
+                        .iter()
+                        .try_for_each(|event| midi_device.emit(Some(*event)));
 
                     if let Err(err) = status_event_emit_result {
                         error!(err = err.as_ref(), "error emitting off status event");

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -316,8 +316,7 @@ where
 
         let num_channels = *track_mapping
             .iter()
-            .map(|entry| entry.1)
-            .flatten()
+            .flat_map(|entry| entry.1)
             .max()
             .ok_or("no max channel found")?;
 
@@ -336,7 +335,7 @@ where
             tracks.into_iter().for_each(|track| {
                 let file_channel = track.file_channel - 1;
                 if let Some(channel_mappings) = track_mapping.get(&track.name.to_string()) {
-                    channel_mappings.into_iter().for_each(|channel_mapping| {
+                    channel_mappings.iter().for_each(|channel_mapping| {
                         let output_channel = channel_mapping - 1;
                         file_channel_to_output_channels
                             .entry(file_channel)


### PR DESCRIPTION
Status can be reported using MIDI events. Certain MIDI controllers can display lights and other things through the use of specific MIDI events, so we'll be using this to report status.

The noisy logging of MIDI playback has been quieted here, as this status bit made exacerbated this even more.

Closes https://github.com/mdwn/mtrack/issues/6