### PR TITLE
MIDI to DMX transformations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ mtrack.
 The playlist can now be specified through the mtrack configuration YAML rather than specified
 separately when using the start command.
 
+Simple MIDI to DMX transformations are now supported. This allows for a simple MIDI event to
+be expanded into multiple, which can then be fed into the DMX engine. This allows for things
+like simple MIDI controllers to control multiple lights.
+
 ## [0.4.1]
 
 Fix: Audio interfaces with spaces at the end can now be selected.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,20 @@ midi:
     # Route these events to the light-show universe.
     universe: light-show
 
+    # Transform the MIDI events into multiple
+    transformers:
+    # Maps the input note into the given list of notes. The velocity will be copied to each
+    # new note.
+    - type: note_mapper
+      input_note: 0
+      convert_to_notes: [0, 1, 2, 4, 5, 6]
+
+    # Maps the input controller into the given list of controllers. The controller value will
+    # be mapped to each new controller.
+    - type: control_change_mapper
+      input_controller: 0
+      convert_to_controllers: [0, 1, 2, 4, 5, 6]
+
 # The DMX configuration for mtrack. This maps OLA universes to light show names defined within
 # song files.
 dmx:
@@ -595,6 +609,19 @@ Additionally, songs can be defined to only recognize specific MIDI channels from
 have a single MIDI file that contains all of your automation, you can restrict light shows to only recognize events from channel 15.
 
 Examples for these configuration options are in the song definition example and mtrack player examples above.
+
+#### Live MIDI to DMX mapping
+
+mtrack is also capable of mapping live MIDI events into the DMX engine. This allows for live control of lighting using a
+MIDI controller. Additionally, transformations can be applied to the incoming MIDI events that allow for singular MIDI messages
+to be transformed into multiple MIDI messages and then fed into the DMX engine, allowing for the control multiple lights. Right now,
+the transformers supported are:
+
+- Note Mapper: This maps one note on a MIDI Channel to multiple notes, all with the same velocity. Works for both note_on and note_off events.
+- Control Change Mapper: This maps one control change event on a MIDI Channel to multiple control change events, all with the same value.
+
+Right now collision behavior is undefined. The intention is to provide some sort of composable mechanism here, so it's very possible that
+this interface will change in the future.
 
 ### MIDI format
 

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -23,6 +23,28 @@ midi:
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the MIDI playback.
   playback_delay: 500ms
 
+  # (Optional) You can route live MIDI events into the DMX engine with this configuration.
+  midi_to_dmx:
+  
+  # Watch for each MIDI event in channel 15.
+  - midi_channel: 15
+    # Route these events to the light-show universe.
+    universe: light-show
+
+    # Transform the MIDI events into multiple
+    transformers:
+    # Maps the input note into the given list of notes. The velocity will be copied to each
+    # new note.
+    - type: note_mapper
+      input_note: 0
+      convert_to_notes: [0, 1, 2, 4, 5, 6]
+
+    # Maps the input controller into the given list of controllers. The controller value will
+    # be mapped to each new controller.
+    - type: control_change_mapper
+      input_controller: 0
+      convert_to_controllers: [0, 1, 2, 4, 5, 6]
+
 # The DMX configuration for mtrack. This maps OLA universes to light show names defined within
 # song files.
 dmx:

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub use self::controller::DEFAULT_GRPC_PORT;
 pub use self::dmx::Dmx;
 pub use self::dmx::Universe;
 pub use self::midi::Midi;
+pub use self::midi::MidiTransformer;
 pub use self::player::Player;
 pub use self::playlist::Playlist;
 pub use self::song::LightShow;

