### PR TITLE
Optimization of audio callback, version bump.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0]
+## [0.8.0] - 2026-02-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0]
+
 ### Added
 
 MIDI-triggered sample playback has been added. Samples can be configured globally or per-song
@@ -25,6 +27,9 @@ latency with zero jitter. At 256 sample buffer size (44.1kHz), latency is approx
 samples stop at exactly the same sample the new one starts, eliminating gaps.
 
 The audio engine has been refactored for lower latency and stability:
+
+Audio is now fully optional. mtrack can run as a pure MIDI or DMX player without any
+audio device configured. This enables dedicated lighting-only or MIDI-only nodes.
 
 A warning is displayed when playing songs that have tracks that are not configured to
 be output in the current player configuration. This will not cause an error, but will be
@@ -70,6 +75,12 @@ Hardware profiles allow multiple complete host configurations in a single config
   may have changed. Run `mtrack devices` to check.
 - **Symphonia replaces hound**: Supports flac, ogg, vorbis, mp3, alac, aac, and anything
   else Symphonia supports, not just wav.
+- **Security**: mtrack now supports running as a dedicated `mtrack` user instead of root
+  via systemd, with updated service definitions and documentation.
+- **Error handling**: Improved error reporting and panic aversion across the player, DMX
+  engine, sample loader, and playlist handling.
+- **Lighting cleanup**: A pass of cleanup on the lighting system, improving code quality
+  across the effect engine, parser, timeline, and layering.
 
 ### Fixed
 
@@ -77,6 +88,7 @@ Hardware profiles allow multiple complete host configurations in a single config
   a hang. This is unlikely to have happened in a live scenario.
 - **Clean device shutdown**: The CPAL output stream now shuts down promptly when the device
   is dropped, fixing a bug where the stream thread would block indefinitely on join.
+- **Lighting bug fixes**: Fixed bugs in the lighting system discovered during cleanup.
 
 ## [0.7.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -324,19 +324,10 @@ where
         let n = std::cmp::min(data.len(), temp_buffer.len());
         let temp_slice = &mut temp_buffer[..n];
         let num_frames = n / num_channels as usize;
-        profiler.on_cb_start();
-        let start_mix = if profile_audio {
-            Some(Instant::now())
-        } else {
-            None
-        };
+        let start = profiler.on_cb_start();
         mixer.process_into_output(temp_slice, num_frames);
