### PR TITLE
Add hardware profiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ A warning is displayed when playing songs that have tracks that are not configur
 be output in the current player configuration. This will not cause an error, but will be
 logged so that it's easier to diagnose a misconfiguration.
 
+Hardware profiles allow multiple complete host configurations in a single config file:
+
+- **Unified profiles** (`profiles`): Define complete per-host configurations in a single list.
+  Each profile specifies audio (required), MIDI (optional), and DMX (optional) for one host.
+  Subsystem presence in profile = required, absence = optional. No global `*_optional` flags.
+- **Hostname filtering**: Each profile can optionally specify a `hostname` constraint so that
+  different hosts sharing the same config file use different devices and channel mappings.
+  Set the `MTRACK_HOSTNAME` environment variable to override the system hostname.
+- **Per-host optionality**: MIDI and DMX can be required on some hosts (present in profile)
+  and optional on others (absent from profile), enabling flexible multi-host setups.
+- **Backwards compatible**: Existing configs using `audio:`, `midi:`, `dmx:`, and `track_mappings:`
+  are automatically normalized into a single profile at startup.
+
 - **Direct callback mode**: The CPAL callback now calls the mixer directly, eliminating the
   intermediate ring buffer. This follows the pattern used by professional audio systems
   (ASIO, CoreAudio, JACK) for lowest possible latency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1160,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "duration-string",