--- a/src/dmx/universe.rs
+++ b/src/dmx/universe.rs
@@ -192,6 +192,8 @@ impl Universe {
                 changed = true;
                 if rates[i] > 0.0 {
                     current[i] = (current[i] + rates[i]).min(target[i])
+                } else if rates[i] == 0.0 {
+                    current[i] = target[i]
                 } else {
                     current[i] = (current[i] + rates[i]).max(target[i])
                 }
@@ -307,6 +309,21 @@ mod test {
         );
 
         assert_eq!([0u8, 50u8, 100u8, 150u8, 200u8], buffer.as_slice()[0..5]);
+
+        // We found a bug with dimming back down, so let's test that here.
+        universe.update_channel_data(2, 50u8, false);
+        universe.update_channel_data(3, 200u8, false);
+        universe.update_channel_data(4, 0, false);
+
+        Universe::approach_target(
+            &universe.rates,
+            &universe.current,
+            &universe.target,
+            &universe.max_channels,
+            &mut buffer,
+        );
+
+        assert_eq!([0u8, 50u8, 50u8, 200u8, 0u8], buffer.as_slice()[0..5]);
     }
 
     #[test]

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -25,6 +25,7 @@ use crate::{config, dmx::engine::Engine, playsync::CancelHandle, songs::Song};
 
 pub(crate) mod midir;
 mod mock;
