### PR TITLE
feat: Add in perpetual durations for all, effect mgmt commands.

### DIFF
--- a/examples/lighting/shows/layer_control_demo.light
+++ b/examples/lighting/shows/layer_control_demo.light
@@ -1,0 +1,67 @@
+// Layer Control Demo
+// Demonstrates grandMA-inspired layer control commands
+//
+// This show demonstrates:
+// - clear() - instantly stop all effects on a layer
+// - release() - gracefully fade out a layer
+// - freeze() / unfreeze() - pause and resume effects
+// - master() - control intensity and speed per layer
+
+show "Layer Control Demo" {
+    // Start with effects on multiple layers
+    @00:00.000
+        front_wash: static color: "#0066ff", dimmer: 100%, layer: background
+        back_wash: rainbow speed: 0.5, layer: midground
+        accent: pulse frequency: 2, dimmer: 80%, layer: foreground
+
+    // Dim the background to 50%
+    @00:05.000
+        master(layer: background, intensity: 50%)
+
+    // Freeze the rainbow - it will hold its current color
+    @00:08.000
+        freeze(layer: midground)
+
+    // Speed up the pulse effect to double speed
+    @00:10.000
+        master(layer: foreground, speed: 200%)
+
+    // Resume the rainbow
+    @00:12.000
+        unfreeze(layer: midground)
+
+    // Gracefully release the foreground with a 2 second fade
+    @00:15.000
+        release(layer: foreground, time: 2s)
+
+    // Add a new strobe effect on foreground (previous one is fading out)
+    @00:16.000
+        strobe_fx: strobe frequency: 8, layer: foreground
+
+    // Slow down the midground rainbow to half speed
+    @00:18.000
+        master(layer: midground, speed: 50%)
+
+    // Restore background to full intensity
+    @00:20.000
+        master(layer: background, intensity: 100%)
+
+    // Clear foreground instantly (panic button style)
+    @00:22.000
+        clear(layer: foreground)
+
+    // Freeze midground using speed=0 (equivalent to freeze command)
+    @00:24.000
+        master(layer: midground, speed: 0%)
+
+    // Resume midground at normal speed
+    @00:26.000
+        master(layer: midground, speed: 100%)
+
+    // Release all layers gracefully at the end
+    @00:30.000
+        release(layer: foreground, time: 1s)
+        release(layer: midground, time: 2s)
+        release(layer: background, time: 3s)
+}
+

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -21,7 +21,20 @@ show_name = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
 show_content = { "{" ~ (tempo | cue)* ~ "}" }
 
-cue = { (time_string | measure_time) ~ effect* }
+cue = { (time_string | measure_time) ~ (effect | layer_command)* }
+
+// Layer control commands (grandMA-inspired)
+layer_command = { layer_command_type ~ "(" ~ layer_command_params? ~ ")" }
+
+layer_command_type = { "release" | "clear" | "freeze" | "unfreeze" | "master" }
+
+layer_command_params = { layer_command_param ~ ("," ~ layer_command_param)* }
+
+layer_command_param = { layer_command_param_name ~ ":" ~ layer_command_param_value }
+
+layer_command_param_name = { "layer" | "time" | "intensity" | "speed" }
+
+layer_command_param_value = { layer_parameter | time_parameter | percentage | number_value }
 
 time_string = @{ "@" ~ (time_mm_ss_mmm | time_ss_mmm) }
 

--- a/src/lighting/layering_tests.rs
+++ b/src/lighting/layering_tests.rs
@@ -1835,18 +1835,18 @@ mod tests {
         println!("✅ Started timeline");
 
         // Update timeline to get effects at different times
-        let effects_at_0s = timeline.update(Duration::from_secs(0));
-        println!("✅ Timeline at 0s: {} effects", effects_at_0s.len());
-        for effect in &effects_at_0s {
+        let result_at_0s = timeline.update(Duration::from_secs(0));
+        println!("✅ Timeline at 0s: {} effects", result_at_0s.effects.len());
+        for effect in &result_at_0s.effects {
             println!(
                 "  Effect: {} blend_mode = {:?}",
                 effect.id, effect.blend_mode
             );
         }
 
-        let effects_at_2s = timeline.update(Duration::from_secs(2));
-        println!("✅ Timeline at 2s: {} effects", effects_at_2s.len());
-        for effect in &effects_at_2s {
+        let result_at_2s = timeline.update(Duration::from_secs(2));
+        println!("✅ Timeline at 2s: {} effects", result_at_2s.effects.len());
+        for effect in &result_at_2s.effects {
             println!(
                 "  Effect: {} blend_mode = {:?}",
                 effect.id, effect.blend_mode
@@ -1854,7 +1854,7 @@ mod tests {
         }
 
         // Start the effects from timeline
-        for effect in effects_at_0s {
+        for effect in result_at_0s.effects {
             engine.start_effect(effect).unwrap();
         }
 
@@ -1863,7 +1863,7 @@ mod tests {
         println!("✅ Applied static effect from timeline");
 
         // Start the dimmer effect from timeline
-        for effect in effects_at_2s {
+        for effect in result_at_2s.effects {
             engine.start_effect(effect).unwrap();
         }
 
@@ -7388,6 +7388,7 @@ mod tests {
             "examples/lighting/shows/crossfade_show.light",
             "examples/lighting/shows/layering_show.light",
             "examples/lighting/shows/comprehensive_show.light",
+            "examples/lighting/shows/layer_control_demo.light",
         ];
 
         for file_path in example_files {


### PR DESCRIPTION
Now, unless a duration is described, all effects will be perpetual until they are replaced. In order to support this, effects management commands have been added. These commands will help explicitly turn off/on/freeze/etc. effects so that turning a perpetual effect off is more predictable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces layer control commands and makes effects perpetual unless timed, updating DSL/grammar, parser, timeline, engines, docs, examples, and tests.
> 
> - **DSL/Parsing**:
>   - Add grandMA-style layer commands: `clear`, `release`, `freeze`, `unfreeze`, `master` to `grammar.pest` and parser (`LayerCommand`, `LayerCommandType`).
>   - Extend `Cue` to include `layer_commands` and parse them with support for `layer`, `time`, `intensity`, `speed`.
> - **Timeline**:
>   - Introduce `TimelineUpdate` returning both `effects` and `layer_commands`.
>   - Process layer commands alongside effects; expose tempo map.
> - **Engines**:
>   - DMX `update_song_lighting`: fetch `TimelineUpdate`, apply layer commands before starting effects.
>   - EffectEngine: implement layer ops (`clear_layer`, `release_layer[_with_time]`, `freeze_layer`, `unfreeze_layer`) and masters (`set/get_layer_intensity_master`, `set/get_layer_speed_master`); handle releasing fades and frozen time in update path.
> - **Effects**:
>   - Make non-timed effects perpetual by default (no implicit durations for `ColorCycle`, `Chase`, `Rainbow`, etc.); update `total_duration`, construction defaults, and crossfade behavior.
>   - Add `EffectLayer` Hash derive and related logic tweaks.
> - **Docs/Examples**:
>   - Add README section for layer controls with examples.
>   - New example show `examples/lighting/shows/layer_control_demo.light`.
> - **Tests**:
>   - Extensive new tests for perpetual effects, layer commands, masters, freezing, releasing, and timeline integration; update existing tests to use `TimelineUpdate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8617eb818d752d38d5178cc3e3457f3f09dc0e06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->