+ "hostname",
  "hound",
  "midir",
  "midly",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +704,7 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1179,6 +1191,7 @@ dependencies = [
  "rubato",
  "serde",
  "serde_yml",
+ "serial_test",
  "shh",
  "spin_sleep",
  "symphonia",
@@ -1974,10 +1987,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "serde"
@@ -2056,6 +2084,32 @@ dependencies = [
  "ryu",
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 crossbeam-channel = "0.5.15"
 thread-priority = "3.0"
 parking_lot = "0.12"
+hostname = "0.4"
 pest = "2.7"
 pest_derive = "2.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ pest_derive = "2.7"
 [dev-dependencies]
 tempfile = "3.14.0"
 hound = "3.5.1"
+serial_test = "3.2.0"
 
 [build-dependencies]
 prost-build = "0.13.4"

--- a/README.md
+++ b/README.md
@@ -478,6 +478,80 @@ track_mappings:
 
 You can start `mtrack` as a process with `mtrack start /path/to/player.yaml`.
 
+### Hardware profiles
+
+If you have multiple devices or run `mtrack` on multiple hosts sharing the same config file,
+you can use hardware profiles instead of the flat `audio:` / `midi:` / `dmx:` / `track_mappings:` sections.
+Each profile represents one complete host configuration with all subsystems. Profiles are filtered
+by hostname; the first match is used.
+
+```yaml
+# Unified profiles: each entry defines one complete host configuration
+profiles:
+  # Raspberry Pi A: Full setup with WING audio + MIDI + DMX
+  - hostname: raspberry-pi-a
+    device: "Behringer WING"
+    sample_rate: 48000
+    sample_format: int
+    bits_per_sample: 32
+    buffer_size: 1024
+    playback_delay: 500ms
+    track_mappings:
+      click: [1]
+      cue: [2]
+      backing-track-l: [3]
+      backing-track-r: [4]
+      keys: [5, 6]
+    midi:
+      device: "Behringer WING"
+      playback_delay: 500ms
+      midi_to_dmx:
+        - midi_channel: 15
+          universe: light-show
+    dmx:
+      dim_speed_modifier: 0.25
+      universes:
+        - universe: 1
+          name: light-show
+
+  # Raspberry Pi B: WING with different channels, MIDI required, no DMX
+  - hostname: raspberry-pi-b
+    device: "Behringer WING"
+    sample_rate: 48000
+    track_mappings:
+      click: [11]
+      cue: [12]
+      backing-track-l: [13]
+      backing-track-r: [14]
+      keys: [15, 16]
+    midi:
+      device: "USB MIDI Interface"
+      playback_delay: 200ms
+    # dmx omitted = optional for this host
+
+  # Fallback: minimal setup for any host (no MIDI/DMX)
+  - device: "Built-in Audio"
+    track_mappings:
+      click: [1]
+      backing-track-l: [1]
+      backing-track-r: [2]
+```
+
+**Subsystem semantics:**
+- **Audio** is always required (every profile must have audio config + track_mappings)
+- **MIDI** and **DMX** are optional:
+  - If present in a profile → required for that host (player waits/retries)
+  - If absent from a profile → optional for that host (player proceeds without it)
+
+Profiles with a `hostname` constraint only apply on hosts whose hostname matches. Profiles
+without a hostname constraint match any host. Set the `MTRACK_HOSTNAME` environment variable
+to override the system hostname (useful for testing or when the OS hostname differs from
+what you want).
+
+The existing flat format (`audio:` + `track_mappings:` + `midi:` + `dmx:`) continues to work
+unchanged. At startup, legacy fields are automatically normalized into a single profile,
+so all internal code paths use the same profile-based logic.
+
 ### mtrack on startup
 
 To have `mtrack` start when the system starts, first create a dedicated system user for the service:

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -62,6 +62,9 @@ midi:
 
 # The DMX configuration for mtrack. This maps OLA universes to light show names defined within
 # song files.
+#
+# For multiple host configs with DMX, use the unified profiles format (see Hardware Profiles section below).
+
 dmx:
   # The DMX engine in mtrack has a dimming engine that can be issued using MIDI program change (PC) commands.
   # This modifier is multiplied by the value of the PC command to give a dimming duration, e.g.
@@ -282,6 +285,68 @@ track_mappings:
   keys:
   - 5
   - 6
+
+# --- Hardware Profiles (alternative to the audio/midi/dmx/track_mappings sections above) ---
+#
+# Use unified profiles when you need:
+#   - Multiple complete host configurations in one config file
+#   - Different track mappings per host (e.g., different Raspberry Pis sharing a config)
+#   - Per-host MIDI/DMX requirements (required on some hosts, optional on others)
+#
+# Profiles are filtered by hostname. The first match is used.
+# Set the MTRACK_HOSTNAME environment variable to override the system hostname.
+#
+# Subsystem semantics:
+#   - Audio: always required (every profile must have it)
+#   - MIDI/DMX: presence = required, absence = optional for that host
+#
+# profiles:
+#   # Raspberry Pi A: Full setup with audio + MIDI + DMX (all required)
+#   - hostname: raspberry-pi-a
+#     device: "Behringer WING"
+#     sample_rate: 48000
+#     sample_format: int
+#     bits_per_sample: 32
+#     buffer_size: 1024
+#     playback_delay: 500ms
+#     track_mappings:
+#       click: [1]
+#       cue: [2]
+#       backing-track-l: [3]
+#       backing-track-r: [4]
+#       keys: [5, 6]
+#     midi:
+#       device: "Behringer WING"
+#       playback_delay: 500ms
+#       midi_to_dmx:
+#         - midi_channel: 15
+#           universe: light-show
+#     dmx:
+#       dim_speed_modifier: 0.25
+#       universes:
+#         - universe: 1
+#           name: light-show
+#
+#   # Raspberry Pi B: Audio + MIDI required, DMX optional (omitted)
+#   - hostname: raspberry-pi-b
+#     device: "Behringer WING"
+#     sample_rate: 48000
+#     track_mappings:
+#       click: [11]
+#       cue: [12]
+#       backing-track-l: [13]
+#       backing-track-r: [14]
+#       keys: [15, 16]
+#     midi:
+#       device: "USB MIDI Interface"
+#       playback_delay: 200ms
+#
+#   # Fallback: minimal audio-only setup (MIDI/DMX optional)
+#   - device: "Built-in Audio"
+#     track_mappings:
+#       click: [1]
+#       backing-track-l: [1]
+#       backing-track-r: [2]
 
 # MIDI-triggered sample configuration.
 # Samples defined here are available globally and can be triggered via MIDI events.

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use tracing::{error, info, span, Level};
+use tracing::{debug, error, info, span, Level};
 
 use super::thread_priority::{
     callback_thread_priority, configure_audio_thread_priority, env_flag, rt_audio_enabled,
@@ -656,9 +656,15 @@ impl Device {
     /// Gets the given cpal device.
     pub fn get(config: config::Audio) -> Result<Device, Box<dyn Error>> {
         let name = config.device();
+        debug!(
+            device_name = %name,
+            device_name_len = name.len(),
+            device_name_trimmed = %name.trim(),
+            "Searching for audio device"
+        );
         match Device::list_cpal_devices()?
             .into_iter()
-            .find(|device| device.name.trim() == name)
+            .find(|device| device.name.trim() == name.trim())
         {
             Some(mut device) => {
                 device.playback_delay = config.playback_delay()?;

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -667,22 +667,19 @@ impl Device {
             available_devices = ?devices.iter().map(|d| &d.name).collect::<Vec<_>>(),
             "Available CPAL devices"
         );
-        match devices
-            .into_iter()
-            .find(|device| {
-                let device_trimmed = device.name.trim();
-                let name_trimmed = name.trim();
-                let matches = device_trimmed == name_trimmed;
-                debug!(
-                    device_name = %device.name,
-                    device_trimmed = %device_trimmed,
-                    looking_for = %name_trimmed,
-                    matches = matches,
-                    "Comparing device"
-                );
-                matches
-            })
-        {
+        match devices.into_iter().find(|device| {
+            let device_trimmed = device.name.trim();
+            let name_trimmed = name.trim();
+            let matches = device_trimmed == name_trimmed;
+            debug!(
+                device_name = %device.name,
+                device_trimmed = %device_trimmed,
+                looking_for = %name_trimmed,
+                matches = matches,
+                "Comparing device"
+            );
+            matches
+        }) {
             Some(mut device) => {
                 device.playback_delay = config.playback_delay()?;
 

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -662,9 +662,26 @@ impl Device {
             device_name_trimmed = %name.trim(),
             "Searching for audio device"
         );
-        match Device::list_cpal_devices()?
+        let devices = Device::list_cpal_devices()?;
+        debug!(
+            available_devices = ?devices.iter().map(|d| &d.name).collect::<Vec<_>>(),
+            "Available CPAL devices"
+        );
+        match devices
             .into_iter()
-            .find(|device| device.name.trim() == name.trim())
+            .find(|device| {
+                let device_trimmed = device.name.trim();
+                let name_trimmed = name.trim();
+                let matches = device_trimmed == name_trimmed;
+                debug!(
+                    device_name = %device.name,
+                    device_trimmed = %device_trimmed,
+                    looking_for = %name_trimmed,
+                    matches = matches,
+                    "Comparing device"
+                );
+                matches
+            })
         {
             Some(mut device) => {
                 device.playback_delay = config.playback_delay()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ mod audio;
 mod controller;
 mod dmx;
 mod error;
+mod hostname;
 pub mod lighting;
 #[cfg(test)]
 pub mod midi;
@@ -22,6 +23,7 @@ pub mod midi;
 mod midi;
 mod player;
 mod playlist;
+mod profile;
 pub mod samples;
 mod song;
 mod statusevents;
@@ -44,6 +46,8 @@ pub use self::midi::ToMidiEvent;
 pub use self::player::Player;
 pub use self::playlist::Playlist;
 // Sample types are exported for external configuration
+pub use self::hostname::resolve_hostname;
+pub use self::profile::Profile;
 #[allow(unused_imports)]
 pub use self::samples::{
     NoteOffBehavior, RetriggerBehavior, SampleDefinition, SampleTrigger, SamplesConfig,

--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -68,6 +68,7 @@ impl Dmx {
     pub fn get_ola_port(&self) -> Option<u16> {
         self.ola_port
     }
+
     /// Gets the dimming speed modifier.
     pub fn dimming_speed_modifier(&self) -> f64 {
         self.dim_speed_modifier

--- a/src/config/hostname.rs
+++ b/src/config/hostname.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+/// Resolves the effective hostname for profile matching.
+///
+/// Priority:
+/// 1. MTRACK_HOSTNAME environment variable (allows override for testing/deployment)
+/// 2. System hostname via gethostname()
+pub fn resolve_hostname() -> String {
+    if let Ok(h) = std::env::var("MTRACK_HOSTNAME") {
+        if !h.is_empty() {
+            return h;
+        }
+    }
+
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hostname_env_override() {
+        // Save original value to restore later.
+        let original = std::env::var("MTRACK_HOSTNAME").ok();
+
+        std::env::set_var("MTRACK_HOSTNAME", "test-host");
+        assert_eq!(resolve_hostname(), "test-host");
+
+        // Restore original.
+        match original {
+            Some(val) => std::env::set_var("MTRACK_HOSTNAME", val),
+            None => std::env::remove_var("MTRACK_HOSTNAME"),
+        }
+    }
+
+    #[test]
+    fn test_hostname_empty_env_falls_back() {
+        let original = std::env::var("MTRACK_HOSTNAME").ok();
+
+        std::env::set_var("MTRACK_HOSTNAME", "");
+        let hostname = resolve_hostname();
+        // Should fall back to system hostname, which should not be empty.
+        assert!(!hostname.is_empty());
+
+        match original {
+            Some(val) => std::env::set_var("MTRACK_HOSTNAME", val),
+            None => std::env::remove_var("MTRACK_HOSTNAME"),
+        }
+    }
+}

--- a/src/config/hostname.rs
+++ b/src/config/hostname.rs
@@ -33,8 +33,10 @@ pub fn resolve_hostname() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_hostname_env_override() {
         // Save original value to restore later.
         let original = std::env::var("MTRACK_HOSTNAME").ok();
@@ -50,6 +52,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_hostname_empty_env_falls_back() {
         let original = std::env::var("MTRACK_HOSTNAME").ok();
 

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -15,6 +15,7 @@ use super::audio::Audio;
 use super::controller::Controller;
 use super::dmx::Dmx;
 use super::midi::Midi;
+use super::profile::{filter_by_hostname, AudioConfig, Profile};
 use super::samples::{SampleDefinition, SampleTrigger, SamplesConfig, DEFAULT_MAX_SAMPLE_VOICES};
 use super::statusevents::StatusEvents;
 use super::trackmappings::TrackMappings;
@@ -22,10 +23,14 @@ use config::{Config, File};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use super::error::ConfigError;
 use std::error::Error;
 use tracing::{error, info};
+
+/// Empty track mappings used as a fallback reference.
+static EMPTY_TRACK_MAPPINGS: LazyLock<HashMap<String, Vec<u16>>> = LazyLock::new(HashMap::new);
 
 /// The configuration for the multitrack player.
 #[derive(Deserialize)]
@@ -34,18 +39,22 @@ pub struct Player {
     controller: Option<Controller>,
     /// The controllers configuration.
     controllers: Option<Vec<Controller>>,
-    /// The audio device to use.
+    /// The audio device to use. (legacy)
     audio_device: Option<String>,
-    /// The audio configuration section.
+    /// The audio configuration section. (legacy)
     audio: Option<Audio>,
-    /// The track mappings for the player.
-    track_mappings: TrackMappings,
-    /// The MIDI device to use. (deprecated)
+    /// The track mappings for the player. (legacy, now optional when using profiles)
+    #[serde(default)]
+    track_mappings: Option<TrackMappings>,
+    /// The MIDI device to use. (legacy)
     midi_device: Option<String>,
-    /// The MIDI configuration section.
+    /// The MIDI configuration section. (legacy)
     midi: Option<Midi>,
-    /// The DMX configuration.
+    /// The DMX configuration. (legacy)
     dmx: Option<Dmx>,
+    /// Unified hardware profiles, tried in priority order.
+    /// Each profile contains audio (required), MIDI (optional), and DMX (optional) configs.
+    profiles: Option<Vec<Profile>>,
     /// Events to emit to report status out via MIDI.
     status_events: Option<StatusEvents>,
     /// The path to the playlist.
@@ -74,15 +83,16 @@ impl Player {
         track_mappings: HashMap<String, Vec<u16>>,
         songs: &str,
     ) -> Player {
-        Player {
+        let mut player = Player {
             controller: None,
             controllers: Some(controllers),
             audio_device: None,
             audio: Some(audio),
-            track_mappings: TrackMappings { track_mappings },
+            track_mappings: Some(TrackMappings { track_mappings }),
             midi_device: None,
             midi,
             dmx,
+            profiles: None,
             status_events: None,
             playlist: None,
             songs: songs.to_string(),
@@ -90,15 +100,54 @@ impl Player {
             samples_file: None,
             sample_triggers: Vec::new(),
             max_sample_voices: None,
-        }
+        };
+        player.normalize();
+        player
     }
 
     /// Deserializes a file from the path into a player configuration struct.
+    /// Legacy configs (audio + track_mappings at top level) are normalized into profiles.
     pub fn deserialize(path: &Path) -> Result<Player, ConfigError> {
-        Ok(Config::builder()
+        let mut player = Config::builder()
             .add_source(File::from(path))
             .build()?
-            .try_deserialize::<Player>()?)
+            .try_deserialize::<Player>()?;
+        player.normalize();
+        Ok(player)
+    }
+
+    /// Normalizes legacy configuration fields into profiles.
+    /// After normalization, `profiles` is the source of truth.
+    fn normalize(&mut self) {
+        if self.profiles.is_none() {
+            // Build a single profile from legacy fields
+            let audio = if let Some(audio) = &self.audio {
+                Some(audio.clone())
+            } else {
+                self.audio_device.as_ref().map(|d| Audio::new(d))
+            };
+
+            if let Some(audio) = audio {
+                let track_mappings = self
+                    .track_mappings
+                    .as_ref()
+                    .map(|tm| tm.track_mappings.clone())
+                    .unwrap_or_default();
+
+                let audio_config = AudioConfig::new(audio, track_mappings);
+
+                let midi = if let Some(midi) = &self.midi {
+                    Some(midi.clone())
+                } else {
+                    self.midi_device.as_ref().map(|d| Midi::new(d, None))
+                };
+
+                let dmx = self.dmx.clone();
+
+                let profile = Profile::new(None, audio_config, midi, dmx);
+                self.profiles = Some(vec![profile]);
+            }
+        }
     }
 
     /// Gets the controllers configuration.
@@ -116,36 +165,71 @@ impl Player {
         vec![]
     }
 
-    /// Gets the audio configuration.
+    /// Returns profiles filtered by hostname and ordered by priority.
+    /// The first matching profile should be used.
+    pub fn profiles(&self, hostname: &str) -> Vec<&Profile> {
+        match &self.profiles {
+            Some(profiles) => filter_by_hostname(profiles, hostname, |p| p.hostname()),
+            None => vec![],
+        }
+    }
+
+    /// Returns all profiles without hostname filtering (for verify command).
+    pub fn all_profiles(&self) -> &[Profile] {
+        match &self.profiles {
+            Some(profiles) => profiles.as_slice(),
+            None => &[],
+        }
+    }
+
+    /// Gets the audio configuration from the first profile.
+    /// Kept for backward compatibility in tests.
+    #[cfg(test)]
     pub fn audio(&self) -> Option<Audio> {
-        if let Some(audio) = &self.audio {
-            return Some(audio.clone());
-        } else if let Some(audio_device) = &self.audio_device {
-            return Some(Audio::new(audio_device));
+        if let Some(profiles) = &self.profiles {
+            if let Some(first) = profiles.first() {
+                return Some(first.audio_config().audio().clone());
+            }
         }
 
         None
     }
 
-    /// Gets the track mapping configuration.
+    /// Gets the track mapping configuration from the first profile.
+    /// Kept for backward compatibility.
     pub fn track_mappings(&self) -> &HashMap<String, Vec<u16>> {
-        &self.track_mappings.track_mappings
+        if let Some(profiles) = &self.profiles {
+            if let Some(first) = profiles.first() {
+                return first.audio_config().track_mappings();
+            }
+        }
+
+        &EMPTY_TRACK_MAPPINGS
     }
 
-    /// Gets the MIDI configuration.
+    /// Gets the MIDI configuration from the first profile.
+    /// Kept for backward compatibility in tests.
+    #[cfg(test)]
     pub fn midi(&self) -> Option<Midi> {
-        if let Some(midi) = &self.midi {
-            return Some(midi.clone());
-        } else if let Some(midi_device) = &self.midi_device {
-            return Some(Midi::new(midi_device, None));
+        if let Some(profiles) = &self.profiles {
+            if let Some(first) = profiles.first() {
+                return first.midi().cloned();
+            }
         }
 
         None
     }
 
-    /// Gets the DMX configuration.
+    /// Gets the DMX configuration from the first profile.
+    /// Kept for backward compatibility.
     pub fn dmx(&self) -> Option<&Dmx> {
-        self.dmx.as_ref()
+        if let Some(profiles) = &self.profiles {
+            if let Some(first) = profiles.first() {
+                return first.dmx();
+            }
+        }
+
+        None
     }
 
     /// Gets the status events configuration.
@@ -211,5 +295,359 @@ impl Player {
     /// Gets the maximum sample voices limit.
     pub fn max_sample_voices(&self) -> u32 {
         self.max_sample_voices.unwrap_or(DEFAULT_MAX_SAMPLE_VOICES)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::path::Path;
+
+    use super::*;
+
+    /// Helper to create a Player from a YAML string via a temp file.
+    fn player_from_yaml(yaml: &str) -> Player {
+        let mut temp = tempfile::NamedTempFile::with_suffix(".yaml").unwrap();
+        temp.write_all(yaml.as_bytes()).unwrap();
+        Player::deserialize(temp.path()).expect("Failed to deserialize")
+    }
+
+    #[test]
+    fn test_legacy_config_normalizes_into_profiles() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+audio:
+  device: mock-device
+  sample_rate: 48000
+track_mappings:
+  click: [1]
+  cue: [2]
+midi:
+  device: mock-midi
+  playback_delay: 500ms
+"#,
+        );
+
+        // Unified profiles should have been created from legacy fields.
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].audio_config().audio().device(), "mock-device");
+        assert_eq!(profiles[0].audio_config().audio().sample_rate(), 48000);
+        assert_eq!(
+            profiles[0].audio_config().track_mappings().get("click"),
+            Some(&vec![1u16])
+        );
+        assert_eq!(
+            profiles[0].audio_config().track_mappings().get("cue"),
+            Some(&vec![2u16])
+        );
+        assert!(profiles[0].hostname().is_none());
+        assert!(profiles[0].midi().is_some());
+        assert_eq!(profiles[0].midi().unwrap().device(), "mock-midi");
+
+        // Backward compat getters should still work.
+        assert_eq!(player.audio().unwrap().device(), "mock-device");
+        assert_eq!(player.track_mappings().get("click"), Some(&vec![1u16]));
+        assert_eq!(player.midi().unwrap().device(), "mock-midi");
+    }
+
+    #[test]
+    fn test_legacy_audio_device_string_normalizes() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+audio_device: mock-device
+track_mappings:
+  drums: [1]
+"#,
+        );
+
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].audio_config().audio().device(), "mock-device");
+        assert_eq!(
+            profiles[0].audio_config().track_mappings().get("drums"),
+            Some(&vec![1u16])
+        );
+    }
+
+    #[test]
+    fn test_legacy_midi_device_string_normalizes() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+audio:
+  device: mock-device
+track_mappings:
+  click: [1]
+midi_device: mock-midi
+"#,
+        );
+
+        let midi = player.midi();
+        assert!(midi.is_some());
+        assert_eq!(midi.unwrap().device(), "mock-midi");
+    }
+
+    #[test]
+    fn test_profiles_parse() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+profiles:
+  - hostname: pi-a
+    device: mock-device-a
+    sample_rate: 48000
+    track_mappings:
+      drums: [1]
+      synth: [2]
+    midi:
+      device: mock-midi-a
+  - hostname: pi-b
+    device: mock-device-b
+    track_mappings:
+      drums: [11]
+      synth: [12]
+    midi:
+      device: mock-midi-b
+    dmx:
+      universes:
+        - universe: 1
+          name: light-show
+  - device: mock-fallback
+    track_mappings:
+      drums: [1]
+"#,
+        );
+
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 3);
+
+        assert_eq!(profiles[0].hostname(), Some("pi-a"));
+        assert_eq!(profiles[0].audio_config().audio().device(), "mock-device-a");
+        assert_eq!(profiles[0].audio_config().audio().sample_rate(), 48000);
+        assert!(profiles[0].midi().is_some());
+        assert!(profiles[0].dmx().is_none());
+
+        assert_eq!(profiles[1].hostname(), Some("pi-b"));
+        assert_eq!(profiles[1].audio_config().audio().device(), "mock-device-b");
+        assert!(profiles[1].midi().is_some());
+        assert!(profiles[1].dmx().is_some());
+
+        assert_eq!(profiles[2].hostname(), None);
+        assert_eq!(profiles[2].audio_config().audio().device(), "mock-fallback");
+        assert!(profiles[2].midi().is_none());
+        assert!(profiles[2].dmx().is_none());
+    }
+
+    #[test]
+    fn test_profiles_filter_by_hostname() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+profiles:
+  - hostname: pi-a
+    device: mock-device-a
+    track_mappings:
+      drums: [1]
+  - hostname: pi-b
+    device: mock-device-b
+    track_mappings:
+      drums: [11]
+  - device: mock-fallback
+    track_mappings:
+      drums: [1]
+"#,
+        );
+
+        // pi-a sees its own profile + the wildcard.
+        let pi_a = player.profiles("pi-a");
+        assert_eq!(pi_a.len(), 2);
+        assert_eq!(pi_a[0].audio_config().audio().device(), "mock-device-a");
+        assert_eq!(pi_a[1].audio_config().audio().device(), "mock-fallback");
+
+        // pi-b sees its own profile + the wildcard.
+        let pi_b = player.profiles("pi-b");
+        assert_eq!(pi_b.len(), 2);
+        assert_eq!(pi_b[0].audio_config().audio().device(), "mock-device-b");
+        assert_eq!(pi_b[1].audio_config().audio().device(), "mock-fallback");
+
+        // Unknown host only sees the wildcard.
+        let unknown = player.profiles("pi-c");
+        assert_eq!(unknown.len(), 1);
+        assert_eq!(unknown[0].audio_config().audio().device(), "mock-fallback");
+    }
+
+    #[test]
+    fn test_profile_without_midi_dmx() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+profiles:
+  - device: mock-device
+    track_mappings:
+      drums: [1]
+"#,
+        );
+
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert!(profiles[0].midi().is_none());
+        assert!(profiles[0].dmx().is_none());
+    }
+
+    #[test]
+    fn test_profiles_take_precedence_over_legacy() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+audio:
+  device: legacy-device
+track_mappings:
+  click: [99]
+profiles:
+  - device: profile-device
+    track_mappings:
+      click: [1]
+"#,
+        );
+
+        // Profiles should be used, not legacy.
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(
+            profiles[0].audio_config().audio().device(),
+            "profile-device"
+        );
+        assert_eq!(
+            profiles[0].audio_config().track_mappings().get("click"),
+            Some(&vec![1u16])
+        );
+
+        // Backward compat getters return from the first profile.
+        assert_eq!(player.audio().unwrap().device(), "profile-device");
+        assert_eq!(player.track_mappings().get("click"), Some(&vec![1u16]));
+    }
+
+    #[test]
+    fn test_no_profiles_when_no_audio_config() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+"#,
+        );
+
+        // No audio at all.
+        assert!(player.all_profiles().is_empty());
+        assert!(player.audio().is_none());
+        assert!(player.track_mappings().is_empty());
+    }
+
+    #[test]
+    fn test_profiles_without_top_level_track_mappings() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+profiles:
+  - device: mock-device
+    track_mappings:
+      drums: [1]
+      synth: [2]
+"#,
+        );
+
+        // Should work without top-level track_mappings.
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(
+            profiles[0].audio_config().track_mappings().get("drums"),
+            Some(&vec![1u16])
+        );
+
+        // Backward compat getter returns from profile.
+        assert_eq!(player.track_mappings().get("drums"), Some(&vec![1u16]));
+    }
+
+    #[test]
+    fn test_hostname_deconfliction() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+profiles:
+  - hostname: pi-a
+    device: "Behringer WING"
+    track_mappings:
+      drums: [1]
+      synth: [2]
+  - hostname: pi-b
+    device: "Behringer WING"
+    track_mappings:
+      drums: [11]
+      synth: [12]
+"#,
+        );
+
+        let pi_a = player.profiles("pi-a");
+        assert_eq!(pi_a.len(), 1);
+        assert_eq!(
+            pi_a[0].audio_config().track_mappings().get("drums"),
+            Some(&vec![1u16])
+        );
+
+        let pi_b = player.profiles("pi-b");
+        assert_eq!(pi_b.len(), 1);
+        assert_eq!(
+            pi_b[0].audio_config().track_mappings().get("drums"),
+            Some(&vec![11u16])
+        );
+
+        // Different device name, same mappings — ensures isolation.
+        let pi_c = player.profiles("pi-c");
+        assert!(pi_c.is_empty());
+    }
+
+    #[test]
+    fn test_normalization_creates_profile() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+audio:
+  device: mock-device
+track_mappings:
+  click: [1]
+dmx:
+  dim_speed_modifier: 0.25
+  universes:
+  - universe: 1
+    name: light-show
+"#,
+        );
+
+        // Legacy dmx config should be normalized into unified profile
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert!(profiles[0].dmx().is_some());
+        assert_eq!(profiles[0].dmx().unwrap().dimming_speed_modifier(), 0.25);
+    }
+
+    #[test]
+    fn test_example_config_backwards_compat() {
+        // The existing examples/mtrack.yaml must still parse without error.
+        let config =
+            Player::deserialize(Path::new("examples/mtrack.yaml")).expect("example config failed");
+
+        assert!(config.audio().is_some());
+        assert_eq!(config.audio().unwrap().device(), "UltraLite-mk5");
+        assert!(config.midi().is_some());
+        assert!(!config.track_mappings().is_empty());
+        assert!(config.dmx().is_some());
+
+        // Should have been normalized into a single unified profile.
+        let profiles = config.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].audio_config().audio().device(), "UltraLite-mk5");
+        assert!(profiles[0].midi().is_some());
+        assert!(profiles[0].dmx().is_some());
     }
 }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,0 +1,250 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use super::audio::Audio;
