### PR TITLE
More in depth lighting documentation, doc updates.

### DIFF
--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -175,10 +175,8 @@ dmx:
 
 # The controller definitions. As of now, the valid kinds of controllers are:
 # - grpc
-# - keyboard
 # - midi
 # - osc
-# Keyboard is largely for testing.
 controllers:
 # The gRPC server configuration.
 - kind: grpc

--- a/src/config/controller.rs
+++ b/src/config/controller.rs
@@ -37,7 +37,6 @@ const DEFAULT_OSC_PLAYLIST_CURRENT_SONG_ELAPSED: &str = "/mtrack/playlist/curren
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum Controller {
     Grpc(GrpcController),
-    Keyboard,
     Midi(MidiController),
     Multi(HashMap<String, Controller>),
     Osc(Box<OscController>),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -181,7 +181,7 @@ mod test {
                 songs,
             )?,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 None,
                 None,

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -292,7 +292,7 @@ mod test {
                 songs,
             )?,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -180,7 +180,7 @@ mod test {
                 songs,
             )?,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -378,7 +378,7 @@ mod test {
                 songs,
             )?,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,7 +473,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
                 songs,
                 playlist,
                 &config::Player::new(
-                    vec![config::Controller::Keyboard {}],
+                    vec![],
                     audio_config,
                     midi_config,
                     dmx_config,

--- a/src/player.rs
+++ b/src/player.rs
@@ -684,7 +684,7 @@ mod test {
                 songs,
             )?,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
@@ -863,7 +863,7 @@ mod test {
             songs,
             playlist,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
@@ -960,7 +960,7 @@ mod test {
             songs,
             playlist,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
@@ -1058,7 +1058,7 @@ mod test {
             songs,
             playlist,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
@@ -1156,7 +1156,7 @@ mod test {
             songs,
             playlist,
             &config::Player::new(
-                vec![config::Controller::Keyboard],
+                vec![],
                 config::Audio::new("mock-device"),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -218,8 +218,7 @@ dmx:
       fixture_types: "lighting/fixture_types"
       venues: "lighting/venues"
 
-controllers:
-  - kind: keyboard
+controllers: []
 
 track_mappings:
   click: [1]
@@ -244,7 +243,6 @@ songs: "songs"
         assert!(config.audio().is_some());
         assert!(config.midi().is_some());
         assert!(config.dmx().is_some());
-        assert!(!config.controllers().is_empty());
 
         // Verify lighting configuration is present
         let dmx_config = config.dmx().unwrap();


### PR DESCRIPTION
More in depth lighting documentation has been added. Additionally, several doc updates have been made, as well as removing references to the dead Keyboard controller.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive documentation for the new lighting system and DSL.
> 
> - Introduces `.light` DSL-based light shows in song YAML and adds extensive reference: effect types, parameters, cueing (time/measure), tempo sections, loops, sequences, offsets, and verification workflow
> - Adds CLI/docs for `verify-light-show`, `active-effects`, and `cues`; updates migration notes and examples
> - Removes `keyboard` controller support: drops enum variant, updates example configs to `controllers: []`, and adjusts tests/main to no longer construct a keyboard controller
> 
> **Risk/Impact**
> - Breaking change: configs using `kind: keyboard` will fail to deserialize; users must remove it or switch to `grpc`, `midi`, or `osc`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6167df56e50e67f9ee1d32663fa9bd73c5fa7fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->