### PR TITLE
feat: Audio playback delay, large config refactor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Configurable playback delays have been added for audio, MIDI, and DMX playback.
+
+A fairly large refactor has been done to the config logic. The motivation is to
+keep (most) of the instantiation of the various pieces of business logic out of
+the config package while simultaneously trying to simplify the configuration of
+the player and its various components.
+
 ## [0.2.1] - Repeatedly attempt to connect to OLA on startup.
 
 Repeatedly attempt to connect to OLA, which should make connecting to DMX on startup

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -13,6 +13,7 @@
 //
 use std::{error::Error, fmt, sync::Arc};
 
+use crate::config::audio::Audio;
 use crate::playsync::CancelHandle;
 use crate::songs::Song;
 use std::collections::HashMap;
@@ -39,12 +40,18 @@ pub fn list_devices() -> Result<Vec<Box<dyn Device>>, Box<dyn Error>> {
 }
 
 /// Gets a device with the given name.
-pub fn get_device(name: &String) -> Result<Arc<dyn Device>, Box<dyn Error>> {
-    if name.starts_with("mock") {
-        return Ok(Arc::new(mock::Device::get(name)));
+pub fn get_device(config: Option<Audio>) -> Result<Arc<dyn Device>, Box<dyn Error>> {
+    let config = match config {
+        Some(config) => config,
+        None => return Err("there must be an audio device specified".into()),
     };
 
-    Ok(Arc::new(cpal::Device::get(name)?))
+    let device = config.device();
+    if device.starts_with("mock") {
+        return Ok(Arc::new(mock::Device::get(device.as_str())));
+    };
+
+    Ok(Arc::new(cpal::Device::get(config)?))
 }
 
 #[cfg(test)]

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use std::{error::Error, time::Duration};
+
+use duration_string::DurationString;
+use serde::Deserialize;
+
+const DEFAULT_AUDIO_PLAYBACK_DELAY: Duration = Duration::ZERO;
+
+/// A YAML representation of the audio configuration.
+#[derive(Deserialize, Clone)]
+pub(crate) struct Audio {
+    /// The audio device.
+    device: String,
+
+    /// Controls how long to wait before playback of an audio file starts.
+    playback_delay: Option<String>,
+}
+
+impl Audio {
+    /// New will create a new Audio configuration.
+    pub fn new(device: String, playback_delay: Option<String>) -> Audio {
+        Audio {
+            device,
+            playback_delay,
+        }
+    }
+
+    /// Returns the device from the configuration.
+    pub fn device(&self) -> String {
+        self.device.clone()
+    }
+
+    /// Returns the playback delay from the configuration.
+    pub fn playback_delay(&self) -> Result<Duration, Box<dyn Error>> {
+        match &self.playback_delay {
+            Some(playback_delay) => Ok(DurationString::from_string(playback_delay.clone())?.into()),
+            None => Ok(DEFAULT_AUDIO_PLAYBACK_DELAY),
+        }
+    }
+}

--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_DMX_DIMMING_SPEED_MODIFIER: f64 = 1.0;
 pub const DEFAULT_DMX_PLAYBACK_DELAY: Duration = Duration::ZERO;
 
 /// A YAML representation of the DMX configuration.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(crate) struct Dmx {
     /// Controls the dim speed modifier. A modifier of 1.0 means a dim speed of 1 == 1.0 second.
     dim_speed_modifier: Option<f64>,

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -23,12 +23,12 @@ use serde::Deserialize;
 const DEFAULT_MIDI_PLAYBACK_DELAY: Duration = Duration::ZERO;
 
 /// A YAML representation of the MIDI configuration.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(crate) struct Midi {
     /// The MIDI device.
     device: String,
 
-    /// Controls how long to wait before playback of a DMX lighting file starts.
+    /// Controls how long to wait before playback of a MIDI file starts.
     playback_delay: Option<String>,
 }
 
@@ -62,7 +62,7 @@ pub(super) trait ToMidiEvent {
 }
 
 /// MIDI events that can be parsed from YAML.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(super) enum Event {
     NoteOff(NoteOff),
@@ -89,7 +89,7 @@ impl ToMidiEvent for Event {
 }
 
 /// A NoteOff event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct NoteOff {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -112,7 +112,7 @@ impl ToMidiEvent for NoteOff {
 }
 
 /// A NoteOn event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct NoteOn {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -135,7 +135,7 @@ impl ToMidiEvent for NoteOn {
 }
 
 /// An Aftertouch event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct Aftertouch {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -158,7 +158,7 @@ impl ToMidiEvent for Aftertouch {
 }
 
 /// A ControlChange event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct ControlChange {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -181,7 +181,7 @@ impl ToMidiEvent for ControlChange {
 }
 
 /// A ProgramChange event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct ProgramChange {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -201,7 +201,7 @@ impl ToMidiEvent for ProgramChange {
 }
 
 /// A ChannelAftertouch event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct ChannelAftertouch {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -221,7 +221,7 @@ impl ToMidiEvent for ChannelAftertouch {
 }
 
 /// A PitchBend event.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct PitchBend {
     /// The channel the MIDI event belongs to.
     channel: u8,

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 // Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
@@ -13,40 +15,81 @@
 //
 use serde::Deserialize;
 
