### PR TITLE
feat: Support inline loops.

### DIFF
--- a/examples/lighting/shows/layer_control_demo.light
+++ b/examples/lighting/shows/layer_control_demo.light
@@ -71,3 +71,4 @@ show "Layer Control Demo" {
 
 
 
+

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -23,7 +23,7 @@ show_name = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
 show_content = { "{" ~ (tempo | cue)* ~ "}" }
 
-cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command | offset_command | reset_measures_command)* }
+cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command | offset_command | reset_measures_command | inline_loop)* }
 
 // Sequence definition rules
 sequence = { "sequence" ~ sequence_name ~ sequence_content }
@@ -32,7 +32,7 @@ sequence_name = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
 sequence_content = { "{" ~ (tempo | sequence_cue)* ~ "}" }
 
-sequence_cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command | offset_command | reset_measures_command)* }
+sequence_cue = { (time_string | measure_time) ~ (effect | layer_command | sequence_reference | stop_sequence_command | offset_command | reset_measures_command | inline_loop)* }
 
 // Sequence reference in a cue
 sequence_reference = { "sequence" ~ sequence_name ~ (","? ~ sequence_params)? }
@@ -47,6 +47,12 @@ sequence_param_value = { loop_parameter | number_value }
 
 // Stop sequence command
 stop_sequence_command = { "stop" ~ "sequence" ~ sequence_name }
+
+// Inline loop - allows repeating a block of cues inline
+inline_loop = { "loop" ~ "{" ~ inline_loop_cue* ~ "}" ~ ","? ~ "repeats" ~ ":" ~ number_value }
+
+// Cues inside an inline loop (timing is relative to loop start)
+inline_loop_cue = { (time_string | measure_time) ~ (effect | layer_command | stop_sequence_command | offset_command | reset_measures_command)* }
 
 // Measure offset commands
 offset_command = { "offset" ~ number_value ~ "measures" }

--- a/src/lighting/parser/tests/basic_parsing_tests.rs
+++ b/src/lighting/parser/tests/basic_parsing_tests.rs
@@ -393,3 +393,419 @@ fn test_parse_fade_in_simple() {
         effect.up_time
     );
 }
