### PR TITLE
Make audio optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,15 @@ logged so that it's easier to diagnose a misconfiguration.
 Hardware profiles allow multiple complete host configurations in a single config file:
 
 - **Unified profiles** (`profiles`): Define complete per-host configurations in a single list.
-  Each profile specifies audio (required), MIDI (optional), and DMX (optional) for one host.
-  Subsystem presence in profile = required, absence = optional. No global `*_optional` flags.
+  Each profile specifies audio (optional), MIDI (optional), and DMX (optional) for one host.
+  All three subsystems are optional — a profile can define any combination (e.g. MIDI-only,
+  DMX-only, audio + MIDI, etc.). Subsystem presence in profile = required, absence = skipped.
 - **Hostname filtering**: Each profile can optionally specify a `hostname` constraint so that
   different hosts sharing the same config file use different devices and channel mappings.
   Set the `MTRACK_HOSTNAME` environment variable to override the system hostname.
-- **Per-host optionality**: MIDI and DMX can be required on some hosts (present in profile)
-  and optional on others (absent from profile), enabling flexible multi-host setups.
+- **Per-host optionality**: All subsystems (audio, MIDI, DMX) can be required on some hosts
+  (present in profile) and optional on others (absent from profile), enabling flexible
+  multi-host setups such as dedicated lighting-only or MIDI-only nodes.
 - **External profiles directory** (`profiles_dir`): Load profiles from individual YAML files in a
   directory instead of (or in addition to) defining them inline. Each file defines one profile.
   Files are sorted by filename for deterministic ordering. Directory profiles are prepended

--- a/README.md
+++ b/README.md
@@ -490,18 +490,19 @@ by hostname; the first match is used.
 profiles:
   # Raspberry Pi A: Full setup with WING audio + MIDI + DMX
   - hostname: raspberry-pi-a
-    device: "Behringer WING"
-    sample_rate: 48000
-    sample_format: int
-    bits_per_sample: 32
-    buffer_size: 1024
-    playback_delay: 500ms
-    track_mappings:
-      click: [1]
-      cue: [2]
-      backing-track-l: [3]
-      backing-track-r: [4]
-      keys: [5, 6]
+    audio:
+      device: "Behringer WING"
+      sample_rate: 48000
+      sample_format: int
+      bits_per_sample: 32
+      buffer_size: 1024
+      playback_delay: 500ms
+      track_mappings:
+        click: [1]
+        cue: [2]
+        backing-track-l: [3]
+        backing-track-r: [4]
+        keys: [5, 6]
     midi:
       device: "Behringer WING"
       playback_delay: 500ms
@@ -516,32 +517,42 @@ profiles:
 
   # Raspberry Pi B: WING with different channels, MIDI required, no DMX
   - hostname: raspberry-pi-b
-    device: "Behringer WING"
-    sample_rate: 48000
-    track_mappings:
-      click: [11]
-      cue: [12]
-      backing-track-l: [13]
-      backing-track-r: [14]
-      keys: [15, 16]
+    audio:
+      device: "Behringer WING"
+      sample_rate: 48000
+      track_mappings:
+        click: [11]
+        cue: [12]
+        backing-track-l: [13]
+        backing-track-r: [14]
+        keys: [15, 16]
     midi:
       device: "USB MIDI Interface"
       playback_delay: 200ms
-    # dmx omitted = optional for this host
+    # dmx omitted = not used on this host
 
