### PR TITLE
fix: Various fixes.

### DIFF
--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -61,8 +61,11 @@ impl Engine {
         let mut maybe_client = None;
 
         // Attempt to connect to OLA 10 times.
-        for _ in 0..10 {
-            thread::sleep(Duration::from_secs(5));
+        for i in 0..10 {
+            // Don't sleep on the first iteration.
+            if i > 0 {
+                thread::sleep(Duration::from_secs(5));
+            }
 
             if let Ok(ola_client) = ola::connect() {
                 maybe_client = Some(ola_client);


### PR DESCRIPTION
Various fixes have been made to improve performance, startup time, and logging consistency. The DMX engine was inadvertently sleeping on the first connection try. The logging in player was (minimally) tweaked. The song reading will now skip git subdirectories and MIDI files.