+
+#[test]
+fn test_inline_loop() {
+    let content = r#"show "Test Show" {
+    tempo {
+        bpm: 120
+        time_signature: 4/4
+    }
+    @0.0
+    loop {
+        @0.0
+        effect: static, color: "red", duration: 1s
+        @1.0
+        effect: static, color: "blue", duration: 1s
+    }, repeats: 3
+}"#;
+
+    let result = parse_light_shows(content);
+    if let Err(e) = &result {
+        println!("Parser error: {}", e);
+    }
+    assert!(result.is_ok());
+    let shows = result.unwrap();
+    let show = &shows["Test Show"];
+
+    // The inline loop with 3 repeats should create 6 cues (2 cues per iteration)
+    // Each iteration is 2 seconds (1s red + 1s blue), so:
+    // Iteration 0: @0.0 red, @1.0 blue
+    // Iteration 1: @2.0 red, @3.0 blue
+    // Iteration 2: @4.0 red, @5.0 blue
+    assert!(
+        show.cues.len() >= 6,
+        "Expected at least 6 cues, got {}",
+        show.cues.len()
+    );
+
+    // Check that we have cues at the expected times
+    let cue_times: Vec<Duration> = show.cues.iter().map(|c| c.time).collect();
+    println!("Cue times: {:?}", cue_times);
+    println!("Number of cues: {}", show.cues.len());
+
+    // Print details about each cue
+    for (i, cue) in show.cues.iter().enumerate() {
+        println!(
+            "Cue {}: time={:?}, effects={}",
+            i,
+            cue.time,
+            cue.effects.len()
+        );
+        for (j, effect) in cue.effects.iter().enumerate() {
+            println!("  Effect {}: {:?}", j, effect.effect_type);
+        }
+    }
+
+    // The loop should create 6 cues (2 cues per iteration × 3 iterations)
+    // Expected times: 0.0, 1.0, 2.0, 3.0, 4.0, 5.0
+    assert_eq!(
+        show.cues.len(),
+        6,
+        "Expected 6 cues, got {}",
+        show.cues.len()
+    );
+
+    // Check that we have cues at the expected times (allowing for small floating point differences)
+    let expected_times = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+    let actual_times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+    for expected in expected_times {
+        assert!(
+            actual_times.iter().any(|&t| (t - expected).abs() < 0.01),
+            "Expected a cue at time {}, but got times: {:?}",
+            expected,
+            actual_times
+        );
+    }
+}
+
+#[test]
+fn test_inline_loop_respects_base_offset() {
+    // Loop starts at absolute @2.5 and should keep its internal relative timing.
+    // Two cues inside the loop at 0.0s and 0.5s, loop duration 1.0s, repeats twice.
+    // Expected cue times: 2.5, 3.0, 3.5, 4.0.
+    let content = r#"show "Offset Loop" {
+    tempo { bpm: 120 }
+    @2.5
+    loop {
+        @0.0
+        band: static, color: "red", duration: 0.5s
+        @0.5
+        band: static, color: "blue", duration: 0.5s
+    }, repeats: 2
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["Offset Loop"];
+    let times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+
+    let expected = vec![2.5, 3.0, 3.5, 4.0];
+    for t in expected {
+        assert!(
+            times.iter().any(|&actual| (actual - t).abs() < 0.01),
+            "expected cue at {t}, got {times:?}"
+        );
+    }
+    assert_eq!(times.len(), 4, "expected 4 cues, got {}", times.len());
+}
+
+#[test]
+fn test_inline_loop_respects_tempo_for_durations() {
+    // Tempo 120 BPM => 0.5s per beat.
+    // One effect per loop iteration, duration 2 beats (1.0s).
+    // Loop duration should be 1.0s; with repeats=2 we expect cues at 0.0 and 1.0.
+    let content = r#"show "Tempo Loop" {
+    tempo { bpm: 120 }
+    @0.0
+    loop {
+        @0.0
+        band: static, color: "red", duration: 2beats
+    }, repeats: 2
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["Tempo Loop"];
+    let times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+    let expected_times = vec![0.0, 1.0];
+    for t in expected_times {
+        assert!(
+            times.iter().any(|&actual| (actual - t).abs() < 0.01),
+            "expected cue at {t}, got {times:?}"
+        );
+    }
+    assert_eq!(times.len(), 2, "expected 2 cues, got {}", times.len());
+
+    // Verify the duration parsed via tempo map (2 beats at 120 BPM = 1.0s)
+    let dur = show.cues[0].effects[0]
+        .total_duration()
+        .expect("duration should be set");
+    assert!(
+        (dur.as_secs_f64() - 1.0).abs() < 0.01,
+        "expected duration ~1.0s, got {:?}",
+        dur
+    );
+}
+
+#[test]
+fn test_inline_loop_inside_sequence_preserves_times() {
+    // Inline loop inside a sequence should expand to distinct cues with absolute times.
+    // Two cues per loop iteration at 0.0s and 0.5s, loop duration 1.0s, repeats twice.
+    // When the sequence is referenced at @0.0 the show should have cues at 0.0, 0.5, 1.0, 1.5.
+    let content = r#"tempo { bpm: 120 }
+sequence "LoopSeq" {
+    @0.0
+    loop {
+        @0.0
+        effect: static, color: "red", duration: 0.5s
+        @0.5
+        effect: static, color: "blue", duration: 0.5s
+    }, repeats: 2
+}
+
+show "UseSeq" {
+    @0.0
+    sequence "LoopSeq"
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["UseSeq"];
+    let times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+
+    let expected = vec![0.0, 0.5, 1.0, 1.5];
+    for t in expected {
+        assert!(
+            times.iter().any(|&actual| (actual - t).abs() < 0.01),
+            "expected cue at {t}, got {times:?}"
+        );
+    }
+    assert_eq!(times.len(), 4, "expected 4 cues, got {}", times.len());
+}
+
+#[test]
+fn test_inline_loop_measure_time_positions() {
+    // Measure-based timings inside an inline loop should be interpreted relative to the loop start.
+    // Tempo 120 BPM, 4/4 => 1 measure = 2.0s, beat spacing = 0.5s.
+    // Loop body cues at @1/1 (0.0s) and @1/3 (1.0s), each duration 1.0s; loop duration = 2.0s.
+    // With repeats: 2, expected cue times: 0.0, 1.0, 2.0, 3.0.
+    let content = r#"show "Measure Loop" {
+    tempo {
+        bpm: 120
+        time_signature: 4/4
+    }
+    @0.0
+    loop {
+        @1/1
+        effect: static, color: "red", duration: 1s
+        @1/3
+        effect: static, color: "blue", duration: 1s
+    }, repeats: 2
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["Measure Loop"];
+    let times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+
+    let expected = vec![0.0, 1.0, 2.0, 3.0];
+    for t in expected.iter() {
+        assert!(
+            times.iter().any(|&actual| (actual - t).abs() < 0.01),
+            "expected cue at {t}, got {times:?}"
+        );
+    }
+    assert_eq!(times.len(), 4, "expected 4 cues, got {}", times.len());
+}
+
+#[test]
+fn test_base_effects_with_inline_loop_out_of_order() {
+    // Test that base effects are scheduled at abs_time even when inline loop cues
+    // are out of order (e.g., @0.5 appears before @0.0 in source)
+    let content = r#"show "Base Effects Loop" {
+    tempo { bpm: 120 }
+    @1.0
+    effect: static, color: "red", duration: 0.5s
+    loop {
+        @0.5
+        effect: static, color: "blue", duration: 0.5s
+        @0.0
+        effect: static, color: "green", duration: 0.5s
+    }, repeats: 1
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["Base Effects Loop"];
+
+    // The base effect should be at @1.0 (abs_time)
+    // The loop cues should be at @1.0 (green) and @1.5 (blue)
+    // So we should have cues at: 1.0 (base red + loop green), 1.5 (loop blue)
+
+    let times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+    println!("Cue times: {:?}", times);
+
+    // Find the cue at 1.0 - it should have both the base red effect and the loop green effect
+    let cue_at_1_0 = show
+        .cues
+        .iter()
+        .find(|c| (c.time.as_secs_f64() - 1.0).abs() < 0.01);
+    assert!(cue_at_1_0.is_some(), "Expected a cue at time 1.0");
+
+    let cue = cue_at_1_0.unwrap();
+    // Should have at least 2 effects: base red + loop green
+    assert!(
+        cue.effects.len() >= 2,
+        "Expected at least 2 effects at time 1.0 (base + loop), got {}",
+        cue.effects.len()
+    );
+
+    // Verify we have a cue at 1.5 with the blue effect
+    let cue_at_1_5 = show
+        .cues
+        .iter()
+        .find(|c| (c.time.as_secs_f64() - 1.5).abs() < 0.01);
+    assert!(cue_at_1_5.is_some(), "Expected a cue at time 1.5");
+
+    // Verify the base effect is at the correct time (1.0), not at 1.5
+    // The bug would put it at 1.5 if expanded_cues[0] was the first loop cue
+    // We verify this by checking that the cue at 1.0 has multiple effects (base + loop)
+    // and the cue at 1.5 only has the loop effect
+    assert!(
+        cue_at_1_5.unwrap().effects.len() == 1,
+        "Cue at 1.5 should only have the loop blue effect, not the base red effect"
+    );
+}
+
+#[test]
+fn test_inline_loop_merging_consistent_between_show_and_sequence() {
+    // Test that base effects and inline loop cues at the same time are merged consistently
+    // in both shows and sequences. The sequence starts at @0.0 and is referenced at @0.0,
+    // so the times should match exactly.
+    let show_content = r#"show "Show Test" {
+    tempo { bpm: 120 }
+    @0.0
+    effect: static, color: "red", duration: 0.5s
+    loop {
+        @0.0
+        effect: static, color: "green", duration: 0.5s
+    }, repeats: 1
+}"#;
+
+    let sequence_content = r#"tempo { bpm: 120 }
+sequence "Seq Test" {
+    @0.0
+    effect: static, color: "red", duration: 0.5s
+    loop {
+        @0.0
+        effect: static, color: "green", duration: 0.5s
+    }, repeats: 1
+}
+
+show "Use Seq" {
+    @0.0
+    sequence "Seq Test"
+}"#;
+
+    // Parse show
+    let shows = parse_light_shows(show_content).expect("show parse should succeed");
+    let show = &shows["Show Test"];
+
+    // Parse sequence
+    let seq_shows = parse_light_shows(sequence_content).expect("sequence parse should succeed");
+    let seq_show = &seq_shows["Use Seq"];
+
+    // Both should have a cue at time 0.0 with 2 effects (base red + loop green merged)
+    let show_cue_at_0_0 = show
+        .cues
+        .iter()
+        .find(|c| (c.time.as_secs_f64() - 0.0).abs() < 0.01);
+    let seq_cue_at_0_0 = seq_show
+        .cues
+        .iter()
+        .find(|c| (c.time.as_secs_f64() - 0.0).abs() < 0.01);
+
+    assert!(
+        show_cue_at_0_0.is_some(),
+        "Show should have a cue at time 0.0"
+    );
+    assert!(
+        seq_cue_at_0_0.is_some(),
+        "Sequence should have a cue at time 0.0"
+    );
+
+    let show_cue = show_cue_at_0_0.unwrap();
+    let seq_cue = seq_cue_at_0_0.unwrap();
+
+    // Both should have 2 effects (base red + loop green merged)
+    assert_eq!(
+        show_cue.effects.len(),
+        2,
+        "Show cue at 0.0 should have 2 effects (base + loop merged), got {}",
+        show_cue.effects.len()
+    );
+    assert_eq!(
+        seq_cue.effects.len(),
+        2,
+        "Sequence cue at 0.0 should have 2 effects (base + loop merged), got {}",
+        seq_cue.effects.len()
+    );
+
+    // Verify both have the same number of cues total
+    assert_eq!(
+        show.cues.len(),
+        seq_show.cues.len(),
+        "Show and sequence should produce the same number of cues"
+    );
+}
+
+#[test]
+fn test_static_effect_duration_includes_up_and_down_time() {
+    // Test that static effects with both duration and up_time/down_time calculate
+    // total duration correctly (up_time + duration + down_time)
+    let content = r#"show "Duration Test" {
+    tempo { bpm: 120 }
+    @0.0
+    effect: static, color: "red", duration: 1s, up_time: 0.5s, down_time: 0.3s
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["Duration Test"];
+    assert_eq!(show.cues.len(), 1, "Should have one cue");
+
+    let effect = &show.cues[0].effects[0];
+    let total_duration = effect
+        .total_duration()
+        .expect("effect should have a duration");
+
+    // Total should be: 0.5s (up_time) + 1.0s (duration) + 0.3s (down_time) = 1.8s
+    let expected_duration = Duration::from_secs_f64(1.8);
+    assert!(
+        (total_duration.as_secs_f64() - expected_duration.as_secs_f64()).abs() < 0.01,
+        "Expected total duration ~1.8s, got {:?}",
+        total_duration
+    );
+}
+
+#[test]
+fn test_inline_loop_with_static_duration_and_up_time() {
+    // Test that inline loops correctly calculate duration when static effects have
+    // both duration and up_time/down_time, preventing loop iterations from overlapping
+    let content = r#"show "Loop Duration Test" {
+    tempo { bpm: 120 }
+    @0.0
+    loop {
+        @0.0
+        effect: static, color: "red", duration: 1s, up_time: 0.5s, down_time: 0.3s
+    }, repeats: 2
+}"#;
+
+    let shows = parse_light_shows(content).expect("parse should succeed");
+    let show = &shows["Loop Duration Test"];
+
+    // Loop duration should be 1.8s (0.5s up + 1.0s duration + 0.3s down)
+    // With repeats: 2, we expect cues at 0.0 and 1.8
+    let times: Vec<f64> = show.cues.iter().map(|c| c.time.as_secs_f64()).collect();
+    let expected_times = vec![0.0, 1.8];
+
+    for expected in expected_times {
+        assert!(
+            times.iter().any(|&actual| (actual - expected).abs() < 0.01),
+            "Expected a cue at time {}, got times: {:?}",
+            expected,
+            times
+        );
+    }
+    assert_eq!(
+        times.len(),
+        2,
+        "Expected 2 cues (one per iteration), got {}",
+        times.len()
+    );
+}

