### PR TITLE
Initialize song configurations from song directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,9 +1228,11 @@ dependencies = [
  "ringbuf",
  "rosc",
  "serde",
+ "serde_yml",
  "shh",
  "spin_sleep",
  "tempfile",
+ "thiserror 2.0.11",
  "tokio",
  "tonic",
  "tonic-build",
@@ -1927,6 +1939,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap 2.7.1",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,17 @@ prost-types = "0.13.4"
 ringbuf = "0.4.7"
 rosc = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_yml = "0.0.12"
 shh = "1.0.1"
 spin_sleep = "1.2.1"
-tokio = { version = "1.42.0", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+thiserror = "2.0.11"
+tokio = { version = "1.42.0", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 tonic = "0.12.3"
 tonic-reflection = "0.12.3"
 tracing = "0.1.41"

--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ $ mtrack play-direct -m my-midi-device -s 0.25 -d universe=1,name=light-show my-
 2024-03-22T21:24:25.676452Z  INFO play song (midir): mtrack::midi::midir: Playing song MIDI. device="my-midi-device:my-midi-device MIDI 1 28:0" song="My cool song" duration="4:14"
 ```
 
+#### Generating default song configurations
+
+Song configurations can be generated using the `songs` command as follows:
+
+
+```
+$ mtrack songs --init /mnt/song-storage
+```
+
+This will create a file called `song.yaml` in each subfolder of `/mnt/storage`. The name of the
+subfolder determines the song's name. WAV files are used as tracks. The track's name is
+determined using the file name and the number of channels within the file. MIDI files are used as
+MIDI playback, MIDI files that start with `dmx_` will be used as light shows. You can edit the generated files to refine the settings to your needs. 
+
 ### Playlists
 
 The playlist definition is a pretty simple config file:

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -346,15 +346,15 @@ mod test {
         let tempwav1 = "tempwav1.wav";
         let tempwav2 = "tempwav2.wav";
 
-        write_wav(tempdir.join(tempwav1), vec![1_i32, 2_i32, 3_i32])?;
-        write_wav(tempdir.join(tempwav2), vec![2_i32, 3_i32])?;
+        write_wav(tempdir.join(tempwav1), vec![vec![1_i32, 2_i32, 3_i32]])?;
+        write_wav(tempdir.join(tempwav2), vec![vec![2_i32, 3_i32]])?;
 
         let track1 = config::Track::new("test 1".into(), tempwav1, Some(1));
         let track2 = config::Track::new("test 2".into(), tempwav2, Some(1));
 
         let song = Song::new(
             &tempdir,
-            &config::Song::new("song name", vec![track1, track2]),
+            &config::Song::new("song name", None, None, None, None, vec![track1, track2]),
         )?;
         let mut mappings: HashMap<String, Vec<u16>> = HashMap::new();
         mappings.insert("test 1".into(), vec![1]);
@@ -391,15 +391,15 @@ mod test {
         let tempwav1 = "tempwav1.wav";
         let tempwav2 = "tempwav2.wav";
 
-        write_wav(tempdir.join(tempwav1), vec![1_i32, 2_i32, 3_i32])?;
-        write_wav(tempdir.join(tempwav2), vec![2_i32, 3_i32])?;
+        write_wav(tempdir.join(tempwav1), vec![vec![1_i32, 2_i32, 3_i32]])?;
+        write_wav(tempdir.join(tempwav2), vec![vec![2_i32, 3_i32]])?;
 
         let track1 = config::Track::new("test 1".into(), tempwav1, Some(1));
         let track2 = config::Track::new("test 2".into(), tempwav2, Some(1));
 
         let song = Song::new(
             &tempdir,
-            &config::Song::new("song name", vec![track1, track2]),
+            &config::Song::new("song name", None, None, None, None, vec![track1, track2]),
         )?;
         let mut mappings: HashMap<String, Vec<u16>> = HashMap::new();
         mappings.insert("test 1".into(), vec![1]);
@@ -429,15 +429,15 @@ mod test {
         let tempwav1 = "tempwav1.wav";
         let tempwav2 = "tempwav2.wav";
 
-        write_wav(tempdir.join(tempwav1), vec![1_i32, 2_i32, 3_i32])?;
-        write_wav(tempdir.join(tempwav2), vec![2_i32, 3_i32])?;
+        write_wav(tempdir.join(tempwav1), vec![vec![1_i32, 2_i32, 3_i32]])?;
+        write_wav(tempdir.join(tempwav2), vec![vec![2_i32, 3_i32]])?;
 
         let track1 = config::Track::new("test 1".into(), tempwav1, Some(1));
         let track2 = config::Track::new("test 2".into(), tempwav2, Some(1));
 
         let song = Song::new(
             &tempdir,
-            &config::Song::new("song name", vec![track1, track2]),
+            &config::Song::new("song name", None, None, None, None, vec![track1, track2]),
         )?;
         let mut mappings: HashMap<String, Vec<u16>> = HashMap::new();
         mappings.insert("test 1".into(), vec![1]);

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -18,7 +18,7 @@ use midly::{
     live::LiveEvent,
     num::{u14, u4, u7},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 const DEFAULT_MIDI_PLAYBACK_DELAY: Duration = Duration::ZERO;
 
@@ -62,7 +62,7 @@ pub trait ToMidiEvent {
 }
 
 /// MIDI events that can be parsed from YAML.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Event {
     NoteOff(NoteOff),
@@ -99,7 +99,7 @@ impl ToMidiEvent for Event {
 }
 
 /// A NoteOff event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct NoteOff {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -122,7 +122,7 @@ impl ToMidiEvent for NoteOff {
 }
 
 /// A NoteOn event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct NoteOn {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -145,7 +145,7 @@ impl ToMidiEvent for NoteOn {
 }
 
 /// An Aftertouch event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct Aftertouch {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -168,7 +168,7 @@ impl ToMidiEvent for Aftertouch {
 }
 
 /// A ControlChange event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct ControlChange {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -191,7 +191,7 @@ impl ToMidiEvent for ControlChange {
 }
 
 /// A ProgramChange event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct ProgramChange {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -211,7 +211,7 @@ impl ToMidiEvent for ProgramChange {
 }
 
 /// A ChannelAftertouch event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct ChannelAftertouch {
     /// The channel the MIDI event belongs to.
     channel: u8,
@@ -231,7 +231,7 @@ impl ToMidiEvent for ChannelAftertouch {
 }
 
 /// A PitchBend event.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct PitchBend {
     /// The channel the MIDI event belongs to.
     channel: u8,

--- a/src/config/track.rs
+++ b/src/config/track.rs
@@ -11,10 +11,10 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A YAML representation of a track.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct Track {
     /// The name of the track.
     name: String,
@@ -26,7 +26,6 @@ pub struct Track {
 
 impl Track {
     /// Creates a new track config.
-    #[cfg(test)]
     pub fn new(name: String, file: &str, file_channel: Option<u16>) -> Track {
         Track {
             name,

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -824,10 +824,13 @@ mod test {
 
         write_wav(
             tempdir.join(tempwav1),
-            vec![1_i32, 2_i32, 3_i32, 4_i32, 5_i32],
+            vec![vec![1_i32, 2_i32, 3_i32, 4_i32, 5_i32]],
         )?;
-        write_wav(tempdir.join(tempwav2), vec![2_i32, 3_i32, 4_i32])?;
-        write_wav(tempdir.join(tempwav3), vec![0_i32, 0_i32, 1_i32, 2_i32])?;
+        write_wav(tempdir.join(tempwav2), vec![vec![2_i32, 3_i32, 4_i32]])?;
+        write_wav(
+            tempdir.join(tempwav3),
+            vec![vec![0_i32, 0_i32, 1_i32, 2_i32]],
+        )?;
 
         let track1 = config::Track::new("test 1".into(), tempwav1, Some(1));
         let track2 = config::Track::new("test 2".into(), tempwav2, Some(1));


### PR DESCRIPTION
This PR will fix issue #84. The `songs` command will accept an option called `--init` which will make mtrack scan the given directory and create song configuration files based on the audio and MIDI files it finds. 