### PR TITLE
Add a MIDI beat clock.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **MIDI beat clock output**: mtrack can now send MIDI beat clock (24 ppqn) to synchronize
+  external gear to song tempo. Enable with `beat_clock: true` in the MIDI configuration. When
+  enabled, mtrack sends Start (0xFA), Timing Clock (0xF8), and Stop (0xFC) messages derived
+  from the MIDI file's tempo map. Beat clock is only emitted for songs whose MIDI files contain
+  explicit tempo change events — songs without a tempo map do not emit beat clock, leaving
+  musicians free to control their own tempo. The beat clock runs on a dedicated thread with
+  `spin_sleep` precision and supports mid-song tempo changes and seeking (Continue 0xFB).
+
 ## [0.9.2] - 2026-03-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -295,6 +295,13 @@ midi:
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the MIDI playback.
   playback_delay: 500ms
 
+  # (Optional) Enable MIDI beat clock output (24 ppqn). When enabled, mtrack sends MIDI System
+  # Real-Time messages (Start, Timing Clock, Stop) to synchronize external gear to the song's
+  # tempo. Beat clock is only sent for songs whose MIDI files contain explicit tempo change events;
+  # songs without a tempo map do not emit beat clock, leaving musicians free to control their own
+  # tempo.
+  beat_clock: true
+
   # (Optional) You can route live MIDI events into the DMX engine with this configuration.
   midi_to_dmx:
   

--- a/examples/mtrack.yaml
+++ b/examples/mtrack.yaml
@@ -44,6 +44,13 @@ midi:
   # (Optional) Once a song is started, mtrack will wait this amount before triggering the MIDI playback.
   playback_delay: 500ms
 
+  # (Optional) Enable MIDI beat clock output (24 ppqn). When enabled, mtrack sends MIDI System
+  # Real-Time messages (Start, Timing Clock, Stop) to synchronize external gear to the song's
+  # tempo. Beat clock is only sent for songs whose MIDI files contain explicit tempo change events;
+  # songs without a tempo map do not emit beat clock, leaving musicians free to control their own
+  # tempo. Defaults to false.
+  beat_clock: true
+
   # (Optional) You can route live MIDI events into the DMX engine with this configuration.
   midi_to_dmx:
   

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -31,6 +31,9 @@ pub struct Midi {
     /// Controls how long to wait before playback of a MIDI file starts.
     playback_delay: Option<String>,
 
+    /// Enable MIDI beat clock output (24 ppqn timing clock).
+    beat_clock: Option<bool>,
+
     /// MIDI to DMX passthrough configurations.
     midi_to_dmx: Option<Vec<MidiToDmx>>,
 }
@@ -41,6 +44,7 @@ impl Midi {
         Midi {
             device: device.to_string(),
             playback_delay,
+            beat_clock: None,
             midi_to_dmx: None,
         }
     }
@@ -56,6 +60,11 @@ impl Midi {
             Some(playback_delay) => Ok(DurationString::from_string(playback_delay.clone())?.into()),
             None => Ok(DEFAULT_MIDI_PLAYBACK_DELAY),
         }
+    }
+
+    /// Returns whether beat clock output is enabled.
+    pub fn beat_clock(&self) -> bool {
+        self.beat_clock.unwrap_or(false)
     }
 
     /// Returns the MIDI to DMX configuration.
