### PR TITLE
Fix: an audio device I use has a space at the end of its identifier, …

### DIFF
--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -150,7 +150,7 @@ impl Device {
         let name = config.device();
         match Device::list_cpal_devices()?
             .into_iter()
-            .find(|device| device.name == *name)
+            .find(|device| device.name.trim() == name)
         {
             Some(mut device) => {
                 device.playback_delay = config.playback_delay()?;


### PR DESCRIPTION
…which doesn't match the trimmed string of the audio device in the config. E.g. 'USB Audio CODEC ' (from the device itself) vs 'USB Audio CODEC'.