### PR TITLE
Fix livelock scenario.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-03-01
+
+### Fixed
+
+- **Buffered audio near-livelock**: Fixed a near-livelock in `BufferedSampleSource` that could
+  cause audio playback to degrade to sparse blips (~3% real-time speed) while lighting continued
+  normally. When the ring buffer underran, the audio callback would acquire the inner source mutex
+  while holding the buffer state mutex, starving the background fill task and creating a
+  self-reinforcing stall. The audio callback no longer acquires the inner source mutex; underruns
+  produce brief silence while the fill task catches up. A new `is_exhausted()` trait method lets
+  the mixer distinguish transient buffer underruns from true end-of-source.
+
 ## [0.9.1] - 2026-02-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -219,8 +219,10 @@ impl AudioMixer {
                     }
                 }
                 Ok(None) => {
-                    active_source.is_finished.store(true, Ordering::Relaxed);
-                    finished_source_ids.push(active_source.id);
+                    if active_source.source.is_exhausted().unwrap_or(true) {
+                        active_source.is_finished.store(true, Ordering::Relaxed);
+                        finished_source_ids.push(active_source.id);
+                    }
                 }
                 Err(_) => {
                     active_source.is_finished.store(true, Ordering::Relaxed);
@@ -415,12 +417,16 @@ impl AudioMixer {
                             }
                         }
                         if frames_got < frames_needed {
-                            debug!(
-                                source_id = active_source.id,
-                                "mixer: source marked finished (read_frames returned fewer frames)"
-                            );
-                            active_source.is_finished.store(true, Ordering::Relaxed);
-                            finished_source_ids.push(active_source.id);
+                            // Buffered sources report false during transient underruns;
+                            // unbuffered sources return None → treated as EOF.
+                            if active_source.source.is_exhausted().unwrap_or(true) {
+                                debug!(
+                                    source_id = active_source.id,
+                                    "mixer: source marked finished (read_frames returned fewer frames)"
+                                );
+                                active_source.is_finished.store(true, Ordering::Relaxed);
+                                finished_source_ids.push(active_source.id);
+                            }
                         }
                     }
                     Err(_) => {
@@ -968,5 +974,175 @@ mod tests {
                                      // Frames 6-7: silence (after cancel)
         assert_eq!(output[12], 0.0);
         assert_eq!(output[14], 0.0);
+    }
+
+    /// A source that returns 0 frames on the first N calls to read_frames
+    /// (simulating buffer underruns), then yields real data. is_exhausted()
+    /// returns Some(false) until truly done — exactly like BufferedSampleSource.
+    struct UnderrunSimSource {
+        inner: Box<dyn ChannelMappedSampleSource>,
+        underrun_calls_remaining: usize,
+        exhausted: AtomicBool,
+    }
+
+    impl UnderrunSimSource {
+        fn new(inner: Box<dyn ChannelMappedSampleSource>, underrun_calls: usize) -> Self {
+            Self {
+                inner,
+                underrun_calls_remaining: underrun_calls,
+                exhausted: AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl ChannelMappedSampleSource for UnderrunSimSource {
+        fn next_sample(
+            &mut self,
+        ) -> Result<Option<f32>, crate::audio::sample_source::error::SampleSourceError> {
+            self.inner.next_sample()
+        }
+
+        fn next_frame(
+            &mut self,
+            output: &mut [f32],
+        ) -> Result<Option<usize>, crate::audio::sample_source::error::SampleSourceError> {
+            self.inner.next_frame(output)
+        }
+
+        fn read_frames(
+            &mut self,
+            output: &mut [f32],
+            max_frames: usize,
+        ) -> Result<usize, crate::audio::sample_source::error::SampleSourceError> {
+            if self.underrun_calls_remaining > 0 {
+                self.underrun_calls_remaining -= 1;
+                return Ok(0); // Simulate empty buffer
+            }
+            let got = self.inner.read_frames(output, max_frames)?;
+            if got < max_frames {
+                self.exhausted.store(true, Ordering::Relaxed);
+            }
+            Ok(got)
+        }
+
+        fn channel_mappings(&self) -> &Vec<Vec<String>> {
+            self.inner.channel_mappings()
+        }
+
+        fn source_channel_count(&self) -> u16 {
+            self.inner.source_channel_count()
+        }
+
+        fn is_exhausted(&self) -> Option<bool> {
+            Some(self.exhausted.load(Ordering::Relaxed))
+        }
+    }
+
+    #[test]
+    fn test_mixer_keeps_source_alive_during_transient_underrun() {
+        // Regression: before the livelock fix, a short read from a buffered
+        // source was unconditionally treated as EOF, causing the mixer to
+        // discard the source even though it still had data.
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.5, 0.8, 0.3, 0.6]; // 4 frames of 1 channel
+        let inner = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        // First call to read_frames returns 0 (underrun), subsequent calls work.
+        let source: Box<dyn ChannelMappedSampleSource + Send + Sync> =
+            Box::new(UnderrunSimSource::new(inner, 1));
+
+        let is_finished = Arc::new(AtomicBool::new(false));
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: is_finished.clone(),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: None,
+        };
+
+        mixer.add_source(active_source);
+
+        // First callback: underrun returns 0 frames → silence.
+        // Source must NOT be removed.
+        let mut output = vec![0.0f32; 4 * 2];
+        mixer.process_into_output(&mut output, 4);
+
+        for &sample in &output {
+            assert_eq!(sample, 0.0, "underrun callback should produce silence");
+        }
+        assert!(
+            !is_finished.load(Ordering::Relaxed),
+            "source must not be marked finished on transient underrun"
+        );
+        assert_eq!(
+            mixer.active_sources.read().len(),
+            1,
+            "source must remain active"
+        );
+
+        // Second callback: data flows normally.
+        let mut output2 = vec![0.0f32; 4 * 2];
+        mixer.process_into_output(&mut output2, 4);
+
+        assert_eq!(output2[0], 0.5); // Frame 0, Ch 0
+        assert_eq!(output2[2], 0.8); // Frame 1, Ch 0
+        assert_eq!(output2[4], 0.3); // Frame 2, Ch 0
+        assert_eq!(output2[6], 0.6); // Frame 3, Ch 0
+    }
+
+    #[test]
+    fn test_mixer_finishes_source_when_truly_exhausted() {
+        // Complement to the underrun test: once is_exhausted() returns
+        // Some(true), the mixer must still clean up the source.
+        let mixer = AudioMixer::new(2, 44100);
+
+        let samples = vec![0.5, 0.8]; // Only 2 frames
+        let inner = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
+
+        // No underruns — source runs out immediately.
+        let source: Box<dyn ChannelMappedSampleSource + Send + Sync> =
+            Box::new(UnderrunSimSource::new(inner, 0));
+
+        let active_source = ActiveSource {
+            id: 1,
+            source,
+            track_mappings: {
+                let mut map = HashMap::new();
+                map.insert("test".to_string(), vec![1]);
+                map
+            },
+            channel_mappings: Vec::new(),
+            cached_source_channel_count: 1,
+            is_finished: Arc::new(AtomicBool::new(false)),
+            cancel_handle: CancelHandle::new(),
+            start_at_sample: None,
+            cancel_at_sample: None,
+        };
+
+        mixer.add_source(active_source);
+
+        // Request 8 frames but source only has 2 and is_exhausted() → Some(true).
+        let mut output = vec![0.0f32; 8 * 2];
+        mixer.process_into_output(&mut output, 8);
+
+        assert_eq!(output[0], 0.5);
+        assert_eq!(output[2], 0.8);
+        for i in 4..16 {
+            assert_eq!(output[i], 0.0, "output[{i}] should be silence");
+        }
+        assert_eq!(
+            mixer.active_sources.read().len(),
+            0,
+            "exhausted source must be removed"
+        );
     }
 }

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -296,37 +296,24 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
             let mut state = self.buffer.state.lock().unwrap();
 
             if state.len_frames == 0 {
-                // Ring buffer underrun: defer to the underlying source rather than
-                // treating this as end‑of‑stream. This is rare and allowed to do
-                // heavier work since it only occurs when our prefetch falls behind.
-                let mut inner = self.inner.lock().unwrap();
-                match inner.next_frame(output) {
-                    Ok(Some(count)) => {
-                        // We got a frame directly; do not mark finished. Let the
-                        // background fill task catch up on its next run.
-                        return Ok(Some(count));
-                    }
-                    Ok(None) => {
-                        state.finished = true;
-                        self.finished_flag.store(true, Ordering::Relaxed);
-                        return Ok(None);
-                    }
-                    Err(e) => {
-                        state.finished = true;
-                        self.finished_flag.store(true, Ordering::Relaxed);
-                        return Err(e);
-                    }
+                if state.finished {
+                    return Ok(None);
                 }
-            }
-
-            let base = state.read_index * channels;
-            output[..channels].copy_from_slice(&state.data[base..(base + channels)]);
-
-            state.read_index = (state.read_index + 1) % self.capacity_frames;
-            state.len_frames -= 1;
-
-            if !state.finished && state.len_frames <= self.refill_threshold_frames {
+                // Buffer underrun but source not exhausted — output silence.
+                // Never acquire self.inner here; the fill task needs it.
+                output[..channels].fill(0.0);
                 maybe_spawn_refill = true;
+                // Fall through to drop state lock, then spawn refill below.
+            } else {
+                let base = state.read_index * channels;
+                output[..channels].copy_from_slice(&state.data[base..(base + channels)]);
+
+                state.read_index = (state.read_index + 1) % self.capacity_frames;
+                state.len_frames -= 1;
+
+                if !state.finished && state.len_frames <= self.refill_threshold_frames {
+                    maybe_spawn_refill = true;
+                }
             }
         }
 
@@ -386,25 +373,6 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
             if !state.finished && state.len_frames <= self.refill_threshold_frames {
                 maybe_spawn_refill = true;
             }
-
-            // Underrun fallback: read directly from the inner source while
-            // holding the state lock. This matches next_frame's lock ordering
-            // and prevents the refill thread from writing frames that would
-            // be played out of chronological order.
-            if frames_read < max_frames && state.len_frames == 0 && !state.finished {
-                let mut inner = self.inner.lock().unwrap();
-                while frames_read < max_frames {
-                    let offset = frames_read * channels;
-                    match inner.next_frame(&mut output[offset..offset + channels]) {
-                        Ok(Some(_)) => frames_read += 1,
-                        Ok(None) | Err(_) => {
-                            state.finished = true;
-                            self.finished_flag.store(true, Ordering::Relaxed);
-                            break;
-                        }
-                    }
-                }
-            }
         }
 
         if maybe_spawn_refill {
@@ -420,5 +388,9 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
 
     fn source_channel_count(&self) -> u16 {
         self.channels
+    }
+
+    fn is_exhausted(&self) -> Option<bool> {
+        Some(self.finished_flag.load(Ordering::Relaxed))
     }
 }

