### PR TITLE
Add MIDI to DMX live mapping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Initialization of a songs directory is now easier, as mtrack can be given an `--init` flag
+when using the `songs` subcommand. This will establish a baseline YAML file in each song
+directory.
+
+Live MIDI can be routed to the DMX engine. This will allow live controlling of lights through
+mtrack.
+
 ## [0.4.1]
 
 Fix: Audio interfaces with spaces at the end can now be selected.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ midi:
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the MIDI playback.
   playback_delay: 500ms
 
+  # (Optional) You can route live MIDI events into the DMX engine with this configuration.
+  midi_to_dmx:
+  
+  # Watch for each MIDI event in channel 15.
+  - midi_channel: 15
+    # Route these events to the light-show universe.
+    universe: light-show
+
 # The directory where all of your songs are located, frequently referred to as the song repository.
 # If the path is not absolute, it will be relative to the location of this file.
 songs: /mnt/song-storage

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -30,6 +30,9 @@ pub struct Midi {
 
     /// Controls how long to wait before playback of a MIDI file starts.
     playback_delay: Option<String>,
+
+    /// MIDI to DMX passthrough configurations.
+    midi_to_dmx: Option<Vec<MidiToDmx>>,
 }
 
 impl Midi {
@@ -38,6 +41,7 @@ impl Midi {
         Midi {
             device: device.to_string(),
             playback_delay,
+            midi_to_dmx: None,
         }
     }
 
@@ -52,6 +56,33 @@ impl Midi {
             Some(playback_delay) => Ok(DurationString::from_string(playback_delay.clone())?.into()),
             None => Ok(DEFAULT_MIDI_PLAYBACK_DELAY),
         }
+    }
+
+    /// Returns the MIDI to DMX configuration.
+    pub fn midi_to_dmx(&self) -> Vec<MidiToDmx> {
+        self.midi_to_dmx.clone().unwrap_or_default()
+    }
+}
+
+/// A YAML representation of the MIDI configuration.
+#[derive(Deserialize, Clone)]
+pub struct MidiToDmx {
+    /// The MIDI channel to pass through to DMX.
+    midi_channel: u8,
+
+    /// The DMX universe to target.
+    universe: String,
+}
+
+impl MidiToDmx {
+    /// The MIDI channel associated with this mapping.
+    pub fn midi_channel(&self) -> u8 {
+        self.midi_channel - 1
+    }
+
+    /// The DMX universe to map the MIDI channel to.
+    pub fn universe(&self) -> String {
+        self.universe.clone()
     }
 }
 

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -225,13 +225,12 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_grpc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new_with_midi_device(
+        let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
-            None,
             &config::Player::new(
                 vec![config::Controller::Keyboard],
                 config::Audio::new("mock-device"),

--- a/src/controller/keyboard.rs
+++ b/src/controller/keyboard.rs
@@ -121,13 +121,12 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_osc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new_with_midi_device(
+        let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
-            None,
             &config::Player::new(
                 vec![config::Controller::Keyboard],
                 config::Audio::new("mock-device"),

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -368,13 +368,12 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_osc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new_with_midi_device(
+        let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
-            None,
             &config::Player::new(
                 vec![config::Controller::Keyboard],
                 config::Audio::new("mock-device"),


### PR DESCRIPTION
Live MIDI events can now be passed directly through to the DMX engine. Some refactoring has been done to support this use case.