### PR TITLE
feat: MIDI playback delay, config refactor.

### DIFF
--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -11,13 +11,49 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::error::Error;
+use std::{error::Error, time::Duration};
 
+use duration_string::DurationString;
 use midly::{
     live::LiveEvent,
     num::{u14, u4, u7},
 };
 use serde::Deserialize;
+
+const DEFAULT_MIDI_PLAYBACK_DELAY: Duration = Duration::ZERO;
+
+/// A YAML representation of the MIDI configuration.
+#[derive(Deserialize)]
+pub(crate) struct Midi {
+    /// The MIDI device.
+    device: String,
+
+    /// Controls how long to wait before playback of a DMX lighting file starts.
+    playback_delay: Option<String>,
+}
+
+impl Midi {
+    /// New will create a new MIDI configuration.
+    pub fn new(device: String, playback_delay: Option<String>) -> Midi {
+        Midi {
+            device,
+            playback_delay,
+        }
+    }
+
+    /// Returns the device from the configuration.
+    pub fn device(&self) -> String {
+        self.device.clone()
+    }
+
+    /// Returns the playback delay from the configuration.
+    pub fn playback_delay(&self) -> Result<Duration, Box<dyn Error>> {
+        match &self.playback_delay {
+            Some(playback_delay) => Ok(DurationString::from_string(playback_delay.clone())?.into()),
+            None => Ok(DEFAULT_MIDI_PLAYBACK_DELAY),
+        }
+    }
+}
 
 /// Implementers must convert to a MIDI live event.
 pub(super) trait ToMidiEvent {

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 use super::controller::Controller;
 use super::dmx::Dmx;
 use super::midi;
+use super::midi::Midi;
 use super::trackmappings::TrackMappings;
 
 /// The configuration for the multitrack player.
@@ -27,8 +28,10 @@ pub(super) struct Player {
     pub audio_device: String,
     /// The track mappings for the player.
     pub track_mappings: TrackMappings,
-    /// The MIDI device to use.
+    /// The MIDI device to use. (deprecated)
     pub midi_device: Option<String>,
+    /// The MIDI configuration section.
+    pub midi: Option<Midi>,
     /// The DMX configuration.
     pub dmx: Option<Dmx>,
     /// Events to emit to report status out via MIDI.

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -14,24 +14,17 @@
 use std::{
     error::Error,
     sync::{Arc, RwLock},
-    time::Duration,
 };
 
 use engine::Engine;
-use universe::{Universe, UniverseConfig};
+use universe::Universe;
+
+use crate::config::dmx::Dmx;
 
 pub mod engine;
 pub mod universe;
 
 /// Gets a device with the given name.
-pub fn create_engine(
-    dimming_speed_modifier: f64,
-    playback_delay: Duration,
-    universe_configs: Vec<UniverseConfig>,
-) -> Result<Arc<RwLock<Engine>>, Box<dyn Error>> {
-    Ok(Arc::new(RwLock::new(Engine::new(
-        dimming_speed_modifier,
-        playback_delay,
-        universe_configs,
-    )?)))
+pub fn create_engine(config: Dmx) -> Result<Arc<RwLock<Engine>>, Box<dyn Error>> {
+    Ok(Arc::new(RwLock::new(Engine::new(config)?)))
 }

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -20,7 +20,7 @@ use std::{
 use midly::live::LiveEvent;
 use tokio::sync::mpsc::Sender;
 
-use crate::{playsync::CancelHandle, songs::Song};
+use crate::{config, playsync::CancelHandle, songs::Song};
 
 pub(crate) mod midir;
 mod mock;
@@ -51,12 +51,13 @@ pub fn list_devices() -> Result<Vec<Box<dyn Device>>, Box<dyn Error>> {
 }
 
 /// Gets a device with the given name.
-pub fn get_device(name: &String) -> Result<Arc<dyn Device>, Box<dyn Error>> {
-    if name.starts_with("mock") {
-        return Ok(Arc::new(mock::Device::get(name)));
+pub fn get_device(config: config::midi::Midi) -> Result<Arc<dyn Device>, Box<dyn Error>> {
+    let device = config.device();
+    if device.starts_with("mock") {
+        return Ok(Arc::new(mock::Device::get(device.as_str())));
     };
 
-    Ok(Arc::new(midir::get(name)?))
+    Ok(Arc::new(midir::get(&config)?))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
MIDI playback now supports a playback delay. Additionally, the MIDI/DMX config objects have been refactored a good bit invert the relationship between them. I'll continue to do this in an effort to simplify.