+mod transform;
 
 /// A MIDI device that can play MIDI files and listen for inputs.
 pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {

--- a/src/midi/transform.rs
+++ b/src/midi/transform.rs
@@ -1,0 +1,251 @@
+// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use midly::num::u7;
+
+#[derive(Clone)]
+pub enum MidiTransformer {
+    NoteMapper(NoteMapper),
+    ControlChangeMapper(ControlChangeMapper),
+}
+
+impl MidiTransformer {
+    pub fn can_process(&self, midi_message: &midly::MidiMessage) -> bool {
+        match self {
+            MidiTransformer::NoteMapper(note_mapper) => note_mapper.can_process(midi_message),
+            MidiTransformer::ControlChangeMapper(control_change_mapper) => {
+                control_change_mapper.can_process(midi_message)
+            }
+        }
+    }
+
+    pub fn transform(&self, midi_message: &midly::MidiMessage) -> Vec<midly::MidiMessage> {
+        match self {
+            MidiTransformer::NoteMapper(note_mapper) => note_mapper.transform(midi_message),
+            MidiTransformer::ControlChangeMapper(control_change_mapper) => {
+                control_change_mapper.transform(midi_message)
+            }
+        }
+    }
+}
+
+/// NoteMapper will map an incoming note and convert it into several notes.
+#[derive(Clone)]
+pub struct NoteMapper {
+    input_note: u7,
+    convert_to_notes: Vec<u7>,
+}
+
+impl NoteMapper {
+    /// Creates a new note mapper.
+    pub fn new(input_note: u7, convert_to_notes: Vec<u7>) -> NoteMapper {
+        NoteMapper {
+            input_note,
+            convert_to_notes,
+        }
+    }
+}
+
+impl NoteMapper {
+    fn can_process(&self, midi_message: &midly::MidiMessage) -> bool {
+        match midi_message {
+            midly::MidiMessage::NoteOn { key: _, vel: _ } => true,
+            midly::MidiMessage::NoteOff { key: _, vel: _ } => true,
+            _ => false,
+        }
+    }
+
+    fn transform(&self, midi_message: &midly::MidiMessage) -> Vec<midly::MidiMessage> {
+        match midi_message {
+            midly::MidiMessage::NoteOn { key, vel } => {
+                if *key == self.input_note {
+                    self.convert_to_notes
+                        .iter()
+                        .map(|key| midly::MidiMessage::NoteOn {
+                            key: *key,
+                            vel: *vel,
+                        })
+                        .collect()
+                } else {
+                    vec![*midi_message]
+                }
+            }
+            midly::MidiMessage::NoteOff { key, vel } => {
+                if *key == self.input_note {
+                    self.convert_to_notes
+                        .iter()
+                        .map(|key| midly::MidiMessage::NoteOff {
+                            key: *key,
+                            vel: *vel,
+                        })
+                        .collect()
+                } else {
+                    vec![*midi_message]
+                }
+            }
+            _ => vec![*midi_message],
+        }
+    }
+}
+
+/// ControlChangeMapper will map an incoming control change and convert it into several control change messages.
+#[derive(Clone)]
+pub struct ControlChangeMapper {
+    input_controller: u7,
+    convert_to_controllers: Vec<u7>,
+}
+
+impl ControlChangeMapper {
+    /// Creates a new note mapper.
+    pub fn new(input_controller: u7, convert_to_controllers: Vec<u7>) -> ControlChangeMapper {
+        ControlChangeMapper {
+            input_controller,
+            convert_to_controllers,
+        }
+    }
+}
+
+impl ControlChangeMapper {
+    fn can_process(&self, midi_message: &midly::MidiMessage) -> bool {
+        match midi_message {
+            midly::MidiMessage::Controller {
+                controller: _,
+                value: _,
+            } => true,
+            _ => false,
+        }
+    }
+
+    fn transform(&self, midi_message: &midly::MidiMessage) -> Vec<midly::MidiMessage> {
+        match midi_message {
+            midly::MidiMessage::Controller { controller, value } => {
+                if *controller == self.input_controller {
+                    self.convert_to_controllers
+                        .iter()
+                        .map(|controller| midly::MidiMessage::Controller {
+                            controller: *controller,
+                            value: *value,
+                        })
+                        .collect()
+                } else {
+                    vec![*midi_message]
+                }
+            }
+            _ => vec![*midi_message],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::error::Error;
+
+    use midly::num::u7;
+
+    use crate::midi::transform::{ControlChangeMapper, MidiTransformer};
+
+    use super::NoteMapper;
+
+    fn note_on(key: u8, vel: u8) -> midly::MidiMessage {
+        midly::MidiMessage::NoteOn {
+            key: u7::from_int_lossy(key),
+            vel: u7::from_int_lossy(vel),
+        }
+    }
+
+    fn note_off(key: u8, vel: u8) -> midly::MidiMessage {
+        midly::MidiMessage::NoteOff {
+            key: u7::from_int_lossy(key),
+            vel: u7::from_int_lossy(vel),
+        }
+    }
+
+    fn control_change(controller: u8, value: u8) -> midly::MidiMessage {
+        midly::MidiMessage::Controller {
+            controller: u7::from_int_lossy(controller),
+            value: u7::from_int_lossy(value),
+        }
+    }
+
+    #[test]
+    fn note_mapper_note_on() -> Result<(), Box<dyn Error>> {
+        let mapper = MidiTransformer::NoteMapper(NoteMapper::new(
+            u7::from_int_lossy(1),
+            u7::slice_from_int(&[2, 3, 4, 5]).to_vec(),
+        ));
+
+        assert!(!mapper.can_process(&control_change(1, 27)));
+        assert!(mapper.can_process(&note_on(1, 27)));
+        let results = mapper.transform(&note_on(1, 27));
+
+        assert_eq!(
+            vec![
+                note_on(2, 27),
+                note_on(3, 27),
+                note_on(4, 27),
+                note_on(5, 27),
+            ],
+            results
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn note_mapper_note_off() -> Result<(), Box<dyn Error>> {
+        let mapper = MidiTransformer::NoteMapper(NoteMapper::new(
+            u7::from_int_lossy(1),
+            u7::slice_from_int(&[2, 3, 4, 5]).to_vec(),
+        ));
+
+        assert!(!mapper.can_process(&control_change(1, 27)));
+        assert!(mapper.can_process(&note_off(1, 27)));
+        let results = mapper.transform(&note_off(1, 27));
+
+        assert_eq!(
+            vec![
+                note_off(2, 27),
+                note_off(3, 27),
+                note_off(4, 27),
+                note_off(5, 27),
+            ],
+            results
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn control_change_mapper() -> Result<(), Box<dyn Error>> {
+        let mapper = MidiTransformer::ControlChangeMapper(ControlChangeMapper::new(
+            u7::from_int_lossy(1),
+            u7::slice_from_int(&[2, 3, 4, 5]).to_vec(),
+        ));
+
+        assert!(!mapper.can_process(&note_on(1, 0)));
+        assert!(mapper.can_process(&control_change(1, 0)));
+        let results = mapper.transform(&control_change(1, 0));
+
+        assert_eq!(
+            vec![
+                control_change(2, 0),
+                control_change(3, 0),
+                control_change(4, 0),
+                control_change(5, 0),
+            ],
+            results
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
MIDI live events can now be transformed into multiple MIDI events for use by the MIDI to DMX live engine. This will allow the use of simple things (like ring based MIDI controllers) to control lighting with a single event type as opposed to having that controller push out dozens of events.

While testing this, an error with CC based DMX engine control was discovered. Basically, the value of the DMX engine going back down did not work as expected. This has been fixed by recognizing the 0 dimming rate as a special case where it just jumps immediately to the expected value.