### PR TITLE
Triggering based on audio input, triggering profiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`output_track` for samples**: Sample definitions now support an `output_track` field that
+  references a track mapping name from the active hardware profile's `track_mappings`. This allows
+  a single sample definition to work across different hardware profiles with different channel
+  assignments. The existing `output_channels` field continues to work unchanged. If both are set,
+  `output_track` takes precedence.
+
+- **Audio trigger input**: Piezoelectric drum triggers (or any transient audio signal) can now
+  trigger sample playback via a standard audio interface input. Configure per-channel threshold,
+  scan window, retrigger lockout, gain, and velocity curve (linear, logarithmic, or fixed).
+  Trigger inputs can fire samples or release voice groups (e.g. cymbal choke). No MIDI hardware
+  required — plug piezos directly into any cpal-supported audio interface.
+
+- **Unified trigger config with `kind` discriminator**: Audio and MIDI trigger inputs now coexist
+  in a single `trigger.inputs` list using a `kind` field (`audio` or `midi`). MIDI triggers
+  defined this way replace the top-level `sample_triggers` section. The `device` field is now
+  optional (only required when audio inputs are present). Legacy `sample_triggers` are
+  automatically converted to `kind: midi` trigger inputs at startup.
+
+### Changed
+
+- **`note_off` renamed to `release_behavior`**: The sample configuration field `note_off` has been
+  renamed to `release_behavior` to better reflect its source-agnostic purpose. The old `note_off`
+  key is still accepted for backwards compatibility.
+
 ## [0.8.0] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -825,42 +825,89 @@ samples:
   kick:
     # The audio file to play. Path is relative to the config file.
     file: samples/kick.wav
-    
+
     # Output channels to route this sample to (1-indexed).
+    # Use output_channels for fixed channel numbers, or output_track to reference
+    # a track mapping name from the active hardware profile.
     output_channels: [3, 4]
-    
+
+    # Alternatively, use output_track to reference a track mapping by name.
+    # This lets the same sample definition work across different hardware profiles
+    # with different channel assignments. If both are set, output_track takes precedence.
+    # output_track: "kick-out"
+
     # Velocity handling configuration.
     velocity:
       # Mode can be: ignore, scale, or layers.
       mode: scale
-    
-    # Behavior when Note Off is received: play_to_completion, stop, or fade.
-    note_off: play_to_completion
-    
+
+    # Behavior when released: play_to_completion, stop, or fade.
+    # (Also accepts "note_off" as a key name for backwards compatibility.)
+    release_behavior: play_to_completion
+
     # Behavior when retriggered while playing: cut or polyphonic.
     retrigger: cut
-    
+
     # Maximum concurrent voices for this sample (optional).
     max_voices: 4
-    
-    # Fade time in milliseconds when note_off is "fade" (default: 50).
+
+    # Fade time in milliseconds when release_behavior is "fade" (default: 50).
     fade_time_ms: 100
+```
+
+When using `output_track`, the sample's output channels are resolved through the active profile's `track_mappings`. This is useful when multiple hosts share a config file but have different channel assignments:
+
+```yaml
+samples:
+  kick:
+    file: samples/kick.wav
+    output_track: "kick-out"     # resolved via profile's track_mappings
+
+profiles:
+  - hostname: pi-a
+    audio:
+      device: "UltraLite-mk5"
+      track_mappings:
+        kick-out: [3, 4]         # pi-a routes kick to channels 3-4
+  - hostname: pi-b
+    audio:
+      device: "UltraLite-mk5"
+      track_mappings:
+        kick-out: [13, 14]       # pi-b routes kick to channels 13-14
 ```
 
 #### Sample Triggers
 
-Triggers map MIDI events to samples. For Note On/Off events, only the channel and key are matched - the velocity from the incoming MIDI event is used for volume scaling or layer selection.
+Triggers map MIDI events to samples. For Note On/Off events, only the channel and key are matched — the velocity from the incoming MIDI event is used for volume scaling or layer selection.
+
+The preferred way to define MIDI triggers is as `kind: midi` inputs in the [trigger configuration](#trigger-configuration):
+
+```yaml
+trigger:
+  inputs:
+    - kind: midi
+      event:
+        type: note_on
+        channel: 10
+        key: 60  # C3
+      sample: kick
+    - kind: midi
+      event:
+        type: note_on
+        channel: 10
+        key: 62  # D3
+      sample: snare
+```
+
+The legacy top-level `sample_triggers` format is still supported and automatically converted at startup:
 
 ```yaml
 sample_triggers:
-  # Map a MIDI Note On event to a sample.
-  # The velocity from the incoming MIDI event is used for volume/layer selection.
 - trigger:
     type: note_on
     channel: 10
     key: 60  # C3
   sample: kick
-
 - trigger:
     type: note_on
     channel: 10
@@ -907,13 +954,15 @@ velocity:
     file: samples/snare_hard.wav
 ```
 
-### Note Off Behavior
+### Release Behavior
 
-Controls what happens when a MIDI Note Off event is received:
+Controls what happens when a voice is released (via MIDI Note Off or audio trigger release):
 
-- **`play_to_completion`** (default) - Ignores Note Off, lets the sample play to the end.
+- **`play_to_completion`** (default) - Ignores the release, lets the sample play to the end.
 - **`stop`** - Immediately stops the sample.
 - **`fade`** - Fades out the sample over the configured `fade_time_ms`.
+
+Note: In configuration files, both `release_behavior` and `note_off` are accepted as key names.
 
 ### Retrigger Behavior
 
@@ -973,6 +1022,210 @@ sample_triggers:
     key: 64
   sample: kick
 ```
+
+## Trigger Configuration
+
+The trigger system provides a unified way to trigger sample playback from both audio inputs (piezo drum triggers) and MIDI events. Audio and MIDI inputs coexist in a single `inputs` list, discriminated by a required `kind` field.
+
+Audio triggers use the same sample engine as MIDI triggers, so all sample features (velocity scaling, voice management, release groups, retrigger behavior) work identically regardless of input source.
+
+### Configuration
+
+Trigger configuration can be placed at the top level (legacy) or inside a hardware profile. Each input requires a `kind` field: `audio` or `midi`. The `device` field is only required when audio inputs are present.
+
+```yaml
+# Inside a hardware profile (recommended):
+profiles:
+  - hostname: drum-pi
+    audio:
+      device: "UltraLite-mk5"
+      track_mappings:
+        kick: [3, 4]
+    trigger:
+      device: "UltraLite-mk5"    # Required for audio inputs
+      sample_rate: 44100
+      # sample_format: int       # "int" or "float" (default: device native)
+      # bits_per_sample: 16      # 16 or 32 (default: device native)
+      # buffer_size: 256         # stream buffer size in frames (default: device default)
+      # crosstalk_window_ms: 4   # suppression window (ms) after any channel fires
+      # crosstalk_threshold: 3.0 # threshold multiplier during suppression
+      inputs:
+        # Audio trigger input (piezo drum trigger)
+        - kind: audio
+          channel: 1
+          sample: "kick"
+          threshold: 0.1
+          retrigger_time_ms: 30
+          scan_time_ms: 5
+          gain: 1.0
+          velocity_curve: linear
+          release_group: "kick"
+          # highpass_freq: 80.0               # high-pass filter cutoff in Hz
+          # dynamic_threshold_decay_ms: 50    # adaptive threshold decay in ms
+        - kind: audio
+          channel: 3
+          sample: "cymbal"
+          threshold: 0.08
+          release_group: "cymbal"
+        - kind: audio
+          channel: 4
+          action: release
+          release_group: "cymbal"
+          threshold: 0.05
+        # MIDI trigger input (alternative to top-level sample_triggers)
+        - kind: midi
+          event:
+            type: note_on
+            channel: 10
+            key: 60
+          sample: kick
+```
+
+Or as a top-level field (legacy, normalized into a profile at startup):
+
+```yaml
+trigger:
+  device: "UltraLite-mk5"
+  sample_rate: 44100
+  inputs:
+    - kind: audio
+      channel: 1
+      sample: "kick"
+      threshold: 0.1
+      retrigger_time_ms: 30
+      scan_time_ms: 5
+      gain: 1.0
+      velocity_curve: linear
+      release_group: "kick"
+```
+
+MIDI-only trigger configs don't need a device:
+
+```yaml
+trigger:
+  inputs:
+    - kind: midi
+      event:
+        type: note_on
+        channel: 10
+        key: 60
+      sample: kick
+    - kind: midi
+      event:
+        type: note_on
+        channel: 10
+        key: 62
+      sample: snare
+```
+
+> **Note:** Top-level `sample_triggers` are still supported for backwards compatibility. At startup they are automatically converted to `kind: midi` inputs in the trigger config. When using profiles, top-level `sample_triggers` are ignored with a warning.
+
+### Stream Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `sample_format` | device native | Sample format for the input stream: `int` or `float` |
+| `bits_per_sample` | device native | Bits per sample: `16` or `32` |
+| `buffer_size` | device default | Stream buffer size in frames; smaller values reduce latency |
+
+### Detection Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `threshold` | 0.1 | Minimum amplitude to trigger (0.0–1.0) |
+| `scan_time_ms` | 5 | Window (ms) after threshold crossing to find the peak amplitude |
+| `retrigger_time_ms` | 30 | Lockout period (ms) after a trigger fires to prevent double-triggering |
+| `gain` | 1.0 | Input gain multiplier applied before threshold comparison |
+| `velocity_curve` | linear | How peak amplitude maps to velocity: `linear`, `logarithmic`, or `fixed` |
+| `fixed_velocity` | 127 | Velocity value when `velocity_curve` is `fixed` |
+
+### Signal Conditioning
+
+Optional signal conditioning features for rejecting false triggers in live stage environments. All default to off for backward compatibility.
+
+#### Per-Input Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `highpass_freq` | *(disabled)* | High-pass filter cutoff in Hz. Rejects low-frequency stage rumble and bass cab vibration using a 2nd-order Butterworth filter. Typical values: 60–120 Hz. |
+| `dynamic_threshold_decay_ms` | *(disabled)* | Decay time (ms) for an adaptive threshold that rises after each hit and exponentially decays back to the base threshold. Prevents piezo ringing from causing false re-triggers after lockout expires. Typical values: 20–80 ms. |
+| `noise_floor_sensitivity` | *(disabled)* | Sensitivity multiplier for adaptive noise floor tracking. When set, the detector continuously estimates ambient noise via an EMA (updated only during Idle state) and raises the effective threshold to `noise_ema * sensitivity` if that exceeds the configured threshold. Can only raise the threshold, never lower it. Typical value: 5.0. |
+| `noise_floor_decay_ms` | 200 | Time constant (ms) for the noise floor EMA. Controls how quickly the estimate tracks changing ambient levels. Smaller values react faster but are noisier; larger values are more stable. Only used when `noise_floor_sensitivity` is set. |
+
+#### Adaptive Noise Floor
+
+If ambient noise on a channel rises during a performance (monitor bleed, rack vibration, stage volume changes), a static threshold can end up below the noise floor and cause phantom triggers. The adaptive noise floor tracker solves this by continuously estimating ambient noise during idle periods and raising the effective threshold when the environment gets louder.
+
+Enable it by setting `noise_floor_sensitivity` on any input. The tracker computes an exponential moving average (EMA) of sample amplitude, updated **only during Idle state** (Scanning and Lockout freeze the estimate so hit transients don't pollute it). The effective threshold becomes `max(configured_threshold, noise_ema * sensitivity)`, so it can only raise the threshold above the configured value, never lower it.
+
+```yaml
+inputs:
+  - kind: audio
+    channel: 1
+    sample: "kick"
+    threshold: 0.1
+    noise_floor_sensitivity: 5.0    # enable adaptive tracking
+    noise_floor_decay_ms: 200       # default; 200ms time constant
+```
+
+#### Device-Level Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `crosstalk_window_ms` | *(disabled)* | Suppression window (ms) after any channel fires during which all other channels have their thresholds temporarily elevated. Rejects vibration bleed between pads on a shared rack. Typical values: 2–6 ms. |
+| `crosstalk_threshold` | *(disabled)* | Threshold multiplier applied to other channels during the crosstalk suppression window (e.g., `3.0` = 3x normal threshold). Both `crosstalk_window_ms` and `crosstalk_threshold` must be set to enable crosstalk suppression. |
+
+### Velocity Curves
+
+- **`linear`**: `velocity = peak * 127` (clamped to 0–127)
+- **`logarithmic`**: Maps the threshold–1.0 range logarithmically to 1–127, giving more sensitivity at lower amplitudes
+- **`fixed`**: Always uses the configured `fixed_velocity` value regardless of amplitude
+
+### Release Groups and Choke
+
+Trigger inputs can specify a `release_group` to enable voice management across inputs:
+
+- When a trigger input fires, the new voice joins the named release group.
+- A separate input with `action: release` can release (stop) all voices in that group.
+- This enables cymbal choke behavior: one piezo triggers the cymbal, another chokes it.
+
+### Latency
+
+Total trigger-to-sound latency is approximately:
+- Scan window: ~5ms (default `scan_time_ms`)
+- Sample engine scheduling delay: ~buffer_size/sample_rate (~5.8ms at 256/44100)
+- **Total: ~11ms**, well under the 20ms threshold for acceptable drum trigger response.
+
+### Calibration
+
+Manually tuning trigger parameters (threshold, gain, scan time, retrigger time, etc.) can be tedious. The `calibrate-triggers` command measures your actual hardware and generates a ready-to-paste YAML trigger configuration:
+
+```
+$ mtrack calibrate-triggers "UltraLite-mk5"
+```
+
+The calibration runs in three phases:
+
+1. **Noise floor measurement** — Keep all pads silent while the tool captures ambient noise for a few seconds.
+2. **Hit capture** — Hit each pad several times at varying velocities, then press Enter.
+3. **Analysis** — The tool analyzes the captured data and prints a YAML trigger config to stdout.
+
+Progress and diagnostics are printed to stderr, so the YAML output can be piped directly to a file:
+
+```
+$ mtrack calibrate-triggers "UltraLite-mk5" > trigger.yaml
+```
+
+Optional flags:
+
+| Flag | Description |
+|------|-------------|
+| `--sample-rate <Hz>` | Override the input sample rate |
+| `--duration <seconds>` | Noise floor measurement duration (default: 3) |
+| `--sample-format <int\|float>` | Override the sample format |
+| `--bits-per-sample <16\|32>` | Override bits per sample |
+
+The generated config includes per-channel `threshold`, `gain`, `scan_time_ms`, `retrigger_time_ms`, and optional `highpass_freq`, `dynamic_threshold_decay_ms`, and device-level `crosstalk_window_ms`/`crosstalk_threshold` — all derived from measured data. Only channels with detected hits are included. Each channel has diagnostic comments showing the number of hits detected, noise floor peak, and max hit amplitude.
 
 ## Light Show Verification
 

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -351,6 +351,51 @@ track_mappings:
 #         - universe: 1
 #           name: light-show
 #
+#   # Drum trigger node: audio output + trigger input
+#   - hostname: drum-pi
+#     audio:
+#       device: "UltraLite-mk5"
+#       track_mappings:
+#         kick: [3, 4]
+#         cymbal: [3, 4]
+#     trigger:
+#       device: "UltraLite-mk5"
+#       sample_rate: 44100
+#       # sample_format: int
+#       # bits_per_sample: 16
+#       # buffer_size: 256
+#       # crosstalk_window_ms: 4
+#       # crosstalk_threshold: 3.0
+#       inputs:
+#         - kind: audio
+#           channel: 1
+#           sample: "kick"
+#           threshold: 0.1
+#           retrigger_time_ms: 30
+#           scan_time_ms: 5
+#           gain: 1.0
+#           velocity_curve: linear
+#           release_group: "kick"
+#           # highpass_freq: 80.0
+#           # dynamic_threshold_decay_ms: 50
+#         - kind: audio
+#           channel: 3
+#           sample: "cymbal"
+#           threshold: 0.08
+#           velocity_curve: logarithmic
+#           release_group: "cymbal"
+#         - kind: audio
+#           channel: 4
+#           action: release
+#           release_group: "cymbal"
+#           threshold: 0.05
+#         - kind: midi
+#           event:
+#             type: note_on
+#             channel: 10
+#             key: 60
+#           sample: kick
+#
 #   # Fallback: minimal audio-only setup
 #   - audio:
 #       device: "Built-in Audio"
@@ -380,12 +425,18 @@ samples:
     # The audio file to play. Path is relative to this config file.
     file: songs/a-really-cool-song/click.wav
     # Output channels to route this sample to (1-indexed).
+    # Use output_channels for fixed channel numbers:
     output_channels: [3, 4]
+    # Or use output_track to reference a track mapping name from the active profile's
+    # track_mappings. This allows the same sample definition to work across different
+    # hardware profiles with different channel assignments:
+    # output_track: "kick-out"
+    # If both are set, output_track takes precedence.
     # Velocity handling mode: ignore, scale, or layers.
     velocity:
       mode: scale
     # Behavior on Note Off: play_to_completion, stop, or fade.
-    note_off: play_to_completion
+    release_behavior: play_to_completion
     # Behavior when retriggered while playing: cut or polyphonic.
     retrigger: cut
     # Maximum concurrent voices for this sample (optional).
@@ -398,7 +449,7 @@ samples:
       mode: ignore
       # Default velocity when mode is ignore (0-127).
       default: 100
-    note_off: play_to_completion
+    release_behavior: play_to_completion
     retrigger: polyphonic
     max_voices: 8
 
@@ -416,10 +467,11 @@ samples:
         file: songs/sound-check/click.wav
       - range: [101, 127]
         file: songs/a-really-fast-one/click.wav
-    note_off: play_to_completion
+    release_behavior: play_to_completion
     retrigger: polyphonic
 
 # Sample triggers map MIDI events to sample names defined above.
+# Legacy top-level form (converted to trigger config MIDI inputs at startup):
 sample_triggers:
   # Trigger the "kick" sample on MIDI Note C3 (note 60) on channel 10.
 - trigger:
@@ -444,3 +496,103 @@ sample_triggers:
 
 # Maximum number of concurrent sample voices globally. Defaults to 32.
 max_sample_voices: 32
+
+# --- Trigger Configuration ---
+#
+# Unified trigger system supporting both audio and MIDI inputs.
+# Each input requires a `kind` field: "audio" or "midi".
+#
+# trigger:
+#   # Device is required when audio inputs are configured.
+#   device: "UltraLite-mk5"
+#   sample_rate: 44100
+#   inputs:
+#     # Audio trigger input (piezo drum trigger)
+#     - kind: audio
+#       channel: 1
+#       sample: "kick"
+#       threshold: 0.1
+#       retrigger_time_ms: 30
+#       scan_time_ms: 5
+#       gain: 1.0
+#       velocity_curve: linear
+#       release_group: "kick"
+#
+#     # MIDI trigger input (replaces sample_triggers)
+#     - kind: midi
+#       event:
+#         type: note_on
+#         channel: 10
+#         key: 60
+#       sample: kick
+#
+#     # MIDI-only config (no device needed)
+#     # trigger:
+#     #   inputs:
+#     #     - kind: midi
+#     #       event:
+#     #         type: note_on
+#     #         channel: 10
+#     #         key: 60
+#     #       sample: kick
+
+# --- Audio Trigger Input (legacy top-level form) ---
+#
+# Trigger sample playback from audio input signals (e.g. piezoelectric drum triggers).
+# Uses the same sample engine as MIDI triggers — all sample features work identically.
+#
+# This can also be placed inside a hardware profile (see the "drum-pi" example in the
+# Hardware Profiles section above). The top-level form here is normalized into a profile
+# at startup.
+#
+# trigger:
+#   # The audio input device name. Run `mtrack devices` to see available devices.
+#   # Only required when audio inputs are configured.
+#   device: "UltraLite-mk5"
+#
+#   # (Optional) Sample rate for the input stream. Defaults to 44100.
+#   sample_rate: 44100
+#
+#   # (Optional) Sample format for the input stream: "int" or "float". Defaults to device native.
+#   sample_format: int
+#
+#   # (Optional) Bits per sample: 16 or 32. Defaults to device native.
+#   bits_per_sample: 16
+#
+#   # (Optional) Stream buffer size in frames. Defaults to device default.
+#   buffer_size: 256
+#
+#   # (Optional) Signal conditioning: crosstalk suppression across channels.
+#   # When any channel fires, other channels' thresholds are temporarily raised.
+#   # crosstalk_window_ms: 4     # Suppression window in ms after any channel fires
+#   # crosstalk_threshold: 3.0   # Threshold multiplier during suppression window
+#
+#   # Per-channel input configuration. Each input requires a `kind` field.
+#   inputs:
+#     # Trigger the "kick" sample on input channel 1.
+#     - kind: audio
+#       channel: 1
+#       sample: "kick"
+#       threshold: 0.1           # Amplitude threshold (0.0-1.0)
+#       retrigger_time_ms: 30    # Lockout period after trigger fires
+#       scan_time_ms: 5          # Peak detection window after threshold crossing
+#       gain: 1.0                # Input gain multiplier
+#       velocity_curve: linear   # linear | logarithmic | fixed
+#       release_group: "kick"    # Voice release group name
+#       # highpass_freq: 80.0                # High-pass filter cutoff in Hz (rejects rumble)
+#       # dynamic_threshold_decay_ms: 50     # Adaptive threshold decay time in ms (rejects ringing)
+#
+#     # Trigger a cymbal sample on input channel 3.
+#     - kind: audio
+#       channel: 3
+#       sample: "cymbal"
+#       threshold: 0.08
+#       velocity_curve: logarithmic
+#       release_group: "cymbal"
+#
+#     # Cymbal choke — releases all voices in the "cymbal" group.
+#     - kind: audio
+#       channel: 4
+#       action: release
+#       release_group: "cymbal"
+#       threshold: 0.05

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -71,6 +71,38 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     fn to_mock(&self) -> Result<Arc<mock::Device>, Box<dyn Error>>;
 }
 
