### PR TITLE
Properly report mtrack version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+`mtrack -V` will report the correct mtrack version.
+
 ## [0.1.7] - Fix dependencies.
 
 Dependencies for mtrack have all been updated. This should hopefully resolve the issue

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.23", features = ["derive"] }
+clap = { version = "4.5.23", features = ["cargo", "derive"] }
 cpal = "0.15.3"
 hound = "3.5.1"
 libc = "0.2.168"

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod songs;
 #[cfg(test)]
 mod test;
 
-use clap::{Parser, Subcommand};
+use clap::{crate_version, Parser, Subcommand};
 use config::init_player_and_controller;
 use dmx::universe::UniverseConfig;
 use player::Player;
@@ -55,7 +55,7 @@ Alias=mtrack.service
 #[derive(Parser)]
 #[clap(
     author = "Michael Wilson",
-    version = "0.1.0",
+    version = crate_version!(),
     about = "A multitrack player."
 )]
 struct Cli {


### PR DESCRIPTION
The mtrack version hadn't been updated in a while. We'll use clap's `crate_version!()` macro to make sure it stays up to date.