### PR TITLE
fix: Disable codecov statuses.

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,4 +1,7 @@
 # Disable github checks, as they're pretty noisy.
 comment: false
-github_checks:
-  annotations: false
+coverage:
+  status:
+    project: false
+    patch: false
+github_checks: false


### PR DESCRIPTION
The codecov statuses are neat, but given how much of mtrack is hardware dependent, it's pretty hard to expand the coverage. As a result, test coverage remains somewhat unideal, but this is known. I don't need every PR telling me this. I'm disabling the codecov checks.