### PR TITLE
feat: Allow for measure offsets.

### DIFF
--- a/examples/lighting/shows/layer_control_demo.light
+++ b/examples/lighting/shows/layer_control_demo.light
@@ -65,3 +65,4 @@ show "Layer Control Demo" {
         release(layer: background, time: 3s)
 }
 
+

--- a/src/lighting/engine/tests.rs
+++ b/src/lighting/engine/tests.rs
@@ -12,8 +12,8 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod tests {
-    use super::*;
     use crate::lighting::effects::*;
     use crate::lighting::engine::EffectEngine;
     use std::collections::HashMap;
@@ -1634,6 +1634,345 @@ mod tests {
             !commands_later.is_empty(),
             "Chase should continue running after tempo change"
         );
+    }
+
+    #[test]
+    fn test_tempo_aware_chase_beats_speed_never_zero() {
+        use crate::lighting::tempo::{
+            TempoChange, TempoChangePosition, TempoMap, TempoTransition, TimeSignature,
+        };
+
+        let mut engine = EffectEngine::new();
+        let fixture1 = create_test_fixture("fixture1", 1, 1);
+        let fixture2 = create_test_fixture("fixture2", 1, 6);
+        let fixture3 = create_test_fixture("fixture3", 1, 11);
+        engine.register_fixture(fixture1);
+        engine.register_fixture(fixture2);
+        engine.register_fixture(fixture3);
+
+        // Tempo map: 120 BPM initially, changes to 60 BPM at 3 seconds
+        let tempo_map = TempoMap::new(
+            Duration::ZERO,
+            120.0,
+            TimeSignature::new(4, 4),
+            vec![TempoChange {
+                position: TempoChangePosition::Time(Duration::from_secs(3)),
+                original_measure_beat: None,
+                bpm: Some(60.0),
+                time_signature: None,
+                transition: TempoTransition::Snap,
+            }],
+        );
+        engine.set_tempo_map(Some(tempo_map));
+
+        // Chase with speed expressed in beats (tempo-aware), using a small beat value
+        // similar to "0.5beats" in the show file. This guards against beats-based
+        // speed resolving to zero due to beats_to_duration returning a degenerate
+        // duration around tempo changes.
+        let effect = EffectInstance::new(
+            "tempo_aware_chase_beats".to_string(),
+            EffectType::Chase {
+                pattern: ChasePattern::Linear,
+                speed: TempoAwareSpeed::Beats(0.5),
+                direction: ChaseDirection::LeftToRight,
+            },
+            vec![
+                "fixture1".to_string(),
+                "fixture2".to_string(),
+                "fixture3".to_string(),
+            ],
+            None,
+            None,
+            None,
+        );
+
+        engine.start_effect(effect).unwrap();
+
+        // Shortly after start at 120 BPM, the chase should generate commands
+        let commands_before = engine.update(Duration::from_millis(100)).unwrap();
+        assert!(
+            !commands_before.is_empty(),
+            "Chase with beats-based speed should generate commands before tempo change"
+        );
+
+        // Advance past the tempo change and ensure the chase still generates commands
+        engine.update(Duration::from_secs(3)).unwrap(); // Advance to tempo change
+        let commands_after = engine.update(Duration::from_millis(100)).unwrap(); // 0.1s after change
+        assert!(
+            !commands_after.is_empty(),
+            "Chase with beats-based speed should still generate commands after tempo change"
+        );
+
+        // And it should continue to run later in time as well
+        let commands_later = engine.update(Duration::from_millis(1000)).unwrap();
+        assert!(
+            !commands_later.is_empty(),
+            "Chase with beats-based speed should continue running after tempo change"
+        );
+    }
+
+    #[test]
+    fn test_chase_after_tempo_change_with_measure_offset() {
+        // Regression test: Replicates scenario where chases after a tempo change
+        // may be missed due to timing/precision issues.
+        // Scenario:
+        // - Tempo change at measure 68/1 (score measure)
+        // - Measure offset of 8
+        // - Random chase at @70/1 (score measure) with speed: 1beats
+        // - Linear chase at @74/1 (score measure) with speed: 0.5beats, direction: right_to_left
+        use crate::lighting::tempo::{
+            TempoChange, TempoChangePosition, TempoMap, TempoTransition, TimeSignature,
+        };
+
+        let mut engine = EffectEngine::new();
+        let fixture1 = create_test_fixture("fixture1", 1, 1);
+        let fixture2 = create_test_fixture("fixture2", 1, 6);
+        let fixture3 = create_test_fixture("fixture3", 1, 11);
+        let fixture4 = create_test_fixture("fixture4", 1, 16);
+        engine.register_fixture(fixture1);
+        engine.register_fixture(fixture2);
+        engine.register_fixture(fixture3);
+        engine.register_fixture(fixture4);
+
+        // Create tempo map: 160 BPM initially, changes to 120 BPM at measure 68/1
+        // Using MeasureBeat position to match the user's scenario
+        let tempo_map = TempoMap::new(
+            Duration::from_secs_f64(1.5), // start_offset of 1.5s
+            160.0,                        // initial BPM
+            TimeSignature::new(4, 4),
+            vec![TempoChange {
+                position: TempoChangePosition::MeasureBeat(68, 1.0),
+                original_measure_beat: Some((68, 1.0)),
+                bpm: Some(120.0),
+                time_signature: None,
+                transition: TempoTransition::Snap,
+            }],
+        );
+        engine.set_tempo_map(Some(tempo_map.clone()));
+
+        // Calculate times for the chases using measure_to_time_with_offset
+        // Measure offset of 8 means score measure 70 becomes playback measure 78
+        let measure_offset = 8;
+        let random_chase_time = tempo_map
+            .measure_to_time_with_offset(70, 1.0, measure_offset)
+            .expect("Should be able to calculate time for measure 70/1");
+        let linear_chase_time = tempo_map
+            .measure_to_time_with_offset(74, 1.0, measure_offset)
+            .expect("Should be able to calculate time for measure 74/1");
+
+        // Create random chase at @70/1 with speed: 1beats
+        let random_chase = EffectInstance::new(
+            "random_chase".to_string(),
+            EffectType::Chase {
+                pattern: ChasePattern::Random,
+                speed: TempoAwareSpeed::Beats(1.0),
+                direction: ChaseDirection::LeftToRight,
+            },
+            vec![
+                "fixture1".to_string(),
+                "fixture2".to_string(),
+                "fixture3".to_string(),
+                "fixture4".to_string(),
+            ],
+            None,
+            None,
+            None,
+        );
+
+        // Create linear chase at @74/1 with speed: 0.5beats, direction: right_to_left
+        let linear_chase = EffectInstance::new(
+            "linear_chase".to_string(),
+            EffectType::Chase {
+                pattern: ChasePattern::Linear,
+                speed: TempoAwareSpeed::Beats(0.5),
+                direction: ChaseDirection::RightToLeft,
+            },
+            vec![
+                "fixture1".to_string(),
+                "fixture2".to_string(),
+                "fixture3".to_string(),
+                "fixture4".to_string(),
+            ],
+            None,
+            None,
+            None,
+        );
+
+        // Advance to just before the random chase
+        let time_before_random = random_chase_time - Duration::from_millis(10);
+        engine.update(time_before_random).unwrap();
+
+        // Start the random chase
+        engine.start_effect(random_chase).unwrap();
+
+        // Test that random chase produces output at various times
+        // Test immediately after start
+        let commands_at_start = engine
+            .update(random_chase_time + Duration::from_millis(16))
+            .unwrap();
+        assert!(
+            !commands_at_start.is_empty(),
+            "Random chase should generate commands immediately after start"
+        );
+
+        // Test a bit later (during the chase)
+        let commands_during = engine
+            .update(random_chase_time + Duration::from_millis(100))
+            .unwrap();
+        assert!(
+            !commands_during.is_empty(),
+            "Random chase should continue generating commands during execution"
+        );
+
+        // Advance to just before the linear chase
+        let time_before_linear = linear_chase_time - Duration::from_millis(10);
+        engine.update(time_before_linear).unwrap();
+
+        // Start the linear chase
+        engine.start_effect(linear_chase).unwrap();
+
+        // Test that linear chase produces output at various times
+        // Test immediately after start
+        let commands_linear_start = engine
+            .update(linear_chase_time + Duration::from_millis(16))
+            .unwrap();
+        assert!(
+            !commands_linear_start.is_empty(),
+            "Linear chase should generate commands immediately after start (at measure 74/1)"
+        );
+
+        // Test a bit later (during the chase)
+        let commands_linear_during = engine
+            .update(linear_chase_time + Duration::from_millis(100))
+            .unwrap();
+        assert!(
+            !commands_linear_during.is_empty(),
+            "Linear chase should continue generating commands during execution"
+        );
+
+        // Test even later to ensure it keeps running
+        let commands_linear_later = engine
+            .update(linear_chase_time + Duration::from_millis(500))
+            .unwrap();
+        assert!(
+            !commands_linear_later.is_empty(),
+            "Linear chase should continue generating commands well into its execution"
+        );
+
+        // Critical test: Verify speed calculation doesn't return zero
+        // This is the suspected issue - beats_to_duration might return a degenerate value
+        // that causes speed to be calculated as 0.0
+        let current_speed = TempoAwareSpeed::Beats(0.5).to_cycles_per_second(
+            Some(&tempo_map),
+            linear_chase_time + Duration::from_millis(100),
+        );
+        assert!(
+            current_speed > 0.0,
+            "Chase speed should never be zero; got speed={} at time after tempo change",
+            current_speed
+        );
+    }
+
+    #[test]
+    fn test_chase_timing_edge_cases_after_tempo_change() {
+        // More aggressive test: Try to catch timing edge cases that might cause
+        // a chase to be missed. Tests multiple time points around tempo changes
+        // and chase start times to catch floating-point precision issues.
+        use crate::lighting::tempo::{
+            TempoChange, TempoChangePosition, TempoMap, TempoTransition, TimeSignature,
+        };
+
+        let mut engine = EffectEngine::new();
+        let fixture1 = create_test_fixture("fixture1", 1, 1);
+        let fixture2 = create_test_fixture("fixture2", 1, 6);
+        let fixture3 = create_test_fixture("fixture3", 1, 11);
+        engine.register_fixture(fixture1);
+        engine.register_fixture(fixture2);
+        engine.register_fixture(fixture3);
+
+        // Create tempo map: 160 BPM initially, changes to 120 BPM at measure 68/1
+        let tempo_map = TempoMap::new(
+            Duration::from_secs_f64(1.5),
+            160.0,
+            TimeSignature::new(4, 4),
+            vec![TempoChange {
+                position: TempoChangePosition::MeasureBeat(68, 1.0),
+                original_measure_beat: Some((68, 1.0)),
+                bpm: Some(120.0),
+                time_signature: None,
+                transition: TempoTransition::Snap,
+            }],
+        );
+        engine.set_tempo_map(Some(tempo_map.clone()));
+
+        let measure_offset = 8;
+        let linear_chase_time = tempo_map
+            .measure_to_time_with_offset(74, 1.0, measure_offset)
+            .expect("Should be able to calculate time for measure 74/1");
+
+        // Test speed calculation at multiple time points around the chase start
+        // This catches edge cases where beats_to_duration might return degenerate values
+        let test_times = [
+            linear_chase_time - Duration::from_millis(1),
+            linear_chase_time,
+            linear_chase_time + Duration::from_nanos(1),
+            linear_chase_time + Duration::from_millis(1),
+            linear_chase_time + Duration::from_millis(10),
+            linear_chase_time + Duration::from_millis(100),
+            linear_chase_time + Duration::from_millis(500),
+        ];
+
+        for (i, test_time) in test_times.iter().enumerate() {
+            let speed =
+                TempoAwareSpeed::Beats(0.5).to_cycles_per_second(Some(&tempo_map), *test_time);
+            assert!(
+                speed > 0.0,
+                "Speed should never be zero at test point {} (time={:?}): got speed={}",
+                i,
+                test_time,
+                speed
+            );
+        }
+
+        // Now test actual chase execution at these edge case times
+        let linear_chase = EffectInstance::new(
+            "linear_chase".to_string(),
+            EffectType::Chase {
+                pattern: ChasePattern::Linear,
+                speed: TempoAwareSpeed::Beats(0.5),
+                direction: ChaseDirection::RightToLeft,
+            },
+            vec![
+                "fixture1".to_string(),
+                "fixture2".to_string(),
+                "fixture3".to_string(),
+            ],
+            None,
+            None,
+            None,
+        );
+
+        // Advance to just before the chase
+        engine
+            .update(linear_chase_time - Duration::from_millis(10))
+            .unwrap();
+        engine.start_effect(linear_chase).unwrap();
+
+        // Test at multiple time points to catch any frame where it might fail
+        for (i, test_time) in test_times.iter().enumerate() {
+            if *test_time >= linear_chase_time {
+                engine.update(*test_time).unwrap();
+                let commands = engine
+                    .update(*test_time + Duration::from_millis(16))
+                    .unwrap();
+                assert!(
+                    !commands.is_empty(),
+                    "Chase should generate commands at test point {} (time={:?})",
+                    i,
+                    test_time
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -21,7 +21,7 @@ show_name = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
 show_content = { "{" ~ (tempo | cue)* ~ "}" }
 
-cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command)* }
+cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command | offset_command | reset_measures_command)* }
 
 // Sequence definition rules
 sequence = { "sequence" ~ sequence_name ~ sequence_content }
