### PR TITLE
Realtime MIDI beat clock fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enabled, mtrack sends Start (0xFA), Timing Clock (0xF8), and Stop (0xFC) messages derived
   from the MIDI file's tempo map. Beat clock is only emitted for songs whose MIDI files contain
   explicit tempo change events — songs without a tempo map do not emit beat clock, leaving
-  musicians free to control their own tempo. The beat clock runs on a dedicated thread with
-  `spin_sleep` precision and supports mid-song tempo changes and seeking (Continue 0xFB).
+  musicians free to control their own tempo. The beat clock runs on a dedicated real-time
+  priority thread with `spin_sleep` precision and supports mid-song tempo changes and seeking
+  (Continue 0xFB). Thread priority can be tuned with `MTRACK_THREAD_PRIORITY` (0–99, default
+  70) or disabled with `MTRACK_DISABLE_RT_AUDIO=1`.
 - **Unified playback clock**: A new `PlaybackClock` abstraction synchronizes MIDI and DMX
   timing to the audio interface's hardware sample counter, eliminating drift between subsystems
   over long songs. When no audio device is present, the clock falls back to `Instant::now()`
@@ -53,12 +55,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **MacOS build fixes**: Resolved build issues on macOS.
+- **MacOS SCHED_FIFO thread priority**: Added clamping of the thread priority to the valid
+  macOS SCHED_FIFO range (15–47) so the default of 70 works on both platforms. SCHED_FIFO
+  failures on macOS CoreAudio threads are now logged at debug level since these threads
+  already use Mach real-time scheduling.
 
 ### Internal
 
 - **Massive test expansion**: Comprehensive test coverage added across all modules including
   player, audio mixer, sample engine, DMX engine, MIDI, controllers (gRPC, OSC, MIDI), TUI,
   web UI, triggers, config parsing, and CLI.
+- **Thread priority module**: Extracted `thread_priority` from `audio/` into a shared
+  top-level module, reused by both the audio callback and MIDI beat clock threads.
+- **Documentation**: Migrated README content into an mdBook documentation site for easier
+  maintenance and hosting.
 - **CI improvements**: cargo tarpaulin now uses a separate cache to avoid conflicts with
   regular builds.
 

--- a/docs/src/deployment/security.md
+++ b/docs/src/deployment/security.md
@@ -6,10 +6,12 @@ privileges. This is the recommended configuration for production deployments.
 **User isolation**: The service runs as the unprivileged `mtrack` user instead of root. The
 `audio` supplementary group provides access to ALSA and MIDI devices under `/dev/snd/`.
 
-**Real-time audio scheduling**: `AmbientCapabilities=CAP_SYS_NICE` allows the `mtrack` user
+**Real-time scheduling**: `AmbientCapabilities=CAP_SYS_NICE` allows the `mtrack` user
 to set elevated thread priorities and use `SCHED_FIFO` real-time scheduling for the audio
