### PR TITLE
Fix playlist name in grpc status.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/examples/lighting_simulator.rs
+++ b/examples/lighting_simulator.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/format.rs
+++ b/src/audio/format.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source.rs
+++ b/src/audio/sample_source.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/channel_mapped.rs
+++ b/src/audio/sample_source/channel_mapped.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/error.rs
+++ b/src/audio/sample_source/error.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/factory.rs
+++ b/src/audio/sample_source/factory.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/memory.rs
+++ b/src/audio/sample_source/memory.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/tests.rs
+++ b/src/audio/sample_source/tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/traits.rs
+++ b/src/audio/sample_source/traits.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/transcoder.rs
+++ b/src/audio/sample_source/transcoder.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/audio/sample_source/wav.rs
+++ b/src/audio/sample_source/wav.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/controller.rs
+++ b/src/config/controller.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/lighting.rs
+++ b/src/config/lighting.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/playlist.rs
+++ b/src/config/playlist.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/song.rs
+++ b/src/config/song.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/statusevents.rs
+++ b/src/config/statusevents.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/track.rs
+++ b/src/config/track.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/config/trackmappings.rs
+++ b/src/config/trackmappings.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -176,6 +176,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
+                "Playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
@@ -190,15 +191,13 @@ mod test {
             None,
         )?);
         let playlist = player.get_playlist();
-        let all_songs_playlist = player.get_all_songs_playlist();
         let binding = player.audio_device();
         let device = binding.to_mock()?;
 
-        let driver = Arc::new(TestDriver::new(player, TestEvent::Unset));
+        let driver = Arc::new(TestDriver::new(player.clone(), TestEvent::Unset));
         let mut controller = super::Controller::new_from_drivers(vec![driver.clone()]);
 
         println!("Playlist: {}", playlist);
-        println!("AllSongs: {}", all_songs_playlist);
 
         // Test the controller directing the player.
         println!("Playlist -> Song 1");
@@ -233,25 +232,25 @@ mod test {
         println!("Switch to AllSongs");
         driver.next_event(TestEvent::AllSongs).await;
         eventually(
-            || all_songs_playlist.current().name() == "Song 1",
+            || player.get_playlist().current().name() == "Song 1",
             "All Songs Playlist never became Song 1",
         );
         println!("AllSongs -> Song 10");
         driver.next_event(TestEvent::Next).await;
         eventually(
-            || all_songs_playlist.current().name() == "Song 10",
+            || player.get_playlist().current().name() == "Song 10",
             "All Songs Playlist never became Song 10",
         );
         println!("AllSongs -> Song 2");
         driver.next_event(TestEvent::Next).await;
         eventually(
-            || all_songs_playlist.current().name() == "Song 2",
+            || player.get_playlist().current().name() == "Song 2",
             "All Songs Playlist never became Song 2",
         );
         println!("AllSongs -> Song 10");
         driver.next_event(TestEvent::Prev).await;
         eventually(
-            || all_songs_playlist.current().name() == "Song 10",
+            || player.get_playlist().current().name() == "Song 10",
             "All Songs Playlist never became Song 10",
         );
         println!("Switch to Playlist");

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -175,6 +175,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
+                "Playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
@@ -189,7 +190,6 @@ mod test {
             None,
         )?);
         let playlist = player.get_playlist();
-        let all_songs_playlist = player.get_all_songs_playlist();
         let binding = player.audio_device();
         let device = binding.to_mock()?;
         let binding = player.midi_device().expect("MIDI device not found");
@@ -204,13 +204,12 @@ mod test {
                 all_songs_event,
                 playlist_event,
             ),
-            player,
+            player.clone(),
         )?;
 
         let _controller = Controller::new_from_drivers(vec![driver]);
 
         println!("Playlist: {}", playlist);
-        println!("AllSongs: {}", all_songs_playlist);
 
         // Test the controller directing the player. Make sure we put
         // unrecognized events in between to make sure that they're ignored.
@@ -271,7 +270,7 @@ mod test {
         midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&all_songs_buf);
         eventually(
-            || all_songs_playlist.current().name() == "Song 1",
+            || player.get_playlist().current().name() == "Song 1",
             "All Songs Playlist never became Song 1",
         );
 