+use super::audio::Audio;
 use super::controller::Controller;
 use super::dmx::Dmx;
-use super::midi;
 use super::midi::Midi;
+use super::statusevents::StatusEvents;
 use super::trackmappings::TrackMappings;
 
 /// The configuration for the multitrack player.
 #[derive(Deserialize)]
 pub(super) struct Player {
     /// The controller configuration.
-    pub controller: Controller,
+    controller: Controller,
     /// The audio device to use.
-    pub audio_device: String,
+    audio_device: Option<String>,
+    /// The audio configuration section.
+    audio: Option<Audio>,
     /// The track mappings for the player.
-    pub track_mappings: TrackMappings,
+    track_mappings: TrackMappings,
     /// The MIDI device to use. (deprecated)
-    pub midi_device: Option<String>,
+    midi_device: Option<String>,
     /// The MIDI configuration section.
-    pub midi: Option<Midi>,
+    midi: Option<Midi>,
     /// The DMX configuration.
-    pub dmx: Option<Dmx>,
+    dmx: Option<Dmx>,
     /// Events to emit to report status out via MIDI.
-    pub status_events: Option<StatusEvents>,
+    status_events: Option<StatusEvents>,
     /// The path to the song definitions.
-    pub songs: String,
+    songs: String,
 }
 
-/// The configuration for emitting status events.
-#[derive(Deserialize)]
-pub(super) struct StatusEvents {
-    /// The events to emit to clear the status.
-    pub off_events: Vec<midi::Event>,
-    /// The events to emit to indicate that the player is idling and waiting for input.
-    pub idling_events: Vec<midi::Event>,
-    /// The events to emit to indicate that the player is currently playing.
-    pub playing_events: Vec<midi::Event>,
+impl Player {
+    /// Gets the controller configuration.
+    pub(crate) fn controller(&self) -> Controller {
+        self.controller.clone()
+    }
+
+    /// Gets the audio configuration.
+    pub(crate) fn audio(&self) -> Option<Audio> {
+        if let Some(audio) = &self.audio {
+            return Some(audio.clone());
+        } else if let Some(audio_device) = &self.audio_device {
+            return Some(Audio::new(audio_device.clone(), None));
+        }
+
+        None
+    }
+
+    /// Gets the track mapping configuration.
+    pub(crate) fn track_mappings(&self) -> HashMap<String, Vec<u16>> {
+        self.track_mappings.track_mappings.clone()
+    }
+
+    /// Gets the MIDI configuration.
+    pub(crate) fn midi(&self) -> Option<Midi> {
+        if let Some(midi) = &self.midi {
+            return Some(midi.clone());
+        } else if let Some(midi_device) = &self.midi_device {
+            return Some(Midi::new(midi_device.clone(), None));
+        }
+
+        None
+    }
+
+    /// Gets the DMX configuration.
+    pub(crate) fn dmx(&self) -> Option<Dmx> {
+        self.dmx.clone()
+    }
+
+    /// Gets the status events configuration.
+    pub(crate) fn status_events(&self) -> Option<StatusEvents> {
+        self.status_events.clone()
+    }
+
+    /// Gets the path to the song definitions.
+    pub(crate) fn songs(&self) -> String {
+        self.songs.clone()
+    }
 }

--- a/src/config/song.rs
+++ b/src/config/song.rs
@@ -18,6 +18,8 @@ use std::{
 
 use serde::Deserialize;
 
+use crate::songs;
+
 use super::{
     midi::{self, ToMidiEvent},
     track,
@@ -125,7 +127,7 @@ impl Song {
                 }),
             self.tracks
                 .iter()
-                .map(|track| track.to_track(&song_path))
+                .map(|track| songs::Track::new(track.with_song_path(&song_path)))
                 .collect::<Result<Vec<crate::songs::Track>, _>>()?,
         )
     }