-callback thread, without requiring root. `CapabilityBoundingSet=CAP_SYS_NICE` ensures this
-is the only capability the process can ever acquire.
+callback thread and the MIDI beat clock thread, without requiring root.
+`CapabilityBoundingSet=CAP_SYS_NICE` ensures this is the only capability the process can
+ever acquire. Without this capability, the beat clock will still function but may exhibit
+more timing jitter under heavy system load.
 
 **Filesystem restrictions**: `ProtectSystem=strict` makes the entire filesystem hierarchy
 read-only, which is sufficient since `mtrack` does not write to disk (logs are emitted to

--- a/docs/src/getting-started/player-config.md
+++ b/docs/src/getting-started/player-config.md
@@ -54,6 +54,13 @@ midi:
   # tempo. Beat clock is only sent for songs whose MIDI files contain explicit tempo change events;
   # songs without a tempo map do not emit beat clock, leaving musicians free to control their own
   # tempo.
+  #
+  # The beat clock thread runs at elevated (real-time) thread priority to minimize timing jitter.
+  # On Linux, this requires CAP_SYS_NICE (granted by the systemd service unit). On macOS, no
+  # special privileges are needed. If real-time scheduling cannot be obtained, the beat clock
+  # still functions but may exhibit more jitter under heavy system load. You can tune the thread
+  # priority with the MTRACK_THREAD_PRIORITY environment variable (0-99, default 70), or disable
+  # real-time scheduling entirely with MTRACK_DISABLE_RT_AUDIO=1.
   beat_clock: true
 
   # (Optional) You can route live MIDI events into the DMX engine with this configuration.

--- a/docs/src/reference/known-limitations.md
+++ b/docs/src/reference/known-limitations.md
@@ -20,6 +20,21 @@ DMX is expected to be well supported through OLA, but the devices that have been
 - RatPac Satellite (Art-Net and sACN)
 - Cinelex Skycast A (sACN)
 
+## MIDI Beat Clock
+
+The MIDI beat clock uses a dedicated real-time thread to deliver 24-ppqn timing
+messages. Accurate tempo requires elevated thread priority:
+
+- **Linux**: Requires `CAP_SYS_NICE` for `SCHED_FIFO` real-time scheduling. The
+  systemd service unit grants this automatically. Without it, jitter may increase
+  under load.
+- **macOS**: Crossplatform thread priority elevation works without special
+  privileges. POSIX `SCHED_FIFO` is not available on macOS CoreAudio threads;
+  this is expected and does not affect timing.
+
+The thread priority can be tuned with `MTRACK_THREAD_PRIORITY` (0–99, default 70)
+or disabled entirely with `MTRACK_DISABLE_RT_AUDIO=1`.
+
 ## General disclaimer
 
 This is my first Rust project, so this is likely cringey, horrible non-idiomatic Rust. Feel free to

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -26,7 +26,6 @@ pub mod format;
 pub mod mixer;
 pub mod mock;
 pub mod sample_source;
-mod thread_priority;
 
 // Re-export the format types for backward compatibility
 pub use context::PlaybackContext;

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -27,8 +27,8 @@ use std::{
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use tracing::{debug, error, info, span, Level};
 
-use super::thread_priority::{
-    callback_thread_priority, configure_audio_thread_priority, env_flag, rt_audio_enabled,
+use crate::thread_priority::{
+    callback_thread_priority, env_flag, promote_to_realtime, rt_audio_enabled,
 };
 
 /// A shared notify handle: a boolean flag protected by a mutex with a condvar for signaling.
@@ -553,7 +553,7 @@ fn create_direct_f32_callback(
     let mut priority_set = false;
 
     move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        configure_audio_thread_priority(callback_priority, rt_audio, &mut priority_set);
+        promote_to_realtime(callback_priority, rt_audio, &mut priority_set);
         process_f32_callback(data, &mixer, &source_rx, num_channels, &mut profiler);
     }
 }
@@ -578,7 +578,7 @@ where
     let mut priority_set = false;
 
     move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-        configure_audio_thread_priority(callback_priority, rt_audio, &mut priority_set);
+        promote_to_realtime(callback_priority, rt_audio, &mut priority_set);
         process_int_callback(
             data,
             &mixer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod songs;
 pub mod state;
 #[cfg(test)]
 pub mod testutil;
+pub(crate) mod thread_priority;
 pub mod trigger;
 pub mod tui;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod songs;
 mod state;
 #[cfg(test)]
 mod testutil;
+mod thread_priority;
 mod trigger;
 mod tui;
 mod util;

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -232,7 +232,12 @@ impl super::Device for Device {
                 let clock_cancel = cancel_handle.clone();
                 let clock_playback_delay = playback_delay;
                 let clock_start_time = start_time;
-                let clock_clock = clock.clone();
+                // Use a dedicated wall clock for beat clock timing instead of
+                // the audio-derived PlaybackClock. The audio clock only updates
+                // once per buffer callback (~23ms at 1024/44.1kHz), causing the
+                // beat clock's spin_sleep to overshoot by variable amounts.
+                // A wall clock provides smooth, sub-millisecond precision.
+                let clock_clock = PlaybackClock::wall();
 
                 // Build a small wrapper that owns the PrecomputedBeatClock data we need.
                 // We can't move midi_sheet into the closure since the note thread uses it,
@@ -248,6 +253,10 @@ impl super::Device for Device {
                 info!("Starting MIDI beat clock thread.");
                 Some((
                     thread::spawn(move || {
+                        // Elevate to real-time thread priority to minimize
+                        // scheduling jitter on clock tick delivery.
+                        promote_to_realtime_thread();
+
                         // Wait for the note thread to signal us after it passes the
                         // external play_barrier.
                         clock_internal_barrier.wait();
@@ -256,17 +265,17 @@ impl super::Device for Device {
                             return;
                         }
 
-                        // Sleep the playback delay
-                        {
-                            while clock_clock.elapsed() < clock_playback_delay {
-                                if clock_cancel.is_cancelled() {
-                                    return;
-                                }
-                                let remaining =
-                                    clock_playback_delay.saturating_sub(clock_clock.elapsed());
-                                spin_sleep::sleep(remaining.min(Duration::from_millis(50)));
-                            }
+                        // Sleep the playback delay using a simple spin_sleep.
+                        if !clock_playback_delay.is_zero() {
+                            spin_sleep::sleep(clock_playback_delay);
                         }
+
+                        if clock_cancel.is_cancelled() {
+                            return;
+                        }
+
+                        // Start the wall clock right before we begin sending.
+                        clock_clock.start();
 
                         run_beat_clock(
                             &mut clock_connection,
@@ -749,6 +758,26 @@ fn play_precomputed(
                 debug!("MIDI send failed: {:?}", e);
             }
         }
+    }
+}
+
+/// Promotes the current thread to real-time priority for low-jitter MIDI clock output.
+///
+/// Uses the shared thread priority utility that sets a high crossplatform priority
+/// and, on Unix systems (Linux and macOS), requests SCHED_FIFO real-time scheduling.
+/// Failures are logged but not fatal — the beat clock will still work, just with
+/// potentially more jitter from OS thread scheduling.
+fn promote_to_realtime_thread() {
+    use crate::thread_priority::{callback_thread_priority, promote_to_realtime, rt_audio_enabled};
+
+    let priority = callback_thread_priority();
+    let rt_enabled = rt_audio_enabled();
+    let mut priority_set = false;
+
+    promote_to_realtime(priority, rt_enabled, &mut priority_set);
+
+    if priority_set {
+        info!("Elevated MIDI beat clock thread priority");
     }
 }
 

--- a/src/thread_priority.rs
+++ b/src/thread_priority.rs
@@ -15,8 +15,10 @@
 use thread_priority::{set_current_thread_priority, ThreadPriority, ThreadPriorityValue};
 use tracing::info;
 
-/// Default priority for the audio callback thread when MTRACK_THREAD_PRIORITY is unset.
-const DEFAULT_CALLBACK_THREAD_PRIORITY: u8 = 70;
+/// Default crossplatform thread priority (0-99) when MTRACK_THREAD_PRIORITY is unset.
+/// On Linux SCHED_FIFO this maps directly to the RT priority (range 1-99).
+/// On macOS SCHED_FIFO the valid range is 15-47, so this value is clamped at call time.
+const DEFAULT_THREAD_PRIORITY: u8 = 70;
 
 /// Reads MTRACK_THREAD_PRIORITY (0-99) once; used when building the callback so we don't touch env in the hot path.
 pub fn callback_thread_priority() -> ThreadPriorityValue {
@@ -31,7 +33,7 @@ fn parse_thread_priority(value: Option<&str>) -> ThreadPriorityValue {
             let n = v.parse::<u8>().ok()?;
             (n < 100).then(|| ThreadPriorityValue::try_from(n).ok())?
         })
-        .unwrap_or_else(|| ThreadPriorityValue::try_from(DEFAULT_CALLBACK_THREAD_PRIORITY).unwrap())
+        .unwrap_or_else(|| ThreadPriorityValue::try_from(DEFAULT_THREAD_PRIORITY).unwrap())
 }
 
 pub(crate) fn env_flag(name: &str) -> bool {
@@ -46,15 +48,23 @@ pub(crate) fn env_flag(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Returns whether we should attempt RT (SCHED_FIFO) scheduling for the audio callback thread.
+/// Returns whether we should attempt RT scheduling for real-time threads.
 /// Default: enabled. Advanced users can opt out with MTRACK_DISABLE_RT_AUDIO=1.
 pub fn rt_audio_enabled() -> bool {
     !env_flag("MTRACK_DISABLE_RT_AUDIO")
 }
 
-pub fn configure_audio_thread_priority(
+/// Promotes the current thread to real-time priority.
+///
+/// Sets a high crossplatform priority and, on Unix systems, requests SCHED_FIFO
+/// real-time scheduling. On macOS, the priority is clamped to the valid SCHED_FIFO
+/// range (15-47). Used by both the audio callback thread and the MIDI beat clock thread.
+///
+/// The `priority_set` flag prevents redundant calls (e.g. in the audio callback which
+/// fires repeatedly).
+pub fn promote_to_realtime(
     priority: ThreadPriorityValue,
-    rt_audio: bool,
+    rt_enabled: bool,
     priority_set: &mut bool,
 ) {
     if *priority_set {
@@ -64,11 +74,21 @@ pub fn configure_audio_thread_priority(
     let _ = set_current_thread_priority(tp);
 
     #[cfg(unix)]
-    if rt_audio {
+    if rt_enabled {
         use thread_priority::unix::{
             set_thread_priority_and_policy, thread_native_id, RealtimeThreadSchedulePolicy,
             ThreadSchedulePolicy,
         };
+
+        // On macOS, SCHED_FIFO priorities must be in 15..=47. Clamp the crossplatform
+        // value to that range so users don't have to worry about platform differences.
+        #[cfg(target_os = "macos")]
+        let tp = {
+            let raw: u8 = priority.into();
+            let clamped = raw.clamp(15, 47);
+            ThreadPriority::Crossplatform(ThreadPriorityValue::try_from(clamped).unwrap())
+        };
+
         let tid = thread_native_id();
         match set_thread_priority_and_policy(
             tid,
@@ -76,12 +96,21 @@ pub fn configure_audio_thread_priority(
             ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Fifo),
         ) {
             Ok(()) => {
-                info!("Enabled RT SCHED_FIFO for audio callback thread");
+                info!("Enabled RT SCHED_FIFO for real-time thread");
             }
             Err(e) => {
+                // On macOS, CoreAudio callback threads use Mach THREAD_TIME_CONSTRAINT_POLICY
+                // and don't support POSIX SCHED_FIFO. The crossplatform priority set above is
+                // sufficient, so log at debug level rather than warn.
+                #[cfg(target_os = "macos")]
+                tracing::debug!(
+                    error = %e,
+                    "SCHED_FIFO unavailable (expected on macOS CoreAudio threads)"
+                );
+                #[cfg(not(target_os = "macos"))]
                 tracing::warn!(
                     error = %e,
-                    "Failed to set RT SCHED_FIFO for audio callback thread"
+                    "Failed to set RT SCHED_FIFO for real-time thread"
                 );
             }
         }
@@ -129,7 +158,7 @@ mod test {
         let prio = parse_thread_priority(None);
         assert_eq!(
             prio,
-            ThreadPriorityValue::try_from(DEFAULT_CALLBACK_THREAD_PRIORITY).unwrap()
+            ThreadPriorityValue::try_from(DEFAULT_THREAD_PRIORITY).unwrap()
         );
     }
 
@@ -157,7 +186,7 @@ mod test {
         let prio = parse_thread_priority(Some("100"));
         assert_eq!(
             prio,
-            ThreadPriorityValue::try_from(DEFAULT_CALLBACK_THREAD_PRIORITY).unwrap()
+            ThreadPriorityValue::try_from(DEFAULT_THREAD_PRIORITY).unwrap()
         );
     }
 
@@ -166,7 +195,7 @@ mod test {
         let prio = parse_thread_priority(Some("not_a_number"));
         assert_eq!(
             prio,
-            ThreadPriorityValue::try_from(DEFAULT_CALLBACK_THREAD_PRIORITY).unwrap()
+            ThreadPriorityValue::try_from(DEFAULT_THREAD_PRIORITY).unwrap()
         );
     }
 
@@ -175,20 +204,20 @@ mod test {
         let prio = parse_thread_priority(Some(""));
         assert_eq!(
             prio,
-            ThreadPriorityValue::try_from(DEFAULT_CALLBACK_THREAD_PRIORITY).unwrap()
+            ThreadPriorityValue::try_from(DEFAULT_THREAD_PRIORITY).unwrap()
         );
     }
 
     #[test]
-    fn configure_audio_thread_priority_idempotent() {
-        let prio = ThreadPriorityValue::try_from(50u8).unwrap();
+    fn promote_to_realtime_idempotent() {
+        let prio = ThreadPriorityValue::try_from(47u8).unwrap();
         let mut priority_set = false;
 
-        configure_audio_thread_priority(prio, false, &mut priority_set);
+        promote_to_realtime(prio, false, &mut priority_set);
         assert!(priority_set);
 
         // Second call should be a no-op (the flag is already set).
-        configure_audio_thread_priority(prio, false, &mut priority_set);
+        promote_to_realtime(prio, false, &mut priority_set);
         assert!(priority_set);
     }
 
@@ -218,12 +247,12 @@ mod test {
     }
 
     #[test]
-    fn configure_with_rt_audio() {
-        let prio = ThreadPriorityValue::try_from(50u8).unwrap();
+    fn promote_with_rt_enabled() {
+        let prio = ThreadPriorityValue::try_from(47u8).unwrap();
         let mut priority_set = false;
 
-        // Exercise the RT audio path (may fail to set RT policy in test env, that's fine)
-        configure_audio_thread_priority(prio, true, &mut priority_set);
+        // Exercise the RT path (may fail to set RT policy in test env, that's fine)
+        promote_to_realtime(prio, true, &mut priority_set);
         assert!(priority_set);
     }
 }


### PR DESCRIPTION
The MIDI beat clock is susceptible to a lot of scheduling jitter. This has been fixed by elevating the MIDI beat clock thread's priority. Since this functionality is common across the audio thread and the MIDI beat clock thread, this has been lifted into its own module. Finally, some changes have been made to ensure the realtime thread bits and pieces work in macOS.