### PR TITLE
fix: Properly stop MIDI playback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Status reporting is now configurable.
 
+Address stopping not working for songs with sparse MIDI files.
+
 ## [0.1.3] - MIDI tuning, accuracy.
 
 MIDI playback is now more accurate and has been tuned to be more in time with audio


### PR DESCRIPTION
MIDI playback was not stopping properly unless a note was played. For songs with a lot of MIDI events, this was fine, but for songs with a small number of MIDI events, this could cause stopping playback to take a very long time.

Sleep will now sleep in small chunks in order to try to detect if the song has been stopped. This will cause the next MIDI event to immediately play, which will then recognize the cancelled connection and immediately stop.

I'm slightly worried that the chunk size I've chosen here is too small and will cause a lot of CPU spinning using the busy sleep that nodi uses. Monitoring top while running this seems to indicate that things are fine.