### PR TITLE
Add in FFT resampling option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `strobe_dmx_offset` fields, allowing accurate strobe DMX calculation for fixtures whose
   strobe channel starts above DMX value 0 (e.g. Astera PixelBrick: offset 7, range 0.4–25 Hz).
 
+- **Configurable FFT resampling**: A new `resampler` option in the audio configuration allows
+  choosing between `sinc` (default, high-quality sinc interpolation) and `fft` (FFT-based
+  resampling, considerably faster for fixed-ratio resampling). The FFT mode can significantly
+  reduce CPU usage on low-power hardware like the Raspberry Pi when source and output sample
+  rates differ. Set `resampler: fft` in the audio config to enable it.
+
 ### Changed
+
+- **Custom MIDI playback engine replaces nodi**: The `nodi` dependency has been removed and replaced
+  with a bespoke MIDI playback engine built on `midly`. MIDI events are pre-computed into absolute-
+  timestamped event streams in a single pass, with wall-clock timing via `spin_sleep` for precise
+  hardware MIDI output. Legacy MIDI-to-DMX light shows are now driven from the effects loop using
+  cursor-based playback rather than spawning separate threads with nodi players, reducing thread
+  count and improving timing consistency.
 
 - **Strobe DMX normalization uses period-linear interpolation**: Strobe frequency-to-DMX mapping
   now interpolates in period-space (1/frequency) rather than frequency-space, matching how most
@@ -97,6 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stale lighting state between songs**: Fixed a bug where DSL songs without tempo blocks would
   inherit stale tempo maps from previous songs. Tempo maps, timelines, and legacy MIDI values are
   now properly cleared on song transitions.
+
+- **DMX timeline completion race**: Fixed a race condition where the effects loop could mark the
+  timeline as finished before the first song had set up its lighting state. The `timeline_finished`
+  flag now initializes to `true` and is only reset when a song begins, preventing premature
+  completion signals.
 
 ## [0.8.0] - 2026-02-20
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ audio:
   # (Optional) The bits per sample (bit depth) to use for the audio device. Defaults to 32.
   bits_per_sample: 32
 
+  # (Optional) Resampling algorithm used when source and output sample rates differ.
+  # "sinc" (default): High-quality sinc interpolation, higher CPU usage.
+  # "fft": FFT-based resampling, considerably faster on low-power hardware (e.g. Raspberry Pi).
+  # resampler: fft
+
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the audio playback.
   playback_delay: 500ms
 

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -26,6 +26,12 @@ audio:
   # (Optional) The bits per sample (bit depth) to use for the audio device. Defaults to 32.
   bits_per_sample: 32
 
+  # (Optional) Resampling algorithm used when source and output sample rates differ.
+  # "sinc" (default) — high-quality sinc interpolation, supports dynamic ratio adjustment.
+  # "fft" — FFT-based resampling, considerably faster on low-power hardware (e.g. Raspberry Pi)
+  #         but does not support dynamic ratio changes.
+  # resampler: sinc
+
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the audio playback.
   playback_delay: 500ms
 
@@ -310,6 +316,7 @@ track_mappings:
 #       sample_format: int
 #       bits_per_sample: 32
 #       buffer_size: 1024
+#       resampler: sinc
 #       playback_delay: 500ms
 #       track_mappings:
 #         click: [1]

--- a/src/audio/context.rs
+++ b/src/audio/context.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use crate::audio::format::TargetFormat;
 use crate::audio::sample_source::BufferFillPool;
+use crate::config::ResamplerType;
 
 /// Context passed into playback and source-creation paths so they can
 /// obtain target format, buffer size, and shared resources (e.g. buffer