--- a/src/config/statusevents.rs
+++ b/src/config/statusevents.rs
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use std::error::Error;
+
+use midly::live::LiveEvent;
+use serde::Deserialize;
+
+use self::midi::ToMidiEvent;
+
+use super::midi;
+
+/// The configuration for emitting status events.
+#[derive(Deserialize, Clone)]
+pub(crate) struct StatusEvents {
+    /// The events to emit to clear the status.
+    off_events: Vec<midi::Event>,
+    /// The events to emit to indicate that the player is idling and waiting for input.
+    idling_events: Vec<midi::Event>,
+    /// The events to emit to indicate that the player is currently playing.
+    playing_events: Vec<midi::Event>,
+}
+
+impl StatusEvents {
+    /// Gets the off events.
+    pub(crate) fn off_events(&self) -> Result<Vec<LiveEvent<'static>>, Box<dyn Error>> {
+        self.off_events
+            .iter()
+            .map(|event| event.to_midi_event())
+            .collect()
+    }
+
+    /// Gets the idling events.
+    pub(crate) fn idling_events(&self) -> Result<Vec<LiveEvent<'static>>, Box<dyn Error>> {
+        self.idling_events
+            .iter()
+            .map(|event| event.to_midi_event())
+            .collect()
+    }
+
+    /// Gets the playing events.
+    pub(crate) fn playing_events(&self) -> Result<Vec<LiveEvent<'static>>, Box<dyn Error>> {
+        self.playing_events
+            .iter()
+            .map(|event| event.to_midi_event())
+            .collect()
+    }
+}

--- a/src/config/track.rs
+++ b/src/config/track.rs
@@ -11,13 +11,13 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::{error::Error, path::Path};
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
 /// A YAML representation of a track.
