### PR TITLE
Concurrency fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-02-28
+
+### Fixed
+
+- **DMX universe deadlock**: Fixed an ABBA deadlock between the effects loop and universe
+  threads caused by reversed lock ordering of the `target` and `rates` RwLocks in
+  `approach_target()`. This could cause lighting to freeze mid-song, after which audio
+  playback and lighting would no longer function until restart. The deadlock was timing-
+  dependent and could occur on any song type (legacy MIDI or DSL).
+
+- **Effects loop resilience**: The persistent effects loop is now wrapped in `catch_unwind`
+  so that a panic in a single tick cannot kill the loop thread. Panics are logged and the
+  loop continues on the next tick.
+
+- **Effects loop heartbeat monitoring**: Barrier threads now monitor the effects loop via an
+  atomic heartbeat counter instead of waiting indefinitely. If the heartbeat is stale for 10
+  seconds, the timeline is force-finished and the song completes gracefully rather than
+  hanging forever.
+
+- **Lost condvar notifications**: `CancelHandle::notify()` now acquires the mutex before
+  signaling, preventing a race where notifications could be lost between a waiter's predicate
+  check and its condvar sleep.
+
+- **Blocking mutexes in async code**: The state sampler and TUI tick now acquire
+  `parking_lot::Mutex` locks via `spawn_blocking` instead of blocking the tokio runtime
+  directly. The TUI log buffer was also migrated from `std::sync::Mutex` to
+  `parking_lot::Mutex` for consistency with the rest of the codebase.
+
 ## [0.9.0] - 2026-02-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -17,8 +17,9 @@ use std::{
     collections::{HashMap, HashSet},
     error::Error,
     fs,
+    panic::AssertUnwindSafe,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{self, Receiver},
         Arc, Barrier,
     },
@@ -85,6 +86,9 @@ pub struct Engine {
     legacy_store: Arc<parking_lot::RwLock<LegacyDmxStore>>,
     /// Active legacy MIDI playbacks dispatched from the effects loop.
     legacy_midi_playbacks: Mutex<Vec<LegacyMidiPlayback>>,
+    /// Heartbeat counter incremented by the effects loop each frame.
+    /// Used by barrier threads to detect if the effects loop has died.
+    effects_loop_heartbeat: Arc<AtomicU64>,
 }
 
 /// A legacy MIDI light show being played back from the effects loop.