@@ -34,6 +35,8 @@ pub struct PlaybackContext {
     /// Shared pool for prefilling BufferedSampleSource. If None, sources
     /// are not wrapped in BufferedSampleSource.
     pub buffer_fill_pool: Option<Arc<BufferFillPool>>,
+    /// Which resampling algorithm to use when sample rates differ.
+    pub resampler_type: ResamplerType,
 }
 
 impl PlaybackContext {
@@ -42,11 +45,13 @@ impl PlaybackContext {
         target_format: TargetFormat,
         buffer_size: usize,
         buffer_fill_pool: Option<Arc<BufferFillPool>>,
+        resampler_type: ResamplerType,
     ) -> Self {
         Self {
             target_format,
             buffer_size,
             buffer_fill_pool,
+            resampler_type,
         }
     }
 }

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -814,6 +814,7 @@ impl AudioDevice for Device {
             self.target_format.clone(),
             self.audio_config.buffer_size(),
             buffer_fill_pool,
+            self.audio_config.resampler(),
         );
 
         // Create channel mapped sources for each track in the song, starting from start_time.

--- a/src/audio/sample_source/channel_mapped.rs
+++ b/src/audio/sample_source/channel_mapped.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use crate::audio::TargetFormat;
+use crate::config::ResamplerType;
 
 use super::error::SampleSourceError;
 use super::traits::{ChannelMappedSampleSource, SampleSource};