--- a/src/audio/sample_source/tests.rs
+++ b/src/audio/sample_source/tests.rs
@@ -2270,6 +2270,40 @@ mod sample_source_tests {
     }
 
     #[test]
+    fn test_unbuffered_source_is_exhausted_returns_none() {
+        // ChannelMappedSource inherits the default is_exhausted() → None.
+        // The mixer treats None as "short read = EOF", preserving legacy behavior.
+        let memory = MemorySampleSource::new(vec![0.1, 0.2], 1, 44100);
+        let source = ChannelMappedSource::new(Box::new(memory), vec![vec!["test".to_string()]], 1);
+        assert_eq!(source.is_exhausted(), None);
+    }
+
+    #[test]
+    fn test_buffered_source_is_exhausted_lifecycle() {
+        // is_exhausted() should return Some(false) while the inner source still
+        // has data, then Some(true) after the source is fully consumed.
+        // Use enough samples that the warmup fill doesn't consume everything
+        // (device_buffer_frames=2 → capacity=8, warmup=2; 32 samples > capacity).
+        let samples: Vec<f32> = (0..32).map(|i| i as f32 * 0.01).collect();
+        let memory = MemorySampleSource::new(samples, 1, 44100);
+        let inner: Box<dyn ChannelMappedSampleSource + Send + Sync> = Box::new(
+            ChannelMappedSource::new(Box::new(memory), vec![vec!["test".to_string()]], 1),
+        );
+
+        let pool = Arc::new(BufferFillPool::new(1).expect("pool"));
+        let mut buffered = BufferedSampleSource::new(inner, pool, 2);
+
+        // Before draining: source is not exhausted.
+        assert_eq!(buffered.is_exhausted(), Some(false));
+
+        // Drain all samples.
+        while buffered.next_sample().unwrap().is_some() {}
+
+        // After draining: source is exhausted.
+        assert_eq!(buffered.is_exhausted(), Some(true));
+    }
+
+    #[test]
     fn test_wav_sample_source_4channel() {
         use crate::testutil::write_wav_with_bits;
         use tempfile::tempdir;

--- a/src/audio/sample_source/traits.rs
+++ b/src/audio/sample_source/traits.rs
@@ -137,6 +137,16 @@ pub trait ChannelMappedSampleSource: Send + Sync {
 
     /// Get the number of source channels in this sample source
     fn source_channel_count(&self) -> u16;
+
+    /// Reports whether this source has permanently exhausted its data.
+    ///
+    /// - `Some(true)` — source is permanently done (EOF reached).
+    /// - `Some(false)` — source still has data; a short/empty read is transient.
+    /// - `None` — source cannot answer (unbuffered sources; legacy behavior where
+    ///   a short read is treated as EOF).
+    fn is_exhausted(&self) -> Option<bool> {
+        None
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In rare circumstances, mtrack can enter a livelock state where playback becomes extremely slow. This will hopefully fix that issue.