### PR TITLE
fix: Bare identifier can be the last thing in the list.

### DIFF
--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -91,6 +91,7 @@ parameter_value = {
     percentage |
     time_parameter |
     direction_parameter |
+    chase_pattern_parameter |
     loop_parameter |
     step_parameter |
     transition_parameter |
@@ -103,7 +104,8 @@ parameter_value = {
 }
 
 // Restrictive bare identifier to avoid swallowing typos
-bare_identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+// Atomic to prevent backtracking issues when it's the last parameter
+bare_identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 
 color_parameter = { 
     quoted_hex_color |
@@ -128,7 +130,14 @@ quoted_rgb_color = @{ "\"" ~ "rgb(" ~ ASCII_DIGIT+ ~ "," ~ " "? ~ ASCII_DIGIT+ ~
 // Supports absolute time (ms, s) and musical time (beats, measures)
 time_parameter = @{ time_value ~ time_unit }
 
-direction_parameter = { "forward" | "backward" | "random" | "pingpong" }
+direction_parameter = {
+    "forward" | "backward" | "random" | "pingpong" |
+    "left_to_right" | "right_to_left" |
+    "top_to_bottom" | "bottom_to_top" |
+    "clockwise" | "counter_clockwise"
+}
+
+chase_pattern_parameter = { "linear" | "snake" | "random" }
 
 loop_parameter = { "once" | "loop" | "pingpong" | "random" }
 

--- a/src/lighting/parser/utils.rs
+++ b/src/lighting/parser/utils.rs
@@ -365,6 +365,7 @@ pub(crate) fn parse_parameter(pair: Pair<Rule>) -> Result<(String, String), Box<
             Rule::percentage
             | Rule::time_parameter
             | Rule::direction_parameter
+            | Rule::chase_pattern_parameter
             | Rule::loop_parameter
             | Rule::step_parameter
             | Rule::transition_parameter


### PR DESCRIPTION
There was a bug when parsing the bare identifier as the last thing in the list.