@@ -546,6 +555,26 @@ mod test {
     fn midi_to_dmx_empty_default() {
         let midi = super::Midi::new("dev", None);
         assert!(midi.midi_to_dmx().is_empty());
+    }
+
+    #[test]
+    fn beat_clock_default_is_false() {
+        let midi = super::Midi::new("dev", None);
+        assert!(!midi.beat_clock());
+    }
+
+    #[test]
+    fn beat_clock_deserialization() -> Result<(), Box<dyn Error>> {
+        let yaml = r#"
+            device: test
+            beat_clock: true
+        "#;
+        let midi: super::Midi = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()?
+            .try_deserialize()?;
+        assert!(midi.beat_clock());
+        Ok(())
     }
 
     #[test]

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -23,6 +23,7 @@ use tokio::sync::mpsc::Sender;
 
 use crate::{config, dmx::engine::Engine, playsync::CancelHandle, songs::Song};
 
+pub(crate) mod beat_clock;
 pub(crate) mod midir;
 pub(crate) mod mock;
 pub(crate) mod playback;

--- a/src/midi/beat_clock.rs
+++ b/src/midi/beat_clock.rs
@@ -1,0 +1,242 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use std::time::Duration;
+
+use super::playback::TempoEntry;
+
+/// Number of MIDI clock pulses per quarter note.
+const CLOCKS_PER_BEAT: u64 = 24;
+
+/// Pre-computed MIDI beat clock: a list of absolute timestamps for each 0xF8 tick.
+pub(crate) struct PrecomputedBeatClock {
+    /// Absolute timestamps for each clock tick.
+    ticks: Vec<Duration>,
+}
+
+impl PrecomputedBeatClock {
+    /// Builds a pre-computed beat clock from a tempo map.
+    ///
+    /// Walks through the tempo map, computing the absolute time of every clock tick
+    /// (24 per quarter note). Between tempo changes, ticks are evenly spaced at the
+    /// current tempo's interval.
+    pub(crate) fn from_tempo_info(
+        tempo_map: &[TempoEntry],
+        ticks_per_beat: u16,
+        total_ticks: u64,
+    ) -> Self {
+        let tpb = ticks_per_beat as f64;
+        // Default tempo: 120 BPM = 500_000 microseconds per beat
+        let default_micros_per_tick = 500_000.0 / tpb;
+
+        // Use fractional tracking in case ticks_per_beat isn't evenly divisible by 24
+        let clock_interval_ticks_f = tpb / CLOCKS_PER_BEAT as f64;
+
+        let mut ticks = Vec::new();
+        let mut micros_per_tick = default_micros_per_tick;
+        let mut elapsed_micros: f64 = 0.0;
+        let mut current_tick: f64 = 0.0;
+        let mut tempo_idx: usize = 0;
+
+        // Walk through the entire MIDI timeline, generating clock ticks
+        while (current_tick as u64) < total_ticks {
+            let next_clock_tick = current_tick + clock_interval_ticks_f;
+
+            // Check if any tempo changes occur before the next clock tick
+            while tempo_idx < tempo_map.len()
+                && (tempo_map[tempo_idx].tick as f64) <= next_clock_tick
+            {
+                let entry = &tempo_map[tempo_idx];
+                if (entry.tick as f64) > current_tick {
+                    // Accumulate time up to the tempo change
+                    elapsed_micros += (entry.tick as f64 - current_tick) * micros_per_tick;
+                    current_tick = entry.tick as f64;
+                }
+                micros_per_tick = entry.micros_per_tick;
+                tempo_idx += 1;
+            }
+
+            // Accumulate time from current position to the next clock tick
+            if next_clock_tick > current_tick {
+                elapsed_micros += (next_clock_tick - current_tick) * micros_per_tick;
+            }
+            current_tick = next_clock_tick;
+
+            if (current_tick as u64) <= total_ticks {
+                ticks.push(Duration::from_micros(elapsed_micros.round() as u64));
+            }
+        }
+
+        PrecomputedBeatClock { ticks }
+    }
+
+    /// Returns the slice of ticks starting from the first tick at or after `start_time`.
+    pub(crate) fn ticks_from(&self, start_time: Duration) -> &[Duration] {
+        let idx = self.ticks.partition_point(|t| *t < start_time);
+        &self.ticks[idx..]
+    }
+
+    /// Returns all ticks.
+    #[cfg(test)]
+    pub(crate) fn ticks(&self) -> &[Duration] {
+        &self.ticks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_tempo_tick_count() {
+        // 480 ticks per beat, 120 BPM (default), 4 beats = 1920 total ticks
+        // Should produce 4 * 24 = 96 clock ticks
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&[], 480, 1920);
+        assert_eq!(beat_clock.ticks().len(), 96);
+    }
+
+    #[test]
+    fn constant_tempo_tick_spacing() {
+        // 480 tpb, default 120 BPM = 500_000 µs/beat
+        // Clock interval = 500_000 / 24 ≈ 20_833 µs
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&[], 480, 480);
+        assert_eq!(beat_clock.ticks().len(), 24);
+
+        // First tick should be at ~20_833 µs (one clock interval)
+        let expected_interval = Duration::from_micros((500_000.0_f64 / 24.0).round() as u64);
+        assert_eq!(beat_clock.ticks()[0], expected_interval);
+
+        // Last tick should be at ~500_000 µs (one beat)
+        let last = beat_clock.ticks()[23];
+        assert!(
+            last >= Duration::from_micros(499_000) && last <= Duration::from_micros(501_000),
+            "last tick at {:?}",
+            last
+        );
+    }
+
+    #[test]
+    fn tempo_change_adjusts_spacing() {
+        // Start at 120 BPM (500_000 µs/beat), change to 60 BPM (1_000_000 µs/beat) at beat 1
+        let tpb = 480u16;
+        let tempo_map = vec![TempoEntry {
+            tick: 480,
+            micros_per_tick: 1_000_000.0 / 480.0,
+        }];
+        // 2 beats total = 960 ticks
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&tempo_map, tpb, 960);
+        // 2 beats * 24 = 48 ticks
+        assert_eq!(beat_clock.ticks().len(), 48);
+
+        // First beat ticks should be spaced at ~20_833 µs (120 BPM)
+        let first_beat_interval =
+            beat_clock.ticks()[1].as_micros() - beat_clock.ticks()[0].as_micros();
+        assert!(
+            (first_beat_interval as i64 - 20_833).unsigned_abs() < 10,
+            "first beat interval: {}",
+            first_beat_interval
+        );
+
+        // Second beat ticks should be spaced at ~41_667 µs (60 BPM)
+        let second_beat_interval =
+            beat_clock.ticks()[25].as_micros() - beat_clock.ticks()[24].as_micros();
+        assert!(
+            (second_beat_interval as i64 - 41_667).unsigned_abs() < 10,
+            "second beat interval: {}",
+            second_beat_interval
+        );
+    }
+
+    #[test]
+    fn ticks_from_seeks_correctly() {
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&[], 480, 960);
+        // 48 ticks total (2 beats)
+        assert_eq!(beat_clock.ticks().len(), 48);
+
+        // Seek to the start
+        assert_eq!(beat_clock.ticks_from(Duration::ZERO).len(), 48);
+
+        // Seek past one beat (500_001 µs) — should skip the first 24 ticks
+        // (the 24th tick lands at exactly 500_000 µs)
+        let from_half = beat_clock.ticks_from(Duration::from_micros(500_001));
+        assert_eq!(from_half.len(), 24);
+    }
+
+    #[test]
+    fn empty_song_produces_no_ticks() {
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&[], 480, 0);
+        assert_eq!(beat_clock.ticks().len(), 0);
+    }
+
+    #[test]
+    fn multiple_tempo_changes() {
+        // Three tempo zones: 120 BPM, 60 BPM, 240 BPM
+        let tpb = 480u16;
+        let tempo_map = vec![
+            TempoEntry {
+                tick: 480,
+                micros_per_tick: 1_000_000.0 / 480.0, // 60 BPM
+            },
+            TempoEntry {
+                tick: 960,
+                micros_per_tick: 250_000.0 / 480.0, // 240 BPM
+            },
+        ];
+        // 3 beats total = 1440 ticks
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&tempo_map, tpb, 1440);
+        // 3 beats * 24 = 72 ticks
+        assert_eq!(beat_clock.ticks().len(), 72);
+    }
+
+    #[test]
+    fn tempo_change_at_tick_zero() {
+        // Tempo change at tick 0 sets the initial tempo (exercises entry.tick == current_tick path)
+        let tpb = 480u16;
+        let tempo_map = vec![TempoEntry {
+            tick: 0,
+            micros_per_tick: 1_000_000.0 / 480.0, // 60 BPM
+        }];
+        // 1 beat = 480 ticks at 60 BPM = 1_000_000 µs
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&tempo_map, tpb, 480);
+        assert_eq!(beat_clock.ticks().len(), 24);
+
+        // Ticks should be spaced at ~41_667 µs (60 BPM)
+        let interval = beat_clock.ticks()[1].as_micros() - beat_clock.ticks()[0].as_micros();
+        assert!(
+            (interval as i64 - 41_667).unsigned_abs() < 10,
+            "interval: {}",
+            interval
+        );
+    }
+
+    #[test]
+    fn non_standard_ticks_per_beat() {
+        // 96 tpb (common in older MIDI files), not evenly divisible by 24
+        // 96 / 24 = 4, so actually it is evenly divisible. Use 100 instead.
+        let tpb = 100u16;
+        let tempo_map = vec![TempoEntry {
+            tick: 0,
+            micros_per_tick: 500_000.0 / 100.0, // 120 BPM
+        }];
+        // 1 beat = 100 ticks
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&tempo_map, tpb, 100);
+        assert_eq!(beat_clock.ticks().len(), 24);
+    }
+
+    #[test]
+    fn ticks_from_past_end_returns_empty() {
+        let beat_clock = PrecomputedBeatClock::from_tempo_info(&[], 480, 480);
+        let from_far = beat_clock.ticks_from(Duration::from_secs(100));
+        assert_eq!(from_far.len(), 0);
+    }
+}

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -57,6 +57,7 @@ type TransformerConfig = (HashMap<u8, String>, HashMap<u8, Vec<MidiTransformer>>
 pub struct Device {
     name: String,
     playback_delay: Duration,
+    beat_clock_enabled: bool,
     input_port: Option<MidiInputPort>,
     output_port: Option<MidiOutputPort>,
     event_connection: Box<Mutex<Option<MidiInputConnection<()>>>>,
@@ -70,6 +71,7 @@ impl Device {
         Device {
             name,
             playback_delay: Duration::ZERO,
+            beat_clock_enabled: false,
             input_port: None,
             output_port: None,
             event_connection: Box::new(Mutex::new(None)),
@@ -210,12 +212,80 @@ impl super::Device for Device {
             song = song.name(),
             duration = song.duration_string(),
             start_time = ?start_time,
+            beat_clock = self.beat_clock_enabled,
             "Playing song MIDI."
         );
 
         let finished = Arc::new(AtomicBool::new(false));
         let playback_delay = self.playback_delay;
         let mut connection = output.connect(output_port, "mtrack player")?;
+
+        // Optionally set up beat clock on a second connection
+        let beat_clock_handle = if self.beat_clock_enabled {
+            if let Some(ref beat_clock) = midi_sheet.beat_clock {
+                let clock_output = MidiOutput::new("mtrack beat clock output")?;
+                let mut clock_connection =
+                    clock_output.connect(output_port, "mtrack beat clock")?;
+                let clock_cancel = cancel_handle.clone();
+                let clock_playback_delay = playback_delay;
+                let clock_start_time = start_time;
+
+                // Build a small wrapper that owns the PrecomputedBeatClock data we need.
+                // We can't move midi_sheet into the closure since the note thread uses it,
+                // so re-extract the tick data.
+                let ticks: Vec<Duration> = beat_clock.ticks_from(Duration::ZERO).to_vec();
+
+                // Internal barrier to synchronize the beat clock thread with the note
+                // playback thread. The note thread will wait on this after the external
+                // play_barrier releases, so both start sending at the same time.
+                let internal_barrier = Arc::new(Barrier::new(2));
+                let clock_internal_barrier = internal_barrier.clone();
+
+                info!("Starting MIDI beat clock thread.");
+                Some((
+                    thread::spawn(move || {
+                        // Wait for the note thread to signal us after it passes the
+                        // external play_barrier.
+                        clock_internal_barrier.wait();
+
+                        if clock_cancel.is_cancelled() {
+                            return;
+                        }
+
+                        // Sleep the playback delay
+                        {
+                            let start = std::time::Instant::now();
+                            while start.elapsed() < clock_playback_delay {
+                                if clock_cancel.is_cancelled() {
+                                    return;
+                                }
+                                let remaining =
+                                    clock_playback_delay.saturating_sub(start.elapsed());
+                                spin_sleep::sleep(remaining.min(Duration::from_millis(50)));
+                            }
+                        }
+
+                        run_beat_clock(
+                            &mut clock_connection,
+                            &ticks,
+                            clock_start_time,
+                            &clock_cancel,
+                        );
+                    }),
+                    internal_barrier,
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        // Extract the internal barrier (if any) for synchronizing the beat clock thread.
+        let (beat_clock_join, beat_clock_internal_barrier) = match beat_clock_handle {
+            Some((handle, barrier)) => (Some(handle), Some(barrier)),
+            None => (None, None),
+        };
 
         let join_handle = {
             let cancel_handle = cancel_handle.clone();
@@ -232,6 +302,7 @@ impl super::Device for Device {
                         play_barrier,
                         finished,
                         exclude_channels: &exclude_midi_channels,
+                        beat_clock_barrier: beat_clock_internal_barrier,
                     },
                 );
             })
@@ -245,6 +316,12 @@ impl super::Device for Device {
 
         if join_handle.join().is_err() {
             return Err("Error while joining thread!".into());
+        }
+
+        if let Some(handle) = beat_clock_join {
+            if handle.join().is_err() {
+                return Err("Error while joining beat clock thread!".into());
+            }
         }
 
         info!("MIDI playback stopped.");
@@ -396,6 +473,7 @@ pub fn get(
 
     let mut midi_device = matches.swap_remove(0);
     midi_device.playback_delay = playback_delay;
+    midi_device.beat_clock_enabled = config.beat_clock();
     midi_device.midi_to_dmx_mappings = midi_to_dmx_mappings;
     midi_device.dmx_engine = dmx_engine;
     midi_device.dmx_midi_transformers = dmx_midi_transformers;
@@ -513,12 +591,18 @@ struct PlaybackContext<'a> {
     play_barrier: Arc<Barrier>,
     finished: Arc<AtomicBool>,
     exclude_channels: &'a HashSet<u8>,
+    beat_clock_barrier: Option<Arc<Barrier>>,
 }
 
 /// Runs the MIDI playback thread body: waits on the barrier, sleeps through
 /// the playback delay (checking for cancellation), then plays events.
 fn run_playback(sender: &mut dyn MidiSender, ctx: PlaybackContext<'_>) {
     ctx.play_barrier.wait();
+
+    // Signal the beat clock thread (if any) to start in sync with us.
+    if let Some(ref barrier) = ctx.beat_clock_barrier {
+        barrier.wait();
+    }
 
     if ctx.cancel_handle.is_cancelled() {
         ctx.finished.store(true, Ordering::Relaxed);
@@ -551,6 +635,69 @@ fn run_playback(sender: &mut dyn MidiSender, ctx: PlaybackContext<'_>) {
 
     ctx.finished.store(true, Ordering::Relaxed);
     ctx.cancel_handle.notify();
+}
+
+/// Serializes a MIDI System Real-Time event to bytes.
+fn realtime_bytes(msg: midly::live::SystemRealtime) -> Vec<u8> {
+    let event = LiveEvent::Realtime(msg);
+    let mut buf = Vec::with_capacity(1);
+    event
+        .write_std(&mut buf)
+        .expect("realtime events are always valid");
+    buf
+}
+
+/// Runs the beat clock on a MIDI sender, sending START/CONTINUE, timing clocks, and STOP.
+fn run_beat_clock(
+    sender: &mut dyn MidiSender,
+    ticks: &[Duration],
+    start_time: Duration,
+    cancel_handle: &CancelHandle,
+) {
+    use midly::live::SystemRealtime;
+
+    // Send START or CONTINUE
+    let start_msg = if start_time == Duration::ZERO {
+        realtime_bytes(SystemRealtime::Start)
+    } else {
+        realtime_bytes(SystemRealtime::Continue)
+    };
+    if let Err(e) = sender.send(&start_msg) {
+        debug!("MIDI beat clock start send failed: {:?}", e);
+    }
+
+    // Find ticks from start_time
+    let idx = ticks.partition_point(|t| *t < start_time);
+    let remaining_ticks = &ticks[idx..];
+
+    let wall_start = std::time::Instant::now();
+    let clock_bytes = realtime_bytes(SystemRealtime::TimingClock);
+    let stop_bytes = realtime_bytes(SystemRealtime::Stop);
+
+    for tick_time in remaining_ticks {
+        if cancel_handle.is_cancelled() {
+            let _ = sender.send(&stop_bytes);
+            return;
+        }
+
+        let target_wall = *tick_time - start_time;
+        let elapsed = wall_start.elapsed();
+        if target_wall > elapsed {
+            spin_sleep::sleep(target_wall - elapsed);
+        }
+
+        if cancel_handle.is_cancelled() {
+            let _ = sender.send(&stop_bytes);
+            return;
+        }
+
+        if let Err(e) = sender.send(&clock_bytes) {
+            debug!("MIDI beat clock send failed: {:?}", e);
+        }
+    }
+
+    // Send STOP when finished
+    let _ = sender.send(&stop_bytes);
 }
 
 /// Plays pre-computed MIDI events through a MIDI sender.
@@ -617,6 +764,7 @@ mod test {
             let device = Device::new_default("my-midi".to_string());
             assert_eq!(device.name, "my-midi");
             assert_eq!(device.playback_delay, Duration::ZERO);
+            assert!(!device.beat_clock_enabled);
             assert!(device.input_port.is_none());
             assert!(device.output_port.is_none());
             assert!(device.midi_to_dmx_mappings.is_empty());
@@ -1459,6 +1607,7 @@ mod test {
                     play_barrier: barrier,
                     finished: finished.clone(),
                     exclude_channels: &exclude,
+                    beat_clock_barrier: None,
                 },
             );
 
@@ -1486,6 +1635,7 @@ mod test {
                     play_barrier: barrier,
                     finished: finished.clone(),
                     exclude_channels: &exclude,
+                    beat_clock_barrier: None,
                 },
             );
 
@@ -1520,6 +1670,7 @@ mod test {
                     play_barrier: barrier,
                     finished: finished.clone(),
                     exclude_channels: &exclude,
+                    beat_clock_barrier: None,
                 },
             );
 
@@ -1548,6 +1699,7 @@ mod test {
                     play_barrier: barrier,
                     finished: finished.clone(),
                     exclude_channels: &exclude,
+                    beat_clock_barrier: None,
                 },
             );
 
@@ -1593,6 +1745,7 @@ mod test {
                     play_barrier: barrier,
                     finished: finished.clone(),
                     exclude_channels: &exclude,
+                    beat_clock_barrier: None,
                 },
             );
 
@@ -1624,6 +1777,7 @@ mod test {
                         play_barrier: barrier_clone,
                         finished: finished_clone,
                         exclude_channels: &exclude,
+                        beat_clock_barrier: None,
                     },
                 );
                 sender
@@ -1639,6 +1793,116 @@ mod test {
             let sender = handle.join().unwrap();
             assert!(finished.load(Ordering::Relaxed));
             assert_eq!(sender.sent.lock().unwrap().len(), 1);
+        }
+    }
+
+    mod run_beat_clock_tests {
+        use super::*;
+        use crate::playsync::CancelHandle;
+        use midly::live::SystemRealtime;
+        use std::sync::Mutex;
+
+        fn start_bytes() -> Vec<u8> {
+            realtime_bytes(SystemRealtime::Start)
+        }
+        fn continue_bytes() -> Vec<u8> {
+            realtime_bytes(SystemRealtime::Continue)
+        }
+        fn stop_bytes() -> Vec<u8> {
+            realtime_bytes(SystemRealtime::Stop)
+        }
+        fn clock_bytes() -> Vec<u8> {
+            realtime_bytes(SystemRealtime::TimingClock)
+        }
+
+        struct MockSender {
+            sent: Mutex<Vec<Vec<u8>>>,
+        }
+
+        impl MockSender {
+            fn new() -> Self {
+                MockSender {
+                    sent: Mutex::new(Vec::new()),
+                }
+            }
+        }
+
+        impl MidiSender for MockSender {
+            fn send(&mut self, bytes: &[u8]) -> Result<(), Box<dyn Error>> {
+                self.sent.lock().unwrap().push(bytes.to_vec());
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn sends_start_clocks_and_stop() {
+            // 1 beat at default 120 BPM = 24 clock ticks
+            let beat_clock = crate::midi::beat_clock::PrecomputedBeatClock::from_tempo_info(
+                &[crate::midi::playback::TempoEntry {
+                    tick: 0,
+                    micros_per_tick: 500_000.0 / 480.0,
+                }],
+                480,
+                480,
+            );
+            let ticks: Vec<Duration> = beat_clock.ticks_from(Duration::ZERO).to_vec();
+            let cancel = CancelHandle::new();
+            let mut sender = MockSender::new();
+
+            run_beat_clock(&mut sender, &ticks, Duration::ZERO, &cancel);
+
+            let sent = sender.sent.lock().unwrap();
+            // START + 24 clock ticks + STOP
+            assert_eq!(sent.len(), 26);
+            assert_eq!(sent[0], start_bytes());
+            for msg in &sent[1..25] {
+                assert_eq!(*msg, clock_bytes());
+            }
+            assert_eq!(sent[25], stop_bytes());
+        }
+
+        #[test]
+        fn sends_continue_when_seeking() {
+            let ticks = vec![Duration::from_millis(500), Duration::from_millis(600)];
+            let cancel = CancelHandle::new();
+            let mut sender = MockSender::new();
+
+            run_beat_clock(&mut sender, &ticks, Duration::from_millis(100), &cancel);
+
+            let sent = sender.sent.lock().unwrap();
+            // CONTINUE + 2 ticks + STOP
+            assert_eq!(sent.len(), 4);
+            assert_eq!(sent[0], continue_bytes());
+        }
+
+        #[test]
+        fn empty_ticks_sends_start_and_stop() {
+            let ticks: Vec<Duration> = Vec::new();
+            let cancel = CancelHandle::new();
+            let mut sender = MockSender::new();
+
+            run_beat_clock(&mut sender, &ticks, Duration::ZERO, &cancel);
+
+            let sent = sender.sent.lock().unwrap();
+            assert_eq!(sent.len(), 2);
+            assert_eq!(sent[0], start_bytes());
+            assert_eq!(sent[1], stop_bytes());
+        }
+
+        #[test]
+        fn cancellation_sends_stop() {
+            let ticks = vec![Duration::from_secs(10), Duration::from_secs(20)];
+            let cancel = CancelHandle::new();
+            cancel.cancel();
+            let mut sender = MockSender::new();
+
+            run_beat_clock(&mut sender, &ticks, Duration::ZERO, &cancel);
+
+            let sent = sender.sent.lock().unwrap();
+            // START + STOP (cancelled before any ticks)
+            assert_eq!(sent.len(), 2);
+            assert_eq!(sent[0], start_bytes());
+            assert_eq!(sent[1], stop_bytes());
         }
     }
 }

--- a/src/midi/playback.rs
+++ b/src/midi/playback.rs
@@ -31,9 +31,9 @@ pub(crate) struct PrecomputedMidi {
 }
 
 /// A tempo change at a specific tick position.
-struct TempoEntry {
-    tick: u64,
-    micros_per_tick: f64,
+pub(crate) struct TempoEntry {
+    pub(crate) tick: u64,
+    pub(crate) micros_per_tick: f64,
 }
 
 /// Result of processing a single track: MIDI events and total track duration.
@@ -110,7 +110,7 @@ impl PrecomputedMidi {
     }
 
     /// Extracts a tempo map from a track (tick position → micros_per_tick).
-    fn extract_tempo_map(track: &[TrackEvent<'_>], tpb: f64) -> Vec<TempoEntry> {
+    pub(crate) fn extract_tempo_map(track: &[TrackEvent<'_>], tpb: f64) -> Vec<TempoEntry> {
         let mut tempo_map = Vec::new();
         let mut tick_position: u64 = 0;
         for event in track {
@@ -196,6 +196,58 @@ impl PrecomputedMidi {
         TrackResult {
             events,
             total_duration: Duration::from_micros(elapsed_micros.round() as u64),
+        }
+    }
+
+    /// Builds the tempo map and total duration (in ticks) from parsed tracks.
+    /// Returns (tempo_map, ticks_per_beat, total_ticks).
+    pub(crate) fn build_tempo_info(
+        tracks: &[Vec<TrackEvent<'_>>],
+        ticks_per_beat: u16,
+        format: Format,
+    ) -> (Vec<TempoEntry>, u16, u64) {
+        let tpb = ticks_per_beat as f64;
+
+        match format {
+            Format::SingleTrack => {
+                let (tempo_map, total_ticks) = if let Some(track) = tracks.first() {
+                    let map = Self::extract_tempo_map(track, tpb);
+                    let total = track.iter().map(|e| e.delta.as_int() as u64).sum::<u64>();
+                    (map, total)
+                } else {
+                    (Vec::new(), 0)
+                };
+                (tempo_map, ticks_per_beat, total_ticks)
+            }
+            Format::Parallel => {
+                let tempo_map = tracks
+                    .first()
+                    .map(|track| Self::extract_tempo_map(track, tpb))
+                    .unwrap_or_default();
+                // Total ticks is the max across all tracks
+                let total_ticks = tracks
+                    .iter()
+                    .map(|track| track.iter().map(|e| e.delta.as_int() as u64).sum::<u64>())
+                    .max()
+                    .unwrap_or(0);
+                (tempo_map, ticks_per_beat, total_ticks)
+            }
+            Format::Sequential => {
+                // For sequential, concatenate tempo maps with tick offsets
+                let mut combined_map = Vec::new();
+                let mut total_ticks: u64 = 0;
+                for track in tracks {
+                    let map = Self::extract_tempo_map(track, tpb);
+                    for entry in map {
+                        combined_map.push(TempoEntry {
+                            tick: entry.tick + total_ticks,
+                            micros_per_tick: entry.micros_per_tick,
+                        });
+                    }
+                    total_ticks += track.iter().map(|e| e.delta.as_int() as u64).sum::<u64>();
+                }
+                (combined_map, ticks_per_beat, total_ticks)
+            }
         }
     }
 
@@ -538,5 +590,72 @@ mod tests {
     fn test_sequential_empty() {
         let midi = PrecomputedMidi::from_tracks(&[], 480, Format::Sequential);
         assert!(midi.is_empty());
+    }
+
+    #[test]
+    fn test_build_tempo_info_no_tempo_events() {
+        let tpb = 480;
+        let track = vec![note_on(0, 0, 60, 100), end_of_track(480)];
+        let (tempo_map, returned_tpb, total_ticks) =
+            PrecomputedMidi::build_tempo_info(&[track], tpb, Format::SingleTrack);
+        assert!(tempo_map.is_empty());
+        assert_eq!(returned_tpb, tpb);
+        assert_eq!(total_ticks, 480);
+    }
+
+    #[test]
+    fn test_build_tempo_info_single_track_with_tempo() {
+        let tpb = 480;
+        let track = vec![
+            tempo_event(0, 500_000),
+            note_on(480, 0, 60, 100),
+            end_of_track(480),
+        ];
+        let (tempo_map, _, total_ticks) =
+            PrecomputedMidi::build_tempo_info(&[track], tpb, Format::SingleTrack);
+        assert_eq!(tempo_map.len(), 1);
+        assert_eq!(tempo_map[0].tick, 0);
+        assert_eq!(total_ticks, 960);
+    }
+
+    #[test]
+    fn test_build_tempo_info_parallel_uses_conductor() {
+        let tpb = 480;
+        let track0 = vec![
+            tempo_event(0, 1_000_000),
+            tempo_event(480, 500_000),
+            end_of_track(0),
+        ];
+        let track1 = vec![note_on(0, 0, 60, 100), end_of_track(960)];
+        let (tempo_map, _, total_ticks) =
+            PrecomputedMidi::build_tempo_info(&[track0, track1], tpb, Format::Parallel);
+        assert_eq!(tempo_map.len(), 2);
+        assert_eq!(tempo_map[0].tick, 0);
+        assert_eq!(tempo_map[1].tick, 480);
+        // Max across tracks: track1 has 960 ticks
+        assert_eq!(total_ticks, 960);
+    }
+
+    #[test]
+    fn test_build_tempo_info_sequential_offsets_ticks() {
+        let tpb = 480;
+        let track1 = vec![tempo_event(0, 500_000), end_of_track(480)];
+        let track2 = vec![tempo_event(0, 1_000_000), end_of_track(480)];
+        let (tempo_map, _, total_ticks) =
+            PrecomputedMidi::build_tempo_info(&[track1, track2], tpb, Format::Sequential);
+        assert_eq!(tempo_map.len(), 2);
+        assert_eq!(tempo_map[0].tick, 0);
+        // Second track's tempo change is offset by first track's total ticks
+        assert_eq!(tempo_map[1].tick, 480);
+        assert_eq!(total_ticks, 960);
+    }
+
+    #[test]
+    fn test_build_tempo_info_empty_tracks() {
+        let (tempo_map, tpb, total_ticks) =
+            PrecomputedMidi::build_tempo_info(&[], 480, Format::Parallel);
+        assert!(tempo_map.is_empty());
+        assert_eq!(tpb, 480);
+        assert_eq!(total_ticks, 0);
     }
 }

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -609,12 +609,34 @@ fn parse_midi(midi_file: &PathBuf) -> Result<MidiSheet, Box<dyn Error>> {
         midly::Timing::Metrical(tpb) => tpb.as_int(),
         _ => return Err("timecode-based MIDI timing not supported".into()),
     };
+    let (tempo_map, tpb, total_ticks) = crate::midi::playback::PrecomputedMidi::build_tempo_info(
+        &smf.tracks,
+        ticks_per_beat,
+        smf.header.format,
+    );
     let precomputed = crate::midi::playback::PrecomputedMidi::from_tracks(
         &smf.tracks,
         ticks_per_beat,
         smf.header.format,
     );
-    Ok(MidiSheet { precomputed })
+    // Only generate beat clock when the MIDI file contains explicit tempo events.
+    // Files without tempo maps have no tempo opinion, so mtrack stays out of the way
+    // and lets musicians control their own tempo.
+    let beat_clock = if tempo_map.is_empty() {
+        None
+    } else {
+        Some(
+            crate::midi::beat_clock::PrecomputedBeatClock::from_tempo_info(
+                &tempo_map,
+                tpb,
+                total_ticks,
+            ),
+        )
+    };
+    Ok(MidiSheet {
+        precomputed,
+        beat_clock,
+    })
 }
 
 /// A light show for the song.
@@ -816,6 +838,7 @@ impl Track {
 /// Contains a pre-computed MIDI timeline for playback.
 pub struct MidiSheet {
     pub(crate) precomputed: crate::midi::playback::PrecomputedMidi,
+    pub(crate) beat_clock: Option<crate::midi::beat_clock::PrecomputedBeatClock>,
 }
 
 /// A registry of songs for use by the multitrack player.
@@ -1680,7 +1703,46 @@ mod test {
         );
         let midi_pb = song_config.midi_playback().unwrap();
         let playback = super::MidiPlayback::new(tempdir.path(), midi_pb)?;
-        let _sheet = playback.midi_sheet()?;
+        let sheet = playback.midi_sheet()?;
+        // No tempo events in the MIDI file, so beat clock should be None
+        assert!(sheet.beat_clock.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn midi_sheet_with_tempo_has_beat_clock() -> Result<(), Box<dyn Error>> {
+        // Create a MIDI file with an explicit tempo event
+        let tempdir = tempfile::tempdir()?;
+        let midi_path = tempdir.path().join("test.mid");
+        let midi_bytes: Vec<u8> = vec![
+            0x4D, 0x54, 0x68, 0x64, // MThd
+            0x00, 0x00, 0x00, 0x06, // chunk length = 6
+            0x00, 0x00, // format 0
+            0x00, 0x01, // 1 track
+            0x00, 0x60, // 96 ticks per beat
+            0x4D, 0x54, 0x72, 0x6B, // MTrk
+            0x00, 0x00, 0x00, 0x0B, // chunk length = 11
+            0x00, 0xFF, 0x51, 0x03, 0x07, 0xA1,
+            0x20, // delta=0, tempo = 500_000 µs (120 BPM)
+            0x60, 0xFF, 0x2F, 0x00, // delta=96, end of track (1 beat later)
+        ];
+        fs::write(&midi_path, &midi_bytes)?;
+        let song_config = crate::config::Song::new(
+            "test",
+            None,
+            Some("test.mid".to_string()),
+            None,
+            None,
+            None,
+            vec![],
+            std::collections::HashMap::new(),
+            vec![],
+        );
+        let midi_pb = song_config.midi_playback().unwrap();
+        let playback = super::MidiPlayback::new(tempdir.path(), midi_pb)?;
+        let sheet = playback.midi_sheet()?;
+        // Has tempo events, so beat clock should be Some
+        assert!(sheet.beat_clock.is_some());
         Ok(())
     }
 


### PR DESCRIPTION
MIDI beat clock can now be emitted by mtrack based on the tempo of associated MIDI files during playback. This will allow for things like setting the tempo of amp modelers for things like delay effects.