@@ -58,6 +59,7 @@ pub fn create_channel_mapped_sample_source(
     source: Box<dyn SampleSource>,
     target_format: TargetFormat,
     channel_mappings: Vec<Vec<String>>,
+    resampler_type: ResamplerType,
 ) -> Result<Box<dyn ChannelMappedSampleSource>, SampleSourceError> {
     let source_format = TargetFormat::new(
         source.sample_rate(),
@@ -73,8 +75,13 @@ pub fn create_channel_mapped_sample_source(
     let channel_count = source.channel_count();
     let sample_source: Box<dyn SampleSource> = if needs_transcoding {
         // Box<dyn SampleSource> now implements SampleSource directly, so we can use it with AudioTranscoder
-        let transcoder =
-            AudioTranscoder::new(source, &source_format, &target_format, channel_count)?;
+        let transcoder = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            channel_count,
+            resampler_type,
+        )?;
         Box::new(transcoder)
     } else {
         source

--- a/src/audio/sample_source/tests.rs
+++ b/src/audio/sample_source/tests.rs
@@ -24,6 +24,7 @@ mod sample_source_tests {
     use crate::audio::sample_source::transcoder::AudioTranscoder;
     use crate::audio::sample_source::{BufferFillPool, BufferedSampleSource, ChannelMappedSource};
     use crate::audio::TargetFormat;
+    use crate::config::ResamplerType;
 
     // ---------------------------------------------------------------------
     // Scaling helpers – direct unit tests for all integer formats
@@ -179,7 +180,13 @@ mod sample_source_tests {
 
         // Create a mock source for testing
         let mock_source = MemorySampleSource::new(vec![0.1, 0.2, 0.3, 0.4, 0.5], 1, 44100);
-        match AudioTranscoder::new(mock_source, &source_format, &target_format, 1) {
+        match AudioTranscoder::new(
+            mock_source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        ) {
             Ok(mut converter) => {
                 // Test resampling by getting samples from the converter
                 let mut output_samples = Vec::with_capacity(100);
@@ -240,7 +247,13 @@ mod sample_source_tests {
 
             // Create a mock source for testing
             let mock_source = MemorySampleSource::new(vec![0.1, 0.2, 0.3], 1, 44100);
-            let converter = AudioTranscoder::new(mock_source, &source_format, &target_format, 1);
+            let converter = AudioTranscoder::new(
+                mock_source,
+                &source_format,
+                &target_format,
+                1,
+                ResamplerType::Sinc,
+            );
 
             if source_rate == target_rate {
                 // Should not need resampling
@@ -273,7 +286,13 @@ mod sample_source_tests {
 
         // Create a mock source for testing
         let mock_source = MemorySampleSource::new(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1, 44100);
-        match AudioTranscoder::new(mock_source, &source_format, &target_format, 1) {
+        match AudioTranscoder::new(
+            mock_source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        ) {
             Ok(mut converter) => {
                 // Test with a simple input to understand the behavior
                 let mut sample_count = 0;
@@ -308,7 +327,13 @@ mod sample_source_tests {
 
             // Create a mock source for testing
             let mock_source = MemorySampleSource::new(vec![0.1, 0.2, 0.3], 1, 44100);
-            let converter = AudioTranscoder::new(mock_source, &source_format, &target_format, 1);
+            let converter = AudioTranscoder::new(
+                mock_source,
+                &source_format,
+                &target_format,
+                1,
+                ResamplerType::Sinc,
+            );
 
             match converter {
                 Ok(converter) => {
@@ -335,8 +360,14 @@ mod sample_source_tests {
             TargetFormat::new(44100, crate::audio::SampleFormat::Float, 32).unwrap();
         // Create a mock source for testing
         let mock_source = MemorySampleSource::new(vec![0.1, 0.2, 0.3, 0.4, 0.5], 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(mock_source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            mock_source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         // Should not need resampling
         // Transcoding is now handled internally by AudioSampleSource
@@ -383,7 +414,13 @@ mod sample_source_tests {
 
         // Create a mock source with the sine wave
         let mock_source = MemorySampleSource::new(input_samples, 1, 44100);
-        match AudioTranscoder::new(mock_source, &source_format, &target_format, 1) {
+        match AudioTranscoder::new(
+            mock_source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        ) {
             Ok(mut converter) => {
                 // Test resampling by getting samples from the converter
                 let mut output_samples = Vec::with_capacity(200);
@@ -468,8 +505,14 @@ mod sample_source_tests {
 
         // First resampling: 44.1kHz -> 48kHz
         let source_1 = MemorySampleSource::new(original_samples.clone(), 1, 44100);
-        let mut converter_1 =
-            AudioTranscoder::new(source_1, &source_format_1, &target_format_1, 1).unwrap();
+        let mut converter_1 = AudioTranscoder::new(
+            source_1,
+            &source_format_1,
+            &target_format_1,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut intermediate_samples = Vec::with_capacity(num_samples);
         loop {
@@ -483,8 +526,14 @@ mod sample_source_tests {
         // Second resampling: 48kHz -> 44.1kHz
         let intermediate_len = intermediate_samples.len();
         let source_2 = MemorySampleSource::new(intermediate_samples, 1, intermediate_rate);
-        let mut converter_2 =
-            AudioTranscoder::new(source_2, &source_format_2, &target_format_2, 1).unwrap();
+        let mut converter_2 = AudioTranscoder::new(
+            source_2,
+            &source_format_2,
+            &target_format_2,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut final_samples = Vec::with_capacity(intermediate_len);
         loop {
@@ -540,8 +589,14 @@ mod sample_source_tests {
         input_samples[50] = 1.0; // Impulse at sample 50
 
         let source = MemorySampleSource::new(input_samples, 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         loop {
@@ -583,8 +638,14 @@ mod sample_source_tests {
         }
 
         let source = MemorySampleSource::new(input_samples.clone(), 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         loop {
@@ -653,8 +714,14 @@ mod sample_source_tests {
         }
 
         let source = MemorySampleSource::new(input_samples, 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, channels).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            channels,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         loop {
@@ -714,8 +781,14 @@ mod sample_source_tests {
             TargetFormat::new(44100, crate::audio::SampleFormat::Float, 32).unwrap();
 
         let source = MemorySampleSource::new(vec![], 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         // Empty input should return None immediately
         assert!(matches!(converter.next_sample(), Ok(None)));
@@ -730,8 +803,14 @@ mod sample_source_tests {
             TargetFormat::new(44100, crate::audio::SampleFormat::Float, 32).unwrap();
 
         let source = MemorySampleSource::new(vec![0.5], 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         loop {
@@ -776,8 +855,14 @@ mod sample_source_tests {
             }
 
             let source = MemorySampleSource::new(input_samples, 1, 44100);
-            let mut converter =
-                AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+            let mut converter = AudioTranscoder::new(
+                source,
+                &source_format,
+                &target_format,
+                1,
+                ResamplerType::Sinc,
+            )
+            .unwrap();
 
             let mut output_samples = Vec::new();
             let mut sample_count = 0;
@@ -838,8 +923,14 @@ mod sample_source_tests {
         }
 
         let source = MemorySampleSource::new(input_samples, 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         let mut sample_count = 0;
@@ -894,8 +985,14 @@ mod sample_source_tests {
         }
 
         let source = MemorySampleSource::new(input_samples, 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         loop {
@@ -937,8 +1034,14 @@ mod sample_source_tests {
 
         for values in test_values {
             let source = MemorySampleSource::new(values, 1, 44100);
-            let mut converter =
-                AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+            let mut converter = AudioTranscoder::new(
+                source,
+                &source_format,
+                &target_format,
+                1,
+                ResamplerType::Sinc,
+            )
+            .unwrap();
 
             let mut output_samples = Vec::new();
             let mut sample_count = 0;
@@ -988,8 +1091,14 @@ mod sample_source_tests {
         }
 
         let source = MemorySampleSource::new(input_samples, 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::new();
         loop {
@@ -1038,8 +1147,14 @@ mod sample_source_tests {
 
         // Resample once: 48kHz -> 44.1kHz
         let source = MemorySampleSource::new(original_samples.clone(), 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::with_capacity(num_samples);
         loop {
@@ -1087,8 +1202,14 @@ mod sample_source_tests {
 
         // First resampling: 48kHz -> 44.1kHz
         let source_1 = MemorySampleSource::new(original_samples.clone(), 1, 44100);
-        let mut converter_1 =
-            AudioTranscoder::new(source_1, &source_format, &target_format, 1).unwrap();
+        let mut converter_1 = AudioTranscoder::new(
+            source_1,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut intermediate_samples = Vec::with_capacity(num_samples);
         loop {
@@ -1101,8 +1222,14 @@ mod sample_source_tests {
 
         // Second resampling: 44.1kHz -> 48kHz (roundtrip)
         let source_2 = MemorySampleSource::new(intermediate_samples, 1, 44100);
-        let mut converter_2 =
-            AudioTranscoder::new(source_2, &target_format, &back_format, 1).unwrap();
+        let mut converter_2 = AudioTranscoder::new(
+            source_2,
+            &target_format,
+            &back_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut final_samples = Vec::with_capacity(original_samples.len());
         loop {
@@ -1161,8 +1288,14 @@ mod sample_source_tests {
 
             // Resample
             let source = MemorySampleSource::new(input_samples.clone(), 1, source_rate);
-            let mut converter =
-                AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+            let mut converter = AudioTranscoder::new(
+                source,
+                &source_format,
+                &target_format,
+                1,
+                ResamplerType::Sinc,
+            )
+            .unwrap();
 
             let mut output_samples = Vec::with_capacity(num_samples);
             loop {
@@ -1217,8 +1350,14 @@ mod sample_source_tests {
 
         // First resampling: 48kHz -> 44.1kHz
         let source_1 = MemorySampleSource::new(input_samples.clone(), 1, 44100);
-        let mut converter_1 =
-            AudioTranscoder::new(source_1, &source_format, &target_format, 2).unwrap();
+        let mut converter_1 = AudioTranscoder::new(
+            source_1,
+            &source_format,
+            &target_format,
+            2,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut intermediate_samples = Vec::with_capacity(input_samples.len());
         loop {
@@ -1232,8 +1371,14 @@ mod sample_source_tests {
         // Second resampling: 44.1kHz -> 48kHz (roundtrip for fair comparison)
         let back_format = TargetFormat::new(48000, crate::audio::SampleFormat::Float, 32).unwrap();
         let source_2 = MemorySampleSource::new(intermediate_samples, 1, 44100);
-        let mut converter_2 =
-            AudioTranscoder::new(source_2, &target_format, &back_format, 2).unwrap();
+        let mut converter_2 = AudioTranscoder::new(
+            source_2,
+            &target_format,
+            &back_format,
+            2,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::with_capacity(input_samples.len());
         loop {
@@ -1322,8 +1467,14 @@ mod sample_source_tests {
 
         // Resample complex signal
         let source = MemorySampleSource::new(input_samples.clone(), 1, 44100);
-        let mut converter =
-            AudioTranscoder::new(source, &source_format, &target_format, 1).unwrap();
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Sinc,
+        )
+        .unwrap();
 
         let mut output_samples = Vec::with_capacity(num_samples);
         loop {
@@ -1361,6 +1512,197 @@ mod sample_source_tests {
             input_energy,
             output_energy
         );
+    }
+
+    // -----------------------------------------------------------------
+    // FFT resampler tests
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_fft_resampler_basic_quality() {
+        // Verify FFT resampler produces reasonable output for a sine wave
+        let source_rate = 48000;
+        let target_rate = 44100;
+        let num_samples = 4800; // 100ms at 48kHz
+        let frequency = 440.0;
+
+        let input_samples: Vec<f32> = (0..num_samples)
+            .map(|i| {
+                (i as f32 * frequency * 2.0 * std::f32::consts::PI / source_rate as f32).sin() * 0.5
+            })
+            .collect();
+
+        let source_format =
+            TargetFormat::new(source_rate, crate::audio::SampleFormat::Float, 32).unwrap();
+        let target_format =
+            TargetFormat::new(target_rate, crate::audio::SampleFormat::Float, 32).unwrap();
+
+        let source = MemorySampleSource::new(input_samples.clone(), 1, source_rate);
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Fft,
+        )
+        .unwrap();
+
+        let mut output_samples = Vec::new();
+        loop {
+            match converter.next_sample() {
+                Ok(Some(sample)) => output_samples.push(sample),
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+
+        // Should produce approximately target_rate/source_rate * num_samples output samples
+        let expected_len = (num_samples as f64 * target_rate as f64 / source_rate as f64) as usize;
+        assert!(
+            output_samples.len() > expected_len / 2,
+            "FFT resampler produced too few samples: {} (expected ~{})",
+            output_samples.len(),
+            expected_len
+        );
+
+        // Check that output has reasonable amplitude (not all zeros or clipped)
+        let rms: f32 = (output_samples.iter().map(|&x| x * x).sum::<f32>()
+            / output_samples.len() as f32)
+            .sqrt();
+        assert!(
+            rms > 0.1 && rms < 1.0,
+            "FFT resampler output RMS out of range: {}",
+            rms
+        );
+    }
+
+    #[test]
+    fn test_fft_resampler_roundtrip() {
+        // Resample 44.1kHz → 48kHz → 44.1kHz and verify signal is preserved
+        let num_samples = 8820; // 200ms at 44.1kHz
+        let frequency = 440.0;
+        let source_rate = 44100u32;
+        let intermediate_rate = 48000u32;
+
+        let original_samples: Vec<f32> = (0..num_samples)
+            .map(|i| {
+                (i as f32 * frequency * 2.0 * std::f32::consts::PI / source_rate as f32).sin() * 0.5
+            })
+            .collect();
+
+        let source_format =
+            TargetFormat::new(source_rate, crate::audio::SampleFormat::Float, 32).unwrap();
+        let intermediate_format =
+            TargetFormat::new(intermediate_rate, crate::audio::SampleFormat::Float, 32).unwrap();
+
+        // Forward: 44.1kHz → 48kHz
+        let source_1 = MemorySampleSource::new(original_samples.clone(), 1, source_rate);
+        let mut converter_1 = AudioTranscoder::new(
+            source_1,
+            &source_format,
+            &intermediate_format,
+            1,
+            ResamplerType::Fft,
+        )
+        .unwrap();
+
+        let mut intermediate_samples = Vec::new();
+        loop {
+            match converter_1.next_sample() {
+                Ok(Some(sample)) => intermediate_samples.push(sample),
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+
+        // Reverse: 48kHz → 44.1kHz
+        let source_2 = MemorySampleSource::new(intermediate_samples, 1, intermediate_rate);
+        let mut converter_2 = AudioTranscoder::new(
+            source_2,
+            &intermediate_format,
+            &source_format,
+            1,
+            ResamplerType::Fft,
+        )
+        .unwrap();
+
+        let mut final_samples = Vec::new();
+        loop {
+            match converter_2.next_sample() {
+                Ok(Some(sample)) => final_samples.push(sample),
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+
+        // Roundtrip should preserve length approximately
+        let len_ratio = final_samples.len() as f64 / original_samples.len() as f64;
+        assert!(
+            (0.9..=1.1).contains(&len_ratio),
+            "FFT roundtrip length ratio out of range: {} ({} vs {})",
+            len_ratio,
+            final_samples.len(),
+            original_samples.len()
+        );
+
+        // Compare RMS preservation (roundtrip should preserve energy)
+        let skip = 2048; // skip filter transients
+        let compare_len = original_samples
+            .len()
+            .min(final_samples.len())
+            .saturating_sub(skip * 2);
+        if compare_len > 100 {
+            let orig_slice = &original_samples[skip..skip + compare_len];
+            let final_slice = &final_samples[skip..skip + compare_len];
+            let orig_rms: f32 =
+                (orig_slice.iter().map(|&x| x * x).sum::<f32>() / orig_slice.len() as f32).sqrt();
+            let final_rms: f32 =
+                (final_slice.iter().map(|&x| x * x).sum::<f32>() / final_slice.len() as f32).sqrt();
+            let rms_ratio = final_rms / orig_rms;
+            assert!(
+                (0.7..=1.3).contains(&rms_ratio),
+                "FFT roundtrip RMS ratio out of range: {:.3} (orig: {:.4}, final: {:.4})",
+                rms_ratio,
+                orig_rms,
+                final_rms
+            );
+        }
+    }
+
+    #[test]
+    fn test_fft_resampler_no_resampling_passthrough() {
+        // When source and target rates match, FFT resampler type should still pass through
+        let source_format =
+            TargetFormat::new(44100, crate::audio::SampleFormat::Float, 32).unwrap();
+        let target_format =
+            TargetFormat::new(44100, crate::audio::SampleFormat::Float, 32).unwrap();
+
+        let samples = vec![0.1, 0.2, 0.3, 0.4, 0.5];
+        let source = MemorySampleSource::new(samples.clone(), 1, 44100);
+        let mut converter = AudioTranscoder::new(
+            source,
+            &source_format,
+            &target_format,
+            1,
+            ResamplerType::Fft,
+        )
+        .unwrap();
+
+        // When rates match, resampler should be None (passthrough)
+        assert!(
+            converter.resampler.is_none(),
+            "Resampler should be None when rates match"
+        );
+
+        let mut output = Vec::new();
+        loop {
+            match converter.next_sample() {
+                Ok(Some(s)) => output.push(s),
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+        assert_eq!(output, samples);
     }
 
     #[test]

--- a/src/audio/sample_source/transcoder.rs
+++ b/src/audio/sample_source/transcoder.rs
@@ -12,18 +12,16 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use crate::audio::TargetFormat;
+use crate::config::ResamplerType;
 use parking_lot::Mutex;
 use rubato::{
-    SincFixedIn, SincInterpolationParameters, SincInterpolationType, VecResampler, WindowFunction,
+    FftFixedIn, SincFixedIn, SincInterpolationParameters, SincInterpolationType, VecResampler,
+    WindowFunction,
 };
+use tracing::info;
 
 use super::error::SampleSourceError;
 use super::traits::SampleSource;
-
-// Import VecResampler trait to bring methods into scope for method resolution
-// The `as _` prevents the "unused import" warning while still bringing trait methods into scope
-#[allow(unused_imports)]
-use rubato::VecResampler as _;
 
 // Resampling configuration constants
 /// Input block size for the sinc resampler.
@@ -107,8 +105,8 @@ impl OutputFifo {
 /// - Return samples from output FIFO one at a time
 pub struct AudioTranscoder<S: SampleSource> {
     source: S,
-    /// Sinc resampler wrapped in Mutex for Sync (contains non-Sync internals)
-    pub resampler: Option<Mutex<SincFixedIn<f32>>>,
+    /// Resampler wrapped in Mutex for Sync (contains non-Sync internals)
+    pub resampler: Option<Mutex<Box<dyn VecResampler<f32>>>>,
     pub source_rate: u32,
     pub target_rate: u32,
     target_bits_per_sample: u16,
@@ -176,34 +174,63 @@ where
         source_format: &TargetFormat,
         target_format: &TargetFormat,
         channels: u16,
+        resampler_type: ResamplerType,
     ) -> Result<Self, SampleSourceError> {
         let needs_resampling = source_format.sample_rate != target_format.sample_rate;
 
         let (resampler, output_scratch) = if needs_resampling {
-            // Use sinc resampling for lower latency and high quality.
-            let sinc_params = SincInterpolationParameters {
-                sinc_len: 256,
-                f_cutoff: 0.95,
-                oversampling_factor: 128,
-                interpolation: SincInterpolationType::Linear,
-                window: WindowFunction::BlackmanHarris2,
-            };
             let resample_ratio =
                 target_format.sample_rate as f64 / source_format.sample_rate as f64;
+            let num_channels = channels as usize;
 
-            let r = SincFixedIn::<f32>::new(
-                resample_ratio,
-                1.0, // max_resample_ratio_relative: no dynamic changes
-                sinc_params,
-                INPUT_BLOCK_SIZE,
-                channels as usize,
-            )
-            .map_err(|_e| {
-                SampleSourceError::ResamplingFailed(
-                    source_format.sample_rate,
-                    target_format.sample_rate,
-                )
-            })?;
+            let r: Box<dyn VecResampler<f32>> = match resampler_type {
+                ResamplerType::Sinc => {
+                    let sinc_params = SincInterpolationParameters {
+                        sinc_len: 256,
+                        f_cutoff: 0.95,
+                        oversampling_factor: 128,
+                        interpolation: SincInterpolationType::Linear,
+                        window: WindowFunction::BlackmanHarris2,
+                    };
+                    Box::new(
+                        SincFixedIn::<f32>::new(
+                            resample_ratio,
+                            1.0,
+                            sinc_params,
+                            INPUT_BLOCK_SIZE,
+                            num_channels,
+                        )
+                        .map_err(|_e| {
+                            SampleSourceError::ResamplingFailed(
+                                source_format.sample_rate,
+                                target_format.sample_rate,
+                            )
+                        })?,
+                    )
+                }
+                ResamplerType::Fft => Box::new(
+                    FftFixedIn::<f32>::new(
+                        source_format.sample_rate as usize,
+                        target_format.sample_rate as usize,
+                        INPUT_BLOCK_SIZE,
+                        2,
+                        num_channels,
+                    )
+                    .map_err(|_e| {
+                        SampleSourceError::ResamplingFailed(
+                            source_format.sample_rate,
+                            target_format.sample_rate,
+                        )
+                    })?,
+                ),
+            };
+
+            info!(
+                resampler = ?resampler_type,
+                from = source_format.sample_rate,
+                to = target_format.sample_rate,
+                "Resampling audio",
+            );
 
             let scratch = r.output_buffer_allocate(true);
             (Some(Mutex::new(r)), scratch)

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ mod track;
 mod trackmappings;
 pub mod trigger;
 
-pub use self::audio::{Audio, StreamBufferSize};
+pub use self::audio::{Audio, ResamplerType, StreamBufferSize};
 pub use self::controller::Controller;
 pub use self::controller::GrpcController;
 pub use self::controller::MidiController;

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -22,6 +22,17 @@ const DEFAULT_AUDIO_PLAYBACK_DELAY: Duration = Duration::ZERO;
 const DEFAULT_BUFFER_SIZE: usize = 1024;
 const DEFAULT_BUFFER_THREADS: usize = 2;
 
+/// Which resampling algorithm to use when source and output sample rates differ.
+#[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResamplerType {
+    /// High-quality sinc interpolation (lower latency, higher CPU). This is the default.
+    #[default]
+    Sinc,
+    /// FFT-based resampling (considerably faster for fixed-ratio resampling).
+    Fft,
+}
+
 /// How to choose the CPAL stream buffer size (period size). Affects latency vs underrun tolerance.
 #[derive(Deserialize, Clone, Debug)]
 #[serde(untagged)]
@@ -64,6 +75,9 @@ pub struct Audio {
     /// Number of worker threads for buffered song sources.
     /// Defaults to a small fixed value; must be >= 1.
     buffer_threads: Option<usize>,
+
+    /// Resampling algorithm: "sinc" (default, high quality) or "fft" (faster on low-power hardware).
+    resampler: Option<ResamplerType>,
 }
 
 impl Audio {
@@ -78,6 +92,7 @@ impl Audio {
             buffer_size: None,
             stream_buffer_size: None,
             buffer_threads: None,
+            resampler: None,
         }
     }
 
@@ -128,6 +143,11 @@ impl Audio {
         self.stream_buffer_size.clone()
     }
 
+    /// Returns the resampling algorithm to use (default: Sinc).
+    pub fn resampler(&self) -> ResamplerType {
+        self.resampler.unwrap_or_default()
+    }
+
     /// Sets the target sample rate.
     #[allow(dead_code)]
     pub fn with_sample_rate(mut self, sample_rate: u32) -> Self {
@@ -160,6 +180,13 @@ impl Audio {
     #[allow(dead_code)]
     pub fn with_stream_buffer_size(mut self, sbs: StreamBufferSize) -> Self {
         self.stream_buffer_size = Some(sbs);
+        self
+    }
+
+    /// Sets the resampling algorithm.
+    #[allow(dead_code)]
+    pub fn with_resampler(mut self, resampler: ResamplerType) -> Self {
+        self.resampler = Some(resampler);
         self
     }
 }

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -117,9 +117,12 @@ impl super::Device for Device {
 
     /// Stops watching events.
     fn stop_watch_events(&self) {
-        self.closed.store(true, Ordering::Relaxed);
-        // Wait for watcher thread to move to next loop iteration.
-        self.barrier.wait();
+        // Only signal the barrier if we're the first caller. A second call
+        // (e.g. from the monitor task after the event thread has exited)
+        // would deadlock because the other barrier party is gone.
+        if !self.closed.swap(true, Ordering::Relaxed) {
+            self.barrier.wait();
+        }
     }
 
     /// Plays the given song through the MIDI interface, starting from a specific time.

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -459,6 +459,7 @@ impl Song {
                 sample_source,
                 context.target_format.clone(),
                 channel_mappings,
+                context.resampler_type,
             )?;
             let source: Box<dyn crate::audio::sample_source::ChannelMappedSampleSource> =
                 if let Some(pool) = &context.buffer_fill_pool {


### PR DESCRIPTION
It's now possible to resample using FFT instead of sinc. This should allow us to get more performance out of mtrack.