### PR TITLE
feat: Light show validation, audio output fixes.

### DIFF
--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -67,10 +67,10 @@ pub fn create_engine(
         }
     };
 
-    Ok(Some(Arc::new(Engine::new(
-        config,
-        lighting_config,
-        base_path,
-        ola_client,
-    )?)))
+    let engine = Arc::new(Engine::new(config, lighting_config, base_path, ola_client)?);
+
+    // Start the persistent effects loop
+    Engine::start_persistent_effects_loop(engine.clone());
+
+    Ok(Some(engine))
 }

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -21,6 +21,7 @@ pub mod system;
 pub mod tempo;
 pub mod timeline;
 pub mod types;
+pub mod validation;
 pub mod visual_consistency_tests;
 
 // Re-export the main types for convenience

--- a/src/lighting/consistency_tests.rs
+++ b/src/lighting/consistency_tests.rs
@@ -17,7 +17,7 @@
 #[cfg(test)]
 mod tests {
     use crate::lighting::effects::*;
-    use crate::lighting::effects::{TempoAwareFrequency, TempoAwareSpeed};
+    use crate::lighting::effects::{CycleTransition, TempoAwareFrequency, TempoAwareSpeed};
     use crate::lighting::engine::EffectEngine;
     use std::collections::HashMap;
     use std::time::Duration;
@@ -316,6 +316,7 @@ mod tests {
                 colors: colors.clone(),
                 speed: TempoAwareSpeed::Fixed(1.0),
                 direction: CycleDirection::Forward,
+                transition: CycleTransition::Snap,
             },
             vec!["fx_rgb".to_string()],
             None,
@@ -332,6 +333,7 @@ mod tests {
                 colors,
                 speed: TempoAwareSpeed::Fixed(1.0),
                 direction: CycleDirection::Forward,
+                transition: CycleTransition::Snap,
             },
             vec!["fx_dim".to_string()],
             None,
@@ -638,8 +640,13 @@ mod tests {
             ],
         ];
         let speeds = [0.5, 1.0, 2.0];
