### PR TITLE
Allow exclusion of MIDI channels from playback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 DMX engine using OLA has been added. Contains a built in dimming engine.
 
+Added the ability to exclude MIDI channels from MIDI playback.
+
 ## [0.1.5] - Initial DMX engine, fixed MIDI clock timing.
 
 Initial DMX engine implemented. This is not quite ready for prime time.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,15 @@ light_shows:
 - universe_name: a-second-light-show
   dmx_file: DMX Light Show 2.mid
 
-# An optional MIDI file to play along with the audio.
-midi_file: Song Automation.mid
+# An optional MIDI playback configuration.
+midi_playback:
+  file: Song Automation.mid
+
+  # MIDI channels from the MIDI file to exclude. Useful if you want to do things like
+  # exclude lighting data from MIDI playback.
+  exclude_midi_channels:
+  - 15
+
 
 # The tracks associated with this song.
 tracks:

--- a/examples/songs/another-cool-song/song.yaml
+++ b/examples/songs/another-cool-song/song.yaml
@@ -5,7 +5,10 @@ midi_event:
   channel: 16
   program: 2
 
-midi_file: song.mid
+midi_playback:
+  file: song.mid
+  exclude_midi_channels:
+  - 15
 
 light_shows:
 - universe_name: light-show

--- a/src/player.rs
+++ b/src/player.rs
@@ -248,7 +248,7 @@ impl Player {
         // Set up the play barrier, which will synchronize the three calls to play.
         let barrier = Arc::new(Barrier::new({
             let mut num_barriers = 1;
-            if song.midi_file.is_some() && midi_device.is_some() {
+            if song.midi_playback.is_some() && midi_device.is_some() {
                 num_barriers += 1;
             }
             if !song.light_shows.is_empty() && dmx_engine.is_some() {


### PR DESCRIPTION
Specific MIDI channels can be excluded from playback. This will be useful for excluding lighting data from MIDI playback if there is other automation present in the file.