+/// Finds a cpal input device by name, searching all available hosts.
+pub(crate) fn find_input_device(name: &str) -> Result<::cpal::Device, Box<dyn Error>> {
+    use ::cpal::traits::{DeviceTrait, HostTrait};
+
+    for host_id in ::cpal::available_hosts() {
+        let host = ::cpal::host_from_id(host_id)?;
+        let devices = match host.input_devices() {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    host = host_id.name(),
+                    error = %e,
+                    "Failed to list input devices for host"
+                );
+                continue;
+            }
+        };
+
+        for device in devices {
+            let device_id = match device.id() {
+                Ok(id) => id.to_string(),
+                Err(_) => continue,
+            };
+            if device_id.trim() == name.trim() {
+                return Ok(device);
+            }
+        }
+    }
+
+    Err(format!("No input device found with name '{}'", name).into())
+}
+
 /// Lists devices known to cpal.
 pub fn list_devices() -> Result<Vec<Box<dyn Device>>, Box<dyn Error>> {
     cpal::Device::list()

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1,0 +1,1107 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Auto-calibration for audio trigger detection parameters.
+//!
+//! Measures the user's hardware (noise floor, hit characteristics) and
+//! generates a ready-to-paste YAML trigger configuration.
+
+use std::error::Error;
+use std::io::{self, BufRead};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use crate::audio::format::SampleFormat;
+use cpal::traits::{DeviceTrait, StreamTrait};
+use parking_lot::Mutex;
+
+/// Configuration for a calibration run.
+pub struct CalibrationConfig {
+    pub device_name: String,
+    pub sample_rate: Option<u32>,
+    pub noise_floor_duration_secs: f32,
+    pub sample_format: Option<SampleFormat>,
+    pub bits_per_sample: Option<u16>,
+}
+
+/// Shared capture buffer for the cpal input callback.
+struct CaptureBuffer {
+    channels: Vec<Mutex<Vec<f32>>>,
+    active: AtomicBool,
+}
+
+/// Noise floor statistics for a single channel.
+struct NoiseFloorStats {
+    peak: f32,
+    rms: f32,
+    low_freq_energy: f32,
+}
+
+/// A detected hit envelope on a single channel.
+struct HitEnvelope {
+    peak_amplitude: f32,
+    onset_sample: usize,
+    peak_sample: usize,
+    decay_sample: usize,
+    ring_end_sample: Option<usize>,
+}
+
+/// Calibrated parameters for a single channel.
+struct ChannelCalibration {
+    channel: u16,
+    threshold: f32,
+    gain: f32,
+    scan_time_ms: u32,
+    retrigger_time_ms: u32,
+    highpass_freq: Option<f32>,
+    dynamic_threshold_decay_ms: Option<u32>,
+    num_hits_detected: usize,
+    noise_floor_peak: f32,
+    max_hit_amplitude: f32,
+}
+
+/// Calibrated crosstalk parameters.
+struct CrosstalkCalibration {
+    crosstalk_window_ms: Option<u32>,
+    crosstalk_threshold: Option<f32>,
+}
+
+/// Resolves stream parameters (channels, sample rate, format) from device and config.
+fn resolve_stream_params(
+    device: &cpal::Device,
+    config: &CalibrationConfig,
+) -> Result<(u16, u32, cpal::SampleFormat), Box<dyn Error>> {
+    let max_device_channels = device
+        .supported_input_configs()
+        .map(|configs| configs.map(|c| c.channels()).max().unwrap_or(0))
+        .unwrap_or(0);
+
+    let channels = if max_device_channels > 0 {
+        max_device_channels
+    } else {
+        device.default_input_config()?.channels()
+    };
+
+    let native_format = device
+        .supported_input_configs()
+        .ok()
+        .and_then(|configs| {
+            configs
+                .filter(|c| c.channels() == channels)
+                .map(|c| c.sample_format())
+                .next()
+        })
+        .unwrap_or(cpal::SampleFormat::F32);
+
+    let stream_format = match (config.sample_format, config.bits_per_sample) {
+        (Some(SampleFormat::Float), _) => cpal::SampleFormat::F32,
+        (Some(SampleFormat::Int), Some(16)) => cpal::SampleFormat::I16,
+        (Some(SampleFormat::Int), _) => cpal::SampleFormat::I32,
+        (None, Some(16)) => cpal::SampleFormat::I16,
+        (None, Some(32)) => native_format,
+        _ => native_format,
+    };
+
+    let default_config = device.default_input_config()?;
+    let sample_rate = config.sample_rate.unwrap_or(default_config.sample_rate());
+
+    Ok((channels, sample_rate, stream_format))
+}
+
+/// Builds a cpal input stream that captures samples into the buffer.
+fn build_capture_stream(
+    device: &cpal::Device,
+    stream_config: &cpal::StreamConfig,
+    buffer: Arc<CaptureBuffer>,
+    num_channels: u16,
+    sample_format: cpal::SampleFormat,
+) -> Result<cpal::Stream, Box<dyn Error>> {
+    match sample_format {
+        cpal::SampleFormat::I16 => {
+            build_capture_stream_typed::<i16>(device, stream_config, buffer, num_channels)
+        }
+        cpal::SampleFormat::I32 => {
+            build_capture_stream_typed::<i32>(device, stream_config, buffer, num_channels)
+        }
+        _ => build_capture_stream_typed::<f32>(device, stream_config, buffer, num_channels),
+    }
+}
+
+/// Typed capture stream builder — converts samples to f32 and pushes to CaptureBuffer.
+fn build_capture_stream_typed<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    buffer: Arc<CaptureBuffer>,
+    num_channels: u16,
+) -> Result<cpal::Stream, Box<dyn Error>>
+where
+    T: cpal::SizedSample + 'static,
+    f32: cpal::FromSample<T>,
+{
+    let stream = device.build_input_stream(
+        config,
+        move |data: &[T], _: &cpal::InputCallbackInfo| {
+            if !buffer.active.load(Ordering::Relaxed) {
+                return;
+            }
+            let nc = num_channels as usize;
+            for frame in data.chunks_exact(nc) {
+                for (ch_idx, raw_sample) in frame.iter().enumerate() {
+                    let sample: f32 = <f32 as cpal::FromSample<T>>::from_sample_(*raw_sample);
+                    buffer.channels[ch_idx].lock().push(sample);
+                }
+            }
+        },
+        move |err| {
+            eprintln!("Capture stream error: {}", err);
+        },
+        None,
+    )?;
+    Ok(stream)
+}
+
+/// Analyzes the noise floor from captured samples.
+fn analyze_noise_floor(samples: &[f32], sample_rate: u32) -> NoiseFloorStats {
+    if samples.is_empty() {
+        return NoiseFloorStats {
+            peak: 0.0,
+            rms: 0.0,
+            low_freq_energy: 0.0,
+        };
+    }
+
+    let peak = samples.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
+
+    let sum_sq: f64 = samples.iter().map(|s| (*s as f64) * (*s as f64)).sum();
+    let rms = (sum_sq / samples.len() as f64).sqrt() as f32;
+
+    // Estimate low-frequency energy using a simple box-filter lowpass.
+    // Window size targets ~100 Hz cutoff.
+    let window_size = (sample_rate as usize / 100).max(1);
+    let low_freq_energy = if samples.len() >= window_size {
+        let mut running_sum: f64 = samples[..window_size].iter().map(|s| *s as f64).sum();
+        let mut lf_sum_sq: f64 = 0.0;
+        let count = samples.len() - window_size + 1;
+        for i in 0..count {
+            let avg = (running_sum / window_size as f64) as f32;
+            lf_sum_sq += (avg as f64) * (avg as f64);
+            if i + window_size < samples.len() {
+                running_sum += samples[i + window_size] as f64;
+                running_sum -= samples[i] as f64;
+            }
+        }
+        (lf_sum_sq / count as f64).sqrt() as f32
+    } else {
+        rms
+    };
+
+    NoiseFloorStats {
+        peak,
+        rms,
+        low_freq_energy,
+    }
+}
+
+/// Computes the detection threshold from a noise floor measurement.
+/// Set at 5x noise peak with a minimum of 0.005 to avoid triggering on silence.
+fn detection_threshold(noise_floor: &NoiseFloorStats) -> f32 {
+    (noise_floor.peak * 5.0).max(0.005)
+}
+
+/// Detects hit envelopes from captured samples.
+///
+/// Uses a holdoff approach: after finding a peak, the signal must stay below
+/// threshold for `holdoff_samples` consecutive samples before the hit is
+/// considered finished. This prevents oscillating/ringing signals from being
+/// split into multiple spurious hits.
+fn detect_hits(
+    samples: &[f32],
+    noise_floor: &NoiseFloorStats,
+    sample_rate: u32,
+) -> Vec<HitEnvelope> {
+    let threshold = detection_threshold(noise_floor);
+    // Holdoff: signal must stay below threshold for this many consecutive
+    // samples before we consider the transient over. 50ms is long enough to
+    // ride out piezo ringing and mic oscillation.
+    let holdoff_samples = (sample_rate as f64 * 0.050) as usize; // 50ms
+
+    let mut hits = Vec::new();
+    let mut i = 0;
+
+    while i < samples.len() {
+        let abs_val = samples[i].abs();
+        if abs_val >= threshold {
+            // Found onset
+            let onset_sample = i;
+            let mut peak_amplitude: f32 = abs_val;
+            let mut peak_sample = i;
+
+            // Walk forward through the entire transient envelope.
+            // Track the peak and find the decay point — the first sample where
+            // the signal stays below threshold for `holdoff_samples` in a row.
+            let mut consecutive_below: usize = 0;
+            let mut decay_sample = i;
+            i += 1;
+            while i < samples.len() {
+                let v = samples[i].abs();
+                if v > peak_amplitude {
+                    peak_amplitude = v;
+                    peak_sample = i;
+                }
+                if v < threshold {
+                    if consecutive_below == 0 {
+                        decay_sample = i; // first sample below threshold
+                    }
+                    consecutive_below += 1;
+                    if consecutive_below >= holdoff_samples {
+                        break;
+                    }
+                } else {
+                    consecutive_below = 0;
+                }
+                i += 1;
+            }
+
+            // If we never got a sustained dip, decay_sample is the last position
+            if consecutive_below < holdoff_samples {
+                decay_sample = if i >= samples.len() {
+                    samples.len() - 1
+                } else {
+                    i
+                };
+            }
+
+            // Find ring end: signal must stay below noise floor peak for
+            // holdoff_samples consecutive samples.
+            let ring_threshold = noise_floor.peak.max(0.001);
+            let mut ring_end_sample = None;
+            let mut j = decay_sample;
+            let mut ring_consecutive: usize = 0;
+            while j < samples.len() {
+                if samples[j].abs() < ring_threshold {
+                    ring_consecutive += 1;
+                    if ring_consecutive >= holdoff_samples {
+                        ring_end_sample = Some(j - holdoff_samples + 1);
+                        break;
+                    }
+                } else {
+                    ring_consecutive = 0;
+                }
+                j += 1;
+            }
+
+            hits.push(HitEnvelope {
+                peak_amplitude,
+                onset_sample,
+                peak_sample,
+                decay_sample,
+                ring_end_sample,
+            });
+
+            // Resume scanning from whichever is furthest: end of decay holdoff,
+            // or end of ring detection. This ensures we skip the entire transient.
+            let resume_from = ring_end_sample
+                .map(|re| re + holdoff_samples)
+                .unwrap_or(decay_sample + holdoff_samples);
+            i = resume_from.max(i);
+        } else {
+            i += 1;
+        }
+    }
+
+    hits
+}
+
+/// Derives calibration parameters for a channel from its noise floor and detected hits.
+fn derive_channel_params(
+    channel: u16,
+    noise_floor: &NoiseFloorStats,
+    hits: &[HitEnvelope],
+    sample_rate: u32,
+) -> ChannelCalibration {
+    let threshold = detection_threshold(noise_floor);
+
+    let max_hit_amplitude = hits.iter().map(|h| h.peak_amplitude).fold(0.0f32, f32::max);
+
+    let gain = if max_hit_amplitude > 0.0 {
+        (0.95 / max_hit_amplitude).clamp(0.1, 50.0)
+    } else {
+        1.0
+    };
+
+    // Scan time: median attack time (onset→peak), converted to ms
+    let scan_time_ms = if !hits.is_empty() {
+        let mut attack_times: Vec<f32> = hits
+            .iter()
+            .map(|h| {
+                let samples = (h.peak_sample - h.onset_sample) as f32;
+                samples / sample_rate as f32 * 1000.0
+            })
+            .collect();
+        attack_times.sort_unstable_by(f32::total_cmp);
+        let median = attack_times[attack_times.len() / 2];
+        (median.ceil() as u32).max(1)
+    } else {
+        5
+    };
+
+    // Retrigger time: median decay time (peak→below threshold) × 1.2 safety margin
+    let retrigger_time_ms = if !hits.is_empty() {
+        let mut decay_times: Vec<f32> = hits
+            .iter()
+            .map(|h| {
+                let samples = h.decay_sample.saturating_sub(h.peak_sample) as f32;
+                samples / sample_rate as f32 * 1000.0
+            })
+            .collect();
+        decay_times.sort_unstable_by(f32::total_cmp);
+        let median = decay_times[decay_times.len() / 2];
+        ((median * 1.2).ceil() as u32).max(5)
+    } else {
+        30
+    };
+
+    // High-pass filter: enable if low-freq energy is significant relative to RMS
+    let highpass_freq =
+        if noise_floor.rms > 0.0 && noise_floor.low_freq_energy / noise_floor.rms > 0.5 {
+            Some(80.0)
+        } else {
+            None
+        };
+
+    // Dynamic threshold decay: median ringing duration if > 5ms
+    let dynamic_threshold_decay_ms = if !hits.is_empty() {
+        let ring_durations: Vec<f32> = hits
+            .iter()
+            .filter_map(|h| {
+                h.ring_end_sample.map(|re| {
+                    let samples = (re - h.decay_sample) as f32;
+                    samples / sample_rate as f32 * 1000.0
+                })
+            })
+            .collect();
+        if !ring_durations.is_empty() {
+            let mut sorted = ring_durations;
+            sorted.sort_unstable_by(f32::total_cmp);
+            let median = sorted[sorted.len() / 2];
+            if median > 5.0 {
+                Some(median.ceil() as u32)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    ChannelCalibration {
+        channel,
+        threshold,
+        gain,
+        scan_time_ms,
+        retrigger_time_ms,
+        highpass_freq,
+        dynamic_threshold_decay_ms,
+        num_hits_detected: hits.len(),
+        noise_floor_peak: noise_floor.peak,
+        max_hit_amplitude,
+    }
+}
+
+/// Analyzes crosstalk between channels.
+fn analyze_crosstalk(
+    all_samples: &[Vec<f32>],
+    all_hits: &[Vec<HitEnvelope>],
+    noise_floors: &[NoiseFloorStats],
+    sample_rate: u32,
+) -> CrosstalkCalibration {
+    let window_samples = ((5.0 / 1000.0) * sample_rate as f64).ceil() as usize;
+    let mut max_offset: usize = 0;
+    let mut max_ratio: f32 = 0.0;
+    let mut found_crosstalk = false;
+
+    for (ch, hits) in all_hits.iter().enumerate() {
+        for hit in hits {
+            let center = hit.peak_sample;
+            // Check other channels for spikes in ±window_samples around this hit
+            for (other_ch, other_samples) in all_samples.iter().enumerate() {
+                if other_ch == ch {
+                    continue;
+                }
+                let other_noise = noise_floors[other_ch].peak.max(0.001);
+                let crosstalk_detect_threshold = other_noise * 3.0;
+
+                let start = center.saturating_sub(window_samples);
+                let end = (center + window_samples).min(other_samples.len());
+
+                for (idx, sample) in other_samples.iter().enumerate().take(end).skip(start) {
+                    let v = sample.abs();
+                    if v > crosstalk_detect_threshold {
+                        found_crosstalk = true;
+                        max_offset = max_offset.max(idx.abs_diff(center));
+                        let ratio = v / other_noise;
+                        max_ratio = max_ratio.max(ratio);
+                    }
+                }
+            }
+        }
+    }
+
+    if found_crosstalk {
+        let window_ms =
+            ((max_offset as f64 / sample_rate as f64 * 1000.0).ceil() as u32 + 1).max(2);
+        let threshold = (max_ratio * 1.5).max(2.0);
+        CrosstalkCalibration {
+            crosstalk_window_ms: Some(window_ms),
+            crosstalk_threshold: Some(threshold),
+        }
+    } else {
+        CrosstalkCalibration {
+            crosstalk_window_ms: None,
+            crosstalk_threshold: None,
+        }
+    }
+}
+
+/// Writes the calibration results as YAML to stdout.
+fn write_yaml(
+    device_name: &str,
+    sample_rate: u32,
+    calibrations: &[ChannelCalibration],
+    crosstalk: &CrosstalkCalibration,
+) {
+    println!("# Auto-calibrated trigger configuration");
+    println!("# Generated by: mtrack calibrate-triggers");
+    println!("trigger:");
+    println!("  device: \"{}\"", device_name);
+    println!("  sample_rate: {}", sample_rate);
+
+    if let (Some(window), Some(thresh)) =
+        (crosstalk.crosstalk_window_ms, crosstalk.crosstalk_threshold)
+    {
+        println!("  crosstalk_window_ms: {}", window);
+        println!("  crosstalk_threshold: {:.1}", thresh);
+    }
+
+    println!("  inputs:");
+    for cal in calibrations {
+        println!("    - channel: {}", cal.channel);
+        println!("      # sample: \"TODO\"");
+        println!("      threshold: {:.4}", cal.threshold);
+        println!("      gain: {:.2}", cal.gain);
+        println!("      scan_time_ms: {}", cal.scan_time_ms);
+        println!("      retrigger_time_ms: {}", cal.retrigger_time_ms);
+        if let Some(freq) = cal.highpass_freq {
+            println!("      highpass_freq: {:.1}", freq);
+        }
+        if let Some(decay) = cal.dynamic_threshold_decay_ms {
+            println!("      dynamic_threshold_decay_ms: {}", decay);
+        }
+        println!(
+            "      # Detected {} hits, noise floor peak: {:.6}, max hit: {:.4}",
+            cal.num_hits_detected, cal.noise_floor_peak, cal.max_hit_amplitude
+        );
+    }
+}
+
+/// Runs the calibration process.
+pub fn run(config: CalibrationConfig) -> Result<(), Box<dyn Error>> {
+    let device = crate::audio::find_input_device(&config.device_name)?;
+
+    let device_id = device
+        .id()
+        .map(|id| id.to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    eprintln!("Found input device: {}", device_id);
+
+    let (channels, sample_rate, stream_format) = resolve_stream_params(&device, &config)?;
+    eprintln!(
+        "Stream config: {} channels, {}Hz, {:?}",
+        channels, sample_rate, stream_format
+    );
+
+    let stream_config = cpal::StreamConfig {
+        channels,
+        sample_rate,
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    // Pre-allocate capacity for expected duration
+    let expected_samples = (config.noise_floor_duration_secs * sample_rate as f32) as usize + 1024;
+
+    // --- Phase 1: Noise floor ---
+    eprintln!(
+        "\nPhase 1: Measuring noise floor ({:.0}s) -- keep all pads silent...",
+        config.noise_floor_duration_secs
+    );
+
+    let buffer = Arc::new(CaptureBuffer {
+        channels: (0..channels)
+            .map(|_| Mutex::new(Vec::with_capacity(expected_samples)))
+            .collect(),
+        active: AtomicBool::new(true),
+    });
+
+    let stream = build_capture_stream(
+        &device,
+        &stream_config,
+        buffer.clone(),
+        channels,
+        stream_format,
+    )?;
+    stream.play()?;
+
+    std::thread::sleep(std::time::Duration::from_secs_f32(
+        config.noise_floor_duration_secs,
+    ));
+
+    buffer.active.store(false, Ordering::Relaxed);
+    drop(stream);
+
+    let noise_samples: Vec<Vec<f32>> = buffer
+        .channels
+        .iter()
+        .map(|ch| std::mem::take(&mut *ch.lock()))
+        .collect();
+
+    let noise_floors: Vec<NoiseFloorStats> = noise_samples
+        .iter()
+        .map(|s| analyze_noise_floor(s, sample_rate))
+        .collect();
+
+    eprintln!("\nNoise floor results:");
+    for (i, nf) in noise_floors.iter().enumerate() {
+        eprintln!(
+            "  Channel {}: peak={:.6}, rms={:.6}",
+            i + 1,
+            nf.peak,
+            nf.rms
+        );
+    }
+
+    // --- Phase 2: Capture hits ---
+    eprintln!("\nPhase 2: Hit each pad several times at varying velocities.");
+    eprintln!("         Press Enter when done.");
+
+    // Allocate generous buffer for hit capture (up to ~60 seconds)
+    let hit_capacity = (60.0 * sample_rate as f32) as usize;
+    let hit_buffer = Arc::new(CaptureBuffer {
+        channels: (0..channels)
+            .map(|_| Mutex::new(Vec::with_capacity(hit_capacity)))
+            .collect(),
+        active: AtomicBool::new(true),
+    });
+
+    let hit_stream = build_capture_stream(
+        &device,
+        &stream_config,
+        hit_buffer.clone(),
+        channels,
+        stream_format,
+    )?;
+    hit_stream.play()?;
+
+    // Wait for user to press Enter
+    let stdin = io::stdin();
+    let _ = stdin.lock().lines().next();
+
+    hit_buffer.active.store(false, Ordering::Relaxed);
+    drop(hit_stream);
+
+    let hit_samples: Vec<Vec<f32>> = hit_buffer
+        .channels
+        .iter()
+        .map(|ch| std::mem::take(&mut *ch.lock()))
+        .collect();
+
+    // --- Phase 3: Analysis ---
+    eprintln!("\nPhase 3: Analyzing captured data...");
+
+    let all_hits: Vec<Vec<HitEnvelope>> = hit_samples
+        .iter()
+        .zip(noise_floors.iter())
+        .map(|(samples, nf)| detect_hits(samples, nf, sample_rate))
+        .collect();
+
+    let mut calibrations = Vec::new();
+    for (i, (hits, nf)) in all_hits.iter().zip(noise_floors.iter()).enumerate() {
+        if hits.is_empty() {
+            continue;
+        }
+        let channel = (i + 1) as u16;
+        eprintln!("  Channel {}: {} hits detected", channel, hits.len());
+        calibrations.push(derive_channel_params(channel, nf, hits, sample_rate));
+    }
+
+    if calibrations.is_empty() {
+        eprintln!("\nNo hits detected on any channel. Make sure your pads are connected and producing signal.");
+        return Ok(());
+    }
+
+    let crosstalk = analyze_crosstalk(&hit_samples, &all_hits, &noise_floors, sample_rate);
+
+    eprintln!();
+    write_yaml(&config.device_name, sample_rate, &calibrations, &crosstalk);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Generates a synthetic transient signal for testing.
+    fn make_transient(
+        noise_level: f32,
+        peak: f32,
+        attack_samples: usize,
+        decay_samples: usize,
+        total_samples: usize,
+        onset: usize,
+    ) -> Vec<f32> {
+        let mut samples = vec![0.0; total_samples];
+
+        // Fill with noise
+        for (i, s) in samples.iter_mut().enumerate() {
+            // Simple deterministic "noise" pattern
+            *s = noise_level * ((i as f32 * 0.7).sin() * 0.5 + (i as f32 * 1.3).cos() * 0.5);
+        }
+
+        // Add transient
+        if onset < total_samples {
+            // Attack ramp
+            for j in 0..attack_samples.min(total_samples - onset) {
+                let t = j as f32 / attack_samples as f32;
+                let idx = onset + j;
+                if idx < total_samples {
+                    samples[idx] = peak * t;
+                }
+            }
+
+            // Decay ramp
+            let peak_pos = onset + attack_samples;
+            for j in 0..decay_samples {
+                let t = 1.0 - (j as f32 / decay_samples as f32);
+                let idx = peak_pos + j;
+                if idx < total_samples {
+                    samples[idx] = peak * t;
+                }
+            }
+        }
+
+        samples
+    }
+
+    #[test]
+    fn test_analyze_noise_floor_silence() {
+        let samples = vec![0.0; 44100];
+        let stats = analyze_noise_floor(&samples, 44100);
+        assert_eq!(stats.peak, 0.0);
+        assert_eq!(stats.rms, 0.0);
+        assert_eq!(stats.low_freq_energy, 0.0);
+    }
+
+    #[test]
+    fn test_analyze_noise_floor_with_noise() {
+        let samples: Vec<f32> = (0..44100).map(|i| 0.002 * (i as f32 * 0.1).sin()).collect();
+        let stats = analyze_noise_floor(&samples, 44100);
+        assert!(stats.peak > 0.0 && stats.peak <= 0.002);
+        assert!(stats.rms > 0.0 && stats.rms < stats.peak);
+    }
+
+    #[test]
+    fn test_detect_hits_single_hit() {
+        let samples = make_transient(0.001, 0.8, 50, 500, 44100, 5000);
+        let nf = NoiseFloorStats {
+            peak: 0.001,
+            rms: 0.0007,
+            low_freq_energy: 0.0003,
+        };
+        let hits = detect_hits(&samples, &nf, 44100);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].peak_amplitude > 0.7);
+        assert!(hits[0].onset_sample >= 5000);
+        assert!(hits[0].peak_sample > hits[0].onset_sample);
+    }
+
+    #[test]
+    fn test_detect_hits_multiple_hits() {
+        let sample_rate = 44100;
+        let total = sample_rate * 3; // 3 seconds
+        let mut samples = vec![0.0f32; total];
+
+        // Add noise
+        for (i, s) in samples.iter_mut().enumerate() {
+            *s = 0.001 * (i as f32 * 0.7).sin();
+        }
+
+        // Add 3 transients well-separated
+        for &onset in &[10000, 50000, 90000] {
+            for j in 0..50 {
+                let idx = onset + j;
+                if idx < total {
+                    samples[idx] = 0.7 * (j as f32 / 50.0);
+                }
+            }
+            for j in 0..2000 {
+                let idx = onset + 50 + j;
+                if idx < total {
+                    samples[idx] = 0.7 * (1.0 - j as f32 / 2000.0);
+                }
+            }
+        }
+
+        let nf = NoiseFloorStats {
+            peak: 0.001,
+            rms: 0.0007,
+            low_freq_energy: 0.0003,
+        };
+        let hits = detect_hits(&samples, &nf, sample_rate as u32);
+        assert_eq!(hits.len(), 3);
+    }
+
+    #[test]
+    fn test_detect_hits_no_hits() {
+        let samples: Vec<f32> = (0..44100).map(|i| 0.001 * (i as f32 * 0.3).sin()).collect();
+        let nf = NoiseFloorStats {
+            peak: 0.003,
+            rms: 0.002,
+            low_freq_energy: 0.001,
+        };
+        let hits = detect_hits(&samples, &nf, 44100);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_detect_hits_with_ringing() {
+        let sample_rate: u32 = 44100;
+        let total = sample_rate as usize * 2;
+        let noise = 0.001;
+
+        // Build a signal: noise + transient + slow decay (ringing)
+        let mut samples = vec![0.0f32; total];
+        for (i, s) in samples.iter_mut().enumerate() {
+            *s = noise * (i as f32 * 0.7).sin();
+        }
+
+        // Transient at sample 5000
+        let onset = 5000;
+        let peak = 0.8;
+        let attack = 30;
+        let decay = 200;
+        let ring_duration = 4000; // ~90ms of ringing
+
+        for j in 0..attack {
+            let idx = onset + j;
+            samples[idx] = peak * (j as f32 / attack as f32);
+        }
+        // Quick decay to threshold-ish level
+        let peak_pos = onset + attack;
+        for j in 0..decay {
+            let idx = peak_pos + j;
+            if idx < total {
+                samples[idx] = peak * (1.0 - j as f32 / decay as f32);
+            }
+        }
+        // Ringing: slowly decaying above noise floor
+        let ring_start = peak_pos + decay;
+        for j in 0..ring_duration {
+            let idx = ring_start + j;
+            if idx < total {
+                // Decay from ~threshold level down to noise
+                let ring_level =
+                    noise * 5.0 * (1.0 - j as f32 / ring_duration as f32) + noise * 0.5;
+                samples[idx] = ring_level * (j as f32 * 2.0).sin();
+            }
+        }
+
+        let nf = NoiseFloorStats {
+            peak: noise,
+            rms: noise * 0.7,
+            low_freq_energy: noise * 0.3,
+        };
+        let hits = detect_hits(&samples, &nf, sample_rate);
+        assert_eq!(hits.len(), 1);
+        // Should have detected ringing
+        assert!(hits[0].ring_end_sample.is_some());
+    }
+
+    #[test]
+    fn test_derive_params_basic() {
+        let nf = NoiseFloorStats {
+            peak: 0.003,
+            rms: 0.002,
+            low_freq_energy: 0.0005,
+        };
+        let hits = vec![HitEnvelope {
+            peak_amplitude: 0.72,
+            onset_sample: 1000,
+            peak_sample: 1100,
+            decay_sample: 2200,
+            ring_end_sample: None,
+        }];
+        let cal = derive_channel_params(1, &nf, &hits, 44100);
+        assert_eq!(cal.channel, 1);
+        // threshold = max(0.003 * 5, 0.005) = 0.015
+        assert!((cal.threshold - 0.015).abs() < 0.001);
+        // gain = 0.95 / 0.72 ≈ 1.319
+        assert!((cal.gain - 1.319).abs() < 0.1);
+        assert!(cal.scan_time_ms >= 1);
+        assert!(cal.retrigger_time_ms >= 5);
+        assert_eq!(cal.highpass_freq, None); // low_freq / rms = 0.25 < 0.5
+    }
+
+    #[test]
+    fn test_derive_params_highpass() {
+        let nf = NoiseFloorStats {
+            peak: 0.003,
+            rms: 0.002,
+            low_freq_energy: 0.0015, // ratio = 0.75 > 0.5
+        };
+        let hits = vec![HitEnvelope {
+            peak_amplitude: 0.5,
+            onset_sample: 1000,
+            peak_sample: 1050,
+            decay_sample: 2000,
+            ring_end_sample: None,
+        }];
+        let cal = derive_channel_params(1, &nf, &hits, 44100);
+        assert_eq!(cal.highpass_freq, Some(80.0));
+    }
+
+    #[test]
+    fn test_derive_params_dynamic_threshold() {
+        let nf = NoiseFloorStats {
+            peak: 0.001,
+            rms: 0.0007,
+            low_freq_energy: 0.0002,
+        };
+        let hits = vec![HitEnvelope {
+            peak_amplitude: 0.6,
+            onset_sample: 1000,
+            peak_sample: 1050,
+            decay_sample: 1500,
+            // ~23ms of ringing at 44100Hz
+            ring_end_sample: Some(1500 + 1000),
+        }];
+        let cal = derive_channel_params(1, &nf, &hits, 44100);
+        assert!(cal.dynamic_threshold_decay_ms.is_some());
+        let decay = cal.dynamic_threshold_decay_ms.unwrap();
+        assert!(decay > 5);
+    }
+
+    #[test]
+    fn test_crosstalk_detected() {
+        let sample_rate: u32 = 44100;
+        let total = 44100;
+
+        // Channel 0: has a hit at sample 5000
+        let mut ch0 = vec![0.0f32; total];
+        for j in 0..100 {
+            let idx = 5000 + j;
+            ch0[idx] = 0.8 * (1.0 - j as f32 / 100.0);
+        }
+
+        // Channel 1: has a correlated spike near sample 5000 (crosstalk)
+        let mut ch1 = vec![0.0f32; total];
+        for j in 0..50 {
+            let idx = 5010 + j;
+            if idx < total {
+                ch1[idx] = 0.05 * (1.0 - j as f32 / 50.0);
+            }
+        }
+
+        let nf0 = NoiseFloorStats {
+            peak: 0.001,
+            rms: 0.0007,
+            low_freq_energy: 0.0003,
+        };
+        let nf1 = NoiseFloorStats {
+            peak: 0.001,
+            rms: 0.0007,
+            low_freq_energy: 0.0003,
+        };
+
+        let hits0 = vec![HitEnvelope {
+            peak_amplitude: 0.8,
+            onset_sample: 5000,
+            peak_sample: 5000,
+            decay_sample: 5100,
+            ring_end_sample: None,
+        }];
+        let hits1 = vec![];
+
+        let all_samples = vec![ch0, ch1];
+        let all_hits = vec![hits0, hits1];
+        let noise_floors = vec![nf0, nf1];
+
+        let ct = analyze_crosstalk(&all_samples, &all_hits, &noise_floors, sample_rate);
+        assert!(ct.crosstalk_window_ms.is_some());
+        assert!(ct.crosstalk_threshold.is_some());
+        assert!(ct.crosstalk_threshold.unwrap() >= 2.0);
+    }
+
+    #[test]
+    fn test_crosstalk_absent() {
+        let total = 44100;
+
+        // Channel 0: hit at sample 5000
+        let mut ch0 = vec![0.0f32; total];
+        for j in 0..100 {
+            ch0[5000 + j] = 0.8 * (1.0 - j as f32 / 100.0);
+        }
+
+        // Channel 1: hit far away at sample 30000 (independent)
+        let mut ch1 = vec![0.0f32; total];
+        for j in 0..100 {
+            ch1[30000 + j] = 0.6 * (1.0 - j as f32 / 100.0);
+        }
+
+        let nf = NoiseFloorStats {
+            peak: 0.001,
+            rms: 0.0007,
+            low_freq_energy: 0.0003,
+        };
+
+        let hits0 = vec![HitEnvelope {
+            peak_amplitude: 0.8,
+            onset_sample: 5000,
+            peak_sample: 5000,
+            decay_sample: 5100,
+            ring_end_sample: None,
+        }];
+        let hits1 = vec![HitEnvelope {
+            peak_amplitude: 0.6,
+            onset_sample: 30000,
+            peak_sample: 30000,
+            decay_sample: 30100,
+            ring_end_sample: None,
+        }];
+
+        let all_samples = vec![ch0, ch1];
+        let all_hits = vec![hits0, hits1];
+        let noise_floors = vec![
+            NoiseFloorStats {
+                peak: nf.peak,
+                rms: nf.rms,
+                low_freq_energy: nf.low_freq_energy,
+            },
+            NoiseFloorStats {
+                peak: 0.001,
+                rms: 0.0007,
+                low_freq_energy: 0.0003,
+            },
+        ];
+
+        let ct = analyze_crosstalk(&all_samples, &all_hits, &noise_floors, 44100);
+        assert!(ct.crosstalk_window_ms.is_none());
+        assert!(ct.crosstalk_threshold.is_none());
+    }
+
+    #[test]
+    fn test_yaml_output() {
+        let calibrations = vec![
+            ChannelCalibration {
+                channel: 1,
+                threshold: 0.0160,
+                gain: 1.32,
+                scan_time_ms: 3,
+                retrigger_time_ms: 25,
+                highpass_freq: Some(80.0),
+                dynamic_threshold_decay_ms: Some(40),
+                num_hits_detected: 12,
+                noise_floor_peak: 0.003200,
+                max_hit_amplitude: 0.7200,
+            },
+            ChannelCalibration {
+                channel: 3,
+                threshold: 0.0080,
+                gain: 1.58,
+                scan_time_ms: 2,
+                retrigger_time_ms: 20,
+                highpass_freq: None,
+                dynamic_threshold_decay_ms: None,
+                num_hits_detected: 8,
+                noise_floor_peak: 0.001600,
+                max_hit_amplitude: 0.6000,
+            },
+        ];
+        let crosstalk = CrosstalkCalibration {
+            crosstalk_window_ms: Some(4),
+            crosstalk_threshold: Some(2.8),
+        };
+
+        // Just verify it doesn't panic — actual output goes to stdout
+        write_yaml("UltraLite-mk5", 44100, &calibrations, &crosstalk);
+    }
+
+    #[test]
+    fn test_detect_hits_oscillating_signal_counts_as_one() {
+        // Simulates what a condenser mic tap looks like: the signal oscillates
+        // above and below threshold many times as it rings down.  Before the
+        // holdoff fix this would produce dozens of spurious hits.
+        let sample_rate: u32 = 44100;
+        let total = sample_rate as usize * 2;
+        let noise = 0.001;
+        let mut samples = vec![0.0f32; total];
+
+        // Background noise
+        for (i, s) in samples.iter_mut().enumerate() {
+            *s = noise * (i as f32 * 0.7).sin();
+        }
+
+        // A single tap at sample 5000: fast attack, then decaying oscillation
+        // that repeatedly crosses the threshold (5 * noise = 0.005).
+        let onset = 5000;
+        let peak = 0.6;
+        // Decaying sinusoid: amplitude * e^(-t/tau) * sin(freq * t)
+        let decay_tau = 3000.0f32; // ~68ms time constant
+        let osc_freq = 800.0; // Hz — fast oscillation
+        let ring_len = 15000; // ~340ms of ringing
+        for j in 0..ring_len {
+            let idx = onset + j;
+            if idx >= total {
+                break;
+            }
+            let t = j as f32;
+            let envelope = peak * (-t / decay_tau).exp();
+            let osc = (2.0 * std::f32::consts::PI * osc_freq * t / sample_rate as f32).sin();
+            samples[idx] = envelope * osc;
+        }
+
+        let nf = NoiseFloorStats {
+            peak: noise,
+            rms: noise * 0.7,
+            low_freq_energy: noise * 0.3,
+        };
+        let hits = detect_hits(&samples, &nf, sample_rate);
+        assert_eq!(
+            hits.len(),
+            1,
+            "Oscillating decay from a single tap should be detected as 1 hit, got {}",
+            hits.len()
+        );
+        assert!(hits[0].peak_amplitude > 0.4);
+    }
+
+    #[test]
+    fn test_analyze_noise_floor_empty() {
+        let stats = analyze_noise_floor(&[], 44100);
+        assert_eq!(stats.peak, 0.0);
+        assert_eq!(stats.rms, 0.0);
+        assert_eq!(stats.low_freq_energy, 0.0);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,6 +173,23 @@ enum Commands {
         #[arg[short, long]]
         host_port: Option<String>,
     },
+    /// Auto-calibrate trigger detection parameters from a connected audio input device.
+    CalibrateTriggers {
+        /// Audio input device name (as shown by `mtrack devices`).
+        device: String,
+        /// Sample rate override.
+        #[arg(long)]
+        sample_rate: Option<u32>,
+        /// Noise floor measurement duration in seconds.
+        #[arg(long, default_value = "3")]
+        duration: f32,
+        /// Sample format override: "int" or "float".
+        #[arg(long)]
+        sample_format: Option<String>,
+        /// Bits per sample override: 16 or 32.
+        #[arg(long)]
+        bits_per_sample: Option<u16>,
+    },
     /// Verifies songs in a repository against the player config.
     Verify {
         /// The path to the mtrack.yaml player config file.
@@ -236,6 +253,19 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 )
             )
         }
+        Commands::CalibrateTriggers {
+            device,
+            sample_rate,
+            duration,
+            sample_format,
+            bits_per_sample,
+        } => local::calibrate_triggers(
+            &device,
+            sample_rate,
+            duration,
+            sample_format,
+            bits_per_sample,
+        )?,
         Commands::VerifyLightShow { show_path, config } => {
             local::verify_light_show(&show_path, config.as_deref())?
         }

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -12,17 +12,22 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+use std::collections::HashSet;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use tracing::info;
+
+use crate::audio::format::SampleFormat;
+use crate::calibrate;
 use crate::config;
 use crate::lighting::parser::parse_light_shows;
 use crate::lighting::validation::validate_groups;
 use crate::playlist::Playlist;
 use crate::songs;
 use crate::verify;
-use std::collections::HashSet;
-use std::error::Error;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tracing::info;
 
 /// Default thread priority on the [0; 100) scale when MTRACK_THREAD_PRIORITY is unset.
 /// On Linux (normal scheduling) this is roughly in the nice -8 to -10 range—higher than default 0 but below max.
@@ -142,6 +147,31 @@ pub async fn start(player_path: &str, playlist_path: Option<String>) -> Result<(
         .join()
         .await?;
     Ok(())
+}
+
+pub fn calibrate_triggers(
+    device: &str,
+    sample_rate: Option<u32>,
+    duration: f32,
+    sample_format: Option<String>,
+    bits_per_sample: Option<u16>,
+) -> Result<(), Box<dyn Error>> {
+    if duration <= 0.0 || !duration.is_finite() {
+        return Err("--duration must be a positive finite number".into());
+    }
+
+    let fmt = sample_format
+        .as_deref()
+        .map(SampleFormat::from_str)
+        .transpose()?;
+
+    calibrate::run(calibrate::CalibrationConfig {
+        device_name: device.to_string(),
+        sample_rate,
+        noise_floor_duration_secs: duration,
+        sample_format: fmt,
+        bits_per_sample,
+    })
 }
 
 pub fn verify_light_show(show_path: &str, config_path: Option<&str>) -> Result<(), Box<dyn Error>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ mod song;
 mod statusevents;
 mod track;
 mod trackmappings;
+pub mod trigger;
 
 pub use self::audio::{Audio, StreamBufferSize};
 pub use self::controller::Controller;
@@ -50,7 +51,7 @@ pub use self::hostname::resolve_hostname;
 pub use self::profile::Profile;
 #[allow(unused_imports)]
 pub use self::samples::{
-    NoteOffBehavior, RetriggerBehavior, SampleDefinition, SampleTrigger, SamplesConfig,
+    ReleaseBehavior, RetriggerBehavior, SampleDefinition, SampleTrigger, SamplesConfig,
     VelocityConfig, VelocityLayer, VelocityMode,
 };
 pub use self::song::{LightShow, LightingShow, MidiPlayback, Song};

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -19,6 +19,7 @@ use super::profile::{filter_by_hostname, AudioConfig, Profile};
 use super::samples::{SampleDefinition, SampleTrigger, SamplesConfig, DEFAULT_MAX_SAMPLE_VOICES};
 use super::statusevents::StatusEvents;
 use super::trackmappings::TrackMappings;
+use super::trigger::{MidiTriggerInput, TriggerConfig, TriggerInput};
 use config::{Config, File};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -27,7 +28,7 @@ use std::sync::LazyLock;
 
 use super::error::ConfigError;
 use std::error::Error;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Empty track mappings used as a fallback reference.
 static EMPTY_TRACK_MAPPINGS: LazyLock<HashMap<String, Vec<u16>>> = LazyLock::new(HashMap::new);
@@ -52,6 +53,8 @@ pub struct Player {
     midi: Option<Midi>,
     /// The DMX configuration. (legacy)
     dmx: Option<Dmx>,
+    /// Audio trigger configuration. (legacy, now in profiles)
+    trigger: Option<TriggerConfig>,
     /// Unified hardware profiles, tried in priority order.
     /// Each profile contains audio (optional), MIDI (optional), and DMX (optional) configs.
     profiles: Option<Vec<Profile>>,
@@ -94,6 +97,7 @@ impl Player {
             midi_device: None,
             midi,
             dmx,
+            trigger: None,
             profiles: None,
             profiles_dir: None,
             status_events: None,
@@ -188,36 +192,71 @@ impl Player {
     /// Normalizes legacy configuration fields into profiles.
     /// After normalization, `profiles` is the source of truth.
     fn normalize(&mut self) {
-        if self.profiles.is_none() {
-            // Build a single profile from legacy fields
-            let audio = if let Some(audio) = &self.audio {
-                Some(audio.clone())
-            } else {
-                self.audio_device.as_ref().map(|d| Audio::new(d))
-            };
-
-            let audio_config = audio.map(|audio| {
-                let track_mappings = self
-                    .track_mappings
-                    .as_ref()
-                    .map(|tm| tm.track_mappings.clone())
-                    .unwrap_or_default();
-                AudioConfig::new(audio, track_mappings)
-            });
-
-            let midi = if let Some(midi) = &self.midi {
-                Some(midi.clone())
-            } else {
-                self.midi_device.as_ref().map(|d| Midi::new(d, None))
-            };
-
-            let dmx = self.dmx.clone();
-
-            // Create a profile if any subsystem is configured.
-            if audio_config.is_some() || midi.is_some() || dmx.is_some() {
-                let profile = Profile::new(None, audio_config, midi, dmx);
-                self.profiles = Some(vec![profile]);
+        if self.profiles.is_some() {
+            // Warn about legacy fields that will be ignored.
+            if self.audio.is_some() || self.audio_device.is_some() {
+                warn!("top-level 'audio'/'audio_device' ignored when 'profiles' is present");
             }
+            if self.midi.is_some() || self.midi_device.is_some() {
+                warn!("top-level 'midi'/'midi_device' ignored when 'profiles' is present");
+            }
+            if self.dmx.is_some() {
+                warn!("top-level 'dmx' ignored when 'profiles' is present");
+            }
+            if self.trigger.is_some() {
+                warn!("top-level 'trigger' ignored when 'profiles' is present");
+            }
+            if self.track_mappings.is_some() {
+                warn!("top-level 'track_mappings' ignored when 'profiles' is present");
+            }
+            if !self.sample_triggers.is_empty() {
+                warn!("top-level 'sample_triggers' ignored when 'profiles' is present");
+            }
+            return;
+        }
+
+        // Build a single profile from legacy fields.
+        let audio = if let Some(audio) = &self.audio {
+            Some(audio.clone())
+        } else {
+            self.audio_device.as_ref().map(|d| Audio::new(d))
+        };
+
+        let audio_config = audio.map(|audio| {
+            let track_mappings = self
+                .track_mappings
+                .as_ref()
+                .map(|tm| tm.track_mappings.clone())
+                .unwrap_or_default();
+            AudioConfig::new(audio, track_mappings)
+        });
+
+        let midi = if let Some(midi) = &self.midi {
+            Some(midi.clone())
+        } else {
+            self.midi_device.as_ref().map(|d| Midi::new(d, None))
+        };
+
+        let dmx = self.dmx.clone();
+        let mut trigger = self.trigger.clone();
+
+        // Convert legacy sample_triggers → TriggerInput::Midi entries
+        if !self.sample_triggers.is_empty() {
+            let trigger_config =
+                trigger.get_or_insert_with(|| TriggerConfig::new_midi_only(vec![]));
+            for st in &self.sample_triggers {
+                trigger_config.add_input(TriggerInput::Midi(MidiTriggerInput::new(
+                    st.trigger().clone(),
+                    st.sample().to_string(),
+                )));
+            }
+        }
+
+        // Create a profile if any subsystem is configured.
+        if audio_config.is_some() || midi.is_some() || dmx.is_some() || trigger.is_some() {
+            let mut profile = Profile::new(None, audio_config, midi, dmx);
+            profile.set_trigger(trigger);
+            self.profiles = Some(vec![profile]);
         }
     }
 
@@ -336,7 +375,7 @@ impl Player {
     pub fn samples_config(&self, player_path: &Path) -> Result<SamplesConfig, Box<dyn Error>> {
         let mut config = SamplesConfig::new(
             self.samples.clone(),
-            self.sample_triggers.clone(),
+            Vec::new(),
             self.max_sample_voices.unwrap_or(DEFAULT_MAX_SAMPLE_VOICES),
         );
 
@@ -777,6 +816,64 @@ dmx:
         assert_eq!(profiles.len(), 1);
         assert!(profiles[0].dmx().is_some());
         assert_eq!(profiles[0].dmx().unwrap().dimming_speed_modifier(), 0.25);
+    }
+
+    #[test]
+    fn test_trigger_only_normalizes_into_profile() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+trigger:
+  device: "UltraLite-mk5"
+  inputs:
+    - kind: audio
+      channel: 1
+      sample: "kick"
+"#,
+        );
+
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert!(profiles[0].audio_config().is_none());
+        assert!(profiles[0].midi().is_none());
+        assert!(profiles[0].dmx().is_none());
+        assert!(profiles[0].trigger().is_some());
+        assert_eq!(
+            profiles[0].trigger().unwrap().device(),
+            Some("UltraLite-mk5")
+        );
+    }
+
+    #[test]
+    fn test_trigger_with_audio_normalizes_into_profile() {
+        let player = player_from_yaml(
+            r#"
+songs: songs
+audio:
+  device: mock-device
+track_mappings:
+  click: [1]
+trigger:
+  device: "UltraLite-mk5"
+  inputs:
+    - kind: audio
+      channel: 1
+      sample: "kick"
+"#,
+        );
+
+        let profiles = player.all_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert!(profiles[0].audio_config().is_some());
+        assert!(profiles[0].trigger().is_some());
+        assert_eq!(
+            profiles[0].audio_config().unwrap().audio().device(),
+            "mock-device"
+        );
+        assert_eq!(
+            profiles[0].trigger().unwrap().device(),
+            Some("UltraLite-mk5")
+        );
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 use super::audio::Audio;
 use super::dmx::Dmx;
 use super::midi::Midi;
+use super::trigger::TriggerConfig;
 
 /// Audio configuration with track mappings.
 #[derive(Deserialize, Clone)]
@@ -63,6 +64,9 @@ pub struct Profile {
 
     /// DMX configuration (optional if absent from profile).
     dmx: Option<Dmx>,
+
+    /// Audio trigger configuration (optional).
+    trigger: Option<TriggerConfig>,
 }
 
 impl Profile {
@@ -78,6 +82,7 @@ impl Profile {
             audio,
             midi,
             dmx,
+            trigger: None,
         }
     }
 
@@ -99,6 +104,16 @@ impl Profile {
     /// Returns the DMX configuration.
     pub fn dmx(&self) -> Option<&Dmx> {
         self.dmx.as_ref()
+    }
+
+    /// Returns the trigger configuration, if present.
+    pub fn trigger(&self) -> Option<&TriggerConfig> {
+        self.trigger.as_ref()
+    }
+
+    /// Sets the trigger configuration (used during legacy config normalization).
+    pub(super) fn set_trigger(&mut self, trigger: Option<TriggerConfig>) {
+        self.trigger = trigger;
     }
 }
 

--- a/src/config/samples.rs
+++ b/src/config/samples.rs
@@ -30,15 +30,21 @@ pub struct SampleDefinition {
     file: Option<String>,
 
     /// The output channels to route this sample to (1-indexed).
+    #[serde(default)]
     output_channels: Vec<u16>,
+
+    /// A track mapping name to resolve output channels from the profile's track_mappings.
+    /// Mutually exclusive with output_channels; if both are set, output_track takes precedence.
+    #[serde(default)]
+    output_track: Option<String>,
 
     /// Velocity handling configuration.
     #[serde(default)]
     velocity: VelocityConfig,
 
-    /// Behavior when a Note Off event is received.
-    #[serde(default)]
-    note_off: NoteOffBehavior,
+    /// Behavior when the voice is released (e.g. Note Off, trigger release).
+    #[serde(default, alias = "note_off")]
+    release_behavior: ReleaseBehavior,
 
     /// Behavior when the sample is retriggered while still playing.
     #[serde(default)]
@@ -48,7 +54,7 @@ pub struct SampleDefinition {
     /// If not set, only the global limit applies.
     max_voices: Option<u32>,
 
-    /// Fade time in milliseconds for note_off: fade behavior.
+    /// Fade time in milliseconds for release_behavior: fade.
     #[serde(default = "default_fade_time_ms")]
     fade_time_ms: u32,
 }
@@ -63,9 +69,14 @@ impl SampleDefinition {
         &self.output_channels
     }
 
-    /// Gets the note-off behavior.
-    pub fn note_off(&self) -> NoteOffBehavior {
-        self.note_off
+    /// Gets the output track name for profile-based routing.
+    pub fn output_track(&self) -> Option<&str> {
+        self.output_track.as_deref()
+    }
+
+    /// Gets the release behavior.
+    pub fn release_behavior(&self) -> ReleaseBehavior {
+        self.release_behavior
     }
 
     /// Gets the retrigger behavior.
@@ -135,7 +146,7 @@ impl SampleDefinition {
         file: Option<String>,
         output_channels: Vec<u16>,
         velocity: VelocityConfig,
-        note_off: NoteOffBehavior,
+        release_behavior: ReleaseBehavior,
         retrigger: RetriggerBehavior,
         max_voices: Option<u32>,
         fade_time_ms: u32,
@@ -143,8 +154,32 @@ impl SampleDefinition {
         Self {
             file,
             output_channels,
+            output_track: None,
             velocity,
-            note_off,
+            release_behavior,
+            retrigger,
+            max_voices,
+            fade_time_ms,
+        }
+    }
+
+    /// Creates a new sample definition with output_track (test only).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_output_track(
+        file: Option<String>,
+        output_track: &str,
+        velocity: VelocityConfig,
+        release_behavior: ReleaseBehavior,
+        retrigger: RetriggerBehavior,
+        max_voices: Option<u32>,
+        fade_time_ms: u32,
+    ) -> Self {
+        Self {
+            file,
+            output_channels: Vec::new(),
+            output_track: Some(output_track.to_string()),
+            velocity,
+            release_behavior,
             retrigger,
             max_voices,
             fade_time_ms,
@@ -239,16 +274,16 @@ impl VelocityLayer {
     }
 }
 
-/// Behavior when a Note Off event is received for a playing sample.
+/// Behavior when a voice is released (e.g. Note Off, trigger release).
 #[derive(Deserialize, Clone, Copy, Serialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum NoteOffBehavior {
-    /// Let the sample play to completion, ignoring Note Off.
+pub enum ReleaseBehavior {
+    /// Let the sample play to completion, ignoring the release.
     #[default]
     PlayToCompletion,
-    /// Immediately stop the sample on Note Off.
+    /// Immediately stop the sample on release.
     Stop,
-    /// Fade out the sample over a short duration on Note Off.
+    /// Fade out the sample over a short duration on release.
     Fade,
 }
 
@@ -274,6 +309,11 @@ pub struct SampleTrigger {
 }
 
 impl SampleTrigger {
+    /// Creates a new SampleTrigger.
+    pub fn new(trigger: midi::Event, sample: String) -> Self {
+        Self { trigger, sample }
+    }
+
     /// Gets the MIDI event that triggers the sample.
     pub fn trigger(&self) -> &midi::Event {
         &self.trigger
@@ -329,6 +369,15 @@ impl SamplesConfig {
         &self.sample_triggers
     }
 
+    /// Adds MIDI triggers, replacing any existing triggers with the same MIDI event.
+    pub fn add_triggers(&mut self, triggers: Vec<SampleTrigger>) {
+        for trigger in triggers {
+            self.sample_triggers
+                .retain(|t| t.trigger != trigger.trigger);
+            self.sample_triggers.push(trigger);
+        }
+    }
+
     /// Merges another config into this one. The other config's values override.
     pub fn merge(&mut self, other: SamplesConfig) {
         // Merge sample definitions (other overrides)
@@ -349,6 +398,8 @@ impl SamplesConfig {
 
 #[cfg(test)]
 mod tests {
+    use config::{Config, File, FileFormat};
+
     use super::*;
 
     #[test]
@@ -357,7 +408,7 @@ mod tests {
             Some("test.wav".to_string()),
             vec![1, 2],
             VelocityConfig::ignore(Some(100)),
-            NoteOffBehavior::PlayToCompletion,
+            ReleaseBehavior::PlayToCompletion,
             RetriggerBehavior::Cut,
             None,
             50,
@@ -378,7 +429,7 @@ mod tests {
             Some("test.wav".to_string()),
             vec![1, 2],
             VelocityConfig::scale(),
-            NoteOffBehavior::PlayToCompletion,
+            ReleaseBehavior::PlayToCompletion,
             RetriggerBehavior::Cut,
             None,
             50,
@@ -404,7 +455,7 @@ mod tests {
             None,
             vec![1, 2],
             VelocityConfig::with_layers(layers, false),
-            NoteOffBehavior::PlayToCompletion,
+            ReleaseBehavior::PlayToCompletion,
             RetriggerBehavior::Polyphonic,
             Some(4),
             50,
@@ -432,7 +483,7 @@ mod tests {
             None,
             vec![1, 2],
             VelocityConfig::with_layers(layers, true), // Scale enabled
-            NoteOffBehavior::PlayToCompletion,
+            ReleaseBehavior::PlayToCompletion,
             RetriggerBehavior::Polyphonic,
             None,
             50,
@@ -458,7 +509,7 @@ mod tests {
             Some("default.wav".to_string()),
             vec![1, 2],
             VelocityConfig::with_layers(layers, false),
-            NoteOffBehavior::PlayToCompletion,
+            ReleaseBehavior::PlayToCompletion,
             RetriggerBehavior::Cut,
             None,
             50,
@@ -481,7 +532,7 @@ mod tests {
                         Some("kick1.wav".to_string()),
                         vec![1],
                         VelocityConfig::ignore(None),
-                        NoteOffBehavior::PlayToCompletion,
+                        ReleaseBehavior::PlayToCompletion,
                         RetriggerBehavior::Cut,
                         None,
                         50,
@@ -493,7 +544,7 @@ mod tests {
                         Some("snare1.wav".to_string()),
                         vec![2],
                         VelocityConfig::ignore(None),
-                        NoteOffBehavior::PlayToCompletion,
+                        ReleaseBehavior::PlayToCompletion,
                         RetriggerBehavior::Cut,
                         None,
                         50,
@@ -511,7 +562,7 @@ mod tests {
                     Some("kick2.wav".to_string()), // Override kick
                     vec![1, 2],
                     VelocityConfig::scale(),
-                    NoteOffBehavior::Stop,
+                    ReleaseBehavior::Stop,
                     RetriggerBehavior::Polyphonic,
                     Some(4),
                     100,
@@ -533,5 +584,101 @@ mod tests {
             config1.samples.get("snare").unwrap().file(),
             Some("snare1.wav")
         );
+    }
+
+    #[test]
+    fn test_release_behavior_yaml_keys() {
+        // The new "release_behavior" key should work
+        let yaml = r#"
+            samples:
+              kick:
+                file: kick.wav
+                output_channels: [1]
+                release_behavior: stop
+        "#;
+        let config: SamplesConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        assert_eq!(
+            config.samples.get("kick").unwrap().release_behavior(),
+            ReleaseBehavior::Stop,
+        );
+
+        // The legacy "note_off" key should also work
+        let yaml = r#"
+            samples:
+              kick:
+                file: kick.wav
+                output_channels: [1]
+                note_off: fade
+        "#;
+        let config: SamplesConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        assert_eq!(
+            config.samples.get("kick").unwrap().release_behavior(),
+            ReleaseBehavior::Fade,
+        );
+    }
+
+    #[test]
+    fn test_output_track_deserialization() {
+        // output_track should deserialize correctly
+        let yaml = r#"
+            samples:
+              kick:
+                file: kick.wav
+                output_track: kick-out
+        "#;
+        let config: SamplesConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        let kick = config.samples.get("kick").unwrap();
+        assert_eq!(kick.output_track(), Some("kick-out"));
+        assert!(kick.output_channels().is_empty());
+
+        // output_channels without output_track should still work
+        let yaml = r#"
+            samples:
+              snare:
+                file: snare.wav
+                output_channels: [3, 4]
+        "#;
+        let config: SamplesConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        let snare = config.samples.get("snare").unwrap();
+        assert_eq!(snare.output_track(), None);
+        assert_eq!(snare.output_channels(), &[3, 4]);
+
+        // Both set: output_track should be present, output_channels also present
+        let yaml = r#"
+            samples:
+              both:
+                file: both.wav
+                output_track: both-out
+                output_channels: [5, 6]
+        "#;
+        let config: SamplesConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        let both = config.samples.get("both").unwrap();
+        assert_eq!(both.output_track(), Some("both-out"));
+        assert_eq!(both.output_channels(), &[5, 6]);
     }
 }

--- a/src/config/trigger.rs
+++ b/src/config/trigger.rs
@@ -1,0 +1,741 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Trigger configuration for audio and MIDI trigger inputs.
+//!
+//! Supports two input kinds:
+//! - `kind: audio` — piezo drum triggers via audio input channels
+//! - `kind: midi` — MIDI event triggers (replaces legacy `sample_triggers`)
+
+use std::str::FromStr;
+
+use serde::Deserialize;
+use tracing::warn;
+
+use super::samples::SampleTrigger;
+use crate::audio::format::SampleFormat;
+
+fn default_threshold() -> f32 {
+    0.1
+}
+
+fn default_retrigger_time_ms() -> u32 {
+    30
+}
+
+fn default_scan_time_ms() -> u32 {
+    5
+}
+
+fn default_gain() -> f32 {
+    1.0
+}
+
+fn default_fixed_velocity() -> u8 {
+    127
+}
+
+fn default_noise_floor_decay_ms() -> u32 {
+    200
+}
+
+/// Configuration for the trigger system.
+#[derive(Deserialize, Clone, Debug)]
+pub struct TriggerConfig {
+    /// The audio input device name (matched against cpal input devices).
+    /// Only required when audio inputs are configured.
+    device: Option<String>,
+    /// Optional sample rate override for the input stream.
+    sample_rate: Option<u32>,
+    /// Target sample format ("int" or "float"). Default: device native.
+    sample_format: Option<String>,
+    /// Target bits per sample (16 or 32). Default: device native.
+    bits_per_sample: Option<u16>,
+    /// Stream buffer size in frames. Default: device default.
+    buffer_size: Option<usize>,
+    /// Per-channel input configurations.
+    #[serde(default)]
+    inputs: Vec<TriggerInput>,
+    /// Crosstalk suppression window in ms after any channel fires.
+    /// Both `crosstalk_window_ms` and `crosstalk_threshold` must be set to enable suppression.
+    crosstalk_window_ms: Option<u32>,
+    /// Threshold multiplier during crosstalk suppression window.
+    /// Both `crosstalk_window_ms` and `crosstalk_threshold` must be set to enable suppression.
+    crosstalk_threshold: Option<f32>,
+}
+
+impl TriggerConfig {
+    /// Returns the device name, if configured.
+    pub fn device(&self) -> Option<&str> {
+        self.device.as_deref()
+    }
+
+    /// Returns the optional sample rate.
+    pub fn sample_rate(&self) -> Option<u32> {
+        self.sample_rate
+    }
+
+    /// Returns the target sample format, if configured.
+    pub fn sample_format(&self) -> Option<SampleFormat> {
+        self.sample_format.as_deref().and_then(|s| {
+            SampleFormat::from_str(s)
+                .inspect_err(|_| {
+                    warn!(
+                        value = s,
+                        "invalid sample_format, expected 'int' or 'float'"
+                    )
+                })
+                .ok()
+        })
+    }
+
+    /// Returns the target bits per sample, if configured.
+    pub fn bits_per_sample(&self) -> Option<u16> {
+        self.bits_per_sample
+    }
+
+    /// Returns the stream buffer size in frames, if configured.
+    pub fn buffer_size(&self) -> Option<usize> {
+        self.buffer_size
+    }
+
+    /// Returns the input configurations.
+    pub fn inputs(&self) -> &[TriggerInput] {
+        &self.inputs
+    }
+
+    /// Returns the crosstalk suppression window in ms, if configured.
+    pub fn crosstalk_window_ms(&self) -> Option<u32> {
+        self.crosstalk_window_ms
+    }
+
+    /// Returns the crosstalk threshold multiplier, if configured.
+    pub fn crosstalk_threshold(&self) -> Option<f32> {
+        self.crosstalk_threshold
+    }
+
+    /// Returns whether any audio inputs are configured.
+    pub fn has_audio_inputs(&self) -> bool {
+        self.inputs
+            .iter()
+            .any(|i| matches!(i, TriggerInput::Audio(_)))
+    }
+
+    /// Extracts MIDI inputs as `SampleTrigger` entries for the sample engine.
+    pub fn midi_triggers(&self) -> Vec<SampleTrigger> {
+        self.inputs
+            .iter()
+            .filter_map(|i| match i {
+                TriggerInput::Midi(midi) => Some(SampleTrigger::new(
+                    midi.event().clone(),
+                    midi.sample().to_string(),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Adds an input to this config.
+    pub fn add_input(&mut self, input: TriggerInput) {
+        self.inputs.push(input);
+    }
+
+    /// Creates an empty TriggerConfig with no device (MIDI-only).
+    pub(crate) fn new_midi_only(inputs: Vec<TriggerInput>) -> Self {
+        Self {
+            device: None,
+            sample_rate: None,
+            sample_format: None,
+            bits_per_sample: None,
+            buffer_size: None,
+            inputs,
+            crosstalk_window_ms: None,
+            crosstalk_threshold: None,
+        }
+    }
+}
+
+#[cfg(test)]
+impl TriggerConfig {
+    /// Creates a new TriggerConfig (test only).
+    pub(crate) fn new(
+        device: Option<&str>,
+        sample_rate: Option<u32>,
+        inputs: Vec<TriggerInput>,
+    ) -> Self {
+        Self {
+            device: device.map(|d| d.to_string()),
+            sample_rate,
+            sample_format: None,
+            bits_per_sample: None,
+            buffer_size: None,
+            inputs,
+            crosstalk_window_ms: None,
+            crosstalk_threshold: None,
+        }
+    }
+}
+
+/// A trigger input, discriminated by `kind`.
+#[derive(Deserialize, Clone, Debug)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TriggerInput {
+    /// Audio trigger input (piezo, line-level, etc.).
+    Audio(AudioTriggerInput),
+    /// MIDI event trigger input.
+    Midi(MidiTriggerInput),
+}
+
+/// What action an input channel performs when triggered.
+#[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerInputAction {
+    /// Fire a sample (default).
+    #[default]
+    Trigger,
+    /// Release voices in the named release group.
+    Release,
+}
+
+/// How amplitude maps to velocity (0-127).
+#[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VelocityCurve {
+    /// Linear mapping: velocity = peak * 127.
+    #[default]
+    Linear,
+    /// Logarithmic mapping: threshold→1.0 maps log-scaled to 1→127.
+    Logarithmic,
+    /// Fixed velocity: always returns the configured fixed_velocity.
+    Fixed,
+}
+
+/// Configuration for a single audio input channel used as a trigger.
+#[derive(Deserialize, Clone, Debug)]
+pub struct AudioTriggerInput {
+    /// 1-indexed input channel number.
+    channel: u16,
+    /// Sample name to trigger (from samples config). Required when action is "trigger".
+    sample: Option<String>,
+    /// Minimum amplitude to trigger (0.0-1.0).
+    #[serde(default = "default_threshold")]
+    threshold: f32,
+    /// Lockout period after trigger fires, in milliseconds.
+    #[serde(default = "default_retrigger_time_ms")]
+    retrigger_time_ms: u32,
+    /// Peak detection window after threshold crossing, in milliseconds.
+    #[serde(default = "default_scan_time_ms")]
+    scan_time_ms: u32,
+    /// Input gain multiplier.
+    #[serde(default = "default_gain")]
+    gain: f32,
+    /// How amplitude maps to velocity.
+    #[serde(default)]
+    velocity_curve: VelocityCurve,
+    /// Velocity value when velocity_curve is "fixed".
+    #[serde(default = "default_fixed_velocity")]
+    fixed_velocity: u8,
+    /// Optional release group name for voice management.
+    release_group: Option<String>,
+    /// What action this input performs (trigger or release).
+    #[serde(default)]
+    action: TriggerInputAction,
+    /// High-pass filter cutoff frequency in Hz.
+    highpass_freq: Option<f32>,
+    /// Decay time for adaptive/dynamic threshold in ms.
+    dynamic_threshold_decay_ms: Option<u32>,
+    /// Noise floor tracking sensitivity multiplier. The adaptive noise floor
+    /// estimate is multiplied by this value to derive a minimum threshold.
+    /// Default: None (disabled). Typical value: 5.0.
+    noise_floor_sensitivity: Option<f32>,
+    /// Time constant for noise floor EMA in ms. Controls how quickly the
+    /// estimate tracks changing ambient levels.
+    #[serde(default = "default_noise_floor_decay_ms")]
+    noise_floor_decay_ms: u32,
+}
+
+impl AudioTriggerInput {
+    /// Returns the 1-indexed channel number.
+    pub fn channel(&self) -> u16 {
+        self.channel
+    }
+
+    /// Returns the sample name, if configured.
+    pub fn sample(&self) -> Option<&str> {
+        self.sample.as_deref()
+    }
+
+    /// Returns the amplitude threshold.
+    pub fn threshold(&self) -> f32 {
+        self.threshold
+    }
+
+    /// Returns the retrigger lockout time in milliseconds.
+    pub fn retrigger_time_ms(&self) -> u32 {
+        self.retrigger_time_ms
+    }
+
+    /// Returns the scan time (peak detection window) in milliseconds.
+    pub fn scan_time_ms(&self) -> u32 {
+        self.scan_time_ms
+    }
+
+    /// Returns the input gain multiplier.
+    pub fn gain(&self) -> f32 {
+        self.gain
+    }
+
+    /// Returns the velocity curve type.
+    pub fn velocity_curve(&self) -> VelocityCurve {
+        self.velocity_curve
+    }
+
+    /// Returns the fixed velocity value.
+    pub fn fixed_velocity(&self) -> u8 {
+        self.fixed_velocity
+    }
+
+    /// Returns the release group name, if configured.
+    pub fn release_group(&self) -> Option<&str> {
+        self.release_group.as_deref()
+    }
+
+    /// Returns the action this input performs.
+    pub fn action(&self) -> TriggerInputAction {
+        self.action
+    }
+
+    /// Returns the high-pass filter cutoff frequency in Hz, if configured.
+    pub fn highpass_freq(&self) -> Option<f32> {
+        self.highpass_freq
+    }
+
+    /// Returns the dynamic threshold decay time in ms, if configured.
+    pub fn dynamic_threshold_decay_ms(&self) -> Option<u32> {
+        self.dynamic_threshold_decay_ms
+    }
+
+    /// Returns the noise floor tracking sensitivity multiplier, if configured.
+    pub fn noise_floor_sensitivity(&self) -> Option<f32> {
+        self.noise_floor_sensitivity
+    }
+
+    /// Returns the noise floor EMA decay time in ms.
+    pub fn noise_floor_decay_ms(&self) -> u32 {
+        self.noise_floor_decay_ms
+    }
+}
+
+#[cfg(test)]
+impl AudioTriggerInput {
+    /// Creates a new trigger input for a sample trigger (test only).
+    pub(crate) fn new_trigger(channel: u16, sample: &str, release_group: Option<&str>) -> Self {
+        Self {
+            channel,
+            sample: Some(sample.to_string()),
+            threshold: default_threshold(),
+            retrigger_time_ms: default_retrigger_time_ms(),
+            scan_time_ms: default_scan_time_ms(),
+            gain: default_gain(),
+            velocity_curve: VelocityCurve::default(),
+            fixed_velocity: default_fixed_velocity(),
+            release_group: release_group.map(|s| s.to_string()),
+            action: TriggerInputAction::Trigger,
+            highpass_freq: None,
+            dynamic_threshold_decay_ms: None,
+            noise_floor_sensitivity: None,
+            noise_floor_decay_ms: default_noise_floor_decay_ms(),
+        }
+    }
+
+    /// Creates a new trigger input for a release action (test only).
+    pub(crate) fn new_release(channel: u16, release_group: &str) -> Self {
+        Self {
+            channel,
+            sample: None,
+            threshold: 0.05,
+            retrigger_time_ms: default_retrigger_time_ms(),
+            scan_time_ms: default_scan_time_ms(),
+            gain: default_gain(),
+            velocity_curve: VelocityCurve::default(),
+            fixed_velocity: default_fixed_velocity(),
+            release_group: Some(release_group.to_string()),
+            action: TriggerInputAction::Release,
+            highpass_freq: None,
+            dynamic_threshold_decay_ms: None,
+            noise_floor_sensitivity: None,
+            noise_floor_decay_ms: default_noise_floor_decay_ms(),
+        }
+    }
+}
+
+/// Configuration for a MIDI event trigger input.
+#[derive(Deserialize, Clone, Debug)]
+pub struct MidiTriggerInput {
+    /// The MIDI event to listen for.
+    event: super::midi::Event,
+    /// The sample name to trigger.
+    sample: String,
+}
+
+impl MidiTriggerInput {
+    /// Returns the MIDI event.
+    pub fn event(&self) -> &super::midi::Event {
+        &self.event
+    }
+
+    /// Returns the sample name.
+    pub fn sample(&self) -> &str {
+        &self.sample
+    }
+
+    /// Creates a new MidiTriggerInput.
+    pub fn new(event: super::midi::Event, sample: String) -> Self {
+        Self { event, sample }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use config::{Config, File, FileFormat};
+
+    use super::*;
+
+    fn unwrap_audio(input: &TriggerInput) -> &AudioTriggerInput {
+        match input {
+            TriggerInput::Audio(audio) => audio,
+            _ => panic!("Expected TriggerInput::Audio"),
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_deserialize() {
+        let yaml = r#"
+            device: "UltraLite-mk5"
+            sample_rate: 44100
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "kick"
+                threshold: 0.1
+                retrigger_time_ms: 30
+                scan_time_ms: 5
+                gain: 1.0
+                velocity_curve: linear
+                release_group: "kick"
+              - kind: audio
+                channel: 3
+                sample: "cymbal"
+                threshold: 0.08
+                release_group: "cymbal"
+              - kind: audio
+                channel: 4
+                action: release
+                release_group: "cymbal"
+                threshold: 0.05
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.device(), Some("UltraLite-mk5"));
+        assert_eq!(config.sample_rate(), Some(44100));
+        assert_eq!(config.inputs().len(), 3);
+
+        let input0 = unwrap_audio(&config.inputs()[0]);
+        assert_eq!(input0.channel(), 1);
+        assert_eq!(input0.sample(), Some("kick"));
+        assert!((input0.threshold() - 0.1).abs() < 0.001);
+        assert_eq!(input0.retrigger_time_ms(), 30);
+        assert_eq!(input0.scan_time_ms(), 5);
+        assert!((input0.gain() - 1.0).abs() < 0.001);
+        assert_eq!(input0.velocity_curve(), VelocityCurve::Linear);
+        assert_eq!(input0.release_group(), Some("kick"));
+        assert_eq!(input0.action(), TriggerInputAction::Trigger);
+
+        let input1 = unwrap_audio(&config.inputs()[1]);
+        assert_eq!(input1.channel(), 3);
+        assert_eq!(input1.sample(), Some("cymbal"));
+        assert_eq!(input1.release_group(), Some("cymbal"));
+        assert_eq!(input1.action(), TriggerInputAction::Trigger);
+
+        let input2 = unwrap_audio(&config.inputs()[2]);
+        assert_eq!(input2.channel(), 4);
+        assert_eq!(input2.sample(), None);
+        assert_eq!(input2.release_group(), Some("cymbal"));
+        assert_eq!(input2.action(), TriggerInputAction::Release);
+    }
+
+    #[test]
+    fn test_trigger_config_defaults() {
+        let yaml = r#"
+            device: "test-device"
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "kick"
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.device(), Some("test-device"));
+        assert_eq!(config.sample_rate(), None);
+
+        let input = unwrap_audio(&config.inputs()[0]);
+        assert!((input.threshold() - 0.1).abs() < 0.001);
+        assert_eq!(input.retrigger_time_ms(), 30);
+        assert_eq!(input.scan_time_ms(), 5);
+        assert!((input.gain() - 1.0).abs() < 0.001);
+        assert_eq!(input.velocity_curve(), VelocityCurve::Linear);
+        assert_eq!(input.fixed_velocity(), 127);
+        assert_eq!(input.release_group(), None);
+        assert_eq!(input.action(), TriggerInputAction::Trigger);
+    }
+
+    #[test]
+    fn test_trigger_config_audio_knobs() {
+        let yaml = r#"
+            device: "UltraLite-mk5"
+            sample_format: int
+            bits_per_sample: 16
+            buffer_size: 512
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "kick"
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.sample_format(), Some(SampleFormat::Int));
+        assert_eq!(config.bits_per_sample(), Some(16));
+        assert_eq!(config.buffer_size(), Some(512));
+
+        // Float format.
+        let yaml_float = r#"
+            device: "test"
+            sample_format: float
+            bits_per_sample: 32
+            inputs: []
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml_float, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.sample_format(), Some(SampleFormat::Float));
+        assert_eq!(config.bits_per_sample(), Some(32));
+        assert_eq!(config.buffer_size(), None);
+    }
+
+    #[test]
+    fn test_signal_conditioning_fields_deserialize() {
+        let yaml = r#"
+            device: "UltraLite-mk5"
+            crosstalk_window_ms: 4
+            crosstalk_threshold: 3.0
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "kick"
+                highpass_freq: 80.0
+                dynamic_threshold_decay_ms: 50
+              - kind: audio
+                channel: 2
+                sample: "snare"
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.crosstalk_window_ms(), Some(4));
+        assert!((config.crosstalk_threshold().unwrap() - 3.0).abs() < 0.001);
+
+        let input0 = unwrap_audio(&config.inputs()[0]);
+        assert!((input0.highpass_freq().unwrap() - 80.0).abs() < 0.001);
+        assert_eq!(input0.dynamic_threshold_decay_ms(), Some(50));
+
+        // Second input should default to None for all new fields.
+        let input1 = unwrap_audio(&config.inputs()[1]);
+        assert_eq!(input1.highpass_freq(), None);
+        assert_eq!(input1.dynamic_threshold_decay_ms(), None);
+    }
+
+    #[test]
+    fn test_signal_conditioning_defaults_to_none() {
+        let yaml = r#"
+            device: "test-device"
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "kick"
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.crosstalk_window_ms(), None);
+        assert_eq!(config.crosstalk_threshold(), None);
+        assert_eq!(unwrap_audio(&config.inputs()[0]).highpass_freq(), None);
+        assert_eq!(
+            unwrap_audio(&config.inputs()[0]).dynamic_threshold_decay_ms(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_velocity_curves_deserialize() {
+        let yaml = r#"
+            device: "test"
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "a"
+                velocity_curve: linear
+              - kind: audio
+                channel: 2
+                sample: "b"
+                velocity_curve: logarithmic
+              - kind: audio
+                channel: 3
+                sample: "c"
+                velocity_curve: fixed
+                fixed_velocity: 100
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(
+            unwrap_audio(&config.inputs()[0]).velocity_curve(),
+            VelocityCurve::Linear
+        );
+        assert_eq!(
+            unwrap_audio(&config.inputs()[1]).velocity_curve(),
+            VelocityCurve::Logarithmic
+        );
+        assert_eq!(
+            unwrap_audio(&config.inputs()[2]).velocity_curve(),
+            VelocityCurve::Fixed
+        );
+        assert_eq!(unwrap_audio(&config.inputs()[2]).fixed_velocity(), 100);
+    }
+
+    #[test]
+    fn test_midi_trigger_input_deserialize() {
+        let yaml = r#"
+            inputs:
+              - kind: midi
+                event:
+                  type: note_on
+                  channel: 10
+                  key: 60
+                sample: kick
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.device(), None);
+        assert_eq!(config.inputs().len(), 1);
+        assert!(!config.has_audio_inputs());
+        assert_eq!(config.midi_triggers().len(), 1);
+        assert_eq!(config.midi_triggers()[0].sample(), "kick");
+    }
+
+    #[test]
+    fn test_mixed_audio_and_midi_inputs() {
+        let yaml = r#"
+            device: "UltraLite-mk5"
+            inputs:
+              - kind: audio
+                channel: 1
+                sample: "kick"
+              - kind: midi
+                event:
+                  type: note_on
+                  channel: 10
+                  key: 60
+                sample: snare
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.inputs().len(), 2);
+        assert!(config.has_audio_inputs());
+        assert_eq!(config.midi_triggers().len(), 1);
+        assert_eq!(config.midi_triggers()[0].sample(), "snare");
+    }
+
+    #[test]
+    fn test_device_optional_for_midi_only() {
+        let yaml = r#"
+            inputs:
+              - kind: midi
+                event:
+                  type: note_on
+                  channel: 10
+                  key: 60
+                sample: kick
+        "#;
+
+        let config: TriggerConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.device(), None);
+        assert!(!config.has_audio_inputs());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 mod audio;
+mod calibrate;
 mod cli;
 mod config;
 mod controller;
@@ -26,6 +27,7 @@ mod samples;
 mod songs;
 #[cfg(test)]
 mod testutil;
+mod trigger;
 mod util;
 mod verify;
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -33,10 +33,12 @@ use tracing::{error, info, span, warn, Level, Span};
 
 use crate::samples::SampleEngine;
 use crate::songs::Songs;
+use crate::trigger::TriggerEngine;
 use crate::{
     audio, config, dmx, midi,
     playlist::{self, Playlist},
     playsync::CancelHandle,
+    samples,
     songs::Song,
 };
 
@@ -70,6 +72,10 @@ pub struct Player {
     dmx_engine: Option<Arc<dmx::engine::Engine>>,
     /// The sample engine for MIDI-triggered samples.
     sample_engine: Option<Arc<RwLock<SampleEngine>>>,
+    /// The audio trigger engine for piezo triggers.
+    /// Held to keep the engine (and its cpal stream + forwarding thread) alive.
+    #[allow(dead_code)]
+    trigger_engine: Option<Arc<TriggerEngine>>,
     /// The playlist to use.
     playlist: Arc<Playlist>,
     /// The all songs playlist.
@@ -119,23 +125,22 @@ impl Player {
         // Audio: if present in profile, required. If absent, optional.
         let (device, mappings, resolved_audio) = if let Some(audio_config) = profile.audio_config()
         {
-            let (device, mappings, resolved_audio) =
-                Self::wait_for_ok("audio device".to_string(), || {
-                    match audio::get_device(Some(audio_config.audio().clone())) {
-                        Ok(device) => {
-                            info!(
-                                device = audio_config.audio().device(),
-                                "Audio device initialized"
-                            );
-                            Ok((
-                                device.clone(),
-                                audio_config.track_mappings().clone(),
-                                audio_config.audio().clone(),
-                            ))
-                        }
-                        Err(e) => Err(format!("audio device: {}", e)),
+            let (device, mappings, resolved_audio) = Self::wait_for_ok("audio device", || {
+                match audio::get_device(Some(audio_config.audio().clone())) {
+                    Ok(device) => {
+                        info!(
+                            device = audio_config.audio().device(),
+                            "Audio device initialized"
+                        );
+                        Ok((
+                            device.clone(),
+                            audio_config.track_mappings().clone(),
+                            audio_config.audio().clone(),
+                        ))
                     }
-                })?;
+                    Err(e) => Err(format!("audio device: {}", e)),
+                }
+            })?;
             (Some(device), Some(mappings), Some(resolved_audio))
         } else {
             info!("Audio not configured in profile; proceeding without audio");
@@ -144,7 +149,7 @@ impl Player {
 
         // DMX: if present in profile, required. If absent, optional.
         let dmx_engine = if let Some(dmx_config) = profile.dmx() {
-            Self::wait_for_ok("dmx engine".to_string(), || {
+            Self::wait_for_ok("dmx engine", || {
                 dmx::create_engine(Some(dmx_config), base_path)
             })?
         } else {
@@ -154,7 +159,7 @@ impl Player {
 
         // MIDI: if present in profile, required. If absent, optional.
         let midi_device = if let Some(midi_config) = profile.midi() {
-            Self::wait_for_ok("midi device".to_string(), || {
+            Self::wait_for_ok("midi device", || {
                 midi::get_device(Some(midi_config.clone()), dmx_engine.clone())
             })?
         } else {
@@ -162,7 +167,7 @@ impl Player {
             None
         };
 
-        let status_events = Self::wait_for_ok("status events".to_string(), || {
+        let status_events = Self::wait_for_ok("status events", || {
             StatusEvents::new(config.status_events())
         })?;
 
@@ -177,12 +182,18 @@ impl Player {
                     .as_ref()
                     .map(|a| a.buffer_size())
                     .unwrap_or(1024);
-                let mut engine = SampleEngine::new(mixer, source_tx, max_voices, buffer_size);
+                let track_mappings = mappings.as_ref().cloned().unwrap_or_default();
+                let mut engine =
+                    SampleEngine::new(mixer, source_tx, max_voices, buffer_size, track_mappings);
 
                 // Load global samples config if available
                 if let Some(base_path) = base_path {
                     match config.samples_config(base_path) {
-                        Ok(samples_config) => {
+                        Ok(mut samples_config) => {
+                            // Add MIDI triggers from profile's trigger config
+                            if let Some(trigger_config) = profile.trigger() {
+                                samples_config.add_triggers(trigger_config.midi_triggers());
+                            }
                             if let Err(e) = engine.load_global_config(&samples_config, base_path) {
                                 warn!(error = %e, "Failed to load global samples config");
                             }
@@ -198,12 +209,64 @@ impl Player {
             _ => None,
         };
 
+        // Initialize the trigger engine if configured and sample engine is available.
+        // Unlike audio/MIDI devices, triggers are non-essential — fail immediately
+        // rather than retrying indefinitely.
+        let trigger_engine = if let (Some(trigger_config), Some(ref sample_engine)) = (
+            profile.trigger().filter(|t| t.has_audio_inputs()),
+            &sample_engine,
+        ) {
+            match TriggerEngine::new(trigger_config) {
+                Ok(engine) => {
+                    let engine: Arc<TriggerEngine> = Arc::new(engine);
+
+                    // Spawn a forwarding thread: reads TriggerActions and dispatches
+                    // to the sample engine. When the TriggerEngine drops, the sender
+                    // closes and the receiver returns Err, ending the thread.
+                    let receiver = engine.subscribe();
+                    let se = sample_engine.clone();
+                    thread::Builder::new()
+                        .name("trigger-fwd".to_string())
+                        .spawn(move || {
+                            let result =
+                                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    while let Ok(action) = receiver.recv() {
+                                        match action {
+                                            samples::TriggerAction::Trigger(event) => {
+                                                let engine = se.read();
+                                                engine.trigger(&event);
+                                            }
+                                            samples::TriggerAction::Release { group } => {
+                                                let engine = se.read();
+                                                engine.release(&group);
+                                            }
+                                        }
+                                    }
+                                }));
+                            if result.is_err() {
+                                error!("Trigger forwarding thread panicked");
+                            }
+                            info!("Trigger forwarding thread exiting");
+                        })?;
+
+                    Some(engine)
+                }
+                Err(e) => {
+                    warn!(error = %e, "Failed to initialize trigger engine, continuing without triggers");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let player = Player {
             device,
             mappings: mappings.map(Arc::new),
             midi_device,
             dmx_engine,
             sample_engine,
+            trigger_engine,
             playlist,
             all_songs: playlist::from_songs(songs)?,
             use_all_songs: Arc::new(AtomicBool::new(false)),
@@ -238,7 +301,7 @@ impl Player {
     /// Wait for constructor function to return an Ok(result) variant.
     /// Respects MTRACK_DEVICE_RETRY_LIMIT: if set to N, tries at most N times then returns
     /// the last error. If unset or 0, retries indefinitely (original behavior).
-    fn wait_for_ok<T, E, F>(name: String, constructor: F) -> Result<T, Box<dyn Error>>
+    fn wait_for_ok<T, E, F>(name: &str, constructor: F) -> Result<T, Box<dyn Error>>
     where
         E: Display + Into<Box<dyn Error>>,
         F: Fn() -> Result<T, E>,

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -12,22 +12,19 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-//! MIDI-triggered sample playback system.
+//! Sample playback system with source-agnostic triggering.
 //!
 //! This module provides:
 //! - Sample loading and caching (in-memory for zero-latency playback)
 //! - MIDI event to sample trigger matching
+//! - Source-agnostic trigger/release via TriggerEvent and TriggerAction
 //! - Voice management with polyphony limits
 //! - Integration with the audio mixer
 
 mod engine;
 mod loader;
+mod trigger;
 mod voice;
 
 pub use engine::SampleEngine;
-
-// These types are exported for potential external use and testing
-#[allow(unused_imports)]
-pub use loader::{LoadedSample, SampleLoader};
-#[allow(unused_imports)]
-pub use voice::{Voice, VoiceManager};
+pub use trigger::{TriggerAction, TriggerEvent};

--- a/src/samples/engine.rs
+++ b/src/samples/engine.rs
@@ -14,20 +14,23 @@
 
 //! Main sample engine that coordinates trigger matching, sample loading, and playback.
 
-use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 
 use midly::live::LiveEvent;
 use midly::MidiMessage;
+use parking_lot::RwLock;
 use tracing::{debug, error, info, warn};
 
 use super::loader::{LoadedSample, SampleLoader};
+use super::trigger::TriggerEvent;
 use super::voice::{Voice, VoiceManager};
 use crate::audio;
 use crate::audio::sample_source::ChannelMappedSource;
-use crate::config::samples::{NoteOffBehavior, SampleDefinition, SampleTrigger, SamplesConfig};
+use crate::config::samples::{ReleaseBehavior, SampleDefinition, SampleTrigger, SamplesConfig};
 use crate::config::ToMidiEvent;
 use crate::playsync::CancelHandle;
 
@@ -51,6 +54,16 @@ struct ActiveSample {
     base_path: PathBuf,
 }
 
+/// Data prepared for sample playback, produced by `prepare_sample`.
+struct PreparedSample {
+    source_id: u64,
+    channel_mapped: Box<ChannelMappedSource>,
+    track_mappings: HashMap<String, Vec<u16>>,
+    channel_count: u16,
+    retrigger: crate::config::samples::RetriggerBehavior,
+    release_behavior: ReleaseBehavior,
+}
+
 /// A trigger definition with pre-converted MIDI event for matching.
 struct ActiveTrigger {
     /// The MIDI event to match (as LiveEvent for efficient comparison).
@@ -72,22 +85,25 @@ pub struct SampleEngine {
     /// Channel for adding sources without lock contention.
     source_tx: crate::audio::SourceSender,
     /// Reference to mixer for sample scheduling.
-    mixer: std::sync::Arc<crate::audio::mixer::AudioMixer>,
+    mixer: Arc<crate::audio::mixer::AudioMixer>,
     /// Fixed delay in samples for consistent trigger latency.
     fixed_delay_samples: u64,
+    /// Track mappings from the active profile, for resolving output_track names.
+    profile_track_mappings: HashMap<String, Vec<u16>>,
 }
 
 impl SampleEngine {
     /// Creates a new sample engine.
     ///
     /// The `buffer_size` is used to calculate the minimum fixed delay for consistent
-    /// trigger latency. The delay is set to 2x the buffer size to ensure samples are
+    /// trigger latency. The delay is set to 1x the buffer size to ensure samples are
     /// always scheduled ahead of the current mixing position.
     pub fn new(
-        mixer: std::sync::Arc<crate::audio::mixer::AudioMixer>,
+        mixer: Arc<crate::audio::mixer::AudioMixer>,
         source_tx: crate::audio::SourceSender,
         max_voices: u32,
         buffer_size: usize,
+        profile_track_mappings: HashMap<String, Vec<u16>>,
     ) -> Self {
         let sample_rate = mixer.sample_rate();
         // Fixed delay of 1x buffer size ensures the sample is scheduled ahead of current mixing
@@ -102,6 +118,7 @@ impl SampleEngine {
             source_tx,
             mixer,
             fixed_delay_samples,
+            profile_track_mappings,
         }
     }
 
@@ -180,23 +197,56 @@ impl SampleEngine {
 
         // Precompute channel labels and track mappings for each loaded file
         // This avoids string formatting and HashMap allocation on every trigger
-        let output_channels = definition.output_channels();
         let loaded_files: HashMap<PathBuf, PrecomputedSampleData> = raw_loaded_files
             .into_iter()
             .map(|(path, loaded)| {
-                let channel_labels: Vec<Vec<String>> = (0..loaded.channel_count())
-                    .map(|_| {
-                        output_channels
+                let (channel_labels, track_mappings) =
+                    if let Some(track_name) = definition.output_track() {
+                        // Resolve output_track through the profile's track_mappings
+                        match self.profile_track_mappings.get(track_name) {
+                            Some(channels) => {
+                                let labels = (0..loaded.channel_count())
+                                    .map(|_| vec![track_name.to_string()])
+                                    .collect();
+                                let mut map = HashMap::new();
+                                map.insert(track_name.to_string(), channels.clone());
+                                (labels, map)
+                            }
+                            None => {
+                                warn!(
+                                sample = name,
+                                track = track_name,
+                                "output_track not found in track_mappings, sample will be silent"
+                            );
+                                (
+                                    (0..loaded.channel_count()).map(|_| Vec::new()).collect(),
+                                    HashMap::new(),
+                                )
+                            }
+                        }
+                    } else if !definition.output_channels().is_empty() {
+                        // Existing synthetic __sample_out_{ch} approach
+                        let output_channels = definition.output_channels();
+                        let labels = (0..loaded.channel_count())
+                            .map(|_| {
+                                output_channels
+                                    .iter()
+                                    .map(|ch| format!("__sample_out_{}", ch))
+                                    .collect()
+                            })
+                            .collect();
+                        let map = output_channels
                             .iter()
-                            .map(|ch| format!("__sample_out_{}", ch))
-                            .collect()
-                    })
-                    .collect();
-
-                let track_mappings: HashMap<String, Vec<u16>> = output_channels
-                    .iter()
-                    .map(|ch| (format!("__sample_out_{}", ch), vec![*ch]))
-                    .collect();
+                            .map(|ch| (format!("__sample_out_{}", ch), vec![*ch]))
+                            .collect();
+                        (labels, map)
+                    } else {
+                        warn!(sample = name, "No output routing configured for sample");
+                        (
+                            (0..loaded.channel_count()).map(|_| Vec::new()).collect(),
+                            HashMap::new(),
+                        )
+                    };
 
                 (
                     path,
@@ -244,6 +294,143 @@ impl SampleEngine {
         Ok(())
     }
 
+    /// Triggers a sample by name using a source-agnostic TriggerEvent.
+    /// This is the common entry point for all trigger sources (MIDI, audio triggers, etc.).
+    pub fn trigger(&self, event: &TriggerEvent) {
+        let prepared = match self.prepare_sample(&event.sample_name, event.velocity) {
+            Some(p) => p,
+            None => return,
+        };
+
+        let source_cancel_handle = CancelHandle::new();
+        let source_cancel_at_sample = Arc::new(AtomicU64::new(0));
+        let is_finished = Arc::new(AtomicBool::new(false));
+
+        let voice = Voice::new(
+            event.sample_name.clone(),
+            event.release_group.clone(),
+            prepared.release_behavior,
+            prepared.source_id,
+            source_cancel_handle.clone(),
+            source_cancel_at_sample.clone(),
+            is_finished.clone(),
+        );
+
+        let start_at_sample = self.mixer.current_sample() + self.fixed_delay_samples;
+
+        let to_stop = {
+            let mut vm = self.voice_manager.write();
+            vm.add_voice(voice, prepared.retrigger)
+        };
+
+        for cancel_at in to_stop {
+            cancel_at.store(start_at_sample, Ordering::Relaxed);
+        }
+
+        let active_source = crate::audio::mixer::ActiveSource {
+            id: prepared.source_id,
+            source: prepared.channel_mapped,
+            track_mappings: prepared.track_mappings,
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: prepared.channel_count,
+            is_finished,
+            cancel_handle: source_cancel_handle,
+            start_at_sample: Some(start_at_sample),
+            cancel_at_sample: Some(source_cancel_at_sample),
+        };
+
+        if let Err(e) = self.source_tx.send(active_source) {
+            error!(error = %e, "Failed to send sample to mixer");
+        }
+
+        debug!(
+            sample = event.sample_name.as_str(),
+            velocity = event.velocity,
+            source_id = prepared.source_id,
+            "Sample triggered"
+        );
+    }
+
+    /// Releases all voices in the named release group.
+    /// Each voice's own ReleaseBehavior (stored at trigger time) determines
+    /// whether it is stopped or allowed to play to completion.
+    pub fn release(&self, group: &str) {
+        let to_stop = {
+            let mut vm = self.voice_manager.write();
+            vm.release(group)
+        };
+
+        let stopped_count = to_stop.len();
+        if !to_stop.is_empty() {
+            for handle in to_stop {
+                handle.cancel();
+            }
+            debug!(group, stopped = stopped_count, "Release handled");
+        }
+    }
+
+    /// Prepares a sample for playback: looks up the definition, resolves the file
+    /// for the given velocity, and creates the audio source. Returns None if the
+    /// sample cannot be prepared (not found, no file for velocity, etc.).
+    fn prepare_sample(&self, sample_name: &str, velocity: u8) -> Option<PreparedSample> {
+        let sample = match self.samples.get(sample_name) {
+            Some(s) => s,
+            None => {
+                warn!(sample = sample_name, "Sample not found");
+                return None;
+            }
+        };
+
+        let (file_path, volume) = match sample.definition.file_for_velocity(velocity) {
+            Some((file, vol)) => {
+                let path = if Path::new(file).is_absolute() {
+                    PathBuf::from(file)
+                } else {
+                    sample.base_path.join(file)
+                };
+                (path, vol)
+            }
+            None => {
+                warn!(
+                    sample = sample_name,
+                    velocity, "No sample file for velocity"
+                );
+                return None;
+            }
+        };
+
+        let precomputed = match sample.loaded_files.get(&file_path) {
+            Some(p) => p,
+            None => {
+                error!(
+                    sample = sample_name,
+                    path = ?file_path,
+                    "Sample file not loaded"
+                );
+                return None;
+            }
+        };
+
+        let source = precomputed.loaded.create_source(volume);
+        let source_id = audio::next_source_id();
+
+        let channel_mapped = ChannelMappedSource::new(
+            Box::new(source),
+            precomputed.channel_labels.clone(),
+            precomputed.loaded.channel_count(),
+        );
+        let track_mappings = precomputed.track_mappings.clone();
+
+        Some(PreparedSample {
+            source_id,
+            channel_mapped: Box::new(channel_mapped),
+            track_mappings,
+            channel_count: precomputed.loaded.channel_count(),
+            retrigger: sample.definition.retrigger(),
+            release_behavior: sample.definition.release_behavior(),
+        })
+    }
+
     /// Processes an incoming MIDI event.
     /// This is the main entry point called when MIDI data is received.
     pub fn process_midi_event(&self, raw_event: &[u8]) {
@@ -259,21 +446,38 @@ impl SampleEngine {
         if let LiveEvent::Midi { channel, message } = &event {
             match message {
                 MidiMessage::NoteOff { key, .. } => {
-                    self.handle_note_off(u8::from(*key), u8::from(*channel) + 1);
+                    let group = Self::midi_release_group(u8::from(*channel) + 1, u8::from(*key));
+                    self.release(&group);
                 }
                 MidiMessage::NoteOn { key, vel } if u8::from(*vel) == 0 => {
                     // Note On with velocity 0 is equivalent to Note Off
-                    self.handle_note_off(u8::from(*key), u8::from(*channel) + 1);
+                    let group = Self::midi_release_group(u8::from(*channel) + 1, u8::from(*key));
+                    self.release(&group);
                 }
                 _ => {}
             }
         }
 
+        // NoteOn with velocity 0 was already handled as a release above — skip trigger matching
+        let is_note_off_as_note_on = matches!(
+            &event,
+            LiveEvent::Midi { message: MidiMessage::NoteOn { vel, .. }, .. }
+            if u8::from(*vel) == 0
+        );
+
         // Check against triggers (hot path - minimal overhead)
         for trigger in &self.triggers {
-            if self.matches_trigger(&event, &trigger.midi_event) {
+            if !is_note_off_as_note_on && self.matches_trigger(&event, &trigger.midi_event) {
                 let velocity = self.extract_velocity(&event);
-                self.trigger_sample(&trigger.sample_name, velocity, &event);
+                let release_group = self
+                    .extract_note_channel(&event)
+                    .map(|(note, channel)| Self::midi_release_group(channel, note));
+                let trigger_event = TriggerEvent {
+                    sample_name: trigger.sample_name.clone(),
+                    velocity,
+                    release_group,
+                };
+                self.trigger(&trigger_event);
             }
         }
     }
@@ -351,6 +555,11 @@ impl SampleEngine {
         }
     }
 
+    /// Builds a release group string for a MIDI note event.
+    fn midi_release_group(channel_1indexed: u8, note: u8) -> String {
+        format!("midi:{}:{}", channel_1indexed, note)
+    }
+
     /// Extracts note and channel from a MIDI event for Note Off matching.
     fn extract_note_channel(&self, event: &LiveEvent) -> Option<(u8, u8)> {
         match event {
@@ -362,159 +571,12 @@ impl SampleEngine {
         }
     }
 
-    /// Triggers a sample by name with the given velocity.
-    fn trigger_sample(&self, sample_name: &str, velocity: u8, event: &LiveEvent) {
-        let sample = match self.samples.get(sample_name) {
-            Some(s) => s,
-            None => {
-                warn!(sample = sample_name, "Sample not found");
-                return;
-            }
-        };
-
-        // Get the file to play based on velocity
-        let (file_path, volume) = match sample.definition.file_for_velocity(velocity) {
-            Some((file, vol)) => {
-                let path = if Path::new(file).is_absolute() {
-                    PathBuf::from(file)
-                } else {
-                    sample.base_path.join(file)
-                };
-                (path, vol)
-            }
-            None => {
-                warn!(
-                    sample = sample_name,
-                    velocity, "No sample file for velocity"
-                );
-                return;
-            }
-        };
-
-        // Get the precomputed sample data
-        let precomputed = match sample.loaded_files.get(&file_path) {
-            Some(p) => p,
-            None => {
-                error!(
-                    sample = sample_name,
-                    path = ?file_path,
-                    "Sample file not loaded"
-                );
-                return;
-            }
-        };
-
-        // Create a new source for playback
-        let source = precomputed.loaded.create_source(volume);
-        let source_id = audio::next_source_id();
-
-        // Use precomputed channel labels and track mappings (no allocations!)
-        let channel_mapped = ChannelMappedSource::new(
-            Box::new(source),
-            precomputed.channel_labels.clone(),
-            precomputed.loaded.channel_count(),
-        );
-        let track_mappings = precomputed.track_mappings.clone();
-
-        // Extract note/channel for Note Off tracking
-        let (trigger_note, trigger_channel) = self
-            .extract_note_channel(event)
-            .map(|(n, c)| (Some(n), Some(c)))
-            .unwrap_or((None, None));
-
-        // Create a per-source cancel handle and scheduled cancel time for lock-free voice stopping
-        let source_cancel_handle = CancelHandle::new();
-        let source_cancel_at_sample = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)); // 0 = no scheduled cancel
-
-        // Create voice entry with its own cancel handle and scheduled cancel time
-        let voice = Voice::new(
-            sample_name.to_string(),
-            trigger_note,
-            trigger_channel,
-            source_id,
-            source_cancel_handle.clone(),
-            source_cancel_at_sample.clone(),
-        );
-
-        // Schedule the source to start at a fixed delay from now for consistent latency
-        let start_at_sample = self.mixer.current_sample() + self.fixed_delay_samples;
-
-        // Acquire voice manager lock BEFORE adding to mixer to prevent race conditions
-        // with concurrent triggers for the same sample (important for cut/monophonic mode)
-        let mut vm = self.voice_manager.write();
-        let to_stop = vm.add_voice(voice, sample.definition.retrigger());
-
-        // Schedule old voices to stop at the same time the new one starts (sample-accurate cut)
-        for cancel_at in to_stop {
-            cancel_at.store(start_at_sample, std::sync::atomic::Ordering::Relaxed);
-        }
-
-        // Add the new source via channel (audio callback receives and adds it)
-        let active_source = crate::audio::mixer::ActiveSource {
-            id: source_id,
-            source: Box::new(channel_mapped),
-            track_mappings,
-            channel_mappings: Vec::new(), // Will be computed by mixer
-            cached_source_channel_count: precomputed.loaded.channel_count(),
-            is_finished: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            cancel_handle: source_cancel_handle.clone(),
-            start_at_sample: Some(start_at_sample),
-            cancel_at_sample: Some(source_cancel_at_sample.clone()),
-        };
-
-        // Send via channel - audio callback handles addition to mixer
-        if let Err(e) = self.source_tx.send(active_source) {
-            error!(error = %e, "Failed to send sample to mixer");
-        }
-        drop(vm);
-
-        debug!(
-            sample = sample_name,
-            velocity, volume, source_id, "Sample triggered"
-        );
-    }
-
-    /// Handles a Note Off event.
-    fn handle_note_off(&self, note: u8, channel: u8) {
-        // Find all samples that might have Note Off behavior
-        // and check their voices
-        let sample_behaviors: Vec<_> = self
-            .samples
-            .iter()
-            .map(|(name, s)| (name.clone(), s.definition.note_off()))
-            .collect();
-
-        for (name, behavior) in sample_behaviors {
-            if behavior == NoteOffBehavior::PlayToCompletion {
-                continue;
-            }
-
-            let mut vm = self.voice_manager.write();
-            let to_stop = vm.handle_note_off(note, channel, behavior);
-            drop(vm);
-
-            let stopped_count = to_stop.len();
-            if !to_stop.is_empty() {
-                // Cancel voices via their handles (lock-free, no mixer write lock needed)
-                for handle in to_stop {
-                    handle.cancel();
-                }
-                debug!(
-                    sample = name,
-                    note,
-                    channel,
-                    stopped = stopped_count,
-                    "Note Off handled"
-                );
-            }
-        }
-    }
-
     /// Stops all sample playback.
     pub fn stop_all(&self) {
-        let mut vm = self.voice_manager.write();
-        let to_stop = vm.clear();
-        drop(vm);
+        let to_stop = {
+            let mut vm = self.voice_manager.write();
+            vm.clear()
+        };
 
         // Cancel all voices via their handles (lock-free)
         let stopped_count = to_stop.len();
@@ -554,8 +616,8 @@ mod tests {
     use super::*;
     use crate::audio::mixer::AudioMixer;
 
-    fn create_test_mixer_and_sender() -> (std::sync::Arc<AudioMixer>, crate::audio::SourceSender) {
-        let mixer = std::sync::Arc::new(AudioMixer::new(2, 44100));
+    fn create_test_mixer_and_sender() -> (Arc<AudioMixer>, crate::audio::SourceSender) {
+        let mixer = Arc::new(AudioMixer::new(2, 44100));
         let (tx, _rx) = crossbeam_channel::unbounded();
         (mixer, tx)
     }
@@ -563,7 +625,7 @@ mod tests {
     #[test]
     fn test_engine_creation() {
         let (mixer, source_tx) = create_test_mixer_and_sender();
-        let engine = SampleEngine::new(mixer, source_tx, 32, 256);
+        let engine = SampleEngine::new(mixer, source_tx, 32, 256, HashMap::new());
 
         assert_eq!(engine.active_voice_count(), 0);
         assert_eq!(engine.samples.len(), 0);
@@ -573,7 +635,7 @@ mod tests {
     #[test]
     fn test_velocity_extraction() {
         let (mixer, source_tx) = create_test_mixer_and_sender();
-        let engine = SampleEngine::new(mixer, source_tx, 32, 256);
+        let engine = SampleEngine::new(mixer, source_tx, 32, 256, HashMap::new());
 
         // Note On
         let note_on = LiveEvent::Midi {
@@ -599,7 +661,7 @@ mod tests {
     #[test]
     fn test_trigger_matching() {
         let (mixer, source_tx) = create_test_mixer_and_sender();
-        let engine = SampleEngine::new(mixer, source_tx, 32, 256);
+        let engine = SampleEngine::new(mixer, source_tx, 32, 256, HashMap::new());
 
         let trigger = LiveEvent::Midi {
             channel: 9.into(), // Channel 10 (0-indexed)
@@ -639,5 +701,105 @@ mod tests {
         assert!(engine.matches_trigger(&event1, &trigger));
         assert!(!engine.matches_trigger(&event2, &trigger));
         assert!(!engine.matches_trigger(&event3, &trigger));
+    }
+
+    #[test]
+    fn test_output_track_resolves_through_track_mappings() {
+        let (mixer, source_tx) = create_test_mixer_and_sender();
+        let mut track_mappings = HashMap::new();
+        track_mappings.insert("kick-out".to_string(), vec![3, 4]);
+        let mut engine = SampleEngine::new(mixer, source_tx, 32, 256, track_mappings);
+
+        let definition = SampleDefinition::new_with_output_track(
+            Some("1Channel44.1k.wav".to_string()),
+            "kick-out",
+            crate::config::samples::VelocityConfig::ignore(None),
+            ReleaseBehavior::PlayToCompletion,
+            crate::config::samples::RetriggerBehavior::Cut,
+            None,
+            50,
+        );
+        let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
+        engine.load_sample("kick", &definition, &base_path).unwrap();
+
+        let sample = engine.samples.get("kick").unwrap();
+        let file_path = base_path.join("1Channel44.1k.wav");
+        let precomputed = sample.loaded_files.get(&file_path).unwrap();
+
+        // Channel labels should reference the track name, not synthetic __sample_out_
+        assert_eq!(precomputed.channel_labels.len(), 1); // mono file
+        assert_eq!(precomputed.channel_labels[0], vec!["kick-out".to_string()]);
+
+        // Track mappings should map the track name to the resolved channels
+        assert_eq!(
+            precomputed.track_mappings.get("kick-out"),
+            Some(&vec![3u16, 4])
+        );
+    }
+
+    #[test]
+    fn test_output_track_not_found_in_track_mappings() {
+        let (mixer, source_tx) = create_test_mixer_and_sender();
+        let mut engine = SampleEngine::new(mixer, source_tx, 32, 256, HashMap::new());
+
+        let definition = SampleDefinition::new_with_output_track(
+            Some("1Channel44.1k.wav".to_string()),
+            "nonexistent-track",
+            crate::config::samples::VelocityConfig::ignore(None),
+            ReleaseBehavior::PlayToCompletion,
+            crate::config::samples::RetriggerBehavior::Cut,
+            None,
+            50,
+        );
+        let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
+        engine.load_sample("kick", &definition, &base_path).unwrap();
+
+        let sample = engine.samples.get("kick").unwrap();
+        let file_path = base_path.join("1Channel44.1k.wav");
+        let precomputed = sample.loaded_files.get(&file_path).unwrap();
+
+        // With missing track, labels should be empty and no track mappings
+        assert_eq!(precomputed.channel_labels.len(), 1); // mono file
+        assert!(precomputed.channel_labels[0].is_empty());
+        assert!(precomputed.track_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_output_channels_still_works() {
+        let (mixer, source_tx) = create_test_mixer_and_sender();
+        let mut engine = SampleEngine::new(mixer, source_tx, 32, 256, HashMap::new());
+
+        let definition = SampleDefinition::new(
+            Some("1Channel44.1k.wav".to_string()),
+            vec![5, 6],
+            crate::config::samples::VelocityConfig::ignore(None),
+            ReleaseBehavior::PlayToCompletion,
+            crate::config::samples::RetriggerBehavior::Cut,
+            None,
+            50,
+        );
+        let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
+        engine
+            .load_sample("snare", &definition, &base_path)
+            .unwrap();
+
+        let sample = engine.samples.get("snare").unwrap();
+        let file_path = base_path.join("1Channel44.1k.wav");
+        let precomputed = sample.loaded_files.get(&file_path).unwrap();
+
+        // Should use synthetic __sample_out_ labels
+        assert_eq!(precomputed.channel_labels.len(), 1); // mono file
+        assert!(precomputed.channel_labels[0].contains(&"__sample_out_5".to_string()));
+        assert!(precomputed.channel_labels[0].contains(&"__sample_out_6".to_string()));
+
+        // Track mappings should map synthetic names to channels
+        assert_eq!(
+            precomputed.track_mappings.get("__sample_out_5"),
+            Some(&vec![5u16])
+        );
+        assert_eq!(
+            precomputed.track_mappings.get("__sample_out_6"),
+            Some(&vec![6u16])
+        );
     }
 }

--- a/src/samples/trigger.rs
+++ b/src/samples/trigger.rs
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Source-agnostic trigger types for sample playback.
+//!
+//! These types decouple the sample engine from any specific trigger source
+//! (MIDI, audio triggers, etc.).
+
+/// A source-agnostic trigger event that fires a sample.
+#[derive(Debug, Clone)]
+pub struct TriggerEvent {
+    /// The name of the sample to trigger (references a SampleDefinition).
+    pub sample_name: String,
+    /// Velocity value (0-127) controlling volume/layer selection.
+    pub velocity: u8,
+    /// Optional release group — voices created by this trigger can be
+    /// released later by matching on this group name.
+    pub release_group: Option<String>,
+}
+
+/// An action produced by a trigger source.
+#[derive(Debug, Clone)]
+pub enum TriggerAction {
+    /// Fire a sample.
+    Trigger(TriggerEvent),
+    /// Release all voices in the named group.
+    Release { group: String },
+}

--- a/src/samples/voice.rs
+++ b/src/samples/voice.rs
@@ -14,30 +14,34 @@
 
 //! Voice management for polyphonic sample playback.
 //!
-//! Handles voice allocation, stealing, and note-off behavior.
+//! Handles voice allocation, stealing, and release group behavior.
+//! Voice management is source-agnostic — it works with any trigger source
+//! (MIDI, audio triggers, etc.) via generic release groups.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 
 use tracing::{debug, warn};
 
-use crate::config::samples::{NoteOffBehavior, RetriggerBehavior};
+use crate::config::samples::{ReleaseBehavior, RetriggerBehavior};
 use crate::playsync::CancelHandle;
 
 /// Global voice ID counter.
 static NEXT_VOICE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Represents an active voice playing a sample.
-pub struct Voice {
+pub(super) struct Voice {
     /// Unique ID for this voice.
     id: u64,
     /// The sample name being played.
     sample_name: String,
-    /// The MIDI note that triggered this voice (for Note Off matching).
-    trigger_note: Option<u8>,
-    /// The MIDI channel that triggered this voice (for Note Off matching).
-    trigger_channel: Option<u8>,
+    /// Optional release group for voice management (e.g. "midi:10:36", "kick").
+    /// Voices in the same release group can be released together.
+    release_group: Option<String>,
+    /// What to do when this voice's release group is released.
+    release_behavior: ReleaseBehavior,
     /// When this voice started playing.
     start_time: Instant,
     /// The audio source ID in the mixer (used for testing/debugging).
@@ -46,53 +50,53 @@ pub struct Voice {
     /// Cancel handle for stopping this voice without lock contention.
     cancel_handle: CancelHandle,
     /// Scheduled sample at which this voice should stop (for sample-accurate cuts).
-    cancel_at_sample: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    cancel_at_sample: Arc<AtomicU64>,
+    /// Shared flag set by the mixer when the audio source finishes playing.
+    is_finished: Arc<AtomicBool>,
 }
 
 impl Voice {
     /// Creates a new voice.
-    pub fn new(
+    pub(super) fn new(
         sample_name: String,
-        trigger_note: Option<u8>,
-        trigger_channel: Option<u8>,
+        release_group: Option<String>,
+        release_behavior: ReleaseBehavior,
         mixer_source_id: u64,
         cancel_handle: CancelHandle,
-        cancel_at_sample: std::sync::Arc<std::sync::atomic::AtomicU64>,
+        cancel_at_sample: Arc<AtomicU64>,
+        is_finished: Arc<AtomicBool>,
     ) -> Self {
         Self {
-            id: NEXT_VOICE_ID.fetch_add(1, Ordering::SeqCst),
+            id: NEXT_VOICE_ID.fetch_add(1, Ordering::Relaxed),
             sample_name,
-            trigger_note,
-            trigger_channel,
+            release_group,
+            release_behavior,
             start_time: Instant::now(),
             mixer_source_id,
             cancel_handle,
             cancel_at_sample,
+            is_finished,
         }
     }
 
-    /// Checks if this voice matches a Note Off event.
-    pub fn matches_note_off(&self, note: u8, channel: u8) -> bool {
-        match (self.trigger_note, self.trigger_channel) {
-            (Some(n), Some(c)) => n == note && c == channel,
-            (Some(n), None) => n == note,
-            _ => false,
-        }
+    /// Checks if this voice belongs to the given release group.
+    fn matches_release(&self, group: &str) -> bool {
+        self.release_group.as_deref() == Some(group)
     }
 
     /// Returns a clone of this voice's cancel handle.
-    pub fn cancel_handle(&self) -> CancelHandle {
+    fn cancel_handle(&self) -> CancelHandle {
         self.cancel_handle.clone()
     }
 
     /// Returns a clone of this voice's cancel_at_sample.
-    pub fn cancel_at_sample(&self) -> std::sync::Arc<std::sync::atomic::AtomicU64> {
+    fn cancel_at_sample(&self) -> Arc<AtomicU64> {
         self.cancel_at_sample.clone()
     }
 }
 
 /// Manages active voices for sample playback.
-pub struct VoiceManager {
+pub(super) struct VoiceManager {
     /// Active voices.
     voices: Vec<Voice>,
     /// Global maximum voices limit.
@@ -103,7 +107,7 @@ pub struct VoiceManager {
 
 impl VoiceManager {
     /// Creates a new voice manager.
-    pub fn new(max_voices: u32) -> Self {
+    pub(super) fn new(max_voices: u32) -> Self {
         Self {
             voices: Vec::new(),
             max_voices,
@@ -112,18 +116,28 @@ impl VoiceManager {
     }
 
     /// Sets the per-sample voice limit.
-    pub fn set_sample_limit(&mut self, sample_name: &str, limit: u32) {
+    pub(super) fn set_sample_limit(&mut self, sample_name: &str, limit: u32) {
         self.sample_limits.insert(sample_name.to_string(), limit);
+    }
+
+    /// Removes voices whose audio source has finished playing in the mixer.
+    /// This prevents PlayToCompletion voices from accumulating indefinitely.
+    fn sweep_finished(&mut self) {
+        self.voices
+            .retain(|v| !v.is_finished.load(Ordering::Relaxed));
     }
 
     /// Adds a new voice, potentially stealing old voices if limits are exceeded.
     /// Returns the cancel_at_sample Arcs for any voices that should be stopped.
     /// The caller can set these to schedule the stop at a specific sample time.
-    pub fn add_voice(
+    pub(super) fn add_voice(
         &mut self,
         voice: Voice,
         retrigger: RetriggerBehavior,
-    ) -> Vec<std::sync::Arc<std::sync::atomic::AtomicU64>> {
+    ) -> Vec<Arc<AtomicU64>> {
+        // Sweep finished voices before checking limits.
+        self.sweep_finished();
+
         let mut voices_to_stop = Vec::new();
 
         // Handle retrigger behavior
@@ -184,43 +198,42 @@ impl VoiceManager {
         voices_to_stop
     }
 
-    /// Handles a Note Off event for the specified note and channel.
+    /// Releases voices matching the given release group.
+    /// Each voice's own ReleaseBehavior determines whether it is stopped.
     /// Returns the cancel handles for voices that should be stopped or faded.
-    pub fn handle_note_off(
-        &mut self,
-        note: u8,
-        channel: u8,
-        behavior: NoteOffBehavior,
-    ) -> Vec<CancelHandle> {
+    pub(super) fn release(&mut self, group: &str) -> Vec<CancelHandle> {
         let mut to_stop = Vec::new();
 
-        match behavior {
-            NoteOffBehavior::PlayToCompletion => {
-                // Do nothing - let the sample play to completion
-            }
-            NoteOffBehavior::Stop | NoteOffBehavior::Fade => {
-                // Find and remove matching voices
-                // Note: Fade currently behaves like Stop (immediate stop, no fade-out)
-                for v in self.voices.iter() {
-                    if v.matches_note_off(note, channel) {
+        for v in self.voices.iter() {
+            if v.matches_release(group) {
+                match v.release_behavior {
+                    ReleaseBehavior::PlayToCompletion => {
+                        // Let this voice play to completion
+                    }
+                    ReleaseBehavior::Stop | ReleaseBehavior::Fade => {
+                        // Note: Fade currently behaves like Stop (immediate stop, no fade-out)
                         to_stop.push(v.cancel_handle());
                     }
                 }
-                self.voices.retain(|v| !v.matches_note_off(note, channel));
             }
         }
+
+        // Remove only the voices that were stopped (not PlayToCompletion ones)
+        self.voices.retain(|v| {
+            !v.matches_release(group) || v.release_behavior == ReleaseBehavior::PlayToCompletion
+        });
 
         to_stop
     }
 
     /// Returns the current number of active voices.
-    pub fn active_count(&self) -> usize {
+    pub(super) fn active_count(&self) -> usize {
         self.voices.len()
     }
 
     /// Clears all voices.
     /// Returns the cancel handles for all voices that should be stopped.
-    pub fn clear(&mut self) -> Vec<CancelHandle> {
+    pub(super) fn clear(&mut self) -> Vec<CancelHandle> {
         let handles: Vec<CancelHandle> = self.voices.iter().map(|v| v.cancel_handle()).collect();
         self.voices.clear();
         handles
@@ -240,43 +253,52 @@ impl std::fmt::Debug for VoiceManager {
 mod tests {
     use super::*;
 
-    fn make_voice(sample: &str, note: Option<u8>, channel: Option<u8>, id: u64) -> Voice {
+    fn make_voice(sample: &str, release_group: Option<&str>, id: u64) -> Voice {
+        make_voice_with_behavior(sample, release_group, id, ReleaseBehavior::Stop)
+    }
+
+    fn make_voice_with_behavior(
+        sample: &str,
+        release_group: Option<&str>,
+        id: u64,
+        release_behavior: ReleaseBehavior,
+    ) -> Voice {
         Voice::new(
             sample.to_string(),
-            note,
-            channel,
+            release_group.map(|s| s.to_string()),
+            release_behavior,
             id,
             CancelHandle::new(),
-            std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicBool::new(false)),
         )
     }
 
     #[test]
-    fn test_voice_note_off_matching() {
-        let voice = make_voice("test", Some(60), Some(10), 1);
+    fn test_voice_release_matching() {
+        let voice = make_voice("test", Some("midi:10:60"), 1);
 
-        assert!(voice.matches_note_off(60, 10));
-        assert!(!voice.matches_note_off(61, 10));
-        assert!(!voice.matches_note_off(60, 11));
+        assert!(voice.matches_release("midi:10:60"));
+        assert!(!voice.matches_release("midi:10:61"));
+        assert!(!voice.matches_release("midi:11:60"));
 
-        // Voice without channel should match any channel
-        let voice2 = make_voice("test", Some(60), None, 2);
-        assert!(voice2.matches_note_off(60, 10));
-        assert!(voice2.matches_note_off(60, 5));
-        assert!(!voice2.matches_note_off(61, 10));
+        // Voice without release group matches nothing
+        let voice2 = make_voice("test", None, 2);
+        assert!(!voice2.matches_release("midi:10:60"));
+        assert!(!voice2.matches_release("anything"));
     }
 
     #[test]
     fn test_voice_manager_cut_retrigger() {
         let mut manager = VoiceManager::new(32);
 
-        let voice1 = make_voice("kick", Some(36), Some(10), 1);
+        let voice1 = make_voice("kick", Some("midi:10:36"), 1);
         let stopped = manager.add_voice(voice1, RetriggerBehavior::Cut);
         assert!(stopped.is_empty());
         assert_eq!(manager.active_count(), 1);
 
         // Add another voice for the same sample - should cut the previous
-        let voice2 = make_voice("kick", Some(36), Some(10), 2);
+        let voice2 = make_voice("kick", Some("midi:10:36"), 2);
         let stopped = manager.add_voice(voice2, RetriggerBehavior::Cut);
         assert_eq!(stopped.len(), 1); // One voice should be stopped
         assert_eq!(manager.active_count(), 1);
@@ -289,14 +311,14 @@ mod tests {
 
         // Add 4 voices - should all be allowed
         for i in 1..=4 {
-            let voice = make_voice("snare", Some(38), Some(10), i);
+            let voice = make_voice("snare", Some("midi:10:38"), i);
             let stopped = manager.add_voice(voice, RetriggerBehavior::Polyphonic);
             assert!(stopped.is_empty());
         }
         assert_eq!(manager.active_count(), 4);
 
         // Add 5th voice - should steal oldest
-        let voice5 = make_voice("snare", Some(38), Some(10), 5);
+        let voice5 = make_voice("snare", Some("midi:10:38"), 5);
         let stopped = manager.add_voice(voice5, RetriggerBehavior::Polyphonic);
         assert_eq!(stopped.len(), 1); // Voice 1 was oldest
         assert_eq!(manager.active_count(), 4);
@@ -307,43 +329,82 @@ mod tests {
         let mut manager = VoiceManager::new(3);
 
         for i in 1..=3 {
-            let voice = make_voice(&format!("sample{}", i), Some(36), Some(10), i);
+            let voice = make_voice(&format!("sample{}", i), Some("midi:10:36"), i);
             let stopped = manager.add_voice(voice, RetriggerBehavior::Polyphonic);
             assert!(stopped.is_empty());
         }
 
         // Add 4th voice - should steal oldest globally
-        let voice4 = make_voice("sample4", Some(36), Some(10), 4);
+        let voice4 = make_voice("sample4", Some("midi:10:36"), 4);
         let stopped = manager.add_voice(voice4, RetriggerBehavior::Polyphonic);
         assert_eq!(stopped.len(), 1);
         assert_eq!(manager.active_count(), 3);
     }
 
     #[test]
-    fn test_note_off_stop() {
+    fn test_release_stop() {
         let mut manager = VoiceManager::new(32);
 
-        let voice1 = make_voice("kick", Some(36), Some(10), 1);
-        let voice2 = make_voice("snare", Some(38), Some(10), 2);
+        let voice1 = make_voice("kick", Some("midi:10:36"), 1);
+        let voice2 = make_voice("snare", Some("midi:10:38"), 2);
         manager.add_voice(voice1, RetriggerBehavior::Polyphonic);
         manager.add_voice(voice2, RetriggerBehavior::Polyphonic);
 
-        // Note Off for kick should stop only the kick
-        let stopped = manager.handle_note_off(36, 10, NoteOffBehavior::Stop);
+        // Release for kick group should stop only the kick
+        let stopped = manager.release("midi:10:36");
         assert_eq!(stopped.len(), 1);
         assert_eq!(manager.active_count(), 1);
     }
 
     #[test]
-    fn test_note_off_play_to_completion() {
+    fn test_release_play_to_completion() {
         let mut manager = VoiceManager::new(32);
 
-        let voice = make_voice("kick", Some(36), Some(10), 1);
+        let voice = make_voice_with_behavior(
+            "kick",
+            Some("midi:10:36"),
+            1,
+            ReleaseBehavior::PlayToCompletion,
+        );
         manager.add_voice(voice, RetriggerBehavior::Polyphonic);
 
-        // Note Off with PlayToCompletion should not stop anything
-        let stopped = manager.handle_note_off(36, 10, NoteOffBehavior::PlayToCompletion);
+        // Voice with PlayToCompletion should not be stopped on release
+        let stopped = manager.release("midi:10:36");
         assert!(stopped.is_empty());
         assert_eq!(manager.active_count(), 1);
+    }
+
+    #[test]
+    fn test_release_custom_group() {
+        let mut manager = VoiceManager::new(32);
+
+        let voice1 = make_voice("cymbal", Some("cymbal"), 1);
+        let voice2 = make_voice("cymbal", Some("cymbal"), 2);
+        let voice3 = make_voice("kick", Some("kick"), 3);
+        manager.add_voice(voice1, RetriggerBehavior::Polyphonic);
+        manager.add_voice(voice2, RetriggerBehavior::Polyphonic);
+        manager.add_voice(voice3, RetriggerBehavior::Polyphonic);
+
+        // Release cymbal group should stop both cymbal voices
+        let stopped = manager.release("cymbal");
+        assert_eq!(stopped.len(), 2);
+        assert_eq!(manager.active_count(), 1);
+    }
+
+    #[test]
+    fn test_release_mixed_behaviors_in_same_group() {
+        let mut manager = VoiceManager::new(32);
+
+        // Two voices in the same group with different ReleaseBehaviors
+        let voice1 =
+            make_voice_with_behavior("ride", Some("cymbal"), 1, ReleaseBehavior::PlayToCompletion);
+        let voice2 = make_voice_with_behavior("hi-hat", Some("cymbal"), 2, ReleaseBehavior::Stop);
+        manager.add_voice(voice1, RetriggerBehavior::Polyphonic);
+        manager.add_voice(voice2, RetriggerBehavior::Polyphonic);
+
+        // Release should only stop the hi-hat (Stop), not the ride (PlayToCompletion)
+        let stopped = manager.release("cymbal");
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(manager.active_count(), 1); // ride still playing
     }
 }

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -12,21 +12,18 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-pub mod audio;
-pub mod calibrate;
-pub mod config;
-pub mod controller;
-pub mod dmx;
-pub mod lighting;
-pub mod midi;
-pub mod player;
-pub mod playlist;
-pub mod playsync;
-pub mod proto;
-pub mod samples;
-pub mod songs;
-#[cfg(test)]
-pub mod testutil;
-pub mod trigger;
-pub mod util;
-pub mod verify;
+//! Audio trigger detection for piezo drum triggers.
+//!
+//! Captures audio input via cpal, detects transient hits using per-channel
+//! state machines, and produces source-agnostic `TriggerAction` events.
+
+mod detector;
+mod engine;
+mod filter;
+
+pub use engine::TriggerEngine;
+
+/// Converts milliseconds to samples, rounding up.
+fn ms_to_samples(ms: u32, sample_rate: u32) -> u32 {
+    ((ms as f64) * (sample_rate as f64) / 1000.0).ceil() as u32
+}

--- a/src/trigger/detector.rs
+++ b/src/trigger/detector.rs
@@ -1,0 +1,845 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Per-channel transient detection state machine.
+//!
+//! States: Idle → Scanning → Lockout → Idle
+//!
+//! - **Idle:** Waits for `|sample * gain| > threshold`, then transitions to Scanning.
+//! - **Scanning:** Tracks peak amplitude for `scan_time` samples, then fires a trigger
+//!   and transitions to Lockout.
+//! - **Lockout:** Waits `retrigger_time` samples, then returns to Idle.
+
+use super::filter::BiquadHighPass;
+use crate::config::trigger::{AudioTriggerInput, TriggerInputAction, VelocityCurve};
+use crate::samples::{TriggerAction, TriggerEvent};
+
+/// Internal state of the detector.
+enum State {
+    /// Waiting for a threshold crossing.
+    Idle,
+    /// Threshold crossed; tracking peak for scan window.
+    Scanning { peak: f32, remaining_samples: u32 },
+    /// Trigger fired; lockout to prevent double-triggering.
+    Lockout { remaining_samples: u32 },
+}
+
+/// Per-channel transient detector.
+pub(super) struct TriggerDetector {
+    state: State,
+    /// Input gain multiplier.
+    gain: f32,
+    /// Amplitude threshold (0.0-1.0).
+    threshold: f32,
+    /// Scan window in samples.
+    scan_samples: u32,
+    /// Lockout period in samples.
+    lockout_samples: u32,
+    /// Velocity curve type.
+    velocity_curve: VelocityCurve,
+    /// Fixed velocity value (used when curve is Fixed).
+    fixed_velocity: u8,
+    /// Sample name to trigger (None for release-only inputs).
+    sample_name: Option<String>,
+    /// Release group for voice management.
+    release_group: Option<String>,
+    /// Action type (trigger or release).
+    action: TriggerInputAction,
+    /// Optional high-pass filter for low-frequency rejection.
+    highpass: Option<BiquadHighPass>,
+    /// Exponential decay coefficient for dynamic threshold.
+    dynamic_decay_coeff: Option<f32>,
+    /// Current dynamic threshold offset (decays toward 0).
+    dynamic_level: f32,
+    /// Remaining samples in crosstalk suppression window.
+    crosstalk_remaining: u32,
+    /// Threshold multiplier during crosstalk suppression.
+    crosstalk_multiplier: f32,
+    /// EMA coefficient for noise floor tracking (None = disabled).
+    noise_floor_alpha: Option<f32>,
+    /// Current noise floor EMA estimate.
+    noise_floor_ema: f32,
+    /// Sensitivity multiplier: noise_ema * sensitivity = adaptive threshold floor.
+    noise_floor_sensitivity: f32,
+}
+
+impl TriggerDetector {
+    /// Creates a detector from an `AudioTriggerInput` configuration.
+    pub(super) fn from_input(input: &AudioTriggerInput, sample_rate: u32) -> Self {
+        Self::new(
+            sample_rate,
+            input.threshold(),
+            input.retrigger_time_ms(),
+            input.scan_time_ms(),
+            input.gain(),
+            input.velocity_curve(),
+            input.fixed_velocity(),
+            input.sample().map(|s| s.to_string()),
+            input.release_group().map(|s| s.to_string()),
+            input.action(),
+            input.highpass_freq(),
+            input.dynamic_threshold_decay_ms(),
+            input.noise_floor_sensitivity(),
+            input.noise_floor_decay_ms(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        sample_rate: u32,
+        threshold: f32,
+        retrigger_time_ms: u32,
+        scan_time_ms: u32,
+        gain: f32,
+        velocity_curve: VelocityCurve,
+        fixed_velocity: u8,
+        sample_name: Option<String>,
+        release_group: Option<String>,
+        action: TriggerInputAction,
+        highpass_freq: Option<f32>,
+        dynamic_threshold_decay_ms: Option<u32>,
+        noise_floor_sensitivity: Option<f32>,
+        noise_floor_decay_ms: u32,
+    ) -> Self {
+        let highpass = highpass_freq.map(|freq| BiquadHighPass::new(freq, sample_rate));
+
+        let dynamic_decay_coeff = dynamic_threshold_decay_ms.map(|ms| {
+            let decay_samples = (ms as f64) * (sample_rate as f64) / 1000.0;
+            (-1.0 / decay_samples).exp() as f32
+        });
+
+        let noise_floor_alpha = noise_floor_sensitivity.map(|_| {
+            let decay_samples = (noise_floor_decay_ms as f64) * (sample_rate as f64) / 1000.0;
+            (-1.0 / decay_samples).exp() as f32
+        });
+
+        Self {
+            state: State::Idle,
+            gain,
+            threshold,
+            scan_samples: super::ms_to_samples(scan_time_ms, sample_rate),
+            lockout_samples: super::ms_to_samples(retrigger_time_ms, sample_rate),
+            velocity_curve,
+            fixed_velocity,
+            sample_name,
+            release_group,
+            action,
+            highpass,
+            dynamic_decay_coeff,
+            dynamic_level: 0.0,
+            crosstalk_remaining: 0,
+            crosstalk_multiplier: 1.0,
+            noise_floor_alpha,
+            noise_floor_ema: 0.0,
+            noise_floor_sensitivity: noise_floor_sensitivity.unwrap_or(0.0),
+        }
+    }
+
+    /// Processes a single audio sample. Returns a `TriggerAction` when a trigger fires.
+    ///
+    /// Applies the high-pass filter (if configured), then delegates to `detect()`.
+    /// The split prevents Lockout→Idle recursion from re-running the filter,
+    /// which would corrupt biquad state.
+    pub(super) fn process_sample(&mut self, sample: f32) -> Option<TriggerAction> {
+        let filtered = match &mut self.highpass {
+            Some(hpf) => hpf.process(sample),
+            None => sample,
+        };
+        self.detect(filtered)
+    }
+
+    /// Core detection state machine operating on (optionally filtered) samples.
+    fn detect(&mut self, sample: f32) -> Option<TriggerAction> {
+        // Decay the dynamic threshold level each sample.
+        if let Some(coeff) = self.dynamic_decay_coeff {
+            self.dynamic_level *= coeff;
+        }
+
+        // Decrement crosstalk suppression counter.
+        if self.crosstalk_remaining > 0 {
+            self.crosstalk_remaining -= 1;
+        }
+
+        let amplitude = (sample * self.gain).abs();
+
+        // Update noise floor EMA during Idle state only.
+        if matches!(self.state, State::Idle) {
+            if let Some(alpha) = self.noise_floor_alpha {
+                self.noise_floor_ema = alpha * self.noise_floor_ema + (1.0 - alpha) * amplitude;
+            }
+        }
+
+        let effective_threshold = self.effective_threshold();
+
+        match &mut self.state {
+            State::Idle => {
+                if amplitude > effective_threshold {
+                    if self.scan_samples == 0 {
+                        // No scan window — fire immediately
+                        let action = self.fire(amplitude);
+                        self.state = State::Lockout {
+                            remaining_samples: self.lockout_samples,
+                        };
+                        return Some(action);
+                    }
+                    // The threshold-crossing sample counts as the first scan sample
+                    // (its amplitude is already recorded as the initial peak), so we
+                    // start the counter at scan_samples - 1.
+                    self.state = State::Scanning {
+                        peak: amplitude,
+                        remaining_samples: self.scan_samples - 1,
+                    };
+                }
+                None
+            }
+            State::Scanning {
+                peak,
+                remaining_samples,
+            } => {
+                if amplitude > *peak {
+                    *peak = amplitude;
+                }
+                if *remaining_samples == 0 {
+                    let final_peak = *peak;
+                    let action = self.fire(final_peak);
+                    self.state = State::Lockout {
+                        remaining_samples: self.lockout_samples,
+                    };
+                    Some(action)
+                } else {
+                    *remaining_samples -= 1;
+                    None
+                }
+            }
+            State::Lockout { remaining_samples } => {
+                if *remaining_samples == 0 {
+                    // Transition to Idle and evaluate this sample immediately.
+                    // Calls detect() (not process_sample()) to avoid re-filtering.
+                    self.state = State::Idle;
+                    return self.detect(sample);
+                }
+                *remaining_samples -= 1;
+                None
+            }
+        }
+    }
+
+    /// Computes the effective threshold, incorporating dynamic level and crosstalk.
+    fn effective_threshold(&self) -> f32 {
+        let adaptive_floor = self.noise_floor_ema * self.noise_floor_sensitivity;
+        let base = self.threshold.max(adaptive_floor) + self.dynamic_level;
+        if self.crosstalk_remaining > 0 {
+            base * self.crosstalk_multiplier
+        } else {
+            base
+        }
+    }
+
+    /// Converts a peak amplitude to a velocity value.
+    fn amplitude_to_velocity(&self, peak: f32) -> u8 {
+        match self.velocity_curve {
+            VelocityCurve::Linear => {
+                let clamped = peak.min(1.0);
+                (clamped * 127.0) as u8
+            }
+            VelocityCurve::Logarithmic => {
+                if peak <= self.threshold {
+                    return 1;
+                }
+                let clamped = peak.min(1.0);
+                let range = 1.0 - self.threshold;
+                if range < f32::EPSILON {
+                    return 127;
+                }
+                // Map threshold→1.0 logarithmically to 1→127
+                let normalized = (clamped - self.threshold) / range;
+                let log_val = (normalized + 1.0).ln() / 2.0_f32.ln();
+                let velocity = 1.0 + log_val * 126.0;
+                (velocity.clamp(1.0, 127.0)) as u8
+            }
+            VelocityCurve::Fixed => self.fixed_velocity,
+        }
+    }
+
+    /// Creates a TriggerAction from the detected peak amplitude.
+    ///
+    /// When dynamic threshold is enabled, sets the dynamic level based on
+    /// how far above threshold the peak was.
+    fn fire(&mut self, peak: f32) -> TriggerAction {
+        // Set dynamic threshold level if enabled.
+        if self.dynamic_decay_coeff.is_some() {
+            self.dynamic_level = (peak - self.threshold).max(0.0);
+        }
+
+        match self.action {
+            TriggerInputAction::Trigger => {
+                let velocity = self.amplitude_to_velocity(peak);
+                TriggerAction::Trigger(TriggerEvent {
+                    sample_name: self.sample_name.clone().unwrap_or_default(),
+                    velocity,
+                    release_group: self.release_group.clone(),
+                })
+            }
+            TriggerInputAction::Release => TriggerAction::Release {
+                group: self.release_group.clone().unwrap_or_default(),
+            },
+        }
+    }
+
+    /// Applies crosstalk suppression from another channel firing.
+    ///
+    /// Sets or extends the suppression window. Uses `max()` to avoid
+    /// shortening an existing window.
+    pub(super) fn apply_crosstalk_suppression(&mut self, window_samples: u32, multiplier: f32) {
+        self.crosstalk_remaining = self.crosstalk_remaining.max(window_samples);
+        self.crosstalk_multiplier = self.crosstalk_multiplier.max(multiplier);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_trigger(action: Option<TriggerAction>) -> TriggerEvent {
+        match action {
+            Some(TriggerAction::Trigger(e)) => e,
+            other => panic!("Expected TriggerAction::Trigger, got {:?}", other),
+        }
+    }
+
+    fn expect_release(action: Option<TriggerAction>) -> String {
+        match action {
+            Some(TriggerAction::Release { group }) => group,
+            other => panic!("Expected TriggerAction::Release, got {:?}", other),
+        }
+    }
+
+    fn make_trigger_detector(threshold: f32, scan_ms: u32, lockout_ms: u32) -> TriggerDetector {
+        TriggerDetector::new(
+            44100,
+            threshold,
+            lockout_ms,
+            scan_ms,
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            Some("kick".to_string()),
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            None,
+            200,
+        )
+    }
+
+    #[test]
+    fn test_below_threshold_no_trigger() {
+        let mut det = make_trigger_detector(0.1, 5, 30);
+        // Feed samples below threshold
+        for _ in 0..1000 {
+            assert!(det.process_sample(0.05).is_none());
+        }
+    }
+
+    #[test]
+    fn test_above_threshold_fires() {
+        let mut det = make_trigger_detector(0.1, 0, 30);
+        // With scan_time=0, should fire immediately on threshold crossing
+        let event = expect_trigger(det.process_sample(0.5));
+        assert_eq!(event.sample_name, "kick");
+        assert_eq!(event.release_group, Some("kick".to_string()));
+        // Linear velocity: 0.5 * 127 = 63
+        assert_eq!(event.velocity, 63);
+    }
+
+    #[test]
+    fn test_peak_detection_during_scan() {
+        // scan_time_ms = 5ms at 44100 = 221 samples
+        let mut det = make_trigger_detector(0.1, 5, 30);
+
+        // Cross threshold
+        assert!(det.process_sample(0.2).is_none());
+
+        // Peak during scan window
+        let scan_samples = ((5.0_f64 * 44100.0) / 1000.0).ceil() as u32;
+        for i in 0..scan_samples {
+            let sample = if i == scan_samples / 2 { 0.8 } else { 0.3 };
+            let result = det.process_sample(sample);
+            if i == scan_samples - 1 {
+                // Should fire on last scan sample — peak was 0.8 → velocity = 101
+                let event = expect_trigger(result);
+                assert_eq!(event.velocity, 101);
+                return;
+            }
+        }
+        panic!("Scan window ended without trigger");
+    }
+
+    #[test]
+    fn test_retrigger_lockout() {
+        let mut det = make_trigger_detector(0.1, 0, 30);
+
+        // First trigger
+        assert!(det.process_sample(0.5).is_some());
+
+        // During lockout, even above-threshold signals should be ignored
+        let lockout_samples = ((30.0_f64 * 44100.0) / 1000.0).ceil() as u32;
+        for _ in 0..lockout_samples {
+            assert!(det.process_sample(0.9).is_none());
+        }
+
+        // After lockout, should trigger again
+        assert!(det.process_sample(0.5).is_some());
+    }
+
+    #[test]
+    fn test_linear_velocity() {
+        let mut det = make_trigger_detector(0.1, 0, 0);
+
+        assert_eq!(expect_trigger(det.process_sample(1.0)).velocity, 127);
+        // Reset by going through idle
+        assert_eq!(expect_trigger(det.process_sample(0.5)).velocity, 63);
+    }
+
+    #[test]
+    fn test_logarithmic_velocity() {
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0,
+            0,
+            1.0,
+            VelocityCurve::Logarithmic,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            None,
+            200,
+        );
+
+        // At threshold → velocity 1
+        assert!(expect_trigger(det.process_sample(0.1001)).velocity <= 2);
+        // At max → velocity 127
+        assert_eq!(expect_trigger(det.process_sample(1.0)).velocity, 127);
+        // Mid-range should be between 1 and 127
+        let vel = expect_trigger(det.process_sample(0.55)).velocity;
+        assert!(vel > 1 && vel < 127);
+    }
+
+    #[test]
+    fn test_fixed_velocity() {
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0,
+            0,
+            1.0,
+            VelocityCurve::Fixed,
+            100,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            None,
+            200,
+        );
+
+        assert_eq!(expect_trigger(det.process_sample(0.5)).velocity, 100);
+        // Different amplitude, same fixed velocity
+        assert_eq!(expect_trigger(det.process_sample(0.9)).velocity, 100);
+    }
+
+    #[test]
+    fn test_release_action() {
+        let mut det = TriggerDetector::new(
+            44100,
+            0.05,
+            0,
+            0,
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            None,
+            Some("cymbal".to_string()),
+            TriggerInputAction::Release,
+            None,
+            None,
+            None,
+            200,
+        );
+
+        assert_eq!(expect_release(det.process_sample(0.3)), "cymbal");
+    }
+
+    #[test]
+    fn test_gain_multiplier() {
+        // With gain=2.0, a 0.06 sample becomes 0.12 which is above 0.1 threshold
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0,
+            0,
+            2.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            None,
+            200,
+        );
+
+        let result = det.process_sample(0.06);
+        assert!(result.is_some(), "Gain should push signal above threshold");
+    }
+
+    #[test]
+    fn test_negative_samples() {
+        let mut det = make_trigger_detector(0.1, 0, 0);
+
+        // Negative sample should still trigger (uses abs)
+        assert_eq!(expect_trigger(det.process_sample(-0.5)).velocity, 63);
+    }
+
+    #[test]
+    fn test_dynamic_threshold_prevents_ringing_retrigger() {
+        // With dynamic threshold enabled, piezo ringing after a hit should not retrigger.
+        // threshold=0.1, lockout=0ms (disabled), scan=0ms, dynamic_decay=50ms
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0, // no lockout
+            0, // no scan
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            Some(50), // 50ms dynamic decay
+            None,
+            200,
+        );
+
+        // Strong hit triggers
+        let result = det.process_sample(0.8);
+        assert!(result.is_some(), "Initial hit should trigger");
+
+        // Immediately after, ringing at 0.3 should NOT retrigger because
+        // dynamic_level was set to 0.8 - 0.1 = 0.7, so effective threshold = 0.1 + 0.7 = 0.8
+        let result = det.process_sample(0.3);
+        assert!(result.is_none(), "Ringing should not retrigger");
+
+        // Even 0.5 should not retrigger right after
+        let result = det.process_sample(0.5);
+        assert!(result.is_none(), "Ringing at 0.5 should not retrigger");
+    }
+
+    #[test]
+    fn test_dynamic_threshold_decays_allows_retrigger() {
+        // After enough time, dynamic threshold decays and allows a real retrigger.
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0, // no lockout
+            0, // no scan
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            Some(10), // 10ms dynamic decay (fast decay for test)
+            None,
+            200,
+        );
+
+        // Strong hit
+        assert!(det.process_sample(0.8).is_some());
+
+        // Feed silence for 200ms (well past 10ms decay) to let dynamic level decay
+        let silence_samples = ((200.0_f64 * 44100.0) / 1000.0).ceil() as u32;
+        for _ in 0..silence_samples {
+            assert!(det.process_sample(0.0).is_none());
+        }
+
+        // Now a real hit at 0.3 should trigger (dynamic level has decayed to ~0)
+        let result = det.process_sample(0.3);
+        assert!(result.is_some(), "Real hit after decay should trigger");
+    }
+
+    #[test]
+    fn test_crosstalk_suppression_elevates_threshold() {
+        let mut det = make_trigger_detector(0.1, 0, 0);
+
+        // Apply crosstalk suppression: 441 samples (10ms), 3x threshold multiplier
+        det.apply_crosstalk_suppression(441, 3.0);
+
+        // Signal at 0.2 is above normal threshold (0.1) but below suppressed (0.3)
+        let result = det.process_sample(0.2);
+        assert!(
+            result.is_none(),
+            "Should be suppressed during crosstalk window"
+        );
+
+        // Signal at 0.4 is above even the suppressed threshold
+        let result = det.process_sample(0.4);
+        assert!(
+            result.is_some(),
+            "Strong signal should overcome crosstalk suppression"
+        );
+    }
+
+    #[test]
+    fn test_crosstalk_suppression_expires() {
+        let mut det = make_trigger_detector(0.1, 0, 0);
+
+        // Apply crosstalk suppression for 100 samples, 5x multiplier
+        det.apply_crosstalk_suppression(100, 5.0);
+
+        // Feed silence to burn through suppression window
+        for _ in 0..100 {
+            det.process_sample(0.0);
+        }
+
+        // After suppression expires, normal threshold applies
+        let result = det.process_sample(0.2);
+        assert!(
+            result.is_some(),
+            "Should trigger normally after suppression expires"
+        );
+    }
+
+    #[test]
+    fn test_crosstalk_suppression_extends_window() {
+        let mut det = make_trigger_detector(0.1, 0, 0);
+
+        // Apply 50 samples of suppression
+        det.apply_crosstalk_suppression(50, 3.0);
+
+        // Burn 30 samples
+        for _ in 0..30 {
+            det.process_sample(0.0);
+        }
+
+        // Extend to 100 samples (should be 100 from now, not 20 remaining)
+        det.apply_crosstalk_suppression(100, 3.0);
+
+        // After 50 more samples (80 total from start), should still be suppressed
+        for _ in 0..50 {
+            det.process_sample(0.0);
+        }
+
+        let result = det.process_sample(0.2);
+        assert!(
+            result.is_none(),
+            "Should still be suppressed after window extension"
+        );
+    }
+
+    #[test]
+    fn test_adaptive_noise_floor_raises_threshold() {
+        // With sensitivity=5.0 and noise at 0.05, adaptive floor = ~0.25.
+        // A signal at 0.3 should barely trigger (just above 0.25).
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1, // base threshold
+            0,   // no lockout
+            0,   // no scan
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            Some(5.0), // noise floor sensitivity
+            200,       // 200ms decay
+        );
+
+        // Feed noise at 0.05 for 1 second to let EMA converge.
+        let noise_samples = 44100;
+        for _ in 0..noise_samples {
+            assert!(det.process_sample(0.05).is_none());
+        }
+
+        // EMA should have converged near 0.05, adaptive floor ≈ 0.25.
+        // Signal at 0.2 should NOT trigger (below adaptive floor).
+        let result = det.process_sample(0.2);
+        assert!(
+            result.is_none(),
+            "Signal below adaptive floor should not trigger"
+        );
+
+        // Signal at 0.3 should trigger (above adaptive floor ≈ 0.25).
+        let result = det.process_sample(0.3);
+        assert!(
+            result.is_some(),
+            "Signal above adaptive floor should trigger"
+        );
+    }
+
+    #[test]
+    fn test_adaptive_noise_floor_disabled_by_default() {
+        // With sensitivity=None, behavior is identical to before.
+        let mut det = make_trigger_detector(0.1, 0, 0);
+
+        // Feed noise at 0.05 for a while.
+        for _ in 0..4410 {
+            assert!(det.process_sample(0.05).is_none());
+        }
+
+        // Signal at 0.2 should trigger immediately (no adaptive floor).
+        let result = det.process_sample(0.2);
+        assert!(
+            result.is_some(),
+            "Without adaptive noise floor, 0.2 should trigger above 0.1 threshold"
+        );
+    }
+
+    #[test]
+    fn test_adaptive_noise_floor_frozen_during_scanning() {
+        // Verify that noise EMA doesn't update during Scanning state.
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1, // base threshold
+            100, // 100ms lockout
+            5,   // 5ms scan
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            Some(5.0),
+            200,
+        );
+
+        // Let EMA settle at low noise.
+        for _ in 0..4410 {
+            det.process_sample(0.01);
+        }
+
+        // Cross threshold to enter Scanning. The threshold-crossing sample
+        // is the last one processed while still in Idle, so capture EMA after it.
+        det.process_sample(0.5);
+        let ema_after_crossing = det.noise_floor_ema;
+
+        // Feed high amplitude during the scan window.
+        let scan_samples = ((5.0_f64 * 44100.0) / 1000.0).ceil() as u32;
+        for _ in 0..scan_samples {
+            det.process_sample(0.8);
+        }
+
+        // EMA should not have changed during Scanning.
+        assert!(
+            (det.noise_floor_ema - ema_after_crossing).abs() < 1e-6,
+            "Noise floor EMA should be frozen during Scanning state"
+        );
+    }
+
+    #[test]
+    fn test_adaptive_noise_floor_frozen_during_lockout() {
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1, // base threshold
+            100, // 100ms lockout
+            0,   // no scan
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            Some(5.0),
+            200,
+        );
+
+        // Let EMA settle at low noise.
+        for _ in 0..4410 {
+            det.process_sample(0.01);
+        }
+
+        // Fire a trigger to enter Lockout.
+        assert!(det.process_sample(0.5).is_some());
+        let ema_after_fire = det.noise_floor_ema;
+
+        // Feed high amplitude during lockout.
+        let lockout_samples = ((100.0_f64 * 44100.0) / 1000.0).ceil() as u32;
+        for _ in 0..lockout_samples {
+            det.process_sample(0.9);
+        }
+
+        // EMA should not have changed during Lockout.
+        assert!(
+            (det.noise_floor_ema - ema_after_fire).abs() < 1e-6,
+            "Noise floor EMA should be frozen during Lockout state"
+        );
+    }
+
+    #[test]
+    fn test_adaptive_noise_floor_recovers_after_noise_drops() {
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0,
+            0,
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            Some(5.0),
+            50, // fast 50ms decay for test
+        );
+
+        // Feed high noise to raise adaptive floor.
+        for _ in 0..44100 {
+            det.process_sample(0.08);
+        }
+
+        // Adaptive floor should be ~0.4 (0.08 * 5.0), so 0.3 won't trigger.
+        let result = det.process_sample(0.3);
+        assert!(result.is_none(), "Should not trigger during high noise");
+
+        // Feed silence for 2 seconds to let EMA decay.
+        for _ in 0..(44100 * 2) {
+            det.process_sample(0.0);
+        }
+
+        // Adaptive floor should have decayed back near 0, so 0.2 triggers.
+        let result = det.process_sample(0.2);
+        assert!(
+            result.is_some(),
+            "Should trigger after noise floor decays back down"
+        );
+    }
+}

--- a/src/trigger/engine.rs
+++ b/src/trigger/engine.rs
@@ -1,0 +1,299 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Audio trigger engine: cpal input stream + event forwarding.
+//!
+//! Opens a cpal input device, routes per-channel samples to `TriggerDetector`
+//! instances, and produces `TriggerAction` events via a crossbeam channel.
+
+use std::error::Error;
+
+use cpal::traits::{DeviceTrait, StreamTrait};
+use crossbeam_channel::{Receiver, Sender};
+use tracing::{debug, error, info, warn};
+
+use super::detector::TriggerDetector;
+use super::ms_to_samples;
+use crate::audio::format::SampleFormat;
+use crate::config::trigger::{TriggerConfig, TriggerInput, TriggerInputAction};
+use crate::samples::TriggerAction;
+
+/// Manages a cpal input stream and per-channel trigger detectors.
+///
+/// The engine captures audio from the configured input device, feeds samples
+/// to the appropriate detectors, and forwards resulting `TriggerAction` events
+/// through a crossbeam channel.
+pub struct TriggerEngine {
+    /// The cpal input stream (kept alive by ownership).
+    _stream: cpal::Stream,
+    /// Receiver for trigger actions produced by detectors.
+    receiver: Receiver<TriggerAction>,
+}
+
+impl TriggerEngine {
+    /// Creates a new trigger engine from configuration.
+    ///
+    /// Opens the named cpal input device, creates detectors for each configured
+    /// input channel, and starts the input stream.
+    pub fn new(config: &TriggerConfig) -> Result<Self, Box<dyn Error>> {
+        let device_name = config
+            .device()
+            .ok_or("Trigger config has audio inputs but no device specified")?;
+        let device = crate::audio::find_input_device(device_name)?;
+
+        let device_id = device
+            .id()
+            .map(|id| id.to_string())
+            .unwrap_or_else(|_| "unknown".to_string());
+        info!(device = %device_id, "Found trigger input device");
+
+        // Query device capabilities once and reuse.
+        let default_config = device.default_input_config()?;
+        let supported_configs: Vec<_> = device
+            .supported_input_configs()
+            .map(|configs| configs.collect())
+            .unwrap_or_default();
+
+        // Open with the device's max supported input channel count, matching how the
+        // output stream works. ALSA plughw will remap/downmix if you request fewer
+        // channels than the hardware provides, so we need the full width to get the
+        // correct physical channels.
+        let channels = supported_configs
+            .iter()
+            .map(|c: &cpal::SupportedStreamConfigRange| c.channels())
+            .max()
+            .filter(|&n| n > 0)
+            .unwrap_or_else(|| default_config.channels());
+
+        // Determine sample format: if the config specifies format/bits, use that;
+        // otherwise auto-detect the device's native format.
+        let native_format = supported_configs
+            .iter()
+            .find(|c| c.channels() == channels)
+            .map(|c| c.sample_format())
+            .unwrap_or(cpal::SampleFormat::F32);
+
+        let stream_format = match (config.sample_format(), config.bits_per_sample()) {
+            (Some(SampleFormat::Float), _) => cpal::SampleFormat::F32,
+            (Some(SampleFormat::Int), Some(16)) => cpal::SampleFormat::I16,
+            (Some(SampleFormat::Int), _) => cpal::SampleFormat::I32,
+            (None, Some(16)) => cpal::SampleFormat::I16,
+            _ => native_format,
+        };
+
+        let sample_rate = config.sample_rate().unwrap_or(default_config.sample_rate());
+
+        let buffer_size = match config.buffer_size() {
+            Some(n) => cpal::BufferSize::Fixed(n as u32),
+            None => cpal::BufferSize::Default,
+        };
+
+        let stream_config = cpal::StreamConfig {
+            channels,
+            sample_rate,
+            buffer_size,
+        };
+
+        info!(
+            sample_rate = sample_rate,
+            channels,
+            stream_format = ?stream_format,
+            buffer_size = ?config.buffer_size(),
+            "Trigger input stream config"
+        );
+
+        // Pre-compute crosstalk parameters (ms → samples) if both fields are set.
+        let crosstalk: Option<(u32, f32)> =
+            match (config.crosstalk_window_ms(), config.crosstalk_threshold()) {
+                (Some(ms), Some(mult)) => {
+                    let window_samples = ms_to_samples(ms, sample_rate);
+                    info!(
+                        crosstalk_window_ms = ms,
+                        crosstalk_threshold = mult,
+                        crosstalk_window_samples = window_samples,
+                        "Crosstalk suppression enabled"
+                    );
+                    Some((window_samples, mult))
+                }
+                _ => None,
+            };
+
+        // Build detectors for each configured input, keyed by 0-indexed channel
+        let mut detector_map: Vec<Option<TriggerDetector>> = (0..channels).map(|_| None).collect();
+
+        for input in config.inputs().iter().filter_map(|i| match i {
+            TriggerInput::Audio(audio) => Some(audio),
+            _ => None,
+        }) {
+            // Validate that trigger actions have a sample name and release actions have a group
+            match input.action() {
+                TriggerInputAction::Trigger => {
+                    if input.sample().is_none_or(|s| s.is_empty()) {
+                        return Err(format!(
+                            "Trigger input on channel {} has action 'trigger' but no sample name configured",
+                            input.channel()
+                        ).into());
+                    }
+                }
+                TriggerInputAction::Release => {
+                    if input.release_group().is_none_or(|s| s.is_empty()) {
+                        return Err(format!(
+                            "Trigger input on channel {} has action 'release' but no release_group configured",
+                            input.channel()
+                        ).into());
+                    }
+                }
+            }
+
+            let ch_idx = input.channel().checked_sub(1).ok_or_else(|| {
+                format!(
+                    "Trigger input channel must be >= 1, got {}",
+                    input.channel()
+                )
+            })? as usize;
+
+            if ch_idx >= channels as usize {
+                warn!(
+                    channel = input.channel(),
+                    device_channels = channels,
+                    "Trigger input channel exceeds device channel count, skipping"
+                );
+                continue;
+            }
+
+            let detector = TriggerDetector::from_input(input, sample_rate);
+
+            detector_map[ch_idx] = Some(detector);
+            debug!(
+                channel = input.channel(),
+                sample = input.sample().unwrap_or("(release)"),
+                "Trigger detector created"
+            );
+        }
+
+        // Create the event channel (bounded to prevent unbounded growth under load)
+        let (tx, rx) = crossbeam_channel::bounded(256);
+
+        // Build the input stream using the resolved sample format
+        let stream = Self::build_input_stream(
+            &device,
+            &stream_config,
+            detector_map,
+            channels,
+            tx,
+            stream_format,
+            crosstalk,
+        )?;
+
+        stream.play()?;
+        info!("Trigger input stream started");
+
+        Ok(TriggerEngine {
+            _stream: stream,
+            receiver: rx,
+        })
+    }
+
+    /// Returns a clone of the trigger action receiver.
+    pub fn subscribe(&self) -> Receiver<TriggerAction> {
+        self.receiver.clone()
+    }
+
+    /// Builds the cpal input stream, matching the device's native sample format.
+    fn build_input_stream(
+        device: &cpal::Device,
+        config: &cpal::StreamConfig,
+        detectors: Vec<Option<TriggerDetector>>,
+        channels: u16,
+        tx: Sender<TriggerAction>,
+        sample_format: cpal::SampleFormat,
+        crosstalk: Option<(u32, f32)>,
+    ) -> Result<cpal::Stream, Box<dyn Error>> {
+        match sample_format {
+            cpal::SampleFormat::I16 => Self::build_input_stream_typed::<i16>(
+                device, config, detectors, channels, tx, crosstalk,
+            ),
+            cpal::SampleFormat::I32 => Self::build_input_stream_typed::<i32>(
+                device, config, detectors, channels, tx, crosstalk,
+            ),
+            _ => Self::build_input_stream_typed::<f32>(
+                device, config, detectors, channels, tx, crosstalk,
+            ),
+        }
+    }
+
+    /// Builds a typed cpal input stream, converting samples to f32 for detection.
+    fn build_input_stream_typed<T>(
+        device: &cpal::Device,
+        config: &cpal::StreamConfig,
+        mut detectors: Vec<Option<TriggerDetector>>,
+        channels: u16,
+        tx: Sender<TriggerAction>,
+        crosstalk: Option<(u32, f32)>,
+    ) -> Result<cpal::Stream, Box<dyn Error>>
+    where
+        T: cpal::SizedSample + 'static,
+        f32: cpal::FromSample<T>,
+    {
+        let stream = device.build_input_stream(
+            config,
+            move |data: &[T], _: &cpal::InputCallbackInfo| {
+                // Data is interleaved: [ch0, ch1, ch2, ..., ch0, ch1, ...]
+                for frame in data.chunks_exact(channels as usize) {
+                    // Track which channels fired in this frame for crosstalk.
+                    let mut fired_channels: u64 = 0;
+
+                    for (ch_idx, raw_sample) in frame.iter().enumerate() {
+                        if let Some(ref mut detector) = detectors[ch_idx] {
+                            let sample: f32 =
+                                <f32 as cpal::FromSample<T>>::from_sample_(*raw_sample);
+                            if let Some(action) = detector.process_sample(sample) {
+                                if ch_idx < 64 {
+                                    fired_channels |= 1u64 << ch_idx;
+                                }
+                                // Non-blocking send — drop events if channel is full
+                                if tx.try_send(action).is_err() {
+                                    error!("Trigger event dropped (channel full)");
+                                }
+                            }
+                        }
+                    }
+
+                    // Apply crosstalk suppression to all OTHER detectors when any fired.
+                    // Crosstalk tracking is limited to the first 64 channels.
+                    if let Some((window_samples, multiplier)) = crosstalk {
+                        if fired_channels != 0 {
+                            for (ch_idx, slot) in detectors.iter_mut().enumerate() {
+                                if ch_idx >= 64 || fired_channels & (1u64 << ch_idx) == 0 {
+                                    if let Some(ref mut detector) = slot {
+                                        detector.apply_crosstalk_suppression(
+                                            window_samples,
+                                            multiplier,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            move |err| {
+                error!(error = %err, "Trigger input stream error");
+            },
+            None,
+        )?;
+
+        Ok(stream)
+    }
+}

--- a/src/trigger/filter.rs
+++ b/src/trigger/filter.rs
@@ -1,0 +1,203 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! 2nd-order Butterworth high-pass biquad filter.
+//!
+//! Rejects low-frequency content (stage rumble, bass cab vibration) from
+//! piezo trigger signals. Uses Direct Form I processing.
+
+use std::f64::consts::{FRAC_1_SQRT_2, PI};
+
+/// A 2nd-order Butterworth high-pass IIR filter (biquad).
+pub(super) struct BiquadHighPass {
+    // Numerator coefficients (pre-divided by a0).
+    b0: f32,
+    b1: f32,
+    b2: f32,
+    // Denominator coefficients (pre-divided by a0).
+    a1: f32,
+    a2: f32,
+    // Input delay line.
+    x1: f32,
+    x2: f32,
+    // Output delay line.
+    y1: f32,
+    y2: f32,
+}
+
+impl BiquadHighPass {
+    /// Creates a new Butterworth high-pass filter.
+    ///
+    /// - `cutoff_hz`: the -3dB cutoff frequency in Hz.
+    /// - `sample_rate`: the audio sample rate in Hz.
+    pub fn new(cutoff_hz: f32, sample_rate: u32) -> Self {
+        // Bilinear transform pre-warped frequency.
+        let omega = 2.0 * PI * (cutoff_hz as f64) / (sample_rate as f64);
+        let cos_omega = omega.cos();
+        let sin_omega = omega.sin();
+        // Q = 1/sqrt(2) for Butterworth (maximally flat).
+        let alpha = sin_omega / (2.0 * FRAC_1_SQRT_2);
+
+        let a0 = 1.0 + alpha;
+        let b0 = ((1.0 + cos_omega) / 2.0) / a0;
+        let b1 = (-(1.0 + cos_omega)) / a0;
+        let b2 = ((1.0 + cos_omega) / 2.0) / a0;
+        let a1 = (-2.0 * cos_omega) / a0;
+        let a2 = (1.0 - alpha) / a0;
+
+        Self {
+            b0: b0 as f32,
+            b1: b1 as f32,
+            b2: b2 as f32,
+            a1: a1 as f32,
+            a2: a2 as f32,
+            x1: 0.0,
+            x2: 0.0,
+            y1: 0.0,
+            y2: 0.0,
+        }
+    }
+
+    /// Processes a single sample through the filter (Direct Form I).
+    pub fn process(&mut self, sample: f32) -> f32 {
+        let output = self.b0 * sample + self.b1 * self.x1 + self.b2 * self.x2
+            - self.a1 * self.y1
+            - self.a2 * self.y2;
+
+        self.x2 = self.x1;
+        self.x1 = sample;
+        self.y2 = self.y1;
+        self.y1 = output;
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dc_rejection() {
+        let mut filter = BiquadHighPass::new(80.0, 44100);
+        // Feed DC (constant 1.0) for enough samples to settle.
+        for _ in 0..10000 {
+            filter.process(1.0);
+        }
+        // After settling, output should be near zero (DC rejected).
+        let out = filter.process(1.0);
+        assert!(out.abs() < 0.001, "DC should be rejected, got {}", out);
+    }
+
+    #[test]
+    fn test_high_frequency_passthrough() {
+        let mut filter = BiquadHighPass::new(80.0, 44100);
+        let freq = 4000.0_f64; // Well above cutoff
+        let sample_rate = 44100.0_f64;
+
+        // Let filter settle with a few cycles.
+        for i in 0..4410 {
+            let sample = (2.0 * PI * freq * (i as f64) / sample_rate).sin() as f32;
+            filter.process(sample);
+        }
+
+        // Measure amplitude over one full cycle.
+        let cycle_samples = (sample_rate / freq).ceil() as usize;
+        let mut max_out: f32 = 0.0;
+        for i in 4410..(4410 + cycle_samples) {
+            let sample = (2.0 * PI * freq * (i as f64) / sample_rate).sin() as f32;
+            let out = filter.process(sample);
+            max_out = max_out.max(out.abs());
+        }
+
+        // High frequency should pass through with minimal attenuation.
+        assert!(
+            max_out > 0.9,
+            "4kHz should pass through, got amplitude {}",
+            max_out
+        );
+    }
+
+    #[test]
+    fn test_below_cutoff_attenuated() {
+        let mut filter = BiquadHighPass::new(200.0, 44100);
+        let freq = 20.0_f64; // Well below cutoff
+        let sample_rate = 44100.0_f64;
+
+        // Let filter settle.
+        for i in 0..44100 {
+            let sample = (2.0 * PI * freq * (i as f64) / sample_rate).sin() as f32;
+            filter.process(sample);
+        }
+
+        // Measure amplitude over one cycle.
+        let cycle_samples = (sample_rate / freq).ceil() as usize;
+        let mut max_out: f32 = 0.0;
+        for i in 44100..(44100 + cycle_samples) {
+            let sample = (2.0 * PI * freq * (i as f64) / sample_rate).sin() as f32;
+            let out = filter.process(sample);
+            max_out = max_out.max(out.abs());
+        }
+
+        // 20Hz with 200Hz cutoff should be heavily attenuated (2nd order = -12dB/octave,
+        // ~3.3 octaves below = ~-40dB).
+        assert!(
+            max_out < 0.05,
+            "20Hz should be attenuated below 200Hz cutoff, got amplitude {}",
+            max_out
+        );
+    }
+
+    #[test]
+    fn test_gain_at_cutoff_is_minus_3db() {
+        let cutoff = 200.0_f64;
+        let sample_rate = 44100.0_f64;
+        let mut filter = BiquadHighPass::new(cutoff as f32, sample_rate as u32);
+
+        // Let filter settle with several seconds of signal at the cutoff frequency.
+        for i in 0..44100 {
+            let sample = (2.0 * PI * cutoff * (i as f64) / sample_rate).sin() as f32;
+            filter.process(sample);
+        }
+
+        // Measure amplitude over one full cycle.
+        let cycle_samples = (sample_rate / cutoff).ceil() as usize;
+        let mut max_out: f32 = 0.0;
+        for i in 44100..(44100 + cycle_samples) {
+            let sample = (2.0 * PI * cutoff * (i as f64) / sample_rate).sin() as f32;
+            let out = filter.process(sample);
+            max_out = max_out.max(out.abs());
+        }
+
+        // Butterworth -3dB at cutoff: gain ≈ 1/sqrt(2) ≈ 0.707.
+        assert!(
+            max_out > 0.65 && max_out < 0.75,
+            "Expected ~0.707 gain at cutoff, got {}",
+            max_out
+        );
+    }
+
+    #[test]
+    fn test_zero_input() {
+        let mut filter = BiquadHighPass::new(80.0, 44100);
+        for _ in 0..1000 {
+            let out = filter.process(0.0);
+            assert!(
+                out.abs() < f32::EPSILON,
+                "Zero input should produce zero output, got {}",
+                out
+            );
+        }
+    }
+}


### PR DESCRIPTION
Triggering based on audio input has been added. The intent of this is to have mtrack function as an edrum module in addition to playing backing tracks. The intent is using a piezoelectric sensor like the Roland KD-10 in order to detect triggers.

Additionally, triggering configuration has been moved inside of the profiles config, as it should have been in the first place. Actual samples are defined in the above config, and what mechanism actually triggers it is defined in the profiles. Furthermore, samples now use a track out instead of a raw audio channel, making the sample definition hardware independent.

MIDI configuration for triggering is also now supported in the profile triggering configuration.