-        let dirs = [CycleDirection::Forward, CycleDirection::Backward];
-        let sample_ms = [0u64, 333, 666, 1000];
+        let dirs = [
+            CycleDirection::Forward,
+            CycleDirection::Backward,
+            CycleDirection::PingPong,
+        ];
+        // Include 500ms to catch PingPong peak edge case (cycle_progress = 0.5)
+        let sample_ms = [0u64, 250, 333, 500, 666, 750, 1000];
 
         for colors in color_sets {
             for speed in speeds {
@@ -657,6 +664,7 @@ mod tests {
                             colors: colors.clone(),
                             speed: TempoAwareSpeed::Fixed(speed),
                             direction,
+                            transition: CycleTransition::Snap,
                         },
                         vec!["fx_rgb".to_string()],
                         None,
@@ -673,6 +681,7 @@ mod tests {
                             colors: colors.clone(),
                             speed: TempoAwareSpeed::Fixed(speed),
                             direction,
+                            transition: CycleTransition::Snap,
                         },
                         vec!["fx_dim".to_string()],
                         None,

--- a/src/lighting/layering_tests.rs
+++ b/src/lighting/layering_tests.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod layering_behavior_tests {
     use super::super::effects::*;
-    use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
     use super::super::engine::EffectEngine;
     use std::collections::HashMap;
     use std::time::Duration;
@@ -555,7 +554,6 @@ mod layering_behavior_tests {
 #[cfg(test)]
 mod layering_show_regression {
     use super::super::effects::*;
-    use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
     use super::super::engine::EffectEngine;
     use std::collections::HashMap;
     use std::time::Duration;
@@ -726,7 +724,6 @@ mod layering_show_regression {
 #[cfg(test)]
 mod tests {
     use super::super::effects::*;
-    use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
     use super::super::engine::EffectEngine;
     use super::super::parser::parse_light_shows;
     use super::super::timeline::LightingTimeline;
@@ -1278,7 +1275,6 @@ mod tests {
     #[test]
     fn test_dimmer_without_dedicated_channel() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Create a fixture without a dedicated dimmer channel
@@ -1388,7 +1384,6 @@ mod tests {
     #[test]
     fn test_dimmer_precedence_and_selective_dimming() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Create a fixture with RGB channels only (no dedicated dimmer)
@@ -1657,7 +1652,6 @@ mod tests {
     #[test]
     fn test_blend_mode_loss_debug() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
         use super::super::parser::parse_light_shows;
         use std::collections::HashMap;
@@ -1775,7 +1769,6 @@ mod tests {
     #[test]
     fn test_timeline_blend_mode_loss() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
         use super::super::parser::parse_light_shows;
         use super::super::timeline::LightingTimeline;
@@ -1945,7 +1938,6 @@ mod tests {
     #[test]
     fn test_multiple_effects_simultaneous() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Initialize tracing
@@ -2134,7 +2126,6 @@ mod tests {
     #[test]
     fn test_astera_pixelblock_real_behavior() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Initialize tracing
@@ -2277,7 +2268,6 @@ mod tests {
     #[test]
     fn test_static_replace_blend_mode() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Initialize tracing
@@ -2365,7 +2355,6 @@ mod tests {
     #[test]
     fn test_static_with_dimmer_parameter() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Initialize tracing
@@ -3307,7 +3296,6 @@ mod tests {
     #[test]
     fn test_real_layering_show_file() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
         use super::super::parser::parse_light_shows;
 
@@ -3429,7 +3417,6 @@ mod tests {
     #[test]
     fn test_layering_show_effect_execution() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
         use super::super::parser::parse_light_shows;
 
@@ -3844,7 +3831,6 @@ mod tests {
     #[test]
     fn test_custom_rgb_dimming() {
         use super::super::effects::*;
-        use super::super::effects::{TempoAwareFrequency, TempoAwareSpeed};
         use super::super::engine::EffectEngine;
 
         // Create a fixture with RGB channels only (no dedicated dimmer)
@@ -4539,6 +4525,7 @@ mod tests {
                 ],
                 speed: TempoAwareSpeed::Fixed(1.0),
                 direction: CycleDirection::Forward,
+                transition: CycleTransition::Snap,
             },
             vec!["test_fixture".to_string()],
             EffectLayer::Background, // Same layer
@@ -5954,6 +5941,7 @@ mod tests {
                 ],
                 speed: TempoAwareSpeed::Fixed(1.0),
                 direction: CycleDirection::Forward,
+                transition: CycleTransition::Snap,
             },
             vec!["back_wash".to_string()],
             EffectLayer::Midground,
@@ -6504,6 +6492,7 @@ mod tests {
                 ],
                 speed: TempoAwareSpeed::Fixed(1.0), // 1 cycle per second
                 direction: CycleDirection::Forward,
+                transition: CycleTransition::Snap,
             },
             vec!["test_fixture".to_string()],
             EffectLayer::Background,

--- a/src/lighting/parser.rs
+++ b/src/lighting/parser.rs
@@ -19,8 +19,8 @@ use std::error::Error;
 use std::time::Duration;
 
 use super::effects::{
-    BlendMode, ChaseDirection, ChasePattern, Color, CycleDirection, DimmerCurve, EffectLayer,
-    EffectType,
+    BlendMode, ChaseDirection, ChasePattern, Color, CycleDirection, CycleTransition, DimmerCurve,
+    EffectLayer, EffectType,
 };
 use super::tempo::{
     TempoChange, TempoChangePosition, TempoMap, TempoTransition, TimeSignature, TransitionCurve,
@@ -448,6 +448,7 @@ fn parse_effect_definition(
                         colors: Vec::new(),
                         speed: super::effects::TempoAwareSpeed::Fixed(1.0),
                         direction: CycleDirection::Forward,
+                        transition: super::effects::CycleTransition::Snap,
                     },
                     "strobe" => EffectType::Strobe {
                         frequency: super::effects::TempoAwareFrequency::Fixed(8.0),
@@ -609,6 +610,7 @@ fn apply_parameters_to_effect_type(
             colors,
             speed,
             direction,
+            transition,
         } => {
             // Add all color parameters
             for color_str in color_parameters {
@@ -632,6 +634,13 @@ fn apply_parameters_to_effect_type(
                             "backward" => CycleDirection::Backward,
                             "pingpong" => CycleDirection::PingPong,
                             _ => CycleDirection::Forward,
+                        };
+                    }
+                    "transition" => {
+                        *transition = match value.as_str() {
+                            "snap" => CycleTransition::Snap,
+                            "fade" => CycleTransition::Fade,
+                            _ => CycleTransition::Snap,
                         };
                     }
                     _ => {}
@@ -2744,6 +2753,7 @@ all_wash: cycle, color: "red", color: "green", color: "blue", speed: 1.5, direct
             colors,
             speed,
             direction,
+            transition: _,
         } = &second_cue.effects[0].effect_type
         {
             assert_eq!(colors.len(), 3, "Cycle effect should have 3 colors");

--- a/src/lighting/validation.rs
+++ b/src/lighting/validation.rs
@@ -1,0 +1,420 @@
+// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+
+use super::parser::LightShow;
+use crate::config::Lighting;
+
+/// Validation result containing information about the validation.
+#[derive(Debug, Clone)]
+pub struct ValidationResult {
+    /// All groups/fixtures referenced in the shows
+    pub groups: HashSet<String>,
+    /// Invalid groups/fixtures (if config was provided)
+    pub invalid_groups: Vec<String>,
+}
+
+impl ValidationResult {
+    /// Returns true if validation passed (no invalid groups)
+    pub fn is_valid(&self) -> bool {
+        self.invalid_groups.is_empty()
+    }
+}
+
+/// Collects all fixture group names used in the given shows.
+pub fn collect_groups(shows: &HashMap<String, LightShow>) -> HashSet<String> {
+    let mut groups = HashSet::new();
+
+    for show in shows.values() {
+        for cue in &show.cues {
+            for effect in &cue.effects {
+                for group in &effect.groups {
+                    groups.insert(group.clone());
+                }
+            }
+        }
+    }
+
+    groups
+}
+
+/// Validates that all groups/fixtures referenced in the shows exist in the config.
+/// Returns a ValidationResult with information about the validation.
+/// If config is None, only collects groups without validation.
+pub fn validate_groups(
+    shows: &HashMap<String, LightShow>,
+    config: Option<&Lighting>,
+) -> ValidationResult {
+    let groups = collect_groups(shows);
+
+    let invalid_groups = if let Some(lighting_config) = config {
+        let valid_groups = lighting_config.groups();
+        let valid_fixtures = lighting_config.fixtures();
+        let mut all_valid_names: HashSet<String> = valid_groups.keys().cloned().collect();
+        all_valid_names.extend(valid_fixtures.keys().cloned());
+
+        groups
+            .iter()
+            .filter(|group| !all_valid_names.contains(*group))
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    ValidationResult {
+        groups,
+        invalid_groups,
+    }
+}
+
+/// Validates light shows and returns an error if validation fails.
+/// This is the main validation function that should be used when loading shows.
+pub fn validate_light_shows(
+    shows: &HashMap<String, LightShow>,
+    config: Option<&Lighting>,
+) -> Result<(), Box<dyn Error>> {
+    let result = validate_groups(shows, config);
+
+    if !result.is_valid() {
+        let mut error_msg = format!(
+            "Light show validation failed: {} invalid group(s)/fixture(s) referenced",
+            result.invalid_groups.len()
+        );
+        for group in &result.invalid_groups {
+            error_msg.push_str(&format!("\n  - {} (not found in config)", group));
+        }
+        return Err(error_msg.into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::lighting::{GroupConstraint, LogicalGroup};
+    use crate::lighting::parser::parse_light_shows;
+    use std::collections::HashMap;
+
+    fn create_test_shows() -> HashMap<String, crate::lighting::parser::LightShow> {
+        let content = r#"show "Test Show 1" {
+    @00:00.000
+    front_wash: static color: "blue", dimmer: 60%
+    back_wash: static color: "red", dimmer: 80%
+}
+
+show "Test Show 2" {
+    @00:00.000
+    movers: cycle color: "green", color: "yellow", speed: 1.0
+    strobes: strobe frequency: 4
+}"#;
+
+        parse_light_shows(content).expect("Failed to parse test shows")
+    }
+
+    fn create_test_config() -> Lighting {
+        let mut groups = HashMap::new();
+        groups.insert(
+            "front_wash".to_string(),
+            LogicalGroup::new(
+                "front_wash".to_string(),
+                vec![GroupConstraint::AllOf(vec![
+                    "wash".to_string(),
+                    "front".to_string(),
+                ])],
+            ),
+        );
+        groups.insert(
+            "back_wash".to_string(),
+            LogicalGroup::new(
+                "back_wash".to_string(),
+                vec![GroupConstraint::AllOf(vec![
+                    "wash".to_string(),
+                    "back".to_string(),
+                ])],
+            ),
+        );
+        groups.insert(
+            "movers".to_string(),
+            LogicalGroup::new(
+                "movers".to_string(),
+                vec![GroupConstraint::AnyOf(vec![
+                    "moving_head".to_string(),
+                    "spot".to_string(),
+                ])],
+            ),
+        );
+        groups.insert(
+            "strobes".to_string(),
+            LogicalGroup::new(
+                "strobes".to_string(),
+                vec![GroupConstraint::AllOf(vec!["strobe".to_string()])],
+            ),
+        );
+
+        let mut fixtures = HashMap::new();
+        fixtures.insert(
+            "emergency_light".to_string(),
+            "Emergency @ 1:500".to_string(),
+        );
+
+        Lighting::new(
+            Some("main_stage".to_string()),
+            Some(fixtures),
+            Some(groups),
+            None, // Don't need directories for validation tests
+        )
+    }
+
+    #[test]
+    fn test_collect_groups_basic() {
+        let shows = create_test_shows();
+        let groups = collect_groups(&shows);
+
+        assert_eq!(groups.len(), 4);
+        assert!(groups.contains("front_wash"));
+        assert!(groups.contains("back_wash"));
+        assert!(groups.contains("movers"));
+        assert!(groups.contains("strobes"));
+    }
+
+    #[test]
+    fn test_collect_groups_empty_show() {
+        let content = r#"show "Empty Show" {
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse empty show");
+        let groups = collect_groups(&shows);
+
+        assert_eq!(groups.len(), 0);
+    }
+
+    #[test]
+    fn test_collect_groups_duplicate_groups() {
+        let content = r#"show "Duplicate Groups" {
+    @00:00.000
+    front_wash: static color: "blue"
+    @00:05.000
+    front_wash: static color: "red"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+        let groups = collect_groups(&shows);
+
+        // Should only have one entry for front_wash even though it's used twice
+        assert_eq!(groups.len(), 1);
+        assert!(groups.contains("front_wash"));
+    }
+
+    #[test]
+    fn test_validate_groups_without_config() {
+        let shows = create_test_shows();
+        let result = validate_groups(&shows, None);
+
+        assert_eq!(result.groups.len(), 4);
+        assert_eq!(result.invalid_groups.len(), 0);
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn test_validate_groups_with_valid_config() {
+        let shows = create_test_shows();
+        let config = create_test_config();
+        let result = validate_groups(&shows, Some(&config));
+
+        assert_eq!(result.groups.len(), 4);
+        assert_eq!(result.invalid_groups.len(), 0);
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn test_validate_groups_with_invalid_groups() {
+        let content = r#"show "Invalid Show" {
+    @00:00.000
+    front_wash: static color: "blue"
+    invalid_group: static color: "red"
+    another_invalid: static color: "green"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+        let config = create_test_config();
+        let result = validate_groups(&shows, Some(&config));
+
+        assert_eq!(result.groups.len(), 3);
+        assert_eq!(result.invalid_groups.len(), 2);
+        assert!(!result.is_valid());
+        assert!(result.invalid_groups.contains(&"invalid_group".to_string()));
+        assert!(result
+            .invalid_groups
+            .contains(&"another_invalid".to_string()));
+        // front_wash should be valid
+        assert!(!result.invalid_groups.contains(&"front_wash".to_string()));
+    }
+
+    #[test]
+    fn test_validate_groups_with_fixtures() {
+        let content = r#"show "Fixture Show" {
+    @00:00.000
+    emergency_light: static color: "red"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+        let config = create_test_config();
+        let result = validate_groups(&shows, Some(&config));
+
+        // emergency_light is defined as a fixture in config, so it should be valid
+        assert_eq!(result.groups.len(), 1);
+        assert_eq!(result.invalid_groups.len(), 0);
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn test_validate_light_shows_valid() {
+        let shows = create_test_shows();
+        let config = create_test_config();
+
+        let result = validate_light_shows(&shows, Some(&config));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_light_shows_valid_no_config() {
+        let shows = create_test_shows();
+
+        let result = validate_light_shows(&shows, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_light_shows_invalid() {
+        let content = r#"show "Invalid Show" {
+    @00:00.000
+    front_wash: static color: "blue"
+    invalid_group: static color: "red"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+        let config = create_test_config();
+
+        let result = validate_light_shows(&shows, Some(&config));
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("invalid_group"));
+        assert!(error_msg.contains("validation failed"));
+    }
+
+    #[test]
+    fn test_validate_light_shows_multiple_invalid() {
+        let content = r#"show "Multiple Invalid" {
+    @00:00.000
+    invalid1: static color: "blue"
+    invalid2: static color: "red"
+    invalid3: static color: "green"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+        let config = create_test_config();
+
+        let result = validate_light_shows(&shows, Some(&config));
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("3 invalid"));
+        assert!(error_msg.contains("invalid1"));
+        assert!(error_msg.contains("invalid2"));
+        assert!(error_msg.contains("invalid3"));
+    }
+
+    #[test]
+    fn test_validate_light_shows_empty() {
+        let content = r#"show "Empty Show" {
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+        let config = create_test_config();
+
+        let result = validate_light_shows(&shows, Some(&config));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validation_result_is_valid() {
+        let mut result = ValidationResult {
+            groups: HashSet::new(),
+            invalid_groups: Vec::new(),
+        };
+        assert!(result.is_valid());
+
+        result.invalid_groups.push("invalid".to_string());
+        assert!(!result.is_valid());
+    }
+
+    #[test]
+    fn test_collect_groups_multiple_shows() {
+        let content = r#"show "Show 1" {
+    @00:00.000
+    group_a: static color: "blue"
+    group_b: static color: "red"
+}
+
+show "Show 2" {
+    @00:00.000
+    group_b: static color: "green"
+    group_c: static color: "yellow"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse shows");
+        let groups = collect_groups(&shows);
+
+        // Should have 3 unique groups (group_b appears in both shows)
+        assert_eq!(groups.len(), 3);
+        assert!(groups.contains("group_a"));
+        assert!(groups.contains("group_b"));
+        assert!(groups.contains("group_c"));
+    }
+
+    #[test]
+    fn test_validate_groups_partial_match() {
+        let content = r#"show "Partial Match" {
+    @00:00.000
+    front_wash: static color: "blue"
+    valid_group: static color: "red"
+    invalid_group: static color: "green"
+}"#;
+        let shows = parse_light_shows(content).expect("Failed to parse show");
+
+        // Create config with only some groups
+        let mut groups = HashMap::new();
+        groups.insert(
+            "front_wash".to_string(),
+            LogicalGroup::new(
+                "front_wash".to_string(),
+                vec![GroupConstraint::AllOf(vec!["wash".to_string()])],
+            ),
+        );
+        groups.insert(
+            "valid_group".to_string(),
+            LogicalGroup::new(
+                "valid_group".to_string(),
+                vec![GroupConstraint::AllOf(vec!["valid".to_string()])],
+            ),
+        );
+
+        let config = Lighting::new(None, None, Some(groups), None);
+
+        let result = validate_groups(&shows, Some(&config));
+
+        assert_eq!(result.groups.len(), 3);
+        assert_eq!(result.invalid_groups.len(), 1);
+        assert!(result.invalid_groups.contains(&"invalid_group".to_string()));
+        assert!(!result.invalid_groups.contains(&"front_wash".to_string()));
+        assert!(!result.invalid_groups.contains(&"valid_group".to_string()));
+    }
+}


### PR DESCRIPTION
Light show validation has been added into the playback path, and validation has been added as a top level command.

Various fixes have been made to the lighting effects engine to make it behave in the way that I expect it to.

Additionally, a fairly significant audio output bug was discovered in the transcoder. This has been fixed. Along with it, a move back, to Sinc interpolation for lower latency has been done.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds DSL light show validation and a new verify command, makes the DMX effects loop persistent with timeline completion handling, and replaces FFT resampling with low‑latency sinc resampling while simplifying audio buffering.
> 
> - **Lighting/DMX**:
>   - **Validation**: Add `lighting/validation.rs` and validate DSL shows in `dmx::Engine::play`; fail fast on read/parse/invalid groups.
>   - **Persistent Effects Loop**: Start a continuous 44Hz loop via `Engine::start_persistent_effects_loop`; introduce `timeline_finished` and notify/wait integration; keep effects running after timeline stop; clear effects only on new song.
>   - **Timeline**: Expose `LightingTimeline::is_finished()`; `LightingTimeline::new` carries tempo map.
>   - **Effects**: Add `CycleTransition` (snap/fade) and color `lerp`; fix color cycle indexing (backward/ping‑pong) and zero‑speed handling for cycle/chase; improve strobe/pulse/chase logic and guards; numerous tests added/adjusted.
>   - **Parser**: Support `transition` for `cycle`; better timing/tempo handling and tests.
> - **CLI**:
>   - New subcommand `VerifyLightShow` to parse and optionally validate shows against config; prints groups and errors.
> - **Songs**:
>   - `DslLightingShow::new` now checks file existence and parsability.
> - **Audio**:
>   - Replace FFT resampler with `rubato::SincFixedIn` using a sliding-window streaming design; add FIFO output; remove threaded buffering; broaden tests/tolerances.
>   - `cpal`: minor loop/notify fixes and iteration cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c0cafa1a0698bce7d09a75d7882a8dea8ccb4b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->