### PR TITLE
Fix fast cancel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Fixed a bug where stopping too fast after playing could produce a hang. This is unlikely to
+have happened in a live scenario.
+
 ## [0.7.0]
 
 A major resampling bug discovered in 0.6.0 was fixed, apologies to everyone who encountered

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -17,7 +17,7 @@ use std::{
     fmt,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
-        Arc, Barrier,
+        Arc,
     },
     thread,
     time::Duration,
@@ -34,6 +34,7 @@ use crate::{
     playsync::CancelHandle,
     songs::Song,
 };
+use std::sync::Barrier;
 
 /// Lock-free circular buffer for zero-copy audio streaming
 struct CircularBuffer {
@@ -561,6 +562,11 @@ impl AudioDevice for Device {
         }
 
         play_barrier.wait();
+
+        if cancel_handle.is_cancelled() {
+            return Ok(());
+        }
+
         spin_sleep::sleep(self.playback_delay);
 
         // Create channel mapped sources for each track in the song, starting from start_time

--- a/src/player.rs
+++ b/src/player.rs
@@ -512,14 +512,10 @@ impl Player {
         let song = self.get_playlist().current();
         info!(song = song.name(), "Stopping playback.");
 
-        // Cancel the playback.
         play_handles.cancel.cancel();
 
-        // Clear the join handle immediately so we can play again
-        // The cleanup task will still run, but we don't need to wait for it
-        // Drop the join handle - it will complete in the background
         drop(play_handles.join);
-        drop(join); // Release the lock
+        drop(join);
 
         // Reset stop_run after a brief delay to allow any remaining cleanup to complete
         let stop_run = self.stop_run.clone();


### PR DESCRIPTION
When cancelling too fast, it's possible for barrier counts to never reach their intended number and hang indefinitely. This is unlikely in a live setting, since the speed you'd need to do this would be extreme, but it makes our tests flaky.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses flaky hangs when cancelling/stopping immediately after starting playback.
> 
> - Add early cancellation checks around `play_barrier.wait()` and before/after playback delays in `audio/cpal`, `midi/midir`, and mocks; return early and notify when cancelled
> - DMX engine: always satisfy barrier counts (spawn no-op threads for unmatched universes/absent shows), wait at barrier before work, re-check cancel before playing, and drop join handles on cancel to avoid deadlocks
> - Player: on `stop()`, cancel and drop join handle immediately; asynchronously reset stop guard to reduce races; mocks update `is_playing` earlier to avoid test flakiness
> - Normalize `Barrier` imports; update CHANGELOG
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bf32d3fb308217e2c7ef718ae36eafe880eaafe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->