### PR TITLE
chore: Expand DMX engine testability.

### DIFF
--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -18,6 +18,7 @@ use duration_string::DurationString;
 use serde::Deserialize;
 
 /// The default DMX dimming speed.
+pub const DEFAULT_OLA_PORT: u16 = 9010;
 pub const DEFAULT_DMX_DIMMING_SPEED_MODIFIER: f64 = 1.0;
 pub const DEFAULT_DMX_PLAYBACK_DELAY: Duration = Duration::ZERO;
 
@@ -30,6 +31,9 @@ pub struct Dmx {
     /// Controls how long to wait before playback of a DMX lighting file starts.
     playback_delay: Option<String>,
 
+    /// The OLA port. Defaults to the default OLA port.
+    ola_port: Option<u16>,
+
     /// The configuration of devices to universes.
     universes: Vec<Universe>,
 }
@@ -39,11 +43,13 @@ impl Dmx {
     pub fn new(
         dim_speed_modifier: Option<f64>,
         playback_delay: Option<String>,
+        ola_port: Option<u16>,
         universes: Vec<Universe>,
     ) -> Dmx {
         Dmx {
             dim_speed_modifier,
             playback_delay,
+            ola_port,
             universes,
         }
     }
@@ -60,6 +66,11 @@ impl Dmx {
             .map_or(Ok(DEFAULT_DMX_PLAYBACK_DELAY), |duration| {
                 Ok(DurationString::from_string(duration.clone())?.into())
             })
+    }
+
+    /// Gets the OLA port to use.
+    pub fn ola_port(&self) -> u16 {
+        self.ola_port.unwrap_or(DEFAULT_OLA_PORT)
     }
 
     /// Converts the configuration into universe configs.

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -11,10 +11,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::{
-    error::Error,
-    sync::{Arc, RwLock},
-};
+use std::{error::Error, sync::Arc};
 
 use engine::Engine;
 use universe::Universe;
@@ -25,12 +22,10 @@ pub mod engine;
 pub mod universe;
 
 /// Gets a device with the given name.
-pub fn create_engine(
-    config: Option<&config::Dmx>,
-) -> Result<Option<Arc<RwLock<Engine>>>, Box<dyn Error>> {
+pub fn create_engine(config: Option<&config::Dmx>) -> Result<Option<Arc<Engine>>, Box<dyn Error>> {
     let config = match config {
         Some(config) => config,
         None => return Ok(None),
     };
-    Ok(Some(Arc::new(RwLock::new(Engine::new(config)?))))
+    Ok(Some(Arc::new(Engine::new(config)?)))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         Some(config::Dmx::new(
                             dmx_dimming_speed_modifier,
                             dmx_playback_delay,
+                            None,
                             universe_configs,
                         ))
                     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -17,7 +17,7 @@ use std::{
     error::Error,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Barrier, RwLock,
+        Arc, Barrier,
     },
     thread,
     time::{Duration, SystemTime},
@@ -51,7 +51,7 @@ pub struct Player {
     /// The MIDI device to play MIDI back through.
     midi_device: Option<Arc<dyn midi::Device>>,
     /// The DMX engine to use.
-    dmx_engine: Option<Arc<RwLock<dmx::engine::Engine>>>,
+    dmx_engine: Option<Arc<dmx::engine::Engine>>,
     /// The playlist to use.
     playlist: Arc<Playlist>,
     /// The all songs playlist.
@@ -289,7 +289,7 @@ impl Player {
         device: Arc<dyn audio::Device>,
         mappings: Arc<HashMap<String, Vec<u16>>>,
         midi_device: Option<Arc<dyn midi::Device>>,
-        dmx_engine: Option<Arc<RwLock<dmx::engine::Engine>>>,
+        dmx_engine: Option<Arc<dmx::engine::Engine>>,
         song: Arc<Song>,
         cancel_handle: CancelHandle,
         play_tx: oneshot::Sender<()>,


### PR DESCRIPTION
The DMX engine has increased testability. This is largely just concerning that the DMX engine starts/stops and whether connections work, but a refactor has taken place to eliminate the need for the RwLock for the DMX engine by properly scoping "self" in several of the DMX engine's internal methods.