@@ -281,7 +280,7 @@ mod test {
         midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         eventually(
-            || all_songs_playlist.current().name() == "Song 10",
+            || player.get_playlist().current().name() == "Song 10",
             "All Songs Playlist never became Song 10",
         );
 
@@ -291,7 +290,7 @@ mod test {
         midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&next_buf);
         eventually(
-            || all_songs_playlist.current().name() == "Song 2",
+            || player.get_playlist().current().name() == "Song 2",
             "All Songs Playlist never became Song 2",
         );
 
@@ -301,7 +300,7 @@ mod test {
         midi_device.mock_event(&unrecognized_buf);
         midi_device.mock_event(&prev_buf);
         eventually(
-            || all_songs_playlist.current().name() == "Song 10",
+            || player.get_playlist().current().name() == "Song 10",
             "All Songs Playlist never became Song 10",
         );
 

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -373,6 +373,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
+                "Playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/dmx/ola_client.rs
+++ b/src/dmx/ola_client.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/dmx/universe.rs
+++ b/src/dmx/universe.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/consistency_tests.rs
+++ b/src/lighting/consistency_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects.rs
+++ b/src/lighting/effects.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/color.rs
+++ b/src/lighting/effects/color.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/error.rs
+++ b/src/lighting/effects/error.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/fixture.rs
+++ b/src/lighting/effects/fixture.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/instance.rs
+++ b/src/lighting/effects/instance.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/state.rs
+++ b/src/lighting/effects/state.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/tempo_aware.rs
+++ b/src/lighting/effects/tempo_aware.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/tests.rs
+++ b/src/lighting/effects/tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/effects/types.rs
+++ b/src/lighting/effects/types.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/layers.rs
+++ b/src/lighting/engine/layers.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/processing.rs
+++ b/src/lighting/engine/processing.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests.rs
+++ b/src/lighting/engine/tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/basic_tests.rs
+++ b/src/lighting/engine/tests/basic_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/chase_tests.rs
+++ b/src/lighting/engine/tests/chase_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/color_cycle_tests.rs
+++ b/src/lighting/engine/tests/color_cycle_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/common.rs
+++ b/src/lighting/engine/tests/common.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/dimmer_tests.rs
+++ b/src/lighting/engine/tests/dimmer_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/effect_management_tests.rs
+++ b/src/lighting/engine/tests/effect_management_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/formatting_tests.rs
+++ b/src/lighting/engine/tests/formatting_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/layer_commands_tests.rs
+++ b/src/lighting/engine/tests/layer_commands_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/pulse_tests.rs
+++ b/src/lighting/engine/tests/pulse_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/rainbow_tests.rs
+++ b/src/lighting/engine/tests/rainbow_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/seeking_tests.rs
+++ b/src/lighting/engine/tests/seeking_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
+++ b/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/static_effect_tests.rs
+++ b/src/lighting/engine/tests/static_effect_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/strobe_tests.rs
+++ b/src/lighting/engine/tests/strobe_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/tempo_aware_tests.rs
+++ b/src/lighting/engine/tests/tempo_aware_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/utility_and_edge_cases_tests.rs
+++ b/src/lighting/engine/tests/utility_and_edge_cases_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/tests/validation_tests.rs
+++ b/src/lighting/engine/tests/validation_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/engine/validation.rs
+++ b/src/lighting/engine/validation.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests.rs
+++ b/src/lighting/layering_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/blend_mode_tests.rs
+++ b/src/lighting/layering_tests/blend_mode_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/chase_tests.rs
+++ b/src/lighting/layering_tests/chase_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/common.rs
+++ b/src/lighting/layering_tests/common.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/conflict_resolution_tests.rs
+++ b/src/lighting/layering_tests/conflict_resolution_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/crossfade_tests.rs
+++ b/src/lighting/layering_tests/crossfade_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/dimmer_tests.rs
+++ b/src/lighting/layering_tests/dimmer_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/dsl_parsing_tests.rs
+++ b/src/lighting/layering_tests/dsl_parsing_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/integration_tests.rs
+++ b/src/lighting/layering_tests/integration_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/static_effect_tests.rs
+++ b/src/lighting/layering_tests/static_effect_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/layering_tests/strobe_tests.rs
+++ b/src/lighting/layering_tests/strobe_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser.rs
+++ b/src/lighting/parser.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/error.rs
+++ b/src/lighting/parser/error.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/grammar.rs
+++ b/src/lighting/parser/grammar.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/show.rs
+++ b/src/lighting/parser/show.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tempo_parse.rs
+++ b/src/lighting/parser/tempo_parse.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests.rs
+++ b/src/lighting/parser/tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/basic_parsing_tests.rs
+++ b/src/lighting/parser/tests/basic_parsing_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/chase_pattern_tests.rs
+++ b/src/lighting/parser/tests/chase_pattern_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/fixture_venue_tests.rs
+++ b/src/lighting/parser/tests/fixture_venue_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/layer_commands_tests.rs
+++ b/src/lighting/parser/tests/layer_commands_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/measure_offset_tests.rs
+++ b/src/lighting/parser/tests/measure_offset_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/parameters_tests.rs
+++ b/src/lighting/parser/tests/parameters_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/sequences_tests.rs
+++ b/src/lighting/parser/tests/sequences_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/tempo_durations_tests.rs
+++ b/src/lighting/parser/tests/tempo_durations_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/tempo_end_to_end_tests.rs
+++ b/src/lighting/parser/tests/tempo_end_to_end_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/tests/tempo_validation_tests.rs
+++ b/src/lighting/parser/tests/tempo_validation_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/types.rs
+++ b/src/lighting/parser/types.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/parser/utils.rs
+++ b/src/lighting/parser/utils.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/tempo.rs
+++ b/src/lighting/tempo.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/timeline.rs
+++ b/src/lighting/timeline.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/types.rs
+++ b/src/lighting/types.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/validation.rs
+++ b/src/lighting/validation.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/lighting/visual_consistency_tests.rs
+++ b/src/lighting/visual_consistency_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -463,7 +463,11 @@ async fn run() -> Result<(), Box<dyn Error>> {
             };
 
             let songs = songs::get_all_songs(Path::new(&repository_path))?;
-            let playlist = Playlist::new(&config::Playlist::new(&[song_name]), Arc::clone(&songs))?;
+            let playlist = Playlist::new(
+                "Playlist",
+                &config::Playlist::new(&[song_name]),
+                Arc::clone(&songs),
+            )?;
 
             let player = Player::new(
                 songs,
@@ -493,6 +497,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
         } => {
             let songs = songs::get_all_songs(Path::new(&repository_path))?;
             let playlist = Playlist::new(
+                "Playlist",
                 &config::Playlist::deserialize(Path::new(&playlist_path))?,
                 songs,
             )?;
@@ -517,6 +522,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
             };
             let songs = songs::get_all_songs(&player_config.songs(player_path))?;
             let playlist = Playlist::new(
+                "Playlist",
                 &config::Playlist::deserialize(playlist_path.as_path())?,
                 songs.clone(),
             )?;

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/midi/transform.rs
+++ b/src/midi/transform.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -592,11 +592,6 @@ impl Player {
         self.playlist.clone()
     }
 
-    /// Gets the all songs playlist used by the player.
-    pub fn get_all_songs_playlist(&self) -> Arc<Playlist> {
-        self.all_songs.clone()
-    }
-
     /// Gets the elapsed time from the play start time.
     pub async fn elapsed(&self) -> Result<Option<Duration>, Box<dyn Error>> {
         let play_start_time = self.play_start_time.lock().await;
@@ -684,6 +679,7 @@ mod test {
         let player = Player::new(
             songs.clone(),
             Playlist::new(
+                "Playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
@@ -860,7 +856,7 @@ mod test {
         let song = songs::Song::new(temp_path, &song_config)?;
         let songs_map = HashMap::from([("Test Song".to_string(), Arc::new(song))]);
         let songs = Arc::new(songs::Songs::new(songs_map));
-        let playlist = Playlist::new(&playlist_config, songs.clone())?;
+        let playlist = Playlist::new("Test Playlist", &playlist_config, songs.clone())?;
 
         // Create player with DMX engine that has lighting config
         let player = Player::new(
@@ -957,7 +953,7 @@ mod test {
         let song = songs::Song::new(temp_path, &song_config)?;
         let songs_map = HashMap::from([("Test Song".to_string(), Arc::new(song))]);
         let songs = Arc::new(songs::Songs::new(songs_map));
-        let playlist = Playlist::new(&playlist_config, songs.clone())?;
+        let playlist = Playlist::new("Test Playlist", &playlist_config, songs.clone())?;
 
         // Create player with DMX engine that has lighting config
         let player = Player::new(
@@ -1055,7 +1051,7 @@ mod test {
         let song = songs::Song::new(temp_path, &song_config)?;
         let songs_map = HashMap::from([("Test Song".to_string(), Arc::new(song))]);
         let songs = Arc::new(songs::Songs::new(songs_map));
-        let playlist = Playlist::new(&playlist_config, songs.clone())?;
+        let playlist = Playlist::new("Test Playlist", &playlist_config, songs.clone())?;
 
         // Create player with DMX engine
         let player = Player::new(
@@ -1153,7 +1149,7 @@ mod test {
         let song = songs::Song::new(temp_path, &song_config)?;
         let songs_map = HashMap::from([("Test Song".to_string(), Arc::new(song))]);
         let songs = Arc::new(songs::Songs::new(songs_map));
-        let playlist = Playlist::new(&playlist_config, songs.clone())?;
+        let playlist = Playlist::new("Test Playlist", &playlist_config, songs.clone())?;
 
         // Create player with DMX engine that has lighting config
         let player = Player::new(

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software
@@ -21,6 +21,8 @@ use std::sync::{Arc, RwLock};
 
 /// Playlist is a playlist for use by a player.
 pub struct Playlist {
+    /// The name of this playlist.
+    name: String,
     /// The songs that this playlist will play.
     songs: Vec<String>,
     /// The current position of the playlist.
@@ -48,6 +50,7 @@ impl fmt::Display for Playlist {
 impl Playlist {
     /// Creates a new playlist.
     pub fn new(
+        name: &str,
         config: &config::Playlist,
         registry: Arc<Songs>,
     ) -> Result<Arc<Playlist>, Box<dyn Error>> {
@@ -58,11 +61,17 @@ impl Playlist {
         }
 
         Ok(Arc::new(Playlist {
+            name: name.to_string(),
             songs: song_names.clone(),
             position: Arc::new(RwLock::new(0)),
             registry: Arc::clone(&registry),
             span: span!(Level::INFO, "playlist"),
         }))
+    }
+
+    /// Returns the name of this playlist.
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Returns the list of songs in the playlist.
@@ -143,7 +152,7 @@ pub fn from_songs(songs: Arc<Songs>) -> Result<Arc<Playlist>, Box<dyn Error>> {
             .into_iter()
             .map(|song| song.name().to_string()),
     );
-    Playlist::new(&config::Playlist::new(&sorted), songs)
+    Playlist::new("All Songs", &config::Playlist::new(&sorted), songs)
 }
 
 #[cfg(test)]
@@ -158,6 +167,7 @@ mod test {
             .expect("Parse songs should have succeeded.");
 
         let playlist = super::Playlist::new(
+            "Test Playlist",
             &config::Playlist::new(&["Song 1".to_string(), "Song 2".to_string()]),
             songs,
         )

--- a/src/playsync.rs
+++ b/src/playsync.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/proto/player/v1/player.proto
+++ b/src/proto/player/v1/player.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Michael Wilson <mike@mdwn.dev>
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
The playlist name is now reported properly in the gRPC status call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns playlist naming across the system and fixes gRPC status to report the active playlist’s display name.
> 
> - Add `name` to `Playlist` and change `Playlist::new` to require a name; create playlists as `"Playlist"` and `"All Songs"`
> - Remove `Player::get_all_songs_playlist`; callers/tests use `player.get_playlist()` and playlist names instead
> - gRPC: `status` now returns `player.get_playlist().name()`, constants updated to `"Playlist"`/`"All Songs"`, and minor error mapping tweak in `get_cues`
> - Update main, MIDI/OSC drivers, tests, and example usages for the new playlist API
> - Misc: update copyright year headers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c96cc85068da9a463e0dc139ee57c2b2c1c70b0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->