### PR TITLE
Bump version to v0.1.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - Initial DMX engine, fixed MIDI clock timing.
+
 Initial DMX engine implemented. This is not quite ready for prime time.
 
 Fixed the MIDI cancelable clock. Not sure what I was thinking when I implemented that.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "cpal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"


### PR DESCRIPTION
The version has been bumped to v0.1.5. I wouldn't normally consider doing this so soon, but the MIDI clock breakage is egregious enough that it needs to be addressed.