-  # Fallback: minimal setup for any host (no MIDI/DMX)
-  - device: "Built-in Audio"
-    track_mappings:
-      click: [1]
-      backing-track-l: [1]
-      backing-track-r: [2]
+  # Lighting-only node: DMX only, no audio or MIDI
+  - hostname: lighting-node
+    dmx:
+      universes:
+        - universe: 1
+          name: light-show
+
+  # Fallback: minimal audio setup for any host (no MIDI/DMX)
+  - audio:
+      device: "Built-in Audio"
+      track_mappings:
+        click: [1]
+        backing-track-l: [1]
+        backing-track-r: [2]
 ```
 
 **Subsystem semantics:**
-- **Audio** is always required (every profile must have audio config + track_mappings)
-- **MIDI** and **DMX** are optional:
-  - If present in a profile → required for that host (player waits/retries)
-  - If absent from a profile → optional for that host (player proceeds without it)
+- All three subsystems (**Audio**, **MIDI**, **DMX**) are optional:
+  - If present in a profile → required for that host (player waits/retries until device is found)
+  - If absent from a profile → skipped for that host (player proceeds without it)
+- A profile can define any combination of subsystems, enabling dedicated roles such as
+  lighting-only nodes, MIDI-only controllers, or full audio + MIDI + DMX setups.
 
 Profiles with a `hostname` constraint only apply on hosts whose hostname matches. Profiles
 without a hostname constraint match any host. Set the `MTRACK_HOSTNAME` environment variable
@@ -565,24 +576,26 @@ profiles_dir: profiles/
 # Directory profiles are prepended before inline profiles.
 profiles:
   # Fallback for any host not matched by a directory profile
-  - device: "Built-in Audio"
-    track_mappings:
-      click: [1]
-      backing-track-l: [1]
-      backing-track-r: [2]
+  - audio:
+      device: "Built-in Audio"
+      track_mappings:
+        click: [1]
+        backing-track-l: [1]
+        backing-track-r: [2]
 ```
 
 ```yaml
 # profiles/01-pi-a.yaml
 hostname: raspberry-pi-a
-device: "Behringer WING"
-sample_rate: 48000
-track_mappings:
-  click: [1]
-  cue: [2]
-  backing-track-l: [3]
-  backing-track-r: [4]
-  keys: [5, 6]
+audio:
+  device: "Behringer WING"
+  sample_rate: 48000
+  track_mappings:
+    click: [1]
+    cue: [2]
+    backing-track-l: [3]
+    backing-track-r: [4]
+    keys: [5, 6]
 midi:
   device: "Behringer WING"
 dmx:

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -297,24 +297,26 @@ track_mappings:
 # Set the MTRACK_HOSTNAME environment variable to override the system hostname.
 #
 # Subsystem semantics:
-#   - Audio: always required (every profile must have it)
-#   - MIDI/DMX: presence = required, absence = optional for that host
+#   - All subsystems (audio, MIDI, DMX) are optional
+#   - Presence in a profile = required for that host (player waits/retries)
+#   - Absence from a profile = skipped for that host (player proceeds without it)
 #
 # profiles:
-#   # Raspberry Pi A: Full setup with audio + MIDI + DMX (all required)
+#   # Raspberry Pi A: Full setup with audio + MIDI + DMX
 #   - hostname: raspberry-pi-a
-#     device: "Behringer WING"
-#     sample_rate: 48000
-#     sample_format: int
-#     bits_per_sample: 32
-#     buffer_size: 1024
-#     playback_delay: 500ms
-#     track_mappings:
-#       click: [1]
-#       cue: [2]
-#       backing-track-l: [3]
-#       backing-track-r: [4]
-#       keys: [5, 6]
+#     audio:
+#       device: "Behringer WING"
+#       sample_rate: 48000
+#       sample_format: int
+#       bits_per_sample: 32
+#       buffer_size: 1024
+#       playback_delay: 500ms
+#       track_mappings:
+#         click: [1]
+#         cue: [2]
+#         backing-track-l: [3]
+#         backing-track-r: [4]
+#         keys: [5, 6]
 #     midi:
 #       device: "Behringer WING"
 #       playback_delay: 500ms
@@ -327,26 +329,35 @@ track_mappings:
 #         - universe: 1
 #           name: light-show
 #
-#   # Raspberry Pi B: Audio + MIDI required, DMX optional (omitted)
+#   # Raspberry Pi B: Audio + MIDI, no DMX
 #   - hostname: raspberry-pi-b
-#     device: "Behringer WING"
-#     sample_rate: 48000
-#     track_mappings:
-#       click: [11]
-#       cue: [12]
-#       backing-track-l: [13]
-#       backing-track-r: [14]
-#       keys: [15, 16]
+#     audio:
+#       device: "Behringer WING"
+#       sample_rate: 48000
+#       track_mappings:
+#         click: [11]
+#         cue: [12]
+#         backing-track-l: [13]
+#         backing-track-r: [14]
+#         keys: [15, 16]
 #     midi:
 #       device: "USB MIDI Interface"
 #       playback_delay: 200ms
 #
-#   # Fallback: minimal audio-only setup (MIDI/DMX optional)
-#   - device: "Built-in Audio"
-#     track_mappings:
-#       click: [1]
-#       backing-track-l: [1]
-#       backing-track-r: [2]
+#   # Lighting-only node: DMX only, no audio or MIDI
+#   - hostname: lighting-node
+#     dmx:
+#       universes:
+#         - universe: 1
+#           name: light-show
+#
+#   # Fallback: minimal audio-only setup
+#   - audio:
+#       device: "Built-in Audio"
+#       track_mappings:
+#         click: [1]
+#         backing-track-l: [1]
+#         backing-track-r: [2]
 
 # --- External Profiles Directory ---
 #

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -53,7 +53,7 @@ pub struct Player {
     /// The DMX configuration. (legacy)
     dmx: Option<Dmx>,
     /// Unified hardware profiles, tried in priority order.
-    /// Each profile contains audio (required), MIDI (optional), and DMX (optional) configs.
+    /// Each profile contains audio (optional), MIDI (optional), and DMX (optional) configs.
     profiles: Option<Vec<Profile>>,
     /// Directory of external profile YAML files, loaded and prepended before inline profiles.
     profiles_dir: Option<String>,
@@ -79,7 +79,7 @@ impl Player {
     #[cfg(test)]
     pub fn new(
         controllers: Vec<Controller>,
-        audio: Audio,
+        audio: Option<Audio>,
         midi: Option<Midi>,
         dmx: Option<Dmx>,
         track_mappings: HashMap<String, Vec<u16>>,
@@ -89,7 +89,7 @@ impl Player {
             controller: None,
             controllers: Some(controllers),
             audio_device: None,
-            audio: Some(audio),
+            audio,
             track_mappings: Some(TrackMappings { track_mappings }),
             midi_device: None,
             midi,
@@ -196,23 +196,25 @@ impl Player {
                 self.audio_device.as_ref().map(|d| Audio::new(d))
             };
 
-            if let Some(audio) = audio {
+            let audio_config = audio.map(|audio| {
                 let track_mappings = self
                     .track_mappings
                     .as_ref()
                     .map(|tm| tm.track_mappings.clone())
                     .unwrap_or_default();
+                AudioConfig::new(audio, track_mappings)
+            });
 
-                let audio_config = AudioConfig::new(audio, track_mappings);
+            let midi = if let Some(midi) = &self.midi {
+                Some(midi.clone())
+            } else {
+                self.midi_device.as_ref().map(|d| Midi::new(d, None))
+            };
 
-                let midi = if let Some(midi) = &self.midi {
-                    Some(midi.clone())
-                } else {
-                    self.midi_device.as_ref().map(|d| Midi::new(d, None))
-                };
+            let dmx = self.dmx.clone();
 
-                let dmx = self.dmx.clone();
-
+            // Create a profile if any subsystem is configured.
+            if audio_config.is_some() || midi.is_some() || dmx.is_some() {
                 let profile = Profile::new(None, audio_config, midi, dmx);
                 self.profiles = Some(vec![profile]);
             }
@@ -257,7 +259,7 @@ impl Player {
     pub fn audio(&self) -> Option<Audio> {
         if let Some(profiles) = &self.profiles {
             if let Some(first) = profiles.first() {
-                return Some(first.audio_config().audio().clone());
+                return first.audio_config().map(|ac| ac.audio().clone());
             }
         }
 
@@ -269,7 +271,9 @@ impl Player {
     pub fn track_mappings(&self) -> &HashMap<String, Vec<u16>> {
         if let Some(profiles) = &self.profiles {
             if let Some(first) = profiles.first() {
-                return first.audio_config().track_mappings();
+                if let Some(audio_config) = first.audio_config() {
+                    return audio_config.track_mappings();
+                }
             }
         }
 
@@ -401,14 +405,28 @@ midi:
         // Unified profiles should have been created from legacy fields.
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].audio_config().audio().device(), "mock-device");
-        assert_eq!(profiles[0].audio_config().audio().sample_rate(), 48000);
         assert_eq!(
-            profiles[0].audio_config().track_mappings().get("click"),
+            profiles[0].audio_config().unwrap().audio().device(),
+            "mock-device"
+        );
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().sample_rate(),
+            48000
+        );
+        assert_eq!(
+            profiles[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("click"),
             Some(&vec![1u16])
         );
         assert_eq!(
-            profiles[0].audio_config().track_mappings().get("cue"),
+            profiles[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("cue"),
             Some(&vec![2u16])
         );
         assert!(profiles[0].hostname().is_none());
@@ -434,9 +452,16 @@ track_mappings:
 
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].audio_config().audio().device(), "mock-device");
         assert_eq!(
-            profiles[0].audio_config().track_mappings().get("drums"),
+            profiles[0].audio_config().unwrap().audio().device(),
+            "mock-device"
+        );
+        assert_eq!(
+            profiles[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("drums"),
             Some(&vec![1u16])
         );
     }
@@ -466,27 +491,30 @@ midi_device: mock-midi
 songs: songs
 profiles:
   - hostname: pi-a
-    device: mock-device-a
-    sample_rate: 48000
-    track_mappings:
-      drums: [1]
-      synth: [2]
+    audio:
+      device: mock-device-a
+      sample_rate: 48000
+      track_mappings:
+        drums: [1]
+        synth: [2]
     midi:
       device: mock-midi-a
   - hostname: pi-b
-    device: mock-device-b
-    track_mappings:
-      drums: [11]
-      synth: [12]
+    audio:
+      device: mock-device-b
+      track_mappings:
+        drums: [11]
+        synth: [12]
     midi:
       device: mock-midi-b
     dmx:
       universes:
         - universe: 1
           name: light-show
-  - device: mock-fallback
-    track_mappings:
-      drums: [1]
+  - audio:
+      device: mock-fallback
+      track_mappings:
+        drums: [1]
 "#,
         );
 
@@ -494,18 +522,30 @@ profiles:
         assert_eq!(profiles.len(), 3);
 
         assert_eq!(profiles[0].hostname(), Some("pi-a"));
-        assert_eq!(profiles[0].audio_config().audio().device(), "mock-device-a");
-        assert_eq!(profiles[0].audio_config().audio().sample_rate(), 48000);
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "mock-device-a"
+        );
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().sample_rate(),
+            48000
+        );
         assert!(profiles[0].midi().is_some());
         assert!(profiles[0].dmx().is_none());
 
         assert_eq!(profiles[1].hostname(), Some("pi-b"));
-        assert_eq!(profiles[1].audio_config().audio().device(), "mock-device-b");
+        assert_eq!(
+            profiles[1].audio_config().unwrap().audio().device(),
+            "mock-device-b"
+        );
         assert!(profiles[1].midi().is_some());
         assert!(profiles[1].dmx().is_some());
 
         assert_eq!(profiles[2].hostname(), None);
-        assert_eq!(profiles[2].audio_config().audio().device(), "mock-fallback");
+        assert_eq!(
+            profiles[2].audio_config().unwrap().audio().device(),
+            "mock-fallback"
+        );
         assert!(profiles[2].midi().is_none());
         assert!(profiles[2].dmx().is_none());
     }
@@ -517,35 +557,53 @@ profiles:
 songs: songs
 profiles:
   - hostname: pi-a
-    device: mock-device-a
-    track_mappings:
-      drums: [1]
+    audio:
+      device: mock-device-a
+      track_mappings:
+        drums: [1]
   - hostname: pi-b
-    device: mock-device-b
-    track_mappings:
-      drums: [11]
-  - device: mock-fallback
-    track_mappings:
-      drums: [1]
+    audio:
+      device: mock-device-b
+      track_mappings:
+        drums: [11]
+  - audio:
+      device: mock-fallback
+      track_mappings:
+        drums: [1]
 "#,
         );
 
         // pi-a sees its own profile + the wildcard.
         let pi_a = player.profiles("pi-a");
         assert_eq!(pi_a.len(), 2);
-        assert_eq!(pi_a[0].audio_config().audio().device(), "mock-device-a");
-        assert_eq!(pi_a[1].audio_config().audio().device(), "mock-fallback");
+        assert_eq!(
+            pi_a[0].audio_config().unwrap().audio().device(),
+            "mock-device-a"
+        );
+        assert_eq!(
+            pi_a[1].audio_config().unwrap().audio().device(),
+            "mock-fallback"
+        );
 
         // pi-b sees its own profile + the wildcard.
         let pi_b = player.profiles("pi-b");
         assert_eq!(pi_b.len(), 2);
-        assert_eq!(pi_b[0].audio_config().audio().device(), "mock-device-b");
-        assert_eq!(pi_b[1].audio_config().audio().device(), "mock-fallback");
+        assert_eq!(
+            pi_b[0].audio_config().unwrap().audio().device(),
+            "mock-device-b"
+        );
+        assert_eq!(
+            pi_b[1].audio_config().unwrap().audio().device(),
+            "mock-fallback"
+        );
 
         // Unknown host only sees the wildcard.
         let unknown = player.profiles("pi-c");
         assert_eq!(unknown.len(), 1);
-        assert_eq!(unknown[0].audio_config().audio().device(), "mock-fallback");
+        assert_eq!(
+            unknown[0].audio_config().unwrap().audio().device(),
+            "mock-fallback"
+        );
     }
 
     #[test]
@@ -554,9 +612,10 @@ profiles:
             r#"
 songs: songs
 profiles:
-  - device: mock-device
-    track_mappings:
-      drums: [1]
+  - audio:
+      device: mock-device
+      track_mappings:
+        drums: [1]
 "#,
         );
 
@@ -576,9 +635,10 @@ audio:
 track_mappings:
   click: [99]
 profiles:
-  - device: profile-device
-    track_mappings:
-      click: [1]
+  - audio:
+      device: profile-device
+      track_mappings:
+        click: [1]
 "#,
         );
 
@@ -586,11 +646,15 @@ profiles:
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 1);
         assert_eq!(
-            profiles[0].audio_config().audio().device(),
+            profiles[0].audio_config().unwrap().audio().device(),
             "profile-device"
         );
         assert_eq!(
-            profiles[0].audio_config().track_mappings().get("click"),
+            profiles[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("click"),
             Some(&vec![1u16])
         );
 
@@ -619,10 +683,11 @@ songs: songs
             r#"
 songs: songs
 profiles:
-  - device: mock-device
-    track_mappings:
-      drums: [1]
-      synth: [2]
+  - audio:
+      device: mock-device
+      track_mappings:
+        drums: [1]
+        synth: [2]
 "#,
         );
 
@@ -630,7 +695,11 @@ profiles:
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 1);
         assert_eq!(
-            profiles[0].audio_config().track_mappings().get("drums"),
+            profiles[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("drums"),
             Some(&vec![1u16])
         );
 
@@ -645,29 +714,39 @@ profiles:
 songs: songs
 profiles:
   - hostname: pi-a
-    device: "Behringer WING"
-    track_mappings:
-      drums: [1]
-      synth: [2]
+    audio:
+      device: "Behringer WING"
+      track_mappings:
+        drums: [1]
+        synth: [2]
   - hostname: pi-b
-    device: "Behringer WING"
-    track_mappings:
-      drums: [11]
-      synth: [12]
+    audio:
+      device: "Behringer WING"
+      track_mappings:
+        drums: [11]
+        synth: [12]
 "#,
         );
 
         let pi_a = player.profiles("pi-a");
         assert_eq!(pi_a.len(), 1);
         assert_eq!(
-            pi_a[0].audio_config().track_mappings().get("drums"),
+            pi_a[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("drums"),
             Some(&vec![1u16])
         );
 
         let pi_b = player.profiles("pi-b");
         assert_eq!(pi_b.len(), 1);
         assert_eq!(
-            pi_b[0].audio_config().track_mappings().get("drums"),
+            pi_b[0]
+                .audio_config()
+                .unwrap()
+                .track_mappings()
+                .get("drums"),
             Some(&vec![11u16])
         );
 
@@ -715,7 +794,10 @@ dmx:
         // Should have been normalized into a single unified profile.
         let profiles = config.all_profiles();
         assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].audio_config().audio().device(), "UltraLite-mk5");
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "UltraLite-mk5"
+        );
         assert!(profiles[0].midi().is_some());
         assert!(profiles[0].dmx().is_some());
     }
@@ -741,21 +823,27 @@ dmx:
             write_profile(
                 &dir.join("profiles"),
                 "pi-a.yaml",
-                "hostname: pi-a\ndevice: device-a\ntrack_mappings:\n  drums: [1]\n",
+                "hostname: pi-a\naudio:\n  device: device-a\n  track_mappings:\n    drums: [1]\n",
             );
             write_profile(
                 &dir.join("profiles"),
                 "pi-b.yml",
-                "hostname: pi-b\ndevice: device-b\ntrack_mappings:\n  drums: [11]\n",
+                "hostname: pi-b\naudio:\n  device: device-b\n  track_mappings:\n    drums: [11]\n",
             );
         });
 
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 2);
         assert_eq!(profiles[0].hostname(), Some("pi-a"));
-        assert_eq!(profiles[0].audio_config().audio().device(), "device-a");
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "device-a"
+        );
         assert_eq!(profiles[1].hostname(), Some("pi-b"));
-        assert_eq!(profiles[1].audio_config().audio().device(), "device-b");
+        assert_eq!(
+            profiles[1].audio_config().unwrap().audio().device(),
+            "device-b"
+        );
     }
 
     #[test]
@@ -765,16 +853,17 @@ dmx:
                 "songs: songs\n",
                 "profiles_dir: profiles/\n",
                 "profiles:\n",
-                "  - device: inline-fallback\n",
-                "    track_mappings:\n",
-                "      drums: [1]\n",
+                "  - audio:\n",
+                "      device: inline-fallback\n",
+                "      track_mappings:\n",
+                "        drums: [1]\n",
             ),
             |dir| {
                 std::fs::create_dir(dir.join("profiles")).unwrap();
                 write_profile(
                     &dir.join("profiles"),
                     "pi-a.yaml",
-                    "hostname: pi-a\ndevice: dir-device\ntrack_mappings:\n  drums: [1]\n",
+                    "hostname: pi-a\naudio:\n  device: dir-device\n  track_mappings:\n    drums: [1]\n",
                 );
             },
         );
@@ -782,11 +871,14 @@ dmx:
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 2);
         // Directory profile comes first.
-        assert_eq!(profiles[0].audio_config().audio().device(), "dir-device");
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "dir-device"
+        );
         assert_eq!(profiles[0].hostname(), Some("pi-a"));
         // Inline profile comes second.
         assert_eq!(
-            profiles[1].audio_config().audio().device(),
+            profiles[1].audio_config().unwrap().audio().device(),
             "inline-fallback"
         );
         assert_eq!(profiles[1].hostname(), None);
@@ -799,9 +891,10 @@ dmx:
                 "songs: songs\n",
                 "profiles_dir: profiles/\n",
                 "profiles:\n",
-                "  - device: inline-device\n",
-                "    track_mappings:\n",
-                "      drums: [1]\n",
+                "  - audio:\n",
+                "      device: inline-device\n",
+                "      track_mappings:\n",
+                "        drums: [1]\n",
             ),
             |dir| {
                 std::fs::create_dir(dir.join("profiles")).unwrap();
@@ -811,7 +904,10 @@ dmx:
         // Only the inline profile should be present.
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].audio_config().audio().device(), "inline-device");
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "inline-device"
+        );
     }
 
     #[test]
@@ -860,7 +956,7 @@ dmx:
             write_profile(
                 &dir.join("profiles"),
                 "pi-a.yaml",
-                "hostname: pi-a\ndevice: device-a\ntrack_mappings:\n  drums: [1]\n",
+                "hostname: pi-a\naudio:\n  device: device-a\n  track_mappings:\n    drums: [1]\n",
             );
             // These should be ignored.
             write_profile(&dir.join("profiles"), "notes.txt", "just some notes");
@@ -884,25 +980,34 @@ dmx:
             write_profile(
                 &dir.join("profiles"),
                 "03-fallback.yml",
-                "device: fallback\ntrack_mappings:\n  drums: [1]\n",
+                "audio:\n  device: fallback\n  track_mappings:\n    drums: [1]\n",
             );
             write_profile(
                 &dir.join("profiles"),
                 "01-pi-a.yaml",
-                "hostname: pi-a\ndevice: device-a\ntrack_mappings:\n  drums: [1]\n",
+                "hostname: pi-a\naudio:\n  device: device-a\n  track_mappings:\n    drums: [1]\n",
             );
             write_profile(
                 &dir.join("profiles"),
                 "02-pi-b.yaml",
-                "hostname: pi-b\ndevice: device-b\ntrack_mappings:\n  drums: [11]\n",
+                "hostname: pi-b\naudio:\n  device: device-b\n  track_mappings:\n    drums: [11]\n",
             );
         });
 
         let profiles = player.all_profiles();
         assert_eq!(profiles.len(), 3);
-        assert_eq!(profiles[0].audio_config().audio().device(), "device-a");
-        assert_eq!(profiles[1].audio_config().audio().device(), "device-b");
-        assert_eq!(profiles[2].audio_config().audio().device(), "fallback");
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "device-a"
+        );
+        assert_eq!(
+            profiles[1].audio_config().unwrap().audio().device(),
+            "device-b"
+        );
+        assert_eq!(
+            profiles[2].audio_config().unwrap().audio().device(),
+            "fallback"
+        );
     }
 
     #[test]
@@ -912,21 +1017,22 @@ dmx:
                 "songs: songs\n",
                 "profiles_dir: profiles/\n",
                 "profiles:\n",
-                "  - device: inline-fallback\n",
-                "    track_mappings:\n",
-                "      drums: [1]\n",
+                "  - audio:\n",
+                "      device: inline-fallback\n",
+                "      track_mappings:\n",
+                "        drums: [1]\n",
             ),
             |dir| {
                 std::fs::create_dir(dir.join("profiles")).unwrap();
                 write_profile(
                     &dir.join("profiles"),
                     "pi-a.yaml",
-                    "hostname: pi-a\ndevice: device-a\ntrack_mappings:\n  drums: [1]\n",
+                    "hostname: pi-a\naudio:\n  device: device-a\n  track_mappings:\n    drums: [1]\n",
                 );
                 write_profile(
                     &dir.join("profiles"),
                     "pi-b.yaml",
-                    "hostname: pi-b\ndevice: device-b\ntrack_mappings:\n  drums: [11]\n",
+                    "hostname: pi-b\naudio:\n  device: device-b\n  track_mappings:\n    drums: [11]\n",
                 );
             },
         );
@@ -934,20 +1040,26 @@ dmx:
         // pi-a sees its directory profile + inline fallback.
         let pi_a = player.profiles("pi-a");
         assert_eq!(pi_a.len(), 2);
-        assert_eq!(pi_a[0].audio_config().audio().device(), "device-a");
-        assert_eq!(pi_a[1].audio_config().audio().device(), "inline-fallback");
+        assert_eq!(pi_a[0].audio_config().unwrap().audio().device(), "device-a");
+        assert_eq!(
+            pi_a[1].audio_config().unwrap().audio().device(),
+            "inline-fallback"
+        );
 
         // pi-b sees its directory profile + inline fallback.
         let pi_b = player.profiles("pi-b");
         assert_eq!(pi_b.len(), 2);
-        assert_eq!(pi_b[0].audio_config().audio().device(), "device-b");
-        assert_eq!(pi_b[1].audio_config().audio().device(), "inline-fallback");
+        assert_eq!(pi_b[0].audio_config().unwrap().audio().device(), "device-b");
+        assert_eq!(
+            pi_b[1].audio_config().unwrap().audio().device(),
+            "inline-fallback"
+        );
 
         // Unknown host sees only inline fallback.
         let unknown = player.profiles("pi-c");
         assert_eq!(unknown.len(), 1);
         assert_eq!(
-            unknown[0].audio_config().audio().device(),
+            unknown[0].audio_config().unwrap().audio().device(),
             "inline-fallback"
         );
     }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -55,9 +55,8 @@ pub struct Profile {
     /// Optional hostname restriction.
     hostname: Option<String>,
 
-    /// Audio configuration (required).
-    #[serde(flatten)]
-    audio_config: AudioConfig,
+    /// Audio configuration (optional if absent from profile).
+    audio: Option<AudioConfig>,
 
     /// MIDI configuration (optional if absent from profile).
     midi: Option<Midi>,
@@ -70,13 +69,13 @@ impl Profile {
     /// Creates a new Profile.
     pub fn new(
         hostname: Option<String>,
-        audio_config: AudioConfig,
+        audio: Option<AudioConfig>,
         midi: Option<Midi>,
         dmx: Option<Dmx>,
     ) -> Self {
         Profile {
             hostname,
-            audio_config,
+            audio,
             midi,
             dmx,
         }
@@ -87,9 +86,9 @@ impl Profile {
         self.hostname.as_deref()
     }
 
-    /// Returns the audio configuration.
-    pub fn audio_config(&self) -> &AudioConfig {
-        &self.audio_config
+    /// Returns the audio configuration, if present.
+    pub fn audio_config(&self) -> Option<&AudioConfig> {
+        self.audio.as_ref()
     }
 
     /// Returns the MIDI configuration.
@@ -132,13 +131,14 @@ mod tests {
     fn test_profile_deserialize() {
         let yaml = r#"
             hostname: pi-a
-            device: mock-device
-            sample_rate: 48000
-            track_mappings:
-              drums:
-                - 1
-              synth:
-                - 2
+            audio:
+              device: mock-device
+              sample_rate: 48000
+              track_mappings:
+                drums:
+                  - 1
+                synth:
+                  - 2
             midi:
               device: mock-midi
             dmx:
@@ -155,18 +155,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(profile.hostname(), Some("pi-a"));
-        assert_eq!(profile.audio_config().audio().device(), "mock-device");
-        assert_eq!(profile.audio_config().audio().sample_rate(), 48000);
+        let audio_config = profile.audio_config().unwrap();
+        assert_eq!(audio_config.audio().device(), "mock-device");
+        assert_eq!(audio_config.audio().sample_rate(), 48000);
         assert_eq!(
-            profile.audio_config().track_mappings().get("drums"),
+            audio_config.track_mappings().get("drums"),
             Some(&vec![1u16])
         );
         assert_eq!(
-            profile.audio_config().track_mappings().get("synth"),
+            audio_config.track_mappings().get("synth"),
             Some(&vec![2u16])
         );
         assert!(profile.midi().is_some());
         assert_eq!(profile.midi().unwrap().device(), "mock-midi");
+        assert!(profile.dmx().is_some());
+    }
+
+    #[test]
+    fn test_profile_without_audio() {
+        let yaml = r#"
+            hostname: lighting-node
+            midi:
+              device: mock-midi
+            dmx:
+              universes:
+                - universe: 1
+                  name: light-show
+        "#;
+
+        let profile: Profile = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(profile.hostname(), Some("lighting-node"));
+        assert!(profile.audio_config().is_none());
+        assert!(profile.midi().is_some());
         assert!(profile.dmx().is_some());
     }
 
@@ -178,9 +204,10 @@ mod tests {
         let midi = Some(Midi::new("midi-device", None));
         let dmx = Some(Dmx::new(None, None, None, vec![], None));
 
-        let profile = Profile::new(Some("pi-a".to_string()), audio_config, midi, dmx);
+        let profile = Profile::new(Some("pi-a".to_string()), Some(audio_config), midi, dmx);
 
         assert_eq!(profile.hostname(), Some("pi-a"));
+        assert!(profile.audio_config().is_some());
         assert!(profile.midi().is_some());
         assert!(profile.dmx().is_some());
     }
@@ -191,9 +218,10 @@ mod tests {
         let track_mappings = HashMap::from([("drums".to_string(), vec![1])]);
         let audio_config = AudioConfig::new(audio, track_mappings);
 
-        let profile = Profile::new(None, audio_config, None, None);
+        let profile = Profile::new(None, Some(audio_config), None, None);
 
         assert_eq!(profile.hostname(), None);
+        assert!(profile.audio_config().is_some());
         assert!(profile.midi().is_none());
         assert!(profile.dmx().is_none());
     }
@@ -203,28 +231,28 @@ mod tests {
         let profiles = vec![
             Profile::new(
                 Some("pi-a".to_string()),
-                AudioConfig::new(
+                Some(AudioConfig::new(
                     Audio::new("device-a"),
                     HashMap::from([("drums".to_string(), vec![1])]),
-                ),
+                )),
                 None,
                 None,
             ),
             Profile::new(
                 Some("pi-b".to_string()),
-                AudioConfig::new(
+                Some(AudioConfig::new(
                     Audio::new("device-b"),
                     HashMap::from([("drums".to_string(), vec![11])]),
-                ),
+                )),
                 None,
                 None,
             ),
             Profile::new(
                 None,
-                AudioConfig::new(
+                Some(AudioConfig::new(
                     Audio::new("fallback"),
                     HashMap::from([("drums".to_string(), vec![1])]),
-                ),
+                )),
                 None,
                 None,
             ),
@@ -233,18 +261,33 @@ mod tests {
         // pi-a matches hostname-specific + wildcard
         let filtered = filter_by_hostname(&profiles, "pi-a", |p| p.hostname());
         assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0].audio_config().audio().device(), "device-a");
-        assert_eq!(filtered[1].audio_config().audio().device(), "fallback");
+        assert_eq!(
+            filtered[0].audio_config().unwrap().audio().device(),
+            "device-a"
+        );
+        assert_eq!(
+            filtered[1].audio_config().unwrap().audio().device(),
+            "fallback"
+        );
 
         // pi-b matches hostname-specific + wildcard
         let filtered = filter_by_hostname(&profiles, "pi-b", |p| p.hostname());
         assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0].audio_config().audio().device(), "device-b");
-        assert_eq!(filtered[1].audio_config().audio().device(), "fallback");
+        assert_eq!(
+            filtered[0].audio_config().unwrap().audio().device(),
+            "device-b"
+        );
+        assert_eq!(
+            filtered[1].audio_config().unwrap().audio().device(),
+            "fallback"
+        );
 
         // unknown host only matches wildcard
         let filtered = filter_by_hostname(&profiles, "pi-c", |p| p.hostname());
         assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].audio_config().audio().device(), "fallback");
+        assert_eq!(
+            filtered[0].audio_config().unwrap().audio().device(),
+            "fallback"
+        );
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -182,7 +182,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 None,
                 None,
                 HashMap::new(),
@@ -191,7 +191,9 @@ mod test {
             None,
         )?);
         let playlist = player.get_playlist();
-        let binding = player.audio_device();
+        let binding = player
+            .audio_device()
+            .expect("audio device should be present");
         let device = binding.to_mock()?;
 
         let driver = Arc::new(TestDriver::new(player.clone(), TestEvent::Unset));

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -303,7 +303,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
                 HashMap::new(),
@@ -311,7 +311,9 @@ mod test {
             ),
             None,
         )?);
-        let binding = player.audio_device();
+        let binding = player
+            .audio_device()
+            .expect("audio device should be present");
         let device = binding.to_mock()?;
 
         // Get a random port.

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -184,7 +184,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
                 HashMap::new(),
@@ -193,7 +193,9 @@ mod test {
             None,
         )?);
         let playlist = player.get_playlist();
-        let binding = player.audio_device();
+        let binding = player
+            .audio_device()
+            .expect("audio device should be present");
         let device = binding.to_mock()?;
         let binding = player.midi_device().expect("MIDI device not found");
         let midi_device = binding.to_mock()?;

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -406,7 +406,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
                 HashMap::new(),
@@ -414,7 +414,9 @@ mod test {
             ),
             None,
         )?);
-        let binding = player.audio_device();
+        let binding = player
+            .audio_device()
+            .expect("audio device should be present");
         let device = binding.to_mock()?;
 
         let driver = Driver::new(Box::new(config::OscController::new()), player.clone())?;
@@ -567,7 +569,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
                 HashMap::new(),
@@ -688,7 +690,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
                 HashMap::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -598,24 +598,29 @@ async fn run() -> Result<(), Box<dyn Error>> {
                     };
 
                     for (i, profile) in profiles_to_check.iter().enumerate() {
+                        let audio_config = match profile.audio_config() {
+                            Some(ac) => ac,
+                            None => {
+                                println!("Skipping profile {} (no audio configured)", i);
+                                continue;
+                            }
+                        };
                         let label = match profile.hostname() {
                             Some(h) => format!(
                                 "profile {} (hostname: {}, device: {})",
                                 i,
                                 h,
-                                profile.audio_config().audio().device()
+                                audio_config.audio().device()
                             ),
                             None => format!(
                                 "profile {} (any host, device: {})",
                                 i,
-                                profile.audio_config().audio().device()
+                                audio_config.audio().device()
                             ),
                         };
                         println!("Checking track mappings for {}...", label);
-                        let track_report = verify::check_all_track_mappings(
-                            &songs,
-                            profile.audio_config().track_mappings(),
-                        );
+                        let track_report =
+                            verify::check_all_track_mappings(&songs, audio_config.track_mappings());
                         report.merge(track_report);
                     }
                 } else {

--- a/src/player.rs
+++ b/src/player.rs
@@ -47,8 +47,8 @@ struct PlayHandles {
 
 /// Groups the parameters needed for `play_files` to avoid excessive argument counts.
 struct PlaybackContext {
-    device: Arc<dyn audio::Device>,
-    mappings: Arc<HashMap<String, Vec<u16>>>,
+    device: Option<Arc<dyn audio::Device>>,
+    mappings: Option<Arc<HashMap<String, Vec<u16>>>>,
     midi_device: Option<Arc<dyn midi::Device>>,
     dmx_engine: Option<Arc<dmx::engine::Engine>>,
     song: Arc<Song>,
@@ -60,10 +60,10 @@ struct PlaybackContext {
 /// Plays back individual wav files as multichannel audio for the configured audio interface.
 #[derive(Clone)]
 pub struct Player {
-    /// The device to play audio through.
-    device: Arc<dyn audio::Device>,
-    /// Mappings of tracks to output channels.
-    mappings: Arc<HashMap<String, Vec<u16>>>,
+    /// The device to play audio through (optional if absent from profile).
+    device: Option<Arc<dyn audio::Device>>,
+    /// Mappings of tracks to output channels (optional if no audio configured).
+    mappings: Option<Arc<HashMap<String, Vec<u16>>>>,
     /// The MIDI device to play MIDI back through.
     midi_device: Option<Arc<dyn midi::Device>>,
     /// The DMX engine to use.
@@ -109,29 +109,38 @@ impl Player {
 
         info!(
             hostname = profile.hostname().unwrap_or("default"),
-            device = profile.audio_config().audio().device(),
+            device = profile
+                .audio_config()
+                .map(|ac| ac.audio().device())
+                .unwrap_or("none"),
             "Using hardware profile"
         );
 
-        // Audio is always required
-        let audio_config = profile.audio_config();
-        let (device, mappings, resolved_audio) =
-            Self::wait_for_ok("audio device".to_string(), || {
-                match audio::get_device(Some(audio_config.audio().clone())) {
-                    Ok(device) => {
-                        info!(
-                            device = audio_config.audio().device(),
-                            "Audio device initialized"
-                        );
-                        Ok((
-                            device.clone(),
-                            audio_config.track_mappings().clone(),
-                            audio_config.audio().clone(),
-                        ))
+        // Audio: if present in profile, required. If absent, optional.
+        let (device, mappings, resolved_audio) = if let Some(audio_config) = profile.audio_config()
+        {
+            let (device, mappings, resolved_audio) =
+                Self::wait_for_ok("audio device".to_string(), || {
+                    match audio::get_device(Some(audio_config.audio().clone())) {
+                        Ok(device) => {
+                            info!(
+                                device = audio_config.audio().device(),
+                                "Audio device initialized"
+                            );
+                            Ok((
+                                device.clone(),
+                                audio_config.track_mappings().clone(),
+                                audio_config.audio().clone(),
+                            ))
+                        }
+                        Err(e) => Err(format!("audio device: {}", e)),
                     }
-                    Err(e) => Err(format!("audio device: {}", e)),
-                }
-            })?;
+                })?;
+            (Some(device), Some(mappings), Some(resolved_audio))
+        } else {
+            info!("Audio not configured in profile; proceeding without audio");
+            (None, None, None)
+        };
 
         // DMX: if present in profile, required. If absent, optional.
         let dmx_engine = if let Some(dmx_config) = profile.dmx() {
@@ -158,10 +167,16 @@ impl Player {
         })?;
 
         // Initialize the sample engine if the audio device supports it
-        let sample_engine = match (device.mixer(), device.source_sender()) {
-            (Some(mixer), Some(source_tx)) => {
+        let sample_engine = match device
+            .as_ref()
+            .and_then(|d| d.mixer().and_then(|m| d.source_sender().map(|s| (m, s))))
+        {
+            Some((mixer, source_tx)) => {
                 let max_voices = config.max_sample_voices();
-                let buffer_size = resolved_audio.buffer_size();
+                let buffer_size = resolved_audio
+                    .as_ref()
+                    .map(|a| a.buffer_size())
+                    .unwrap_or(1024);
                 let mut engine = SampleEngine::new(mixer, source_tx, max_voices, buffer_size);
 
                 // Load global samples config if available
@@ -185,7 +200,7 @@ impl Player {
 
         let player = Player {
             device,
-            mappings: Arc::new(mappings),
+            mappings: mappings.map(Arc::new),
             midi_device,
             dmx_engine,
             sample_engine,
@@ -258,7 +273,7 @@ impl Player {
 
     /// Gets the audio device currently in use by the player.
     #[cfg(test)]
-    pub fn audio_device(&self) -> Arc<dyn audio::Device> {
+    pub fn audio_device(&self) -> Option<Arc<dyn audio::Device>> {
         self.device.clone()
     }
 
@@ -427,7 +442,9 @@ impl Player {
         }
 
         // Warn about tracks with no mapping in the config.
-        crate::verify::warn_unmapped_tracks(&song, &self.mappings);
+        if let Some(ref mappings) = self.mappings {
+            crate::verify::warn_unmapped_tracks(&song, mappings);
+        }
 
         let play_start_time = self.play_start_time.clone();
 
@@ -528,32 +545,46 @@ impl Player {
             start_time,
         } = ctx;
 
-        // Set up the play barrier, which will synchronize the three calls to play.
-        let barrier = Arc::new(Barrier::new({
-            let mut num_barriers = 1;
-            if song.midi_playback().is_some() && midi_device.is_some() {
-                num_barriers += 1;
+        // Set up the play barrier, which will synchronize the subsystem threads.
+        let has_audio = device.is_some();
+        let mut num_barriers = 0;
+        if has_audio {
+            num_barriers += 1;
+        }
+        if song.midi_playback().is_some() && midi_device.is_some() {
+            num_barriers += 1;
+        }
+        if !song.light_shows().is_empty() && dmx_engine.is_some() {
+            num_barriers += song.light_shows().len();
+        }
+        if !song.dsl_lighting_shows().is_empty() && dmx_engine.is_some() {
+            num_barriers += 1; // One barrier for the lighting timeline
+        }
+
+        // If no subsystems are active, signal success immediately and return.
+        if num_barriers == 0 {
+            info!(
+                song = song.name(),
+                "No playback subsystems active for this song; completing immediately"
+            );
+            if play_tx.send(Ok(())).is_err() {
+                error!("Error while sending to finish channel (receiver dropped).");
             }
-            if !song.light_shows().is_empty() && dmx_engine.is_some() {
-                num_barriers += song.light_shows().len();
-            }
-            if !song.dsl_lighting_shows().is_empty() && dmx_engine.is_some() {
-                num_barriers += 1; // One barrier for the lighting timeline
-            }
-            num_barriers
-        }));
+            return;
+        }
+
+        let barrier = Arc::new(Barrier::new(num_barriers));
 
         let audio_outcome: Arc<parking_lot::Mutex<Option<Result<(), String>>>> =
             Arc::new(parking_lot::Mutex::new(None));
 
-        let audio_join_handle = {
-            let device = device.clone();
+        let audio_join_handle = if let (Some(device), Some(mappings)) = (device, mappings) {
             let song = song.clone();
             let barrier = barrier.clone();
             let cancel_handle = cancel_handle.clone();
             let audio_outcome = audio_outcome.clone();
 
-            thread::spawn(move || {
+            Some(thread::spawn(move || {
                 let song_name = song.name().to_string();
                 let result = device.play_from(song, &mappings, cancel_handle, barrier, start_time);
                 if let Err(ref e) = result {
@@ -566,7 +597,9 @@ impl Player {
                 let outcome = result.map_err(|e| e.to_string());
                 let mut guard = audio_outcome.lock();
                 *guard = Some(outcome);
-            })
+            }))
+        } else {
+            None
         };
 
         let dmx_join_handle = dmx_engine.map(|dmx_engine| {
@@ -611,8 +644,10 @@ impl Player {
             None
         };
 
-        if let Err(e) = audio_join_handle.join() {
-            error!("Error waiting for audio to stop playing: {:?}", e)
+        if let Some(audio_join_handle) = audio_join_handle {
+            if let Err(e) = audio_join_handle.join() {
+                error!("Error waiting for audio to stop playing: {:?}", e)
+            }
         }
 
         if let Some(dmx_join_handle) = dmx_join_handle {
@@ -627,13 +662,17 @@ impl Player {
             }
         }
 
-        let outcome = audio_outcome.lock().take().unwrap_or_else(|| {
-            warn!(
-                "Audio thread did not set outcome (e.g. panicked before setting); \
-                 treating as success so playlist is not stuck"
-            );
+        let outcome = if has_audio {
+            audio_outcome.lock().take().unwrap_or_else(|| {
+                warn!(
+                    "Audio thread did not set outcome (e.g. panicked before setting); \
+                     treating as success so playlist is not stuck"
+                );
+                Ok(())
+            })
+        } else {
             Ok(())
-        });
+        };
         if play_tx.send(outcome).is_err() {
             error!("Error while sending to finish channel (receiver dropped).")
         }
@@ -858,7 +897,7 @@ mod test {
             )?,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
                 HashMap::new(),
@@ -866,7 +905,9 @@ mod test {
             ),
             None,
         )?;
-        let binding = player.audio_device();
+        let binding = player
+            .audio_device()
+            .expect("audio device should be present");
         let device = binding.to_mock()?;
         let midi_device = player
             .midi_device()
@@ -1039,7 +1080,7 @@ mod test {
             playlist,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
                 HashMap::new(),
@@ -1138,7 +1179,7 @@ mod test {
             playlist,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
                 HashMap::new(),
@@ -1238,7 +1279,7 @@ mod test {
             playlist,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
                 HashMap::new(),
@@ -1338,7 +1379,7 @@ mod test {
             playlist,
             &config::Player::new(
                 vec![],
-                config::Audio::new("mock-device"),
+                Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 Some(dmx_config),
                 HashMap::new(),


### PR DESCRIPTION
Audio is now optional in the case that a user wants to use mtrack as a pure MIDI or DMX player.