@@ -192,6 +196,7 @@ impl Engine {
             watcher_handle: Mutex::new(None),
             legacy_store,
             legacy_midi_playbacks: Mutex::new(Vec::new()),
+            effects_loop_heartbeat: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -203,8 +208,10 @@ impl Engine {
         // Use a weak reference to avoid preventing Engine from being dropped.
         // The thread will exit when the weak reference can no longer be upgraded.
         let weak_engine = Arc::downgrade(&engine);
+        let heartbeat = engine.effects_loop_heartbeat.clone();
 
         let handle = thread::spawn(move || {
+            info!("Effects loop started.");
             let mut last_update = std::time::Instant::now();
             let target_frame_time = Duration::from_secs_f64(1.0 / 44.0); // 44Hz
 
@@ -213,6 +220,7 @@ impl Engine {
             loop {
                 // Try to upgrade the weak reference - if it fails, the Engine was dropped
                 let Some(engine) = weak_engine.upgrade() else {
+                    info!("Effects loop exiting: engine was dropped.");
                     break;
                 };
 
@@ -220,41 +228,30 @@ impl Engine {
                 let dt = now.duration_since(last_update);
 
                 if dt >= target_frame_time {
-                    // Tick the legacy store to interpolate dimming values
-                    engine.legacy_store.read().tick();
-
-                    // Advance legacy MIDI playback cursors and dispatch events
-                    engine.advance_legacy_midi_playbacks();
-
-                    // Update effects engine and apply to universes
-                    if let Err(e) = engine.update_effects() {
-                        error!("Error updating effects: {}", e);
-                    }
-
-                    // Update song lighting timeline with actual song time
-                    let song_time = engine.get_song_time();
-                    if let Err(e) = engine.update_song_lighting(song_time) {
-                        error!("Error updating song lighting: {}", e);
-                    }
-
-                    // Check if all lighting has finished (DSL timeline cues + legacy MIDI playbacks)
-                    // and notify the waiting thread if so
-                    if !engine.timeline_finished.load(Ordering::Relaxed) {
-                        let timeline_done = {
-                            let timeline = engine.current_song_timeline.lock();
-                            timeline.as_ref().is_none_or(|tl| tl.is_finished())
+                    // Wrap tick in catch_unwind to prevent a panic from killing
+                    // the effects loop thread (which would freeze all lighting).
+                    // Safety: parking_lot mutexes do not poison on panic — they
+                    // release normally — so logical state inconsistency from a
+                    // partial update is acceptable for best-effort recovery.
+                    let engine_ref = AssertUnwindSafe(&engine);
+                    let result = std::panic::catch_unwind(move || {
+                        Self::effects_loop_tick(&engine_ref);
+                    });
+                    if let Err(panic_info) = result {
+                        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                            s.to_string()
+                        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                            s.clone()
+                        } else {
+                            "unknown panic".to_string()
                         };
-                        let legacy_done = engine.legacy_playbacks_finished();
-
-                        if timeline_done && legacy_done {
-                            engine.timeline_finished.store(true, Ordering::Relaxed);
-                            // Notify the cancel handle so wait() returns
-                            if let Some(ref cancel_handle) = *engine.timeline_cancel_handle.lock() {
-                                cancel_handle.notify();
-                            }
-                        }
+                        error!(
+                            panic_message = msg,
+                            "Effects loop caught panic! Continuing to prevent lighting freeze."
+                        );
                     }
 
+                    heartbeat.fetch_add(1, Ordering::Relaxed);
                     last_update = now;
                 }
 
@@ -263,11 +260,51 @@ impl Engine {
 
                 thread::sleep(Duration::from_millis(1));
             }
+            info!("Effects loop exited.");
         });
 
         // Store the handle so it can be joined on drop.
         // The thread will stop when the Engine is dropped (weak upgrade fails).
         *engine.effects_loop_handle.lock() = Some(handle);
+    }
+
+    /// One frame of the effects loop, extracted for catch_unwind.
+    fn effects_loop_tick(&self) {
+        // Tick the legacy store to interpolate dimming values
+        self.legacy_store.read().tick();
+
+        // Advance legacy MIDI playback cursors and dispatch events
+        self.advance_legacy_midi_playbacks();
+
+        // Update effects engine and apply to universes
+        if let Err(e) = self.update_effects() {
+            error!("Error updating effects: {}", e);
+        }
+
+        // Update song lighting timeline with actual song time
+        let song_time = self.get_song_time();
+        if let Err(e) = self.update_song_lighting(song_time) {
+            error!("Error updating song lighting: {}", e);
+        }
+
+        // Check if all lighting has finished (DSL timeline cues + legacy MIDI playbacks)
+        // and notify the waiting thread if so
+        if !self.timeline_finished.load(Ordering::Relaxed) {
+            let timeline_done = {
+                let timeline = self.current_song_timeline.lock();
+                timeline.as_ref().is_none_or(|tl| tl.is_finished())
+            };
+            let legacy_done = self.legacy_playbacks_finished();
+
+            if timeline_done && legacy_done {
+                info!("Lighting timeline finished. Notifying barrier.");
+                self.timeline_finished.store(true, Ordering::Relaxed);
+                // Notify the cancel handle so wait() returns
+                if let Some(ref cancel_handle) = *self.timeline_cancel_handle.lock() {
+                    cancel_handle.notify();
+                }
+            }
+        }
     }
 
     #[cfg(test)]
@@ -594,9 +631,14 @@ impl Engine {
                     first_legacy = false;
                     let cancel_handle = cancel_handle.clone();
                     let timeline_finished = dmx_engine.timeline_finished.clone();
+                    let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
                     thread::spawn(move || {
                         play_barrier.wait();
-                        cancel_handle.wait(timeline_finished);
+                        Self::wait_for_timeline_with_heartbeat(
+                            &cancel_handle,
+                            timeline_finished,
+                            &heartbeat,
+                        );
                     })
                 } else {
                     thread::spawn(move || {
@@ -612,9 +654,14 @@ impl Engine {
             let cancel_handle_clone = cancel_handle.clone();
             let timeline_finished = dmx_engine.timeline_finished.clone();
             let play_barrier_clone = play_barrier.clone();
+            let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
             join_handles.push(thread::spawn(move || {
                 play_barrier_clone.wait();
-                cancel_handle_clone.wait(timeline_finished);
+                Self::wait_for_timeline_with_heartbeat(
+                    &cancel_handle_clone,
+                    timeline_finished,
+                    &heartbeat,
+                );
             }));
         }
 
@@ -1046,6 +1093,52 @@ impl Engine {
             timeline.cues()
         } else {
             Vec::new()
+        }
+    }
+
+    /// Waits for the lighting timeline to finish, periodically checking the
+    /// effects loop heartbeat. If the heartbeat goes stale for 10s, forces
+    /// `timeline_finished` to true so DMX playback can unblock.
+    fn wait_for_timeline_with_heartbeat(
+        cancel_handle: &CancelHandle,
+        timeline_finished: Arc<AtomicBool>,
+        heartbeat: &AtomicU64,
+    ) {
+        // Check every 5 seconds; declare dead after 2 consecutive stale checks (10s).
+        const CHECK_INTERVAL: Duration = Duration::from_secs(5);
+        const MAX_STALE_CHECKS: u32 = 2;
+
+        let mut last_heartbeat = heartbeat.load(Ordering::Relaxed);
+        let mut stale_count: u32 = 0;
+
+        loop {
+            if cancel_handle.wait_with_timeout(timeline_finished.clone(), CHECK_INTERVAL) {
+                // Condition met (cancelled or timeline finished).
+                return;
+            }
+
+            // Timed out — check if the effects loop is still alive.
+            let current_heartbeat = heartbeat.load(Ordering::Relaxed);
+            if current_heartbeat == last_heartbeat {
+                stale_count += 1;
+                if stale_count >= MAX_STALE_CHECKS {
+                    error!(
+                        "Effects loop heartbeat stale for {}s — assuming dead. \
+                         Forcing timeline_finished to unblock DMX playback.",
+                        CHECK_INTERVAL.as_secs() * u64::from(MAX_STALE_CHECKS),
+                    );
+                    timeline_finished.store(true, Ordering::Relaxed);
+                    return;
+                }
+                warn!(
+                    stale_count,
+                    "Effects loop heartbeat stale — will force-finish if it persists."
+                );
+            } else {
+                // Heartbeat is advancing; reset stale counter.
+                stale_count = 0;
+                last_heartbeat = current_heartbeat;
+            }
         }
     }
 

--- a/src/dmx/universe.rs
+++ b/src/dmx/universe.rs
@@ -203,6 +203,11 @@ impl Universe {
 
     /// Takes the given inputs and approaches the current expected DMX values.
     /// Returns true if anything changed.
+    ///
+    /// Lock ordering: target → rates → current.  This matches the write-side
+    /// ordering in `update_effect_commands` (target → rates) and
+    /// `update_channel_data` (target → rates → current) to prevent ABBA
+    /// deadlocks between the universe thread and the effects loop.
     fn approach_target(
         rates: &Arc<RwLock<Vec<f64>>>,
         current: &Arc<RwLock<Vec<f64>>>,
@@ -210,9 +215,9 @@ impl Universe {
         max_channels: &Arc<AtomicU16>,
         buffer: &mut DmxBuffer,
     ) -> bool {
-        let mut current = current.write();
-        let rates = rates.read();
         let target = target.read();
+        let rates = rates.read();
+        let mut current = current.write();
 
         let mut changed = false;
         for i in 0..usize::from(max_channels.load(Ordering::Relaxed)) {

--- a/src/playsync.rs
+++ b/src/playsync.rs
@@ -61,9 +61,29 @@ impl CancelHandle {
         });
     }
 
+    /// Waits for the cancel handle to be cancelled or for finished to be set to true,
+    /// with a timeout. Returns `true` if the condition was met, `false` if timed out.
+    pub fn wait_with_timeout(
+        &self,
+        finished: Arc<AtomicBool>,
+        timeout: std::time::Duration,
+    ) -> bool {
+        let mut guard = self.cancelled.lock();
+        let result = self.condvar.wait_while_for(
+            &mut guard,
+            |cancelled| *cancelled == CancelState::Untouched && !finished.load(Ordering::Relaxed),
+            timeout,
+        );
+        !result.timed_out()
+    }
+
     /// Notifies the cancel handle to see if this the song has been cancelled or if the
     /// particular element has finished.
+    ///
+    /// Acquires the mutex before signaling so the notification cannot be lost
+    /// between a waiter's predicate check and its condvar sleep.
     pub fn notify(&self) {
+        let _guard = self.cancelled.lock();
         self.condvar.notify_all();
     }
 
@@ -72,7 +92,8 @@ impl CancelHandle {
         let mut cancel_state = self.cancelled.lock();
         if *cancel_state == CancelState::Untouched {
             *cancel_state = CancelState::Cancelled;
-            self.notify();
+            // Signal directly — we already hold the mutex.
+            self.condvar.notify_all();
         }
     }
 }
@@ -110,5 +131,35 @@ mod test {
 
         assert!(join.join().is_ok());
         assert!(!cancel_handle.is_cancelled());
+    }
+
+    #[test]
+    fn test_wait_with_timeout_returns_true_when_finished() {
+        let cancel_handle = CancelHandle::new();
+        let finished = Arc::new(AtomicBool::new(true));
+        assert!(cancel_handle.wait_with_timeout(finished, std::time::Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn test_wait_with_timeout_returns_false_on_timeout() {
+        let cancel_handle = CancelHandle::new();
+        let finished = Arc::new(AtomicBool::new(false));
+        assert!(!cancel_handle.wait_with_timeout(finished, std::time::Duration::from_millis(50)));
+    }
+
+    #[test]
+    fn test_wait_with_timeout_returns_true_when_cancelled() {
+        let cancel_handle = CancelHandle::new();
+        let finished = Arc::new(AtomicBool::new(false));
+
+        let join = {
+            let cancel_handle = cancel_handle.clone();
+            thread::spawn(move || {
+                cancel_handle.wait_with_timeout(finished, std::time::Duration::from_secs(10))
+            })
+        };
+
+        cancel_handle.cancel();
+        assert!(join.join().unwrap());
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -57,27 +57,37 @@ async fn sampler_loop(
     let mut interval = time::interval(Duration::from_millis(50));
     interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
-    // Cache the dimmer map — fixture registry doesn't change at runtime
+    // Cache the dimmer map — fixture registry doesn't change at runtime.
+    // Use spawn_blocking to keep the parking_lot lock off the async runtime.
     let has_dimmer_map: HashMap<String, bool> = {
-        let engine = effect_engine.lock();
-        engine
-            .get_fixture_registry()
-            .iter()
-            .map(|(name, info)| (name.clone(), info.channels.contains_key("dimmer")))
-            .collect()
+        let engine = effect_engine.clone();
+        tokio::task::spawn_blocking(move || {
+            let engine = engine.lock();
+            engine
+                .get_fixture_registry()
+                .iter()
+                .map(|(name, info)| (name.clone(), info.channels.contains_key("dimmer")))
+                .collect()
+        })
+        .await
+        .expect("spawn_blocking panicked")
     };
 
     loop {
         interval.tick().await;
 
-        // Hold the lock only long enough to clone the raw data out.
-        // Sorting and snapshot conversion happen outside the lock to avoid
-        // blocking the 44Hz effects loop in dmx/engine.rs.
+        // Clone data out under a blocking lock — sorting and snapshot
+        // conversion happen outside to avoid blocking the 44Hz effects loop.
         let (states, mut active_effects) = {
-            let engine = effect_engine.lock();
-            let states = engine.get_fixture_states();
-            let effects: Vec<String> = engine.get_active_effects().keys().cloned().collect();
-            (states, effects)
+            let engine = effect_engine.clone();
+            tokio::task::spawn_blocking(move || {
+                let engine = engine.lock();
+                let states = engine.get_fixture_states();
+                let effects: Vec<String> = engine.get_active_effects().keys().cloned().collect();
+                (states, effects)
+            })
+            .await
+            .expect("spawn_blocking panicked")
         };
 
         active_effects.sort();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -126,10 +126,15 @@ impl App {
             .collect();
         self.active_effects = snapshot.active_effects.clone();
 
-        // Update log buffer
+        // Update log buffer (acquire parking_lot mutex off the async runtime).
         if let Some(buffer) = super::logging::get_log_buffer() {
-            if let Ok(buffer) = buffer.lock() {
-                self.log_lines = buffer.iter().cloned().collect();
+            if let Ok(lines) = tokio::task::spawn_blocking(move || {
+                let buffer = buffer.lock();
+                buffer.iter().cloned().collect::<Vec<String>>()
+            })
+            .await
+            {
+                self.log_lines = lines;
             }
         }
     }

--- a/src/tui/logging.rs
+++ b/src/tui/logging.rs
@@ -11,9 +11,10 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
+use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::fmt;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
@@ -82,7 +83,8 @@ impl<S: Subscriber> Layer<S> for TuiLogLayer {
 
         let line = format!("{} {}: {}", level, target, visitor.message);
 
-        if let Ok(mut buffer) = self.buffer.lock() {
+        {
+            let mut buffer = self.buffer.lock();
             if buffer.len() >= self.capacity {
                 buffer.pop_front();
             }


### PR DESCRIPTION
A few different concurrency fixes have been made to mtrack, with the most egregious being a potential deadlock in the lighting engine. I never ran into this live, but I have on my WSL2 dev machine.