### PR TITLE
Robustness in output stream.

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 // Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
 //
 // This program is free software: you can redistribute it and/or modify it under
@@ -12,6 +11,8 @@ use std::any::Any;
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
+use std::any::Any;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{error::Error, fmt, sync::Arc, time::Duration};
 
 use crate::config;
@@ -28,6 +29,14 @@ pub mod sample_source;
 
 // Re-export the format types for backward compatibility
 pub use format::{SampleFormat, TargetFormat};
+
+/// Global source ID counter shared by song playback and sample triggers so IDs are unique.
+static SOURCE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Returns the next unique source ID for the mixer. Used by both song play_from and sample engine.
+pub(crate) fn next_source_id() -> u64 {
+    SOURCE_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Type alias for the channel sender used to add sources to the mixer.
 pub type SourceSender = crossbeam_channel::Sender<mixer::ActiveSource>;

--- a/src/samples/engine.rs
+++ b/src/samples/engine.rs
@@ -17,7 +17,6 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 
 use midly::live::LiveEvent;
@@ -26,13 +25,11 @@ use tracing::{debug, error, info, warn};
 
 use super::loader::{LoadedSample, SampleLoader};
 use super::voice::{Voice, VoiceManager};
+use crate::audio;
 use crate::audio::sample_source::ChannelMappedSource;
 use crate::config::samples::{NoteOffBehavior, SampleDefinition, SampleTrigger, SamplesConfig};
 use crate::config::ToMidiEvent;
 use crate::playsync::CancelHandle;
-
-/// Global source ID counter for the mixer.
-static NEXT_SOURCE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Precomputed data for a loaded sample file, avoiding allocations during trigger.
 struct PrecomputedSampleData {
@@ -412,7 +409,7 @@ impl SampleEngine {
 
         // Create a new source for playback
         let source = precomputed.loaded.create_source(volume);
-        let source_id = NEXT_SOURCE_ID.fetch_add(1, Ordering::SeqCst);
+        let source_id = audio::next_source_id();
 
         // Use precomputed channel labels and track mappings (no allocations!)
         let channel_mapped = ChannelMappedSource::new(


### PR DESCRIPTION
The audio callbacks should now be a lot more robust, and the output stream will be rebuilt on failure. A bug was discovered and fixed where the source IDs generated for both songs and samples could collide, which could result in a sample trigger with the same source ID as a song causing both the sample and the song to stop.