### PR TITLE
Fix legacy MIDI to DMX off by 1 error.

### DIFF
--- a/src/dmx/universe.rs
+++ b/src/dmx/universe.rs
@@ -80,6 +80,13 @@ impl Universe {
             .expect("Unable to get global dim rate read lock")
     }
 
+    #[cfg(test)]
+    pub fn get_target_value(&self, channel_index: usize) -> f64 {
+        self.target
+            .read()
+            .expect("Unable to get universe target read lock")[channel_index]
+    }
+
     /// Updates the dim speed.
     pub fn update_dim_speed(&self, dim_rate: Duration) {
         let mut global_dim_rate = self


### PR DESCRIPTION
With our new lighting engine, we inadvertently introduced an error with legacy MIDI light shows that caused the MIDI mapping of channels to be off by 1 in most cases. This has been fixed, and a regression test has been added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes legacy MIDI channel mapping**
> 
> - Adjusts MIDI handling to map 0-based `key`/`controller` values to 1-based DMX channels (`+1`) in `engine.rs` for `NoteOn/Off` and `Controller` messages
> - Adds `test_midi_to_dmx_channel_mapping` to verify correct channel updates and scaling
> - Introduces test-only `Universe::get_target_value` accessor for assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75906222fee7239ba0126f9d0e702c57ee7156be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->