### PR TITLE
chore: DRY, engine, effect improvements.

### DIFF
--- a/src/lighting/effects.rs
+++ b/src/lighting/effects.rs
@@ -28,7 +28,7 @@ pub use color::Color;
 pub use error::EffectError;
 pub use fixture::{FixtureCapabilities, FixtureInfo, FixtureProfile, StrobeStrategy};
 pub use instance::EffectInstance;
-pub use state::{ChannelState, DmxCommand, FixtureState};
+pub use state::{is_multiplier_channel, ChannelState, DmxCommand, FixtureState};
 pub use tempo_aware::{TempoAwareFrequency, TempoAwareSpeed};
 pub use types::{
     BlendMode, ChaseDirection, ChasePattern, CycleDirection, CycleTransition, DimmerCurve,


### PR DESCRIPTION
Refactor so that the lighting engine is simplified. Refactored the effects so that there's less repetition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors lighting engine, effects, and parsers to remove duplication with shared helpers, simplify conflict/processing logic, and expose `is_multiplier_channel`.
> 
> - **Engine**:
>   - Extracts `format_effect_for_logging` and `preserve_conflicting_permanent_effects`; avoids unnecessary clones; tweaks layer speed handling and effect ordering; simplifies conflict checks and blend-mode compatibility in `engine/layers.rs`.
>   - Uses `is_multiplier_channel` when filtering locked channels; streamlines multiplier key removal on temporary effect completion.
> - **Effects**:
>   - Exports `is_multiplier_channel` from `effects` and defines it in `state`.
>   - `color.rs`: refactors HSV→RGB via sector mapping; adds small `lerp` helper.
>   - `fixture.rs`: adds `layer_suffix`; DRYs multiplier keys (`_dimmer_mult*`, `_pulse_mult*`) and normalizes RGB `u8`→`f64`.
>   - `state.rs`: minor DMX multiplier consolidation and readability tweaks.
>   - `tempo_aware.rs`: adds rate/measure/beat conversion helpers; consolidates duration→rate logic.
> - **Processing**:
>   - Adds `cycle_progress`, `phase`, and `calculate_color_indices`; reuses across color cycle, strobe, chase, rainbow, and pulse; applies crossfade uniformly; simplifies dimmer path.
> - **Parser**:
>   - `effect_parse.rs` and `show.rs`: introduce helpers (color normalization, score-time/offset math, sequence duration/loop parsing); replace repeated logic and centralize sequence ref parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4671503039d46c2d50493fcb868f1676d6ad402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->