@@ -30,7 +30,7 @@ sequence_name = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
 sequence_content = { "{" ~ (tempo | sequence_cue)* ~ "}" }
 
-sequence_cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command)* }
+sequence_cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command | offset_command | reset_measures_command)* }
 
 // Sequence reference in a cue
 sequence_reference = { "sequence" ~ sequence_name ~ (","? ~ sequence_params)? }
@@ -45,6 +45,10 @@ sequence_param_value = { loop_parameter | number_value }
 
 // Stop sequence command
 stop_sequence_command = { "stop" ~ "sequence" ~ sequence_name }
+
+// Measure offset commands
+offset_command = { "offset" ~ number_value ~ "measures" }
+reset_measures_command = { "reset_measures" }
 
 // Layer control commands (grandMA-inspired)
 layer_command = { layer_command_type ~ "(" ~ layer_command_params? ~ ")" }

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -330,11 +330,13 @@ pub(crate) fn apply_parameters_to_effect_type(
             for (key, value) in parameters {
                 match key.as_str() {
                     "pattern" => {
-                        *pattern = match value.as_str() {
+                        // Strip quotes if present, trim whitespace, and convert to lowercase for case-insensitive matching
+                        let clean_value = value.trim_matches('"').trim().to_lowercase();
+                        *pattern = match clean_value.as_str() {
                             "linear" => ChasePattern::Linear,
                             "snake" => ChasePattern::Snake,
                             "random" => ChasePattern::Random,
-                            _ => ChasePattern::Linear,
+                            _ => ChasePattern::Linear, // Default to Linear if pattern doesn't match
                         };
                     }
                     "speed" => match parse_speed_string(value, tempo_map) {
@@ -344,7 +346,9 @@ pub(crate) fn apply_parameters_to_effect_type(
                         }
                     },
                     "direction" => {
-                        *direction = match value.as_str() {
+                        // Strip quotes if present (e.g., "right_to_left" -> right_to_left)
+                        let clean_value = value.trim_matches('"').trim();
+                        *direction = match clean_value {
                             "left_to_right" => ChaseDirection::LeftToRight,
                             "right_to_left" => ChaseDirection::RightToLeft,
                             "top_to_bottom" => ChaseDirection::TopToBottom,


### PR DESCRIPTION
In order to more easily align with various composition programs, there's now the ability to add in offsets to measure counts. This will help account for repeated sections which can cause measure count offsets. Tempo maps respect the offsets.

In a group, light candidates are now sorted in lexicographic naming order. Parsing of chase directions now respects the use of quotes.