--- a/src/lighting/parser/types.rs
+++ b/src/lighting/parser/types.rs
@@ -135,6 +135,19 @@ impl Effect {
             return Some(*duration);
         }
 
+        // For static effects, if duration is specified in effect_type, use it as the hold_time
+        // and include up_time and down_time in the total calculation
+        if let EffectType::Static {
+            duration: Some(static_duration),
+            ..
+        } = &self.effect_type
+        {
+            let duration = self.up_time.unwrap_or(Duration::from_secs(0))
+                + *static_duration
+                + self.down_time.unwrap_or(Duration::from_secs(0));
+            return Some(duration);
+        }
+
         let duration = self.up_time.unwrap_or(Duration::from_secs(0))
             + self.hold_time.unwrap_or(Duration::from_secs(0))
             + self.down_time.unwrap_or(Duration::from_secs(0));


### PR DESCRIPTION
Inline loops are now supported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds inline loop support to the DSL and parser (with time-aware expansion/merging), adjusts static effect duration calculation, and introduces comprehensive tests.
> 
> - **DSL/Grammar**:
>   - Add `inline_loop` and `inline_loop_cue` rules; allow inline loops in `cue` and `sequence_cue`.
> - **Parser**:
>   - Implement `parse_and_expand_inline_loop` and enable inline loop expansion in shows and sequences.
>   - Change sequence cue parsing to return multiple `UnexpandedSequenceCue`s and merge inline loop content with base cue when times match.
>   - Ensure cues are sorted chronologically and `last_time` reflects furthest expanded time; respect tempo, offsets, and measure-based timing within loops.
>   - Preserve base effects timing when loop cues are out of order; consistent merging behavior between shows and sequences.
> - **Effects**:
>   - `Effect::total_duration()` now includes `Static` effect `duration` plus `up_time`/`down_time`.
> - **Tests**:
>   - Add tests covering inline loop timing, base offsets, tempo-driven durations, measure-time positions, sequence integration, merging consistency, and static duration calculations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b84566a017420f679549ad71f7c8e2a507487b02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->