-        profiler.on_mix_done(start_mix);
-        let start_convert = if profile_audio {
-            Some(Instant::now())
-        } else {
-            None
-        };
+        profiler.on_mix_done(start);
+        let start_convert = start.map(|_| Instant::now());
         let zero = T::from_sample(0.0);
         for (out, &sample) in data[..n].iter_mut().zip(temp_slice.iter()) {
             *out = T::from_sample(sample);

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -363,7 +363,7 @@ impl Drop for OutputManager {
             .collect();
         drop(active_sources); // Release the read lock
         if !source_ids.is_empty() {
-            self.mixer.remove_sources(source_ids);
+            self.mixer.remove_sources(&source_ids);
         }
 
         // Signal the output thread to shut down and wake it from the condvar wait.

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -15,7 +15,7 @@
 use crate::audio::sample_source::ChannelMappedSampleSource;
 use parking_lot::{Mutex, RwLock};
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -24,10 +24,12 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-// Thread-local scratch for process_into_output. Size 128 avoids resize in the callback
-// for typical multichannel sources; >128 channels may still trigger a one-time resize.
+// Thread-local scratch buffers for process_into_output.
+// BATCH_READ_SCRATCH: 8192 samples covers 512 frames * 16 channels; resized if needed.
+// SOURCES_SCRATCH: reuses the Vec across callbacks to avoid per-callback heap allocation.
 thread_local! {
-    static SOURCE_FRAME_SCRATCH: RefCell<Vec<f32>> = RefCell::new(vec![0.0; 128]);
+    static BATCH_READ_SCRATCH: RefCell<Vec<f32>> = RefCell::new(vec![0.0; 8192]);
+    static SOURCES_SCRATCH: RefCell<Vec<Arc<Mutex<ActiveSource>>>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Core audio mixing logic that's independent of any audio backend
@@ -144,12 +146,11 @@ impl AudioMixer {
     }
 
     /// Removes sources by ID
-    pub fn remove_sources(&self, source_ids: Vec<u64>) {
-        let source_ids_set: HashSet<u64> = source_ids.into_iter().collect();
+    pub fn remove_sources(&self, source_ids: &[u64]) {
         let mut sources = self.active_sources.write();
         sources.retain(|source| {
             let source_guard = source.lock();
-            !source_ids_set.contains(&source_guard.id)
+            !source_ids.contains(&source_guard.id)
         });
     }
 
@@ -168,7 +169,7 @@ impl AudioMixer {
             sources.clone()
         };
 
-        let mut finished_source_ids = HashSet::new();
+        let mut finished_source_ids = Vec::new();
         // Reusable scratch buffer for source frames (max 64 channels should cover most cases)
         let mut source_frame_buffer = vec![0.0f32; 64];
 
@@ -179,7 +180,7 @@ impl AudioMixer {
             if active_source.is_finished.load(Ordering::Relaxed)
                 || active_source.cancel_handle.is_cancelled()
             {
-                finished_source_ids.insert(active_source.id);
+                finished_source_ids.push(active_source.id);
                 continue;
             }
 
@@ -216,22 +217,18 @@ impl AudioMixer {
                 }
                 Ok(None) => {
                     active_source.is_finished.store(true, Ordering::Relaxed);
-                    finished_source_ids.insert(active_source.id);
+                    finished_source_ids.push(active_source.id);
                 }
                 Err(_) => {
                     active_source.is_finished.store(true, Ordering::Relaxed);
-                    finished_source_ids.insert(active_source.id);
+                    finished_source_ids.push(active_source.id);
                 }
             }
         }
 
         // Remove finished sources in a separate, quick write lock
         if !finished_source_ids.is_empty() {
-            let mut sources = self.active_sources.write();
-            sources.retain(|source| {
-                let source_guard = source.lock();
-                !finished_source_ids.contains(&source_guard.id)
-            });
+            self.remove_sources(&finished_source_ids);
         }
 
         // Update performance statistics (test only)
@@ -288,16 +285,21 @@ impl AudioMixer {
         // Clear the buffer once
         output.fill(0.0);
 
-        // Get a snapshot of source references to process (minimize lock duration)
-        let sources_to_process = {
-            let sources = self.active_sources.read();
-            sources.clone()
-        };
+        // Take the scratch Vec (reuses capacity across callbacks, avoids heap alloc)
+        let mut sources_to_process =
+            SOURCES_SCRATCH.with(|cell| std::mem::take(&mut *cell.borrow_mut()));
+        sources_to_process.clear();
 
-        let mut finished_source_ids = HashSet::new();
+        // Fill from active_sources (quick read lock)
+        {
+            let sources = self.active_sources.read();
+            sources_to_process.extend(sources.iter().cloned());
+        }
+
+        let mut finished_source_ids: Vec<u64> = Vec::new();
 
         // Process each active source across all frames
-        for active_source_arc in sources_to_process {
+        for active_source_arc in sources_to_process.iter() {
             let mut active_source = active_source_arc.lock();
 
             if active_source.is_finished.load(Ordering::Relaxed)
@@ -312,7 +314,7 @@ impl AudioMixer {
                     },
                     "mixer: source marked finished (skip)"
                 );
-                finished_source_ids.insert(active_source.id);
+                finished_source_ids.push(active_source.id);
                 continue;
             }
 
@@ -327,7 +329,7 @@ impl AudioMixer {
                         "mixer: source marked finished (cancel_at_sample reached)"
                     );
                     active_source.is_finished.store(true, Ordering::Relaxed);
-                    finished_source_ids.insert(active_source.id);
+                    finished_source_ids.push(active_source.id);
                     continue;
                 }
             }
@@ -365,46 +367,53 @@ impl AudioMixer {
             };
 
             let source_channel_count = active_source.cached_source_channel_count as usize;
-            SOURCE_FRAME_SCRATCH.with(|cell| {
+            let frames_needed = end_frame - start_frame;
+
+            BATCH_READ_SCRATCH.with(|cell| {
                 let mut buf = cell.borrow_mut();
-                if buf.len() < source_channel_count {
-                    buf.resize(source_channel_count, 0.0);
+                let batch_samples = frames_needed * source_channel_count;
+                if buf.len() < batch_samples {
+                    buf.resize(batch_samples, 0.0);
                 }
-                let sbuf = &mut buf[..source_channel_count];
-                for frame_index in start_frame..end_frame {
-                    match active_source.source.next_frame(sbuf) {
-                        Ok(Some(_count)) => {
-                            for (source_channel, &sample) in sbuf.iter().enumerate() {
+                let batch_buf = &mut buf[..batch_samples];
+
+                match active_source.source.read_frames(batch_buf, frames_needed) {
+                    Ok(frames_got) => {
+                        for frame_idx in 0..frames_got {
+                            let src_offset = frame_idx * source_channel_count;
+                            let dst_base = (start_frame + frame_idx) * channels;
+                            for (source_channel, &sample) in batch_buf
+                                [src_offset..src_offset + source_channel_count]
+                                .iter()
+                                .enumerate()
+                            {
                                 if let Some(output_channels) =
                                     active_source.channel_mappings.get(source_channel)
                                 {
-                                    let base = frame_index * channels;
                                     for &output_index in output_channels {
                                         if output_index < channels {
-                                            output[base + output_index] += sample;
+                                            output[dst_base + output_index] += sample;
                                         }
                                     }
                                 }
                             }
                         }
-                        Ok(None) => {
+                        if frames_got < frames_needed {
                             debug!(
                                 source_id = active_source.id,
-                                "mixer: source marked finished (next_frame returned None)"
+                                "mixer: source marked finished (read_frames returned fewer frames)"
                             );
                             active_source.is_finished.store(true, Ordering::Relaxed);
-                            finished_source_ids.insert(active_source.id);
-                            break;
+                            finished_source_ids.push(active_source.id);
                         }
-                        Err(_) => {
-                            debug!(
-                                source_id = active_source.id,
-                                "mixer: source marked finished (next_frame error)"
-                            );
-                            active_source.is_finished.store(true, Ordering::Relaxed);
-                            finished_source_ids.insert(active_source.id);
-                            break;
-                        }
+                    }
+                    Err(_) => {
+                        debug!(
+                            source_id = active_source.id,
+                            "mixer: source marked finished (read_frames error)"
+                        );
+                        active_source.is_finished.store(true, Ordering::Relaxed);
+                        finished_source_ids.push(active_source.id);
                     }
                 }
             });
@@ -421,12 +430,14 @@ impl AudioMixer {
                 remaining_before = self.active_sources.read().len(),
                 "mixer: removing finished sources"
             );
-            let mut sources = self.active_sources.write();
-            sources.retain(|source| {
-                let source_guard = source.lock();
-                !finished_source_ids.contains(&source_guard.id)
-            });
+            self.remove_sources(&finished_source_ids);
         }
+
+        // Put back the scratch Vec for reuse (drop Arc refs first)
+        sources_to_process.clear();
+        SOURCES_SCRATCH.with(|cell| {
+            *cell.borrow_mut() = sources_to_process;
+        });
     }
 
     /// Gets the number of output channels

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -366,6 +366,12 @@ impl AudioMixer {
                 num_frames
             };
 
+            // cancel_at_sample can be set by another thread to a value before
+            // start_at_sample, making end_frame < start_frame. Skip gracefully.
+            if end_frame <= start_frame {
+                continue;
+            }
+
             let source_channel_count = active_source.cached_source_channel_count as usize;
             let frames_needed = end_frame - start_frame;
 
@@ -629,6 +635,49 @@ mod tests {
         }
         for frame in frames.iter().take(64).skip(34) {
             assert_eq!(*frame, 0.0);
+        }
+    }
+
+    #[test]
+    fn test_cancel_before_start_does_not_panic() {
+        // Regression: when cancel_at_sample < start_at_sample, the subtraction
+        // end_frame - start_frame would underflow. The mixer must handle this
+        // gracefully (produce silence, no panic).
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.5; 1024]; // plenty of audio
+        let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        // start_at_sample=400, cancel_at_sample=200 — cancel comes before start
+        let cancel_at = Arc::new(AtomicU64::new(200));
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: Some(400),
+            cancel_at_sample: Some(cancel_at),
+        };
+
+        mixer.add_source(active_source);
+
+        // Process a buffer that spans both cancel and start points.
+        // current_sample starts at 0, buffer covers samples 0..512.
+        // end_frame = (200 - 0) = 200, start_frame = (400 - 0) = 400.
+        // Without the fix this would panic on 200 - 400.
+        let mut output = vec![0.0f32; 512 * 2];
+        mixer.process_into_output(&mut output, 512);
+
+        // Source should have produced silence (skipped entirely)
+        for &sample in &output {
+            assert_eq!(sample, 0.0);
         }
     }
 }

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -145,7 +145,10 @@ impl AudioMixer {
         sources.push(Arc::new(Mutex::new(source)));
     }
 
-    /// Removes sources by ID
+    /// Removes sources by ID.
+    /// Note: `source_ids.contains()` is O(M) per retained source, making this
+    /// O(N * M) overall. This is fine for typical counts (< 32 sources) but would
+    /// need a HashSet if source counts ever grow significantly.
     pub fn remove_sources(&self, source_ids: &[u64]) {
         let mut sources = self.active_sources.write();
         sources.retain(|source| {
@@ -368,6 +371,8 @@ impl AudioMixer {
 
             // cancel_at_sample can be set by another thread to a value before
             // start_at_sample, making end_frame < start_frame. Skip gracefully.
+            // The source stays alive for one extra callback; on the next callback
+            // the early cancel_at_sample check (above) will fire and remove it.
             if end_frame <= start_frame {
                 continue;
             }
@@ -375,6 +380,11 @@ impl AudioMixer {
             let source_channel_count = active_source.cached_source_channel_count as usize;
             let frames_needed = end_frame - start_frame;
 
+            // Safety invariant: BATCH_READ_SCRATCH is reused across source iterations
+            // without clearing. This is safe because we only read back
+            // `frames_got * source_channel_count` samples from the buffer, and
+            // `read_frames` is required to write exactly that many samples.
+            // Stale data beyond that range is never accessed.
             BATCH_READ_SCRATCH.with(|cell| {
                 let mut buf = cell.borrow_mut();
                 let batch_samples = frames_needed * source_channel_count;
@@ -679,5 +689,284 @@ mod tests {
         for &sample in &output {
             assert_eq!(sample, 0.0);
         }
+
+        // The source lingers for one callback (skipped via `continue`), then on
+        // the next callback the early cancel_at_sample check removes it.
+        let mut output2 = vec![0.0f32; 512 * 2];
+        mixer.process_into_output(&mut output2, 512);
+        for &sample in &output2 {
+            assert_eq!(sample, 0.0);
+        }
+        // After two callbacks the source should be cleaned up.
+        assert_eq!(mixer.active_sources.read().len(), 0);
+    }
+
+    #[test]
+    fn test_process_into_output_basic() {
+        // Verify that process_into_output produces the same audio as process_frames
+        // for a start-aligned source (no scheduling).
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.5, 0.8, 0.3, 0.6]; // 4 frames of 1 channel
+        let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: None,
+        };
+
+        mixer.add_source(active_source);
+
+        let mut output = vec![0.0f32; 4 * 2]; // 4 frames * 2 channels
+        mixer.process_into_output(&mut output, 4);
+
+        assert_eq!(output[0], 0.5); // Frame 0, Ch 0
+        assert_eq!(output[1], 0.0); // Frame 0, Ch 1 (unmapped)
+        assert_eq!(output[2], 0.8); // Frame 1, Ch 0
+        assert_eq!(output[3], 0.0); // Frame 1, Ch 1
+        assert_eq!(output[4], 0.3); // Frame 2, Ch 0
+        assert_eq!(output[5], 0.0); // Frame 2, Ch 1
+        assert_eq!(output[6], 0.6); // Frame 3, Ch 0
+        assert_eq!(output[7], 0.0); // Frame 3, Ch 1
+    }
+
+    #[test]
+    fn test_process_into_output_start_at_sample_mid_buffer() {
+        // Source starts partway through the buffer (start_at_sample > current_sample).
+        let mixer = AudioMixer::new(2, 44100);
+
+        // 4 frames of 1 channel; source should start at frame index 2 in the buffer.
+        let samples = vec![0.1, 0.2, 0.3, 0.4];
+        let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: Some(2), // Start at sample 2
+            cancel_at_sample: None,
+        };
+
+        mixer.add_source(active_source);
+
+        // Buffer covers samples 0..4 (4 frames). Source starts at sample 2.
+        let mut output = vec![0.0f32; 4 * 2];
+        mixer.process_into_output(&mut output, 4);
+
+        // Frames 0-1 should be silence, frames 2-3 should have source audio.
+        assert_eq!(output[0], 0.0); // Frame 0, Ch 0 (before start)
+        assert_eq!(output[1], 0.0); // Frame 0, Ch 1
+        assert_eq!(output[2], 0.0); // Frame 1, Ch 0 (before start)
+        assert_eq!(output[3], 0.0); // Frame 1, Ch 1
+        assert_eq!(output[4], 0.1); // Frame 2, Ch 0 (source starts)
+        assert_eq!(output[5], 0.0); // Frame 2, Ch 1
+        assert_eq!(output[6], 0.2); // Frame 3, Ch 0
+        assert_eq!(output[7], 0.0); // Frame 3, Ch 1
+    }
+
+    #[test]
+    fn test_process_into_output_cancel_at_sample_mid_buffer() {
+        // Source is cancelled partway through the buffer.
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+        let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        let cancel_at = Arc::new(AtomicU64::new(3)); // Cancel at sample 3
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: Some(cancel_at),
+        };
+
+        mixer.add_source(active_source);
+
+        // Buffer covers samples 0..8. Source plays frames 0..3 then stops.
+        let mut output = vec![0.0f32; 8 * 2];
+        mixer.process_into_output(&mut output, 8);
+
+        // Frames 0-2 should have audio, frames 3-7 should be silence.
+        assert_eq!(output[0], 0.1); // Frame 0
+        assert_eq!(output[2], 0.2); // Frame 1
+        assert_eq!(output[4], 0.3); // Frame 2
+        assert_eq!(output[6], 0.0); // Frame 3 (after cancel)
+        assert_eq!(output[8], 0.0); // Frame 4
+        assert_eq!(output[10], 0.0); // Frame 5
+    }
+
+    #[test]
+    fn test_process_into_output_source_finishes_before_buffer_end() {
+        // Source has fewer frames than the buffer size.
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.7, 0.9]; // Only 2 frames of 1 channel
+        let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: None,
+        };
+
+        mixer.add_source(active_source);
+
+        // Request 8 frames but source only has 2.
+        let mut output = vec![0.0f32; 8 * 2];
+        mixer.process_into_output(&mut output, 8);
+
+        // Frames 0-1 should have audio, the rest should be silence.
+        assert_eq!(output[0], 0.7); // Frame 0, Ch 0
+        assert_eq!(output[1], 0.0); // Frame 0, Ch 1
+        assert_eq!(output[2], 0.9); // Frame 1, Ch 0
+        assert_eq!(output[3], 0.0); // Frame 1, Ch 1
+        for i in 4..16 {
+            assert_eq!(output[i], 0.0, "output[{i}] should be silence");
+        }
+
+        // Source should have been marked finished and cleaned up.
+        assert_eq!(mixer.active_sources.read().len(), 0);
+    }
+
+    #[test]
+    fn test_process_into_output_multiple_sources() {
+        // Two sources mixed together through process_into_output.
+        let mixer = AudioMixer::new(2, 44100);
+
+        let source1 = create_test_source(
+            vec![0.5, 0.3],
+            2,
+            vec![vec!["ch0".to_string()], vec!["ch1".to_string()]],
+        );
+        let source2 = create_test_source(
+            vec![0.2, 0.1],
+            2,
+            vec![vec!["ch0".to_string()], vec!["ch1".to_string()]],
+        );
+
+        let active_source1 = ActiveSource {
+            id: 1,
+            source: source1,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("ch0".to_string(), vec![1]);
+                map.insert("ch1".to_string(), vec![2]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 2,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: None,
+        };
+
+        let active_source2 = ActiveSource {
+            id: 2,
+            source: source2,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("ch0".to_string(), vec![1]);
+                map.insert("ch1".to_string(), vec![2]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 2,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: None,
+        };
+
+        mixer.add_source(active_source1);
+        mixer.add_source(active_source2);
+
+        let mut output = vec![0.0f32; 2]; // 1 frame * 2 channels
+        mixer.process_into_output(&mut output, 1);
+
+        assert!((output[0] - 0.7).abs() < 1e-6); // 0.5 + 0.2
+        assert!((output[1] - 0.4).abs() < 1e-6); // 0.3 + 0.1
+    }
+
+    #[test]
+    fn test_process_into_output_start_and_cancel_mid_buffer() {
+        // Source starts and stops within the same buffer.
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+        let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        let cancel_at = Arc::new(AtomicU64::new(6)); // Cancel at sample 6
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: Some(2), // Start at sample 2
+            cancel_at_sample: Some(cancel_at),
+        };
+
+        mixer.add_source(active_source);
+
+        // Buffer covers samples 0..8. Source plays frames 2..6.
+        let mut output = vec![0.0f32; 8 * 2];
+        mixer.process_into_output(&mut output, 8);
+
+        // Frames 0-1: silence (before start)
+        assert_eq!(output[0], 0.0);
+        assert_eq!(output[2], 0.0);
+        // Frames 2-5: audio (4 frames from the source)
+        assert_eq!(output[4], 0.1); // Frame 2: first source frame
+        assert_eq!(output[6], 0.2); // Frame 3
+        assert_eq!(output[8], 0.3); // Frame 4
+        assert_eq!(output[10], 0.4); // Frame 5
+                                     // Frames 6-7: silence (after cancel)
+        assert_eq!(output[12], 0.0);
+        assert_eq!(output[14], 0.0);
     }
 }

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -275,8 +275,8 @@ impl BufferedSampleSource {
 impl ChannelMappedSampleSource for BufferedSampleSource {
     fn next_sample(&mut self) -> Result<Option<f32>, SampleSourceError> {
         let channels = self.channels as usize;
-        let mut frame = [0.0f32; 64];
-        match self.next_frame(&mut frame[..channels])? {
+        let mut frame = vec![0.0f32; channels];
+        match self.next_frame(&mut frame)? {
             Some(count) if count > 0 => Ok(Some(frame[0])),
             _ => Ok(None),
         }
@@ -343,9 +343,14 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
         max_frames: usize,
     ) -> Result<usize, SampleSourceError> {
         let channels = self.channels as usize;
+        debug_assert!(
+            output.len() >= max_frames * channels,
+            "read_frames: output buffer too small ({} < {})",
+            output.len(),
+            max_frames * channels,
+        );
         let mut frames_read = 0;
         let mut maybe_spawn_refill = false;
-        let mut need_direct_reads = false;
 
         {
             let mut state = self.buffer.state.lock().unwrap();
@@ -382,24 +387,21 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
                 maybe_spawn_refill = true;
             }
 
-            // If we still need frames and the buffer is empty, fall back to direct reads
+            // Underrun fallback: read directly from the inner source while
+            // holding the state lock. This matches next_frame's lock ordering
+            // and prevents the refill thread from writing frames that would
+            // be played out of chronological order.
             if frames_read < max_frames && state.len_frames == 0 && !state.finished {
-                need_direct_reads = true;
-            }
-        }
-
-        // Underrun fallback: read directly from the inner source
-        if need_direct_reads {
-            let mut inner = self.inner.lock().unwrap();
-            while frames_read < max_frames {
-                let offset = frames_read * channels;
-                match inner.next_frame(&mut output[offset..offset + channels]) {
-                    Ok(Some(_)) => frames_read += 1,
-                    Ok(None) | Err(_) => {
-                        let mut state = self.buffer.state.lock().unwrap();
-                        state.finished = true;
-                        self.finished_flag.store(true, Ordering::Relaxed);
-                        break;
+                let mut inner = self.inner.lock().unwrap();
+                while frames_read < max_frames {
+                    let offset = frames_read * channels;
+                    match inner.next_frame(&mut output[offset..offset + channels]) {
+                        Ok(Some(_)) => frames_read += 1,
+                        Ok(None) | Err(_) => {
+                            state.finished = true;
+                            self.finished_flag.store(true, Ordering::Relaxed);
+                            break;
+                        }
                     }
                 }
             }

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -275,8 +275,8 @@ impl BufferedSampleSource {
 impl ChannelMappedSampleSource for BufferedSampleSource {
     fn next_sample(&mut self) -> Result<Option<f32>, SampleSourceError> {
         let channels = self.channels as usize;
-        let mut frame = vec![0.0f32; channels];
-        match self.next_frame(&mut frame[..])? {
+        let mut frame = [0.0f32; 64];
+        match self.next_frame(&mut frame[..channels])? {
             Some(count) if count > 0 => Ok(Some(frame[0])),
             _ => Ok(None),
         }
@@ -335,6 +335,81 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
         }
 
         Ok(Some(channels))
+    }
+
+    fn read_frames(
+        &mut self,
+        output: &mut [f32],
+        max_frames: usize,
+    ) -> Result<usize, SampleSourceError> {
+        let channels = self.channels as usize;
+        let mut frames_read = 0;
+        let mut maybe_spawn_refill = false;
+        let mut need_direct_reads = false;
+
+        {
+            let mut state = self.buffer.state.lock().unwrap();
+
+            let available = state.len_frames.min(max_frames);
+            if available > 0 {
+                let read_start = state.read_index;
+                let read_end = read_start + available;
+
+                if read_end <= self.capacity_frames {
+                    // Contiguous region — single copy
+                    let src_start = read_start * channels;
+                    let src_end = read_end * channels;
+                    output[..available * channels].copy_from_slice(&state.data[src_start..src_end]);
+                } else {
+                    // Wrap-around — two copies
+                    let first_part = self.capacity_frames - read_start;
+                    let first_samples = first_part * channels;
+                    let src_start = read_start * channels;
+                    output[..first_samples]
+                        .copy_from_slice(&state.data[src_start..src_start + first_samples]);
+
+                    let second_samples = (available - first_part) * channels;
+                    output[first_samples..first_samples + second_samples]
+                        .copy_from_slice(&state.data[..second_samples]);
+                }
+
+                state.read_index = (read_start + available) % self.capacity_frames;
+                state.len_frames -= available;
+                frames_read = available;
+            }
+
+            if !state.finished && state.len_frames <= self.refill_threshold_frames {
+                maybe_spawn_refill = true;
+            }
+
+            // If we still need frames and the buffer is empty, fall back to direct reads
+            if frames_read < max_frames && state.len_frames == 0 && !state.finished {
+                need_direct_reads = true;
+            }
+        }
+
+        // Underrun fallback: read directly from the inner source
+        if need_direct_reads {
+            let mut inner = self.inner.lock().unwrap();
+            while frames_read < max_frames {
+                let offset = frames_read * channels;
+                match inner.next_frame(&mut output[offset..offset + channels]) {
+                    Ok(Some(_)) => frames_read += 1,
+                    Ok(None) | Err(_) => {
+                        let mut state = self.buffer.state.lock().unwrap();
+                        state.finished = true;
+                        self.finished_flag.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if maybe_spawn_refill {
+            self.spawn_refill_if_needed();
+        }
+
+        Ok(frames_read)
     }
 
     fn channel_mappings(&self) -> &Vec<Vec<String>> {

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -101,7 +101,7 @@ impl BufferedSampleSource {
         device_buffer_frames: usize,
     ) -> Self {
         let channels = inner.source_channel_count() as usize;
-        let capacity_frames = cmp::max(device_buffer_frames * 4, device_buffer_frames.max(1));
+        let capacity_frames = (device_buffer_frames * 4).max(1);
         let warmup_min_frames = device_buffer_frames.max(1);
         let refill_threshold_frames = capacity_frames / 2;
 

--- a/src/audio/sample_source/traits.rs
+++ b/src/audio/sample_source/traits.rs
@@ -101,7 +101,10 @@ pub trait ChannelMappedSampleSource: Send + Sync {
 
     /// Read multiple frames in a batch, writing interleaved samples into `output`.
     /// Returns the number of frames successfully read. Fewer than `max_frames`
-    /// means the source is finished (or an error occurred on a frame boundary).
+    /// means the source is finished or an error occurred on a frame boundary.
+    /// On error, returns `Ok(frames_read)` with however many frames were
+    /// successfully written before the error — callers should treat a short
+    /// read as end-of-source rather than checking for `Err`.
     /// `output` must have room for at least `max_frames * source_channel_count()` samples.
     fn read_frames(
         &mut self,
@@ -118,9 +121,9 @@ pub trait ChannelMappedSampleSource: Send + Sync {
         let mut frames_read = 0;
         for frame_idx in 0..max_frames {
             let offset = frame_idx * channel_count;
-            match self.next_frame(&mut output[offset..offset + channel_count])? {
-                Some(_) => frames_read += 1,
-                None => break,
+            match self.next_frame(&mut output[offset..offset + channel_count]) {
+                Ok(Some(_)) => frames_read += 1,
+                Ok(None) | Err(_) => break,
             }
         }
         Ok(frames_read)

--- a/src/audio/sample_source/traits.rs
+++ b/src/audio/sample_source/traits.rs
@@ -109,6 +109,12 @@ pub trait ChannelMappedSampleSource: Send + Sync {
         max_frames: usize,
     ) -> Result<usize, SampleSourceError> {
         let channel_count = self.source_channel_count() as usize;
+        debug_assert!(
+            output.len() >= max_frames * channel_count,
+            "read_frames: output buffer too small ({} < {})",
+            output.len(),
+            max_frames * channel_count,
+        );
         let mut frames_read = 0;
         for frame_idx in 0..max_frames {
             let offset = frame_idx * channel_count;

--- a/src/audio/sample_source/traits.rs
+++ b/src/audio/sample_source/traits.rs
@@ -99,6 +99,27 @@ pub trait ChannelMappedSampleSource: Send + Sync {
         Ok(Some(channel_count))
     }
 
+    /// Read multiple frames in a batch, writing interleaved samples into `output`.
+    /// Returns the number of frames successfully read. Fewer than `max_frames`
+    /// means the source is finished (or an error occurred on a frame boundary).
+    /// `output` must have room for at least `max_frames * source_channel_count()` samples.
+    fn read_frames(
+        &mut self,
+        output: &mut [f32],
+        max_frames: usize,
+    ) -> Result<usize, SampleSourceError> {
+        let channel_count = self.source_channel_count() as usize;
+        let mut frames_read = 0;
+        for frame_idx in 0..max_frames {
+            let offset = frame_idx * channel_count;
+            match self.next_frame(&mut output[offset..offset + channel_count])? {
+                Some(_) => frames_read += 1,
+                None => break,
+            }
+        }
+        Ok(frames_read)
+    }
+
     /// Get the channel mappings for this source
     /// Returns a Vec where each element corresponds to a source channel
     /// Each Vec<String> contains the labels that source channel maps to


### PR DESCRIPTION
Reduce the lock contention and unnecessary allocations in the audio thread. Additionally, the version has been bumped to 0.8.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time audio mixing and source buffering APIs; performance-oriented changes can subtly affect timing, cancellation, and audio correctness despite added tests.
> 
> **Overview**
> Improves audio callback performance by switching mixing to **batched frame reads** via a new `ChannelMappedSampleSource::read_frames` API and updating the mixer to reuse thread-local scratch buffers for both source lists and sample batches, reducing lock contention and per-callback allocations.
> 
> Hardens scheduling/cancellation behavior in `AudioMixer::process_into_output` (gracefully handling cancel-before-start) and adds a focused test suite covering start/cancel mid-buffer and early termination behavior. Also bumps the project version to `0.8.0` and updates the changelog accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 343a6ca78fd0ebc27d5d606956d6c47ff4fb936a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->