### PR TITLE
Don't track testutil for coverage, expand trigger tests.

### DIFF
--- a/.licensure.yml
+++ b/.licensure.yml
@@ -8,6 +8,7 @@ excludes:
   - LICENSE.*
   - .*\.(md|rst|txt)
   - Cargo.toml
+  - tarpaulin.toml
   - .*\.yaml
   - .*\.wav
   - .*\.mp3

--- a/src/trigger/detector.rs
+++ b/src/trigger/detector.rs
@@ -803,6 +803,83 @@ mod tests {
     }
 
     #[test]
+    fn test_highpass_filter_path() {
+        // Create detector with highpass enabled to cover the Some(hpf) branch
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0,
+            0,
+            1.0,
+            VelocityCurve::Linear,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            Some(80.0), // Enable highpass at 80Hz
+            None,
+            None,
+            200,
+        );
+
+        // A strong transient should still trigger through the highpass
+        let result = det.process_sample(0.9);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_logarithmic_velocity_at_threshold() {
+        // Tests the `peak <= threshold` branch returning velocity 1
+        let mut det = TriggerDetector::new(
+            44100,
+            0.1,
+            0,
+            0,
+            1.0,
+            VelocityCurve::Logarithmic,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            None,
+            200,
+        );
+
+        // Trigger with a sample barely above threshold — the peak recorded
+        // will be just above threshold. The amplitude_to_velocity sees the peak.
+        // With scan=0 and lockout=0, fire() is called with the raw amplitude.
+        let event = expect_trigger(det.process_sample(0.1001));
+        // At threshold, logarithmic returns 1
+        assert!(event.velocity <= 2);
+    }
+
+    #[test]
+    fn test_logarithmic_velocity_threshold_equals_one() {
+        // Tests the `range < EPSILON` branch returning velocity 127
+        let mut det = TriggerDetector::new(
+            44100,
+            1.0, // threshold = 1.0, so range = 1.0 - 1.0 = 0.0
+            0,
+            0,
+            2.0, // gain=2 so amplitude of 0.6 * 2 = 1.2 > threshold 1.0
+            VelocityCurve::Logarithmic,
+            127,
+            Some("kick".to_string()),
+            None,
+            TriggerInputAction::Trigger,
+            None,
+            None,
+            None,
+            200,
+        );
+
+        let event = expect_trigger(det.process_sample(0.6));
+        assert_eq!(event.velocity, 127);
+    }
+
+    #[test]
     fn test_adaptive_noise_floor_recovers_after_noise_drops() {
         let mut det = TriggerDetector::new(
             44100,

--- a/src/trigger/engine.rs
+++ b/src/trigger/engine.rs
@@ -657,6 +657,67 @@ mod test {
         }
 
         #[test]
+        fn multiple_channels_fire_independently() {
+            let (tx, rx) = crossbeam_channel::bounded(16);
+            let mut detectors: Vec<Option<TriggerDetector>> =
+                vec![Some(make_detector(44100)), Some(make_detector(44100))];
+
+            // Both channels loud
+            let frame = [0.9f32, 0.9];
+            let fired = process_frame(&frame, &mut detectors, &tx, None);
+
+            // Both channels should fire
+            assert_eq!(fired, 0b11);
+            assert!(rx.try_recv().is_ok());
+            assert!(rx.try_recv().is_ok());
+        }
+
+        #[test]
+        fn fired_bitmask_reflects_channel_index() {
+            let (tx, _rx) = crossbeam_channel::bounded(16);
+            // Only channel 1 (index 1) has a detector
+            let mut detectors: Vec<Option<TriggerDetector>> =
+                vec![None, Some(make_detector(44100)), None];
+
+            let frame = [0.0f32, 0.9, 0.0];
+            let fired = process_frame(&frame, &mut detectors, &tx, None);
+
+            assert_eq!(fired, 0b10); // bit 1 set
+        }
+
+        #[test]
+        fn crosstalk_suppression_prevents_trigger_on_other_channel() {
+            let (tx, rx) = crossbeam_channel::bounded(16);
+
+            // Create two detectors with low threshold
+            let make_low_threshold = || {
+                let mut input = AudioTriggerInput::new_trigger(1, "test");
+                input.set_threshold(0.1);
+                input.set_retrigger_time_ms(0);
+                input.set_scan_time_ms(0);
+                TriggerDetector::from_input(&input, 44100)
+            };
+
+            let mut detectors: Vec<Option<TriggerDetector>> =
+                vec![Some(make_low_threshold()), Some(make_low_threshold())];
+
+            // Frame 1: ch0 fires loud, ch1 is quiet — ch1 gets crosstalk suppression
+            let frame = [0.9f32, 0.0];
+            let fired = process_frame(&frame, &mut detectors, &tx, Some((441, 5.0)));
+            assert_eq!(fired & 1, 1); // ch0 fired
+
+            // Drain the event
+            while rx.try_recv().is_ok() {}
+
+            // Frame 2: ch1 has a moderate signal that would normally trigger (0.3 > 0.1)
+            // but crosstalk suppression raised its threshold to 0.1 * 5.0 = 0.5
+            let frame = [0.0f32, 0.3];
+            let fired = process_frame(&frame, &mut detectors, &tx, Some((441, 5.0)));
+            assert_eq!(fired, 0, "ch1 should be suppressed by crosstalk");
+            assert!(rx.try_recv().is_err());
+        }
+
+        #[test]
         fn crosstalk_suppression_applied_to_non_firing_channels() {
             let (tx, _rx) = crossbeam_channel::bounded(16);
             let mut detectors: Vec<Option<TriggerDetector>> =

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,2 @@
+[default]
+exclude-files = ["src/testutil/*"]


### PR DESCRIPTION
testutil is no longer tracked for code coverage, and triggering tests are now expanded.