### PR TITLE
fix: Don't use the hound outside of sample_sources or tests.

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -12,7 +12,6 @@ use std::any::Any;
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use hound::SampleFormat;
 use std::{error::Error, fmt, sync::Arc};
 
 use crate::config;
@@ -22,51 +21,13 @@ use std::collections::HashMap;
 use std::sync::Barrier;
 
 pub mod cpal;
+pub mod format;
 pub mod mixer;
 pub mod mock;
 pub mod sample_source;
 
-/// Target audio format for transcoding
-#[derive(Debug, Clone, PartialEq)]
-pub struct TargetFormat {
-    /// Sample rate in Hz
-    pub sample_rate: u32,
-    /// Sample format (integer or float)
-    pub sample_format: SampleFormat,
-    /// Bits per sample
-    pub bits_per_sample: u16,
-}
-
-impl TargetFormat {
-    /// Creates a new TargetFormat
-    pub fn new(
-        sample_rate: u32,
-        sample_format: SampleFormat,
-        bits_per_sample: u16,
-    ) -> Result<Self, Box<dyn Error>> {
-        // Basic sanity check - let the audio interface decide what's actually supported
-        if sample_rate == 0 {
-            return Err("Sample rate must be greater than 0".into());
-        }
-
-        Ok(TargetFormat {
-            sample_rate,
-            sample_format,
-            bits_per_sample,
-        })
-    }
-}
-
-impl Default for TargetFormat {
-    /// Creates a default target format (44.1kHz, 16-bit integer)
-    fn default() -> Self {
-        TargetFormat {
-            sample_rate: 44100,
-            sample_format: SampleFormat::Int,
-            bits_per_sample: 16,
-        }
-    }
-}
+// Re-export the format types for backward compatibility
+pub use format::{SampleFormat, TargetFormat};
 
 pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Plays the given song through the audio interface.

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -24,12 +24,11 @@ use std::{
 };
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use hound::SampleFormat;
 use tracing::{error, info, span, Level};
 
 use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
 use crate::{
-    audio::{Device as AudioDevice, TargetFormat},
+    audio::{Device as AudioDevice, SampleFormat, TargetFormat},
     config,
     playsync::CancelHandle,
     songs::Song,
@@ -183,7 +182,8 @@ impl OutputManager {
             // Create the output stream based on the target format
             // Map hound::SampleFormat to the appropriate CPAL stream type
 
-            let stream_result = if target_format.sample_format == hound::SampleFormat::Float {
+            let stream_result = if target_format.sample_format == crate::audio::SampleFormat::Float
+            {
                 let mut callback = create_single_thread_callback::<f32>(
                     mixer.clone(),
                     source_rx.clone(),

--- a/src/audio/format.rs
+++ b/src/audio/format.rs
@@ -1,0 +1,169 @@
+// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use std::{error::Error, fmt};
+
+/// Sample format enumeration for audio processing
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SampleFormat {
+    /// Integer samples (e.g., 16-bit, 24-bit, 32-bit)
+    Int,
+    /// Floating point samples (e.g., 32-bit float, 64-bit float)
+    Float,
+}
+
+impl SampleFormat {
+    /// Convert from string representation
+    pub fn from_str(s: &str) -> Result<Self, Box<dyn Error>> {
+        match s {
+            "float" | "Float" => Ok(SampleFormat::Float),
+            "int" | "Int" => Ok(SampleFormat::Int),
+            _ => Err(format!("Unsupported sample format: {}", s).into()),
+        }
+    }
+
+    /// Convert to string representation
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SampleFormat::Float => "float",
+            SampleFormat::Int => "int",
+        }
+    }
+}
+
+impl fmt::Display for SampleFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Target audio format for transcoding
+#[derive(Debug, Clone, PartialEq)]
+pub struct TargetFormat {
+    /// Sample rate in Hz
+    pub sample_rate: u32,
+    /// Sample format (integer or float)
+    pub sample_format: SampleFormat,
+    /// Bits per sample
+    pub bits_per_sample: u16,
+}
+
+impl TargetFormat {
+    /// Creates a new TargetFormat
+    pub fn new(
+        sample_rate: u32,
+        sample_format: SampleFormat,
+        bits_per_sample: u16,
+    ) -> Result<Self, Box<dyn Error>> {
+        // Basic sanity check - let the audio interface decide what's actually supported
+        if sample_rate == 0 {
+            return Err("Sample rate must be greater than 0".into());
+        }
+
+        Ok(TargetFormat {
+            sample_rate,
+            sample_format,
+            bits_per_sample,
+        })
+    }
+}
+
+impl Default for TargetFormat {
+    /// Creates a default target format (44.1kHz, 16-bit integer)
+    fn default() -> Self {
+        TargetFormat {
+            sample_rate: 44100,
+            sample_format: SampleFormat::Int,
+            bits_per_sample: 16,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sample_format_from_str() {
+        // Test valid formats
+        assert_eq!(
+            SampleFormat::from_str("float").unwrap(),
+            SampleFormat::Float
+        );
+        assert_eq!(
+            SampleFormat::from_str("Float").unwrap(),
+            SampleFormat::Float
+        );
+        assert_eq!(SampleFormat::from_str("int").unwrap(), SampleFormat::Int);
+        assert_eq!(SampleFormat::from_str("Int").unwrap(), SampleFormat::Int);
+    }
+
+    #[test]
+    fn test_sample_format_from_str_invalid() {
+        // Test invalid formats
+        assert!(SampleFormat::from_str("invalid").is_err());
+        assert!(SampleFormat::from_str("").is_err());
+        assert!(SampleFormat::from_str("double").is_err());
+    }
+
+    #[test]
+    fn test_sample_format_as_str() {
+        assert_eq!(SampleFormat::Float.as_str(), "float");
+        assert_eq!(SampleFormat::Int.as_str(), "int");
+    }
+
+    #[test]
+    fn test_sample_format_display() {
+        assert_eq!(format!("{}", SampleFormat::Float), "float");
+        assert_eq!(format!("{}", SampleFormat::Int), "int");
+    }
+
+    #[test]
+    fn test_target_format_new() {
+        // Test valid creation
+        let format = TargetFormat::new(44100, SampleFormat::Float, 32).unwrap();
+        assert_eq!(format.sample_rate, 44100);
+        assert_eq!(format.sample_format, SampleFormat::Float);
+        assert_eq!(format.bits_per_sample, 32);
+
+        let format = TargetFormat::new(48000, SampleFormat::Int, 16).unwrap();
+        assert_eq!(format.sample_rate, 48000);
+        assert_eq!(format.sample_format, SampleFormat::Int);
+        assert_eq!(format.bits_per_sample, 16);
+    }
+
+    #[test]
+    fn test_target_format_new_invalid() {
+        // Test invalid sample rate
+        assert!(TargetFormat::new(0, SampleFormat::Float, 32).is_err());
+    }
+
+    #[test]
+    fn test_target_format_default() {
+        let format = TargetFormat::default();
+        assert_eq!(format.sample_rate, 44100);
+        assert_eq!(format.sample_format, SampleFormat::Int);
+        assert_eq!(format.bits_per_sample, 16);
+    }
+
+    #[test]
+    fn test_target_format_equality() {
+        let format1 = TargetFormat::new(44100, SampleFormat::Float, 32).unwrap();
+        let format2 = TargetFormat::new(44100, SampleFormat::Float, 32).unwrap();
+        let format3 = TargetFormat::new(48000, SampleFormat::Float, 32).unwrap();
+
+        assert_eq!(format1, format2);
+        assert_ne!(format1, format3);
+    }
+}

--- a/src/audio/sample_source.rs
+++ b/src/audio/sample_source.rs
@@ -923,23 +923,27 @@ mod tests {
         // Test duration calculation for mono audio
         let samples = vec![1.0, 2.0, 3.0, 4.0, 5.0]; // 5 samples
         let source = MemorySampleSource::new(samples.clone(), 1, 44100);
-        
+
         // Calculate expected duration using the same formula as the implementation
         let total_samples = samples.len() as f64;
         let samples_per_channel = total_samples / 1.0; // mono
         let duration_secs = samples_per_channel / 44100.0;
         let expected_duration = std::time::Duration::from_secs_f64(duration_secs);
-        
+
         let actual_duration = source.duration().unwrap();
-        
+
         // Allow for small rounding differences
         let diff = if actual_duration > expected_duration {
             actual_duration - expected_duration
         } else {
             expected_duration - actual_duration
         };
-        assert!(diff < std::time::Duration::from_micros(1), 
-                "Duration mismatch: expected {:?}, got {:?}", expected_duration, actual_duration);
+        assert!(
+            diff < std::time::Duration::from_micros(1),
+            "Duration mismatch: expected {:?}, got {:?}",
+            expected_duration,
+            actual_duration
+        );
     }
 
     #[test]
@@ -947,23 +951,27 @@ mod tests {
         // Test duration calculation for stereo audio
         let samples = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // 6 samples (3 frames * 2 channels)
         let source = MemorySampleSource::new(samples.clone(), 2, 44100);
-        
+
         // Calculate expected duration using the same formula as the implementation
         let total_samples = samples.len() as f64;
         let samples_per_channel = total_samples / 2.0; // stereo
         let duration_secs = samples_per_channel / 44100.0;
         let expected_duration = std::time::Duration::from_secs_f64(duration_secs);
-        
+
         let actual_duration = source.duration().unwrap();
-        
+
         // Allow for small rounding differences
         let diff = if actual_duration > expected_duration {
             actual_duration - expected_duration
         } else {
             expected_duration - actual_duration
         };
-        assert!(diff < std::time::Duration::from_micros(1), 
-                "Duration mismatch: expected {:?}, got {:?}", expected_duration, actual_duration);
+        assert!(
+            diff < std::time::Duration::from_micros(1),
+            "Duration mismatch: expected {:?}, got {:?}",
+            expected_duration,
+            actual_duration
+        );
     }
 
     #[test]

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -14,8 +14,9 @@
 use std::{error::Error, time::Duration};
 
 use duration_string::DurationString;
-use hound::SampleFormat;
 use serde::Deserialize;
+
+use crate::audio::SampleFormat;
 
 const DEFAULT_AUDIO_PLAYBACK_DELAY: Duration = Duration::ZERO;
 
@@ -71,9 +72,7 @@ impl Audio {
     /// Returns the target sample format (default: Float)
     pub fn sample_format(&self) -> Result<SampleFormat, Box<dyn Error>> {
         match self.sample_format.as_deref() {
-            Some("float") | Some("Float") => Ok(SampleFormat::Float),
-            Some("int") | Some("Int") => Ok(SampleFormat::Int),
-            Some(format) => Err(format!("Unsupported sample format: {}", format).into()),
+            Some(format) => SampleFormat::from_str(format),
             None => Ok(SampleFormat::Float), // Default to float for better precision
         }
     }

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -24,41 +24,6 @@ use std::{
 #[cfg(test)]
 use hound::{SampleFormat, WavSpec, WavWriter};
 
-/// Audio test utilities for generating test signals and validating results
-#[cfg(test)]
-pub mod audio_test_utils {
-    /// Calculate RMS (Root Mean Square) of a signal
-    pub fn calculate_rms(samples: &[f32]) -> f32 {
-        if samples.is_empty() {
-            return 0.0;
-        }
-
-        let sum_squares: f32 = samples.iter().map(|&x| x * x).sum();
-        (sum_squares / samples.len() as f32).sqrt()
-    }
-
-    /// Calculate Signal-to-Noise Ratio (SNR) in dB
-    pub fn calculate_snr(original: &[f32], processed: &[f32]) -> f32 {
-        if original.len() != processed.len() {
-            return 0.0;
-        }
-
-        let signal_power = calculate_rms(original).powi(2);
-        let noise_power = original
-            .iter()
-            .zip(processed.iter())
-            .map(|(o, p)| (o - p).powi(2))
-            .sum::<f32>()
-            / original.len() as f32;
-
-        if noise_power == 0.0 {
-            return f32::INFINITY;
-        }
-
-        10.0 * (signal_power / noise_power).log10()
-    }
-}
-
 /// Wait for the given predicate to return true or fail.
 #[inline]
 #[cfg(test)]
@@ -169,4 +134,39 @@ pub fn write_wav_with_bits<S: hound::Sample + Copy + 'static>(
     }
 
     Ok(())
+}
+
+/// Audio test utilities for generating test signals and validating results
+#[cfg(test)]
+pub mod audio_test_utils {
+    /// Calculate RMS (Root Mean Square) of a signal
+    pub fn calculate_rms(samples: &[f32]) -> f32 {
+        if samples.is_empty() {
+            return 0.0;
+        }
+
+        let sum_squares: f32 = samples.iter().map(|&x| x * x).sum();
+        (sum_squares / samples.len() as f32).sqrt()
+    }
+
+    /// Calculate Signal-to-Noise Ratio (SNR) in dB
+    pub fn calculate_snr(original: &[f32], processed: &[f32]) -> f32 {
+        if original.len() != processed.len() {
+            return 0.0;
+        }
+
+        let signal_power = calculate_rms(original).powi(2);
+        let noise_power = original
+            .iter()
+            .zip(processed.iter())
+            .map(|(o, p)| (o - p).powi(2))
+            .sum::<f32>()
+            / original.len() as f32;
+
+        if noise_power == 0.0 {
+            return f32::INFINITY;
+        }
+
+        10.0 * (signal_power / noise_power).log10()
+    }
 }


### PR DESCRIPTION
hound should not be used outside of sample_sources or in tests. This excises the use of hound::SampleFormat as well as direct calls to hound elsewhere in the codebase where it doesn't make sense.