+use super::dmx::Dmx;
+use super::midi::Midi;
+
+/// Audio configuration with track mappings.
+#[derive(Deserialize, Clone)]
+pub struct AudioConfig {
+    #[serde(flatten)]
+    audio: Audio,
+    track_mappings: HashMap<String, Vec<u16>>,
+}
+
+impl AudioConfig {
+    /// Creates a new AudioConfig.
+    pub fn new(audio: Audio, track_mappings: HashMap<String, Vec<u16>>) -> Self {
+        AudioConfig {
+            audio,
+            track_mappings,
+        }
+    }
+
+    /// Returns the audio configuration.
+    pub fn audio(&self) -> &Audio {
+        &self.audio
+    }
+
+    /// Returns the track mappings.
+    pub fn track_mappings(&self) -> &HashMap<String, Vec<u16>> {
+        &self.track_mappings
+    }
+}
+
+/// A unified hardware profile representing one complete host configuration.
+/// Profiles are tried in list order; the first one whose hostname matches (or has
+/// no constraint) is used.
+#[derive(Deserialize, Clone)]
+pub struct Profile {
+    /// Optional hostname restriction.
+    hostname: Option<String>,
+
+    /// Audio configuration (required).
+    #[serde(flatten)]
+    audio_config: AudioConfig,
+
+    /// MIDI configuration (optional if absent from profile).
+    midi: Option<Midi>,
+
+    /// DMX configuration (optional if absent from profile).
+    dmx: Option<Dmx>,
+}
+
+impl Profile {
+    /// Creates a new Profile.
+    pub fn new(
+        hostname: Option<String>,
+        audio_config: AudioConfig,
+        midi: Option<Midi>,
+        dmx: Option<Dmx>,
+    ) -> Self {
+        Profile {
+            hostname,
+            audio_config,
+            midi,
+            dmx,
+        }
+    }
+
+    /// Returns the optional hostname constraint.
+    pub fn hostname(&self) -> Option<&str> {
+        self.hostname.as_deref()
+    }
+
+    /// Returns the audio configuration.
+    pub fn audio_config(&self) -> &AudioConfig {
+        &self.audio_config
+    }
+
+    /// Returns the MIDI configuration.
+    pub fn midi(&self) -> Option<&Midi> {
+        self.midi.as_ref()
+    }
+
+    /// Returns the DMX configuration.
+    pub fn dmx(&self) -> Option<&Dmx> {
+        self.dmx.as_ref()
+    }
+}
+
+/// Filters profiles by hostname. Returns profiles that either have no hostname
+/// constraint or whose hostname matches the given value.
+pub fn filter_by_hostname<'a, P, F>(
+    profiles: &'a [P],
+    hostname: &str,
+    get_hostname: F,
+) -> Vec<&'a P>
+where
+    F: Fn(&'a P) -> Option<&'a str>,
+{
+    profiles
+        .iter()
+        .filter(|p| match get_hostname(p) {
+            Some(h) => h == hostname,
+            None => true,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+
+    use super::*;
+
+    #[test]
+    fn test_profile_deserialize() {
+        let yaml = r#"
+            hostname: pi-a
+            device: mock-device
+            sample_rate: 48000
+            track_mappings:
+              drums:
+                - 1
+              synth:
+                - 2
+            midi:
+              device: mock-midi
+            dmx:
+              universes:
+                - universe: 1
+                  name: light-show
+        "#;
+
+        let profile: Profile = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(profile.hostname(), Some("pi-a"));
+        assert_eq!(profile.audio_config().audio().device(), "mock-device");
+        assert_eq!(profile.audio_config().audio().sample_rate(), 48000);
+        assert_eq!(
+            profile.audio_config().track_mappings().get("drums"),
+            Some(&vec![1u16])
+        );
+        assert_eq!(
+            profile.audio_config().track_mappings().get("synth"),
+            Some(&vec![2u16])
+        );
+        assert!(profile.midi().is_some());
+        assert_eq!(profile.midi().unwrap().device(), "mock-midi");
+        assert!(profile.dmx().is_some());
+    }
+
+    #[test]
+    fn test_profile_with_all_subsystems() {
+        let audio = Audio::new("test-device");
+        let track_mappings = HashMap::from([("drums".to_string(), vec![1, 2])]);
+        let audio_config = AudioConfig::new(audio, track_mappings);
+        let midi = Some(Midi::new("midi-device", None));
+        let dmx = Some(Dmx::new(None, None, None, vec![], None));
+
+        let profile = Profile::new(Some("pi-a".to_string()), audio_config, midi, dmx);
+
+        assert_eq!(profile.hostname(), Some("pi-a"));
+        assert!(profile.midi().is_some());
+        assert!(profile.dmx().is_some());
+    }
+
+    #[test]
+    fn test_profile_without_midi_dmx() {
+        let audio = Audio::new("test-device");
+        let track_mappings = HashMap::from([("drums".to_string(), vec![1])]);
+        let audio_config = AudioConfig::new(audio, track_mappings);
+
+        let profile = Profile::new(None, audio_config, None, None);
+
+        assert_eq!(profile.hostname(), None);
+        assert!(profile.midi().is_none());
+        assert!(profile.dmx().is_none());
+    }
+
+    #[test]
+    fn test_filter_by_hostname() {
+        let profiles = vec![
+            Profile::new(
+                Some("pi-a".to_string()),
+                AudioConfig::new(
+                    Audio::new("device-a"),
+                    HashMap::from([("drums".to_string(), vec![1])]),
+                ),
+                None,
+                None,
+            ),
+            Profile::new(
+                Some("pi-b".to_string()),
+                AudioConfig::new(
+                    Audio::new("device-b"),
+                    HashMap::from([("drums".to_string(), vec![11])]),
+                ),
+                None,
+                None,
+            ),
+            Profile::new(
+                None,
+                AudioConfig::new(
+                    Audio::new("fallback"),
+                    HashMap::from([("drums".to_string(), vec![1])]),
+                ),
+                None,
+                None,
+            ),
+        ];
+
+        // pi-a matches hostname-specific + wildcard
+        let filtered = filter_by_hostname(&profiles, "pi-a", |p| p.hostname());
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].audio_config().audio().device(), "device-a");
+        assert_eq!(filtered[1].audio_config().audio().device(), "fallback");
+
+        // pi-b matches hostname-specific + wildcard
+        let filtered = filter_by_hostname(&profiles, "pi-b", |p| p.hostname());
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].audio_config().audio().device(), "device-b");
+        assert_eq!(filtered[1].audio_config().audio().device(), "fallback");
+
+        // unknown host only matches wildcard
+        let filtered = filter_by_hostname(&profiles, "pi-c", |p| p.hostname());
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].audio_config().audio().device(), "fallback");
+    }
+}

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -26,6 +26,7 @@ use std::thread;
 #[cfg(not(test))]
 use std::time::Duration;
 use std::{error::Error, path::Path, sync::Arc};
