### PR TITLE
feat: DMX playback delay.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "duration-string"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04782251e09dc67c90d694d89e9a3e5fc6cfe883df1b203202de672d812fb299"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +743,7 @@ version = "0.2.1"
 dependencies = [
  "clap",
  "cpal",
+ "duration-string",
  "futures",
  "hound",
  "libc",
@@ -744,7 +751,6 @@ dependencies = [
  "midly",
  "nodi",
  "ola",
- "regex",
  "ringbuf",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ exclude = [
 [dependencies]
 clap = { version = "4.5.23", features = ["cargo", "derive"] }
 cpal = "0.15.3"
+duration-string = "0.5.2"
 futures = "0.3.31"
 hound = "3.5.1"
 libc = "0.2.168"
@@ -30,7 +31,6 @@ midir = "0.10.1"
 midly = "0.5.3"
 nodi = { version = "1.0.1", features = ["hybrid-sleep", "midir"] }
 ola = "0.1.0"
-regex = "1.11.1"
 ringbuf = "0.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,3 @@
 # Disable github checks, as they're pretty noisy.
+comment: false
 github_checks: false

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,2 @@
+# Disable github checks, as they're pretty noisy.
+github_checks: false

--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -12,6 +12,9 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use std::time::Duration;
+
+use duration_string::DurationString;
 use serde::Deserialize;
 
 use crate::dmx::universe::UniverseConfig;
@@ -22,6 +25,9 @@ pub(super) struct Dmx {
     /// Controls the dim speed modifier. A modifier of 1.0 means a dim speed of 1 == 1.0 second.
     dim_speed_modifier: Option<f64>,
 
+    /// Controls how long to wait before playback of a DMX lighting file starts.
+    playback_delay: Option<String>,
+
     /// The configuration of devices to universes.
     universes: Vec<Universe>,
 }
@@ -30,6 +36,13 @@ impl Dmx {
     /// Gets the dimming speed modifier.
     pub(super) fn get_dimming_speed_modifier(&self) -> Option<f64> {
         self.dim_speed_modifier
+    }
+
+    /// Gets the playback delay.
+    pub(super) fn get_playback_delay(&self) -> Result<Option<Duration>, duration_string::Error> {
+        self.playback_delay.as_ref().map_or(Ok(None), |duration| {
+            Ok(Some(DurationString::from_string(duration.clone())?.into()))
+        })
     }
 
     /// Converts the configuration into universe configs.

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -11,7 +11,11 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::sync::{Arc, RwLock};
+use std::{
+    error::Error,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use engine::Engine;
 use universe::{Universe, UniverseConfig};
@@ -22,10 +26,12 @@ pub mod universe;
 /// Gets a device with the given name.
 pub fn create_engine(
     dimming_speed_modifier: f64,
+    playback_delay: Duration,
     universe_configs: Vec<UniverseConfig>,
-) -> Arc<RwLock<Engine>> {
-    Arc::new(RwLock::new(Engine::new(
+) -> Result<Arc<RwLock<Engine>>, Box<dyn Error>> {
+    Ok(Arc::new(RwLock::new(Engine::new(
         dimming_speed_modifier,
+        playback_delay,
         universe_configs,
-    )))
+    )?)))
 }


### PR DESCRIPTION
A configurable delay has been added to DMX playback. I've found that the lights play ahead of the click. This will allow us to tune this so that it lines up more properly with the click. There's also now one client per DMX engine as opposed to N clients for N DMX universes.

This should also be implemented for audio playback and MIDI playback, but those will be separate PRs.