### PR TITLE
Remove PlayDirect, rename playlists.

### DIFF
--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -46,6 +46,7 @@ pub struct Dmx {
 
 impl Dmx {
     /// Creates a new DMX configuration.
+    #[cfg(test)]
     pub fn new(
         dim_speed_modifier: Option<f64>,
         playback_delay: Option<String>,
@@ -111,6 +112,7 @@ pub struct Universe {
 
 impl Universe {
     /// Creates a new universe configuration.
+    #[cfg(test)]
     pub fn new(universe: u16, name: String) -> Universe {
         Universe { universe, name }
     }

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -52,6 +52,7 @@ pub struct Player {
 }
 
 impl Player {
+    #[cfg(test)]
     pub fn new(
         controllers: Vec<Controller>,
         audio: Audio,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -176,7 +176,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
-                "Playlist",
+                "playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -30,8 +30,8 @@ use crate::{
 };
 
 // Playlist name constants.
-const PLAYLIST_NAME: &str = "Playlist";
-const ALL_SONGS_NAME: &str = "All Songs";
+const PLAYLIST_NAME: &str = "playlist";
+const ALL_SONGS_NAME: &str = "all_songs";
 
 /// A controller that controls a player using gRPC.
 pub struct Driver {
@@ -287,7 +287,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
-                "Playlist",
+                "playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,
@@ -337,8 +337,8 @@ mod test {
         let resp = client.status(StatusRequest {}).await?;
         let status = resp.into_inner();
         assert_eq!(
-            status.playlist_name, "Playlist",
-            "Initial playlist name should be 'Playlist'"
+            status.playlist_name, "playlist",
+            "Initial playlist name should be 'playlist'"
         );
 
         println!("Playlist -> Song 1");
@@ -362,12 +362,12 @@ mod test {
             .await?;
         assert_eq!(player.get_playlist().current().name(), "Song 1");
 
-        // Verify playlist name changed to "All Songs" in status
+        // Verify playlist name changed to "all_songs" in status
         let resp = client.status(StatusRequest {}).await?;
         let status = resp.into_inner();
         assert_eq!(
-            status.playlist_name, "All Songs",
-            "Playlist name should be 'All Songs' after switching"
+            status.playlist_name, "all_songs",
+            "Playlist name should be 'all_songs' after switching"
         );
 
         let resp = client.next(NextRequest {}).await?;
@@ -393,12 +393,12 @@ mod test {
         println!("Switch to Playlist");
         assert_eq!(player.get_playlist().current().name(), "Song 1");
 
-        // Verify playlist name changed back to "Playlist" in status
+        // Verify playlist name changed back to "playlist" in status
         let resp = client.status(StatusRequest {}).await?;
         let status = resp.into_inner();
         assert_eq!(
-            status.playlist_name, "Playlist",
-            "Playlist name should be 'Playlist' after switching back"
+            status.playlist_name, "playlist",
+            "Playlist name should be 'playlist' after switching back"
         );
 
         let resp = client.next(NextRequest {}).await?;
@@ -421,8 +421,8 @@ mod test {
         let resp = client.status(StatusRequest {}).await?;
         let status = resp.into_inner();
         assert_eq!(
-            status.playlist_name, "Playlist",
-            "Playlist name should still be 'Playlist' after playback"
+            status.playlist_name, "playlist",
+            "Playlist name should still be 'playlist' after playback"
         );
         assert_eq!(status.current_song.unwrap().name, "Song 5");
 

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -175,7 +175,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
-                "Playlist",
+                "playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -373,7 +373,7 @@ mod test {
         let player = Arc::new(Player::new(
             songs.clone(),
             Playlist::new(
-                "Playlist",
+                "playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,

--- a/src/player.rs
+++ b/src/player.rs
@@ -456,26 +456,6 @@ impl Player {
         }
     }
 
-    /// Wait for the current song to stop. Just waits until the is playing mutex is finished. Returns true
-    /// if a song was waited for.
-    pub async fn wait_for_current_song(&self) -> Result<bool, Box<dyn Error>> {
-        let _enter = self.span.enter();
-
-        let mut join = self.join.lock().await;
-        Ok(match join.as_mut() {
-            Some(join) => {
-                info!(
-                    song = self.get_playlist().current().name(),
-                    "Waiting for song to finish.",
-                );
-                // Wait for the mutex to become available and immediately drop it.
-                (&mut join.join).await?;
-                true
-            }
-            None => false,
-        })
-    }
-
     /// Next goes to the next entry in the playlist.
     pub async fn next(&self) -> Arc<Song> {
         let join = self.join.lock().await;
@@ -679,7 +659,7 @@ mod test {
         let player = Player::new(
             songs.clone(),
             Playlist::new(
-                "Playlist",
+                "playlist",
                 &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
                 songs,
             )?,

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -152,7 +152,7 @@ pub fn from_songs(songs: Arc<Songs>) -> Result<Arc<Playlist>, Box<dyn Error>> {
             .into_iter()
             .map(|song| song.name().to_string()),
     );
-    Playlist::new("All Songs", &config::Playlist::new(&sorted), songs)
+    Playlist::new("all_songs", &config::Playlist::new(&sorted), songs)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
PlayDirect has been removed, playlists have been renamed back to their original names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Breaking change: CLI**
> 
> - Removes `PlayDirect` command and associated parsing/instant-play logic from `main.rs`
> 
> **Playlist naming standardization**
> 
> - Renames playlist identifiers to lowercase (`"playlist"`, `"all_songs"`) across gRPC/OSC controllers, tests, status reporting, and CLI usage
> 
> **Test scaffolding and cleanup**
> 
> - Gates `config::Dmx::new`, `config::player::Player::new`, and `config::dmx::Universe::new` behind `#[cfg(test)]`
> - Removes `Player::wait_for_current_song` and tidies imports/logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d9c5d3e15d450cb9b0ffe43c29083e5083269c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->