+use tracing::info;
 
 /// Gets a device with the given name.
 pub fn create_engine(
@@ -76,6 +77,11 @@ pub fn create_engine(
     };
 
     let engine = Arc::new(Engine::new(config, lighting_config, base_path, ola_client)?);
+
+    info!(
+        lighting = lighting_config.is_some(),
+        "DMX engine initialized"
+    );
 
     // Start the persistent effects loop
     Engine::start_persistent_effects_loop(engine.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,10 @@ enum Commands {
         /// Only check specific categories (e.g., "track-mappings"). Runs all checks if omitted.
         #[arg(long)]
         check: Option<Vec<String>>,
+        /// Hostname to verify against. When audio_profiles are used, this filters which profiles
+        /// to check. If omitted, all profiles are verified.
+        #[arg(long)]
+        hostname: Option<String>,
     },
 }
 
@@ -556,7 +560,11 @@ async fn run() -> Result<(), Box<dyn Error>> {
         Commands::VerifyLightShow { show_path, config } => {
             verify_light_show(&show_path, config.as_deref())?;
         }
-        Commands::Verify { config, check } => {
+        Commands::Verify {
+            config,
+            check,
+            hostname,
+        } => {
             let config_path = Path::new(&config);
             let player_config = config::Player::deserialize(config_path)?;
             let songs_path = player_config.songs(config_path);
@@ -574,9 +582,48 @@ async fn run() -> Result<(), Box<dyn Error>> {
 
             // Track mapping checks.
             if run_all || checks.iter().any(|c| c == "track-mappings") {
-                let track_report =
-                    verify::check_all_track_mappings(&songs, player_config.track_mappings());
-                report.merge(track_report);
+                let all_profiles = player_config.all_profiles();
+
+                if all_profiles.len() > 1 {
+                    // Profile mode: verify each profile's track mappings.
+                    let profiles_to_check: Vec<&config::Profile> = match &hostname {
+                        Some(h) => {
+                            let filtered = player_config.profiles(h);
+                            if filtered.is_empty() {
+                                eprintln!("Warning: no profiles match hostname '{}'", h);
+                            }
+                            filtered
+                        }
+                        None => all_profiles.iter().collect(),
+                    };
+
+                    for (i, profile) in profiles_to_check.iter().enumerate() {
+                        let label = match profile.hostname() {
+                            Some(h) => format!(
+                                "profile {} (hostname: {}, device: {})",
+                                i,
+                                h,
+                                profile.audio_config().audio().device()
+                            ),
+                            None => format!(
+                                "profile {} (any host, device: {})",
+                                i,
+                                profile.audio_config().audio().device()
+                            ),
+                        };
+                        println!("Checking track mappings for {}...", label);
+                        let track_report = verify::check_all_track_mappings(
+                            &songs,
+                            profile.audio_config().track_mappings(),
+                        );
+                        report.merge(track_report);
+                    }
+                } else {
+                    // Single profile (legacy or single profile): verify as before.
+                    let track_report =
+                        verify::check_all_track_mappings(&songs, player_config.track_mappings());
+                    report.merge(track_report);
+                }
             }
 
             verify::print_report(&report, &songs);

--- a/src/player.rs
+++ b/src/player.rs
@@ -98,15 +98,60 @@ impl Player {
         let span = span!(Level::INFO, "player");
         let _enter = span.enter();
 
-        let device = Self::wait_for_ok("audio device".to_string(), || {
-            audio::get_device(config.audio())
-        })?;
-        let dmx_engine = Self::wait_for_ok("dmx engine".to_string(), || {
-            dmx::create_engine(config.dmx(), base_path)
-        })?;
-        let midi_device = Self::wait_for_ok("midi device".to_string(), || {
-            midi::get_device(config.midi(), dmx_engine.clone())
-        })?;
+        let hostname = config::resolve_hostname();
+        info!(hostname = %hostname, "Resolved hostname for hardware profiles");
+
+        // Get the first matching profile
+        let profiles = config.profiles(&hostname);
+        let profile = profiles
+            .first()
+            .ok_or("No matching hardware profile found")?;
+
+        info!(
+            hostname = profile.hostname().unwrap_or("default"),
+            "Using hardware profile"
+        );
+
+        // Audio is always required
+        let audio_config = profile.audio_config();
+        let (device, mappings, resolved_audio) =
+            Self::wait_for_ok("audio device".to_string(), || {
+                match audio::get_device(Some(audio_config.audio().clone())) {
+                    Ok(device) => {
+                        info!(
+                            device = audio_config.audio().device(),
+                            "Audio device initialized"
+                        );
+                        Ok((
+                            device.clone(),
+                            audio_config.track_mappings().clone(),
+                            audio_config.audio().clone(),
+                        ))
+                    }
+                    Err(e) => Err(format!("audio device: {}", e)),
+                }
+            })?;
+
+        // DMX: if present in profile, required. If absent, optional.
+        let dmx_engine = if let Some(dmx_config) = profile.dmx() {
+            Self::wait_for_ok("dmx engine".to_string(), || {
+                dmx::create_engine(Some(dmx_config), base_path)
+            })?
+        } else {
+            info!("DMX not configured in profile; proceeding without DMX");
+            None
+        };
+
+        // MIDI: if present in profile, required. If absent, optional.
+        let midi_device = if let Some(midi_config) = profile.midi() {
+            Self::wait_for_ok("midi device".to_string(), || {
+                midi::get_device(Some(midi_config.clone()), dmx_engine.clone())
+            })?
+        } else {
+            info!("MIDI not configured in profile; proceeding without MIDI");
+            None
+        };
+
         let status_events = Self::wait_for_ok("status events".to_string(), || {
             StatusEvents::new(config.status_events())
         })?;
@@ -115,7 +160,7 @@ impl Player {
         let sample_engine = match (device.mixer(), device.source_sender()) {
             (Some(mixer), Some(source_tx)) => {
                 let max_voices = config.max_sample_voices();
-                let buffer_size = config.audio().map(|a| a.buffer_size()).unwrap_or(1024);
+                let buffer_size = resolved_audio.buffer_size();
                 let mut engine = SampleEngine::new(mixer, source_tx, max_voices, buffer_size);
 
                 // Load global samples config if available
@@ -139,7 +184,7 @@ impl Player {
 
         let player = Player {
             device,
-            mappings: Arc::new(config.track_mappings().clone()),
+            mappings: Arc::new(mappings),
             midi_device,
             dmx_engine,
             sample_engine,

--- a/src/player.rs
+++ b/src/player.rs
@@ -109,6 +109,7 @@ impl Player {
 
         info!(
             hostname = profile.hostname().unwrap_or("default"),
+            device = profile.audio_config().audio().device(),
             "Using hardware profile"
         );
 


### PR DESCRIPTION
A singular config can now contain multiple hardware profiles. This is useful when using a singular mtrack configuration on multiple hosts. For example, if you're sharing backing tracks + configuration between multiple people, or if you have different rigs that you want to behave differently depending on the attached hardware, this can bridge that gap.