### PR TITLE
Make playlist path on mtrack start optional, configure through yaml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ directory.
 Live MIDI can be routed to the DMX engine. This will allow live controlling of lights through
 mtrack.
 
+The playlist can now be specified through the mtrack configuration YAML rather than specified
+separately when using the start command.
+
 ## [0.4.1]
 
 Fix: Audio interfaces with spaces at the end can now be selected.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ To start mtrack as a standalone player that's controllable by MIDI, you'll need 
 player config file:
 
 ```yaml
+# The directory where all of your songs are located, frequently referred to as the song repository.
+# If the path is not absolute, it will be relative to the location of this file.
+songs: /mnt/song-storage
+
+# The path to the playlist file.
+playlist: /mnt/playlist.yaml
+
 # The audio configuration for mtrack.
 audio:
   # This audio device will be matched as best as possible against the devices on your system.
@@ -261,10 +268,6 @@ midi:
   - midi_channel: 15
     # Route these events to the light-show universe.
     universe: light-show
-
-# The directory where all of your songs are located, frequently referred to as the song repository.
-# If the path is not absolute, it will be relative to the location of this file.
-songs: /mnt/song-storage
 
 # The DMX configuration for mtrack. This maps OLA universes to light show names defined within
 # song files.
@@ -432,7 +435,7 @@ track_mappings:
   - 6
 ```
 
-You can start `mtrack` as a process with `mtrack start /path/to/player.yaml /path/to/playlist.yaml`.
+You can start `mtrack` as a process with `mtrack start /path/to/player.yaml`.
 
 ### mtrack on startup
 
@@ -443,15 +446,12 @@ $ sudo mtrack systemd > /etc/systemd/system/mtrack.service
 ```
 
 Note that the service expects that `mtrack` is available at the location `/usr/local/bin/mtrack`. It also
-expects you to define your player configuration and playlist in `/etc/default/mtrack`. This file
-should contain two variables: `MTRACK_CONFIG` and `PLAYLIST`:
+expects you to define your player configuration in `/etc/default/mtrack`. This file
+should contain one variable: `MTRACK_CONFIG`:
 
 ```
 # The configuration for the mtrack player.
 MTRACK_CONFIG=/mnt/storage/mtrack.yaml
-
-# The playlist to use.
-PLAYLIST=/mnt/storage/playlist.yaml
 ```
 
 Once that's defined, you can start it with:

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -1,3 +1,10 @@
+# The directory where all of your songs are located, frequently referred to as the song repository.
+# If the path is not absolute, it will be relative to the location of this file.
+songs: songs
+
+# The path to the playlist file.
+playlist: playlist.yaml
+
 # The audio configuration for mtrack.
 audio:
   # This audio device will be matched as best as possible against the devices on your system.
@@ -15,10 +22,6 @@ midi:
 
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the MIDI playback.
   playback_delay: 500ms
-
-# The directory where all of your songs are located, frequently referred to as the song repository.
-# If the path is not absolute, it will be relative to the location of this file.
-songs: songs
 
 # The DMX configuration for mtrack. This maps OLA universes to light show names defined within
 # song files.

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -45,6 +45,8 @@ pub struct Player {
     dmx: Option<Dmx>,
     /// Events to emit to report status out via MIDI.
     status_events: Option<StatusEvents>,
+    /// The path to the playlist.
+    playlist: Option<String>,
     /// The path to the song definitions.
     songs: String,
 }
@@ -68,6 +70,7 @@ impl Player {
             midi,
             dmx,
             status_events: None,
+            playlist: None,
             songs: songs.to_string(),
         }
     }
@@ -133,6 +136,11 @@ impl Player {
     /// Gets the status events configuration.
     pub fn status_events(&self) -> Option<StatusEvents> {
         self.status_events.clone()
+    }
+
+    /// Gets the path to the playlist.
+    pub fn playlist(&self) -> Option<PathBuf> {
+        self.playlist.as_ref().map(PathBuf::from)
     }
 
     /// Gets the path to the song definitions.


### PR DESCRIPTION
The playlist path can now be configured directly through the mtrack YAML configuration. This will make it so that you don't have to change /etc/default/mtrack every time you want to alter a playlist.