### PR TITLE
Host by default on 0.0.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Web UI**: A new web-based interface for controlling and monitoring mtrack from a browser.
-  The web UI is always available when running `mtrack start`, served on `http://127.0.0.1:8080`
+  The web UI is always available when running `mtrack start`, served on `http://0.0.0.0:8080`
   by default. Use `--web-port` and `--web-address` to customize. Features include:
   - Real-time playback control (play/stop/next/prev) with progress bar
   - Playlist management with song selection

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Start the player:
 $ mtrack start /path/to/player.yaml
 ```
 
-The web UI will be available at `http://127.0.0.1:8080`.
+The web UI will be available at `http://localhost:8080`.
 
 ## Documentation
 

--- a/docs/src/interfaces/web-ui.md
+++ b/docs/src/interfaces/web-ui.md
@@ -1,13 +1,13 @@
 # Web UI
 
 `mtrack` includes a web-based interface for controlling and monitoring the player from a browser.
-The web UI is always available when running `mtrack start`, served at `http://127.0.0.1:8080`
-by default.
+The web UI is always available when running `mtrack start`, served on all interfaces at
+port 8080 by default (`http://0.0.0.0:8080`).
 
 Use `--web-port` and `--web-address` to customize:
 
 ```
-$ mtrack start /path/to/player.yaml --web-port 9090 --web-address 0.0.0.0
+$ mtrack start /path/to/player.yaml --web-port 9090 --web-address 127.0.0.1
 ```
 
 The web UI provides:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,8 +115,8 @@ enum Commands {
         /// Port for the web UI and lighting simulator (default: 8080).
         #[arg(long, default_value = "8080")]
         web_port: u16,
-        /// Bind address for the web UI and lighting simulator (default: 127.0.0.1).
-        #[arg(long, default_value = "127.0.0.1")]
+        /// Bind address for the web UI and lighting simulator (default: 0.0.0.0).
+        #[arg(long, default_value = "0.0.0.0")]
         web_address: String,
     },
     /// Plays the current song in the playlist.
@@ -446,7 +446,7 @@ mod tests {
                     assert!(playlist_path.is_none());
                     assert!(!tui);
                     assert_eq!(web_port, 8080);
-                    assert_eq!(web_address, "127.0.0.1");
+                    assert_eq!(web_address, "0.0.0.0");
                 }
                 _ => panic!("expected Start command"),
             }


### PR DESCRIPTION
By default, mtrack will now host on 0.0.0.0. This will make hosting on a headless Pi easier without needing extra configuration.