-#[derive(Deserialize)]
-pub(super) struct Track {
+#[derive(Deserialize, Clone)]
+pub(crate) struct Track {
     /// The name of the track.
     name: String,
     /// The file associated with the track.
@@ -27,11 +27,38 @@ pub(super) struct Track {
 }
 
 impl Track {
-    /// Converts this track configuration into a Track object.
-    pub(super) fn to_track(&self, song_path: &Path) -> Result<crate::songs::Track, Box<dyn Error>> {
-        crate::songs::Track::new(
+    /// Creates a new track config.
+    pub(crate) fn new(name: String, file: String, file_channel: Option<u16>) -> Track {
+        Track {
+            name,
+            file,
+            file_channel,
+        }
+    }
+
+    /// Gets the name of the track.
+    pub(crate) fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Gets the file associated with the track.
+    pub(crate) fn file(&self) -> String {
+        self.file.clone()
+    }
+
+    /// Gets the file channel of the track to use.
+    pub(crate) fn file_channel(&self) -> Option<u16> {
+        self.file_channel
+    }
+
+    /// Creates a new copy of track with the song path prefixed to the file path.
+    pub(crate) fn with_song_path(&self, song_path: &PathBuf) -> Track {
+        Self::new(
             self.name.clone(),
-            Path::join(song_path, self.file.clone()),
+            Path::join(song_path, self.file.clone())
+                .to_str()
+                .expect("unable to decode song path")
+                .into(),
             self.file_channel,
         )
     }

--- a/src/controller/drivers.rs
+++ b/src/controller/drivers.rs
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use std::{error::Error, sync::Arc};
+
+use tracing::error;
+
+use super::Driver;
+
+pub(super) fn driver_from_midi_config(
+    config: &crate::config::controller::MidiController,
+    midi_device: Option<Arc<dyn crate::midi::Device>>,
+) -> Result<crate::controller::midi::Driver, Box<dyn Error>> {
+    match midi_device {
+        Some(midi_device) => Ok(crate::controller::midi::Driver::new(
+            midi_device,
+            config.play()?,
+            config.prev()?,
+            config.next()?,
+            config.stop()?,
+            config.all_songs()?,
+            config.playlist()?,
+        )),
+        None => Err("No MIDI device found for MIDI controller.".into()),
+    }
+}
+
+/// Creates a controller driver from the config.
+pub(super) fn driver(
+    config: crate::config::controller::Controller,
+    midi_device: Option<Arc<dyn crate::midi::Device>>,
+) -> Result<Arc<dyn Driver>, Box<dyn Error>> {
+    match config {
+        crate::config::controller::Controller::Midi(config) => match midi_device {
+            Some(midi_device) => match driver_from_midi_config(&config, Some(midi_device)) {
+                Ok(driver) => Ok(Arc::new(driver)),
+                Err(error) => Err(error),
+            },
+            None => Err("No MIDI device found for MIDI controller.".into()),
+        },
+        crate::config::controller::Controller::Keyboard => {
+            Ok(Arc::new(crate::controller::keyboard::Driver::new()))
+        }
+        crate::config::controller::Controller::Multi(vec) => {
+            Ok(Arc::new(crate::controller::multi::Driver::new(
+                vec.iter()
+                    .filter_map(|d| match d {
+                        (_key, crate::config::controller::Controller::Keyboard) => {
+                            Some(crate::controller::multi::SubDriver::Keyboard(Arc::new(
+                                crate::controller::keyboard::Driver::new(),
+                            )))
+                        }
+
+                        (_key, crate::config::controller::Controller::Midi(midi_controller)) => {
+                            let midi_driver_result =
+                                driver_from_midi_config(midi_controller, midi_device.clone());
+                            match midi_driver_result {
+                                Ok(driver) => Some(crate::controller::multi::SubDriver::Midi(
+                                    Arc::new(driver),
+                                )),
+                                Err(_e) => None,
+                            }
+                        }
+
+                        (_key, crate::config::controller::Controller::Multi(_vec)) => {
+                            error!("Recursive multi controllers are not supported");
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )))
+        }
+    }
+}

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -230,7 +230,7 @@ mod test {
             all_songs_playlist.clone(),
             None,
         );
-        let _controller = Controller::new(player, driver)?;
+        let _controller = Controller::new_from_driver(player, driver);
 
         println!("Playlist: {}", playlist);
         println!("AllSongs: {}", all_songs_playlist);

--- a/src/controller/multi.rs
+++ b/src/controller/multi.rs
@@ -159,7 +159,7 @@ mod test {
             all_songs_playlist.clone(),
             None,
         );
-        let _controller = Controller::new(player, driver);
+        let _controller = Controller::new_from_driver(player, driver);
 
         println!("Playlist: {}", playlist);
         println!("AllSongs: {}", all_songs_playlist);

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -25,6 +25,10 @@ pub mod engine;
 pub mod universe;
 
 /// Gets a device with the given name.
-pub fn create_engine(config: Dmx) -> Result<Arc<RwLock<Engine>>, Box<dyn Error>> {
-    Ok(Arc::new(RwLock::new(Engine::new(config)?)))
+pub fn create_engine(config: Option<Dmx>) -> Result<Option<Arc<RwLock<Engine>>>, Box<dyn Error>> {
+    let config = match config {
+        Some(config) => config,
+        None => return Ok(None),
+    };
+    Ok(Some(Arc::new(RwLock::new(Engine::new(config)?))))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod songs;
 mod test;
 
 use clap::{crate_version, Parser, Subcommand};
+use config::audio::Audio;
 use config::dmx::{Dmx, Universe};
 use config::init_player_and_controller;
 use config::midi::Midi;
@@ -208,12 +209,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .push(channel);
             }
 
-            let device = audio::get_device(&device_name)?;
+            let device = audio::get_device(Some(Audio::new(device_name, None)))?;
             let midi_device = match midi_device_name {
-                Some(midi_device_name) => Some(midi::get_device(Midi::new(
-                    midi_device_name,
-                    midi_playback_delay,
-                ))?),
+                Some(midi_device_name) => {
+                    midi::get_device(Some(Midi::new(midi_device_name, midi_playback_delay)))?
+                }
                 None => None,
             };
             let dmx_engine = match dmx_universe_config {
@@ -260,11 +260,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     if universe_configs.is_empty() {
                         None
                     } else {
-                        Some(dmx::create_engine(Dmx::new(
+                        dmx::create_engine(Some(Dmx::new(
                             dmx_dimming_speed_modifier,
                             dmx_playback_delay,
                             universe_configs,
-                        ))?)
+                        )))?
                     }
                 }
                 None => None,

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -51,13 +51,20 @@ pub fn list_devices() -> Result<Vec<Box<dyn Device>>, Box<dyn Error>> {
 }
 
 /// Gets a device with the given name.
-pub fn get_device(config: config::midi::Midi) -> Result<Arc<dyn Device>, Box<dyn Error>> {
-    let device = config.device();
-    if device.starts_with("mock") {
-        return Ok(Arc::new(mock::Device::get(device.as_str())));
+pub fn get_device(
+    config: Option<config::midi::Midi>,
+) -> Result<Option<Arc<dyn Device>>, Box<dyn Error>> {
+    let config = match config {
+        Some(config) => config,
+        None => return Ok(None),
     };
 
-    Ok(Arc::new(midir::get(&config)?))
+    let device = config.device();
+    if device.starts_with("mock") {
+        return Ok(Some(Arc::new(mock::Device::get(device.as_str()))));
+    };
+
+    Ok(Some(Arc::new(midir::get(&config)?)))
 }
 
 #[cfg(test)]

--- a/src/player.rs
+++ b/src/player.rs
@@ -507,15 +507,16 @@ pub struct StatusEvents {
 impl StatusEvents {
     /// Creates a new status events configuration.
     pub fn new(
-        off_events: Vec<LiveEvent<'static>>,
-        idling_events: Vec<LiveEvent<'static>>,
-        playing_events: Vec<LiveEvent<'static>>,
-    ) -> StatusEvents {
-        StatusEvents {
-            off_events,
-            idling_events,
-            playing_events,
-        }
+        config: Option<crate::config::statusevents::StatusEvents>,
+    ) -> Result<Option<StatusEvents>, Box<dyn Error>> {
+        Ok(match config {
+            Some(config) => Some(StatusEvents {
+                off_events: config.off_events()?,
+                idling_events: config.idling_events()?,
+                playing_events: config.playing_events()?,
+            }),
+            None => None,
+        })
     }
 }
 

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -277,12 +277,12 @@ pub struct Track {
 }
 
 impl Track {
-    pub fn new(
-        name: String,
-        track_file: PathBuf,
-        file_channel: Option<u16>,
-    ) -> Result<Track, Box<dyn Error>> {
-        let reader = WavReader::open(track_file.clone())?;
+    pub fn new(config: crate::config::track::Track) -> Result<Track, Box<dyn Error>> {
+        let track_file = PathBuf::from(config.file());
+        let file_channel = config.file_channel();
+        let name = config.name();
+
+        let reader = WavReader::open(&track_file)?;
         let spec = reader.spec();
         let sample_rate = spec.sample_rate;
         let duration = Duration::from_secs(u64::from(reader.duration()) / u64::from(sample_rate));
@@ -709,9 +709,21 @@ mod test {
         write_wav(tempwav2_path.clone(), vec![2_i32, 3_i32, 4_i32])?;
         write_wav(tempwav3_path.clone(), vec![0_i32, 0_i32, 1_i32, 2_i32])?;
 
-        let track1 = super::Track::new("test 1".into(), tempwav1_path, Some(1))?;
-        let track2 = super::Track::new("test 2".into(), tempwav2_path, Some(1))?;
-        let track3 = super::Track::new("test 3".into(), tempwav3_path, Some(1))?;
+        let track1 = super::Track::new(config::track::Track::new(
+            "test 1".into(),
+            tempwav1_path.to_string_lossy().into(),
+            Some(1),
+        ))?;
+        let track2 = super::Track::new(config::track::Track::new(
+            "test 2".into(),
+            tempwav2_path.to_string_lossy().into(),
+            Some(1),
+        ))?;
+        let track3 = super::Track::new(config::track::Track::new(
+            "test 3".into(),
+            tempwav3_path.to_string_lossy().into(),
+            Some(1),
+        ))?;
 
         let song = super::Song::new(
             "song name".into(),


### PR DESCRIPTION
Audio playback delay has been added.

A fairly large refactor has been done to clean up the config logic as well as exercise the config code more in tests. This shouldn't change anything, but the overall idea is to have less cross-purpose code w/r/t configuration, e.g. no creating new tracks in config, no creating controller drivers in config, etc.

The songs config has not yet been refactored.