### PR TITLE
Prep for 0.7.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+[0.7.0]
+
+A major resampling bug discovered in 0.6.0 was fixed, apologies to everyone who encountered
+it. 0.6.0 was pulled for this.
+
+A new lighting engine has been added that mimics grandMA style lighting consoles. There are
+multiple layers and multiple effects. It exists entirely differently from the MIDI to DMX
+conversion that was written before, but it lives along side the previous functionality.
+In general, I found the MIDI to DMX engine to be too cumbersome so I'm hoping this new
+engine is easier to deal with. It has its own DSL as well. Feedback on all of this would be
+appreciated.
+
+The play-direct command was removed, as I think it's outlived its purpose, which was largely
+for testing.
+
+OSC commands now broadcast back to any connecting clients. Right now these clients are never
+forgotten, so it's possible to DDoS mtrack, so be responsible with your network security!
+
 [0.6.0]
 
 **Note**: You can now explicitly specify the sample rate, sample format, and bits per

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"


### PR DESCRIPTION
Everything has been bumped and prepared for the 0.7.0 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release prep for 0.7.0**
> 
> - Bumps crate version to `0.7.0` in `Cargo.toml` and `Cargo.lock`
> - Updates `CHANGELOG.md` for 0.7.0: fixes major resampling bug from 0.6.0; adds new grandMA-style lighting engine with its own DSL; removes `play-direct` command; OSC commands now broadcast to connected clients
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb4056f4f0ed98a3a86085386b242e7aea176bda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->