### PR TITLE
Initial work for configuration creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Mutable configuration store**: A new `ConfigStore` wraps the player configuration in a
+  `tokio::sync::RwLock`, enabling runtime config mutations with optimistic concurrency control
+  via whole-config checksums. Mutations are persisted atomically to the YAML config file on
+  every change. The store is accessible from the `Player` via `player.config_store()`.
+- **Config gRPC RPCs**: Eight new RPCs on `PlayerService` for reading and mutating configuration
+  at runtime: `GetConfig`, `UpdateAudio`, `UpdateMidi`, `UpdateDmx`, `UpdateControllers`,
+  `AddProfile`, `UpdateProfile`, `RemoveProfile`. Stale checksums return `FAILED_PRECONDITION`.
+- **Config REST endpoints**: New REST API endpoints for config mutations:
+  `GET /api/config/store`, `PUT /api/config/{audio,midi,dmx,controllers}`,
+  `POST /api/config/profiles`, `PUT /api/config/profiles/:index`,
+  `DELETE /api/config/profiles/:index`. Stale checksums return 409 Conflict.
+- **Config round-trip test**: A serialize/deserialize round-trip test validates that
+  `config::Player` survives YAML serialization via `yaml-rust2` without data loss.
+
+### Changed
+
+- `config::Player` and `config::TrackMappings` now derive `Clone`, enabling the config store
+  to snapshot the full configuration.
+- `config::Player` gained setter methods (`set_audio`, `set_midi`, `set_dmx`,
+  `set_controllers`, `profiles_mut`) for structured config mutations.
+
 ## [0.10.1] - 2026-03-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,6 +1902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "shh",
  "spin_sleep",
  "symphonia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ hostname = "0.4"
 pest = "2.8"
 pest_derive = "2.8"
 serde_json = "1.0"
+sha2 = "0.10"
 ratatui = "0.30"
 crossterm = "0.29"
 

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -122,6 +122,10 @@ pub async fn start(
     apply_thread_priority();
     let player_path = &Path::new(player_path);
     let player_config = config::Player::deserialize(player_path)?;
+    let config_store = Arc::new(config::ConfigStore::new(
+        player_config.clone(),
+        player_path.to_path_buf(),
+    ));
     let mut playlist_path = playlist_path
         .as_ref()
         .map(PathBuf::from)
@@ -154,6 +158,7 @@ pub async fn start(
         &player_config,
         player_path.parent(),
     )?);
+    player.set_config_store(config_store);
 
     // Start the shared state sampler if a DMX engine (with effect engine) is present.
     // Both the TUI and the simulator subscribe to this channel.

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ mod profile;
 pub mod samples;
 mod song;
 mod statusevents;
+pub mod store;
 mod track;
 mod trackmappings;
 pub mod trigger;
@@ -56,4 +57,5 @@ pub use self::samples::{
 };
 pub use self::song::{LightShow, LightingShow, MidiPlayback, Song};
 pub use self::statusevents::StatusEvents;
+pub use self::store::ConfigStore;
 pub use self::track::Track;

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -32,6 +32,17 @@ pub enum ConfigError {
         path: PathBuf,
         source: config::ConfigError,
     },
+
+    #[error(
+        "Checksum mismatch: config has changed since last read; re-fetch to get current state"
+    )]
+    StaleChecksum { expected: String, actual: String },
+
+    #[error("Config serialization error: {0}")]
+    StoreSerialization(String),
+
+    #[error("Invalid profile index {index} (have {len} profiles)")]
+    InvalidProfileIndex { index: usize, len: usize },
 }
 
 #[cfg(test)]

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -34,7 +34,7 @@ use tracing::{error, info, warn};
 static EMPTY_TRACK_MAPPINGS: LazyLock<HashMap<String, Vec<u16>>> = LazyLock::new(HashMap::new);
 
 /// The configuration for the multitrack player.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct Player {
     /// The controller configuration.
     controller: Option<Controller>,
@@ -433,6 +433,35 @@ impl Player {
     /// Gets the maximum sample voices limit.
     pub fn max_sample_voices(&self) -> u32 {
         self.max_sample_voices.unwrap_or(DEFAULT_MAX_SAMPLE_VOICES)
+    }
+
+    /// Sets the audio configuration.
+    pub fn set_audio(&mut self, audio: Option<Audio>) {
+        self.audio = audio;
+    }
+
+    /// Sets the MIDI configuration.
+    pub fn set_midi(&mut self, midi: Option<Midi>) {
+        self.midi = midi;
+    }
+
+    /// Sets the DMX configuration.
+    pub fn set_dmx(&mut self, dmx: Option<Dmx>) {
+        self.dmx = dmx;
+    }
+
+    /// Sets the controllers configuration. Pass an empty vec or None to clear.
+    pub fn set_controllers(&mut self, controllers: Vec<Controller>) {
+        if controllers.is_empty() {
+            self.controllers = None;
+        } else {
+            self.controllers = Some(controllers);
+        }
+    }
+
+    /// Returns a mutable reference to the profiles list.
+    pub fn profiles_mut(&mut self) -> &mut Option<Vec<Profile>> {
+        &mut self.profiles
     }
 }
 
@@ -1515,5 +1544,52 @@ samples:
         let player = Player::deserialize(&config_path).unwrap();
         let sc = player.samples_config(&config_path).unwrap();
         assert!(sc.samples().contains_key("hat"));
+    }
+
+    #[test]
+    fn test_serialize_deserialize_round_trip() {
+        let yaml = r#"
+songs: songs
+profiles:
+  - hostname: pi-a
+    audio:
+      device: mock-device
+      sample_rate: 48000
+      track_mappings:
+        click: [1]
+        cue: [2]
+    midi:
+      device: mock-midi
+      playback_delay: 500ms
+    dmx:
+      universes:
+        - universe: 1
+          name: main
+    controllers:
+      - kind: grpc
+        port: 43234
+      - kind: osc
+  - audio:
+      device: fallback
+      track_mappings:
+        drums: [1, 2]
+"#;
+
+        let player = player_from_yaml(yaml);
+
+        // Serialize to YAML via util::to_yaml_string
+        let serialized =
+            crate::util::to_yaml_string(&player).expect("serialization should succeed");
+
+        // Deserialize the serialized YAML back
+        let mut temp = tempfile::NamedTempFile::with_suffix(".yaml").unwrap();
+        temp.write_all(serialized.as_bytes()).unwrap();
+        let round_tripped =
+            Player::deserialize(temp.path()).expect("round-trip deserialization should succeed");
+
+        // Compare by serializing both to JSON (deterministic field order)
+        let json1 = serde_json::to_value(&player).unwrap();
+        let json2 = serde_json::to_value(&round_tripped).unwrap();
+        assert_eq!(json1, json2, "round-trip should preserve all config values");
     }
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1,0 +1,659 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Mutable configuration store backed by a YAML file on disk.
+//!
+//! Wraps a `config::Player` in a `tokio::sync::RwLock`, supports optimistic
+//! concurrency via a whole-config checksum, and persists every mutation
+//! atomically to the original YAML file.
+
+use std::path::PathBuf;
+
+use tokio::sync::{broadcast, RwLock};
+
+use super::audio::Audio;
+use super::controller::Controller;
+use super::dmx::Dmx;
+use super::error::ConfigError;
+use super::midi::Midi;
+use super::player::Player;
+use super::profile::Profile;
+use crate::util::to_yaml_string;
+use crate::webui::config_io::atomic_write;
+
+/// A snapshot of the current configuration with its checksum.
+pub struct ConfigSnapshot {
+    pub config: Player,
+    pub checksum: String,
+}
+
+impl std::fmt::Debug for ConfigSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConfigSnapshot")
+            .field("checksum", &self.checksum)
+            .finish()
+    }
+}
+
+/// Mutable configuration store.
+///
+/// The store wraps the full `config::Player` in a `RwLock`. Every mutation
+/// validates an expected checksum (optimistic concurrency), updates the
+/// in-memory config, persists to disk atomically, and broadcasts a change
+/// signal.
+pub struct ConfigStore {
+    inner: RwLock<Player>,
+    path: PathBuf,
+    change_tx: broadcast::Sender<()>,
+}
+
+/// Computes a deterministic hex-encoded SHA-256 hash of a YAML string.
+fn compute_checksum(yaml: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(yaml.as_bytes());
+    format!("{:x}", hash)
+}
+
+impl ConfigStore {
+    /// Creates a new ConfigStore wrapping an already-loaded config.
+    pub fn new(config: Player, path: PathBuf) -> Self {
+        let (change_tx, _) = broadcast::channel(16);
+        Self {
+            inner: RwLock::new(config),
+            path,
+            change_tx,
+        }
+    }
+
+    /// Returns a snapshot of the current config with its checksum.
+    #[allow(dead_code)]
+    pub async fn read(&self) -> Result<ConfigSnapshot, ConfigError> {
+        let guard = self.inner.read().await;
+        let yaml =
+            to_yaml_string(&*guard).map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+        let checksum = compute_checksum(&yaml);
+        Ok(ConfigSnapshot {
+            config: guard.clone(),
+            checksum,
+        })
+    }
+
+    /// Returns the serialized YAML and checksum without cloning the config.
+    pub async fn read_yaml(&self) -> Result<(String, String), ConfigError> {
+        let guard = self.inner.read().await;
+        let yaml =
+            to_yaml_string(&*guard).map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+        let checksum = compute_checksum(&yaml);
+        Ok((yaml, checksum))
+    }
+
+    /// Subscribes to change notifications.
+    #[allow(dead_code)]
+    pub fn subscribe(&self) -> broadcast::Receiver<()> {
+        self.change_tx.subscribe()
+    }
+
+    /// Applies a fallible mutation to the config. Like `mutate`, but the closure
+    /// can return an error to abort the mutation.
+    async fn try_mutate<F>(
+        &self,
+        expected_checksum: &str,
+        mutate_fn: F,
+    ) -> Result<ConfigSnapshot, ConfigError>
+    where
+        F: FnOnce(&mut Player) -> Result<(), ConfigError>,
+    {
+        self.mutate_inner(expected_checksum, |config| {
+            mutate_fn(config)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Applies an infallible mutation to the config. The expected checksum is
+    /// validated before mutation, and the config is persisted and broadcast after.
+    async fn mutate<F>(
+        &self,
+        expected_checksum: &str,
+        mutate_fn: F,
+    ) -> Result<ConfigSnapshot, ConfigError>
+    where
+        F: FnOnce(&mut Player),
+    {
+        self.mutate_inner(expected_checksum, |config| {
+            mutate_fn(config);
+            Ok(())
+        })
+        .await
+    }
+
+    /// Core mutation implementation. Validates checksum, applies closure,
+    /// persists to disk, and broadcasts.
+    ///
+    /// Note: blocking I/O (atomic_write) is performed under the write lock.
+    /// This is acceptable because config mutations are rare, user-initiated
+    /// operations — not on any hot path.
+    async fn mutate_inner<F>(
+        &self,
+        expected_checksum: &str,
+        mutate_fn: F,
+    ) -> Result<ConfigSnapshot, ConfigError>
+    where
+        F: FnOnce(&mut Player) -> Result<(), ConfigError>,
+    {
+        let mut guard = self.inner.write().await;
+
+        // Compute current checksum and validate.
+        let current_yaml =
+            to_yaml_string(&*guard).map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+        let current_checksum = compute_checksum(&current_yaml);
+
+        if current_checksum != expected_checksum {
+            return Err(ConfigError::StaleChecksum {
+                expected: expected_checksum.to_string(),
+                actual: current_checksum,
+            });
+        }
+
+        // Apply the mutation.
+        mutate_fn(&mut guard)?;
+
+        // Serialize and persist.
+        let new_yaml =
+            to_yaml_string(&*guard).map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+        let new_checksum = compute_checksum(&new_yaml);
+
+        atomic_write(&self.path, &new_yaml).map_err(ConfigError::StoreSerialization)?;
+
+        // Broadcast change (ignore error if no receivers).
+        let _ = self.change_tx.send(());
+
+        Ok(ConfigSnapshot {
+            config: guard.clone(),
+            checksum: new_checksum,
+        })
+    }
+
+    /// Updates the audio configuration.
+    pub async fn update_audio(
+        &self,
+        audio: Option<Audio>,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.mutate(checksum, |config| {
+            config.set_audio(audio);
+        })
+        .await
+    }
+
+    /// Updates the MIDI configuration.
+    pub async fn update_midi(
+        &self,
+        midi: Option<Midi>,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.mutate(checksum, |config| {
+            config.set_midi(midi);
+        })
+        .await
+    }
+
+    /// Updates the DMX configuration.
+    pub async fn update_dmx(
+        &self,
+        dmx: Option<Dmx>,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.mutate(checksum, |config| {
+            config.set_dmx(dmx);
+        })
+        .await
+    }
+
+    /// Updates the controllers configuration.
+    pub async fn update_controllers(
+        &self,
+        controllers: Vec<Controller>,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.mutate(checksum, |config| {
+            config.set_controllers(controllers);
+        })
+        .await
+    }
+
+    /// Adds a profile.
+    pub async fn add_profile(
+        &self,
+        profile: Profile,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.mutate(checksum, |config| {
+            let profiles = config.profiles_mut();
+            match profiles {
+                Some(list) => list.push(profile),
+                None => *profiles = Some(vec![profile]),
+            }
+        })
+        .await
+    }
+
+    /// Updates a profile at the given index.
+    pub async fn update_profile(
+        &self,
+        index: usize,
+        profile: Profile,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.try_mutate(checksum, |config| {
+            let list = config
+                .profiles_mut()
+                .as_mut()
+                .ok_or(ConfigError::InvalidProfileIndex { index, len: 0 })?;
+            if index >= list.len() {
+                return Err(ConfigError::InvalidProfileIndex {
+                    index,
+                    len: list.len(),
+                });
+            }
+            list[index] = profile;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Removes a profile at the given index.
+    pub async fn remove_profile(
+        &self,
+        index: usize,
+        checksum: &str,
+    ) -> Result<ConfigSnapshot, ConfigError> {
+        self.try_mutate(checksum, |config| {
+            let list = config
+                .profiles_mut()
+                .as_mut()
+                .ok_or(ConfigError::InvalidProfileIndex { index, len: 0 })?;
+            if index >= list.len() {
+                return Err(ConfigError::InvalidProfileIndex {
+                    index,
+                    len: list.len(),
+                });
+            }
+            list.remove(index);
+            Ok(())
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_player(yaml: &str) -> Player {
+        let mut temp = tempfile::NamedTempFile::with_suffix(".yaml").unwrap();
+        temp.write_all(yaml.as_bytes()).unwrap();
+        Player::deserialize(temp.path()).unwrap()
+    }
+
+    fn basic_yaml() -> &'static str {
+        r#"
+songs: songs
+profiles:
+  - audio:
+      device: mock-device
+      track_mappings:
+        click: [1]
+"#
+    }
+
+    #[tokio::test]
+    async fn checksum_stable_for_same_content() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap1 = store.read().await.unwrap();
+        let snap2 = store.read().await.unwrap();
+        assert_eq!(snap1.checksum, snap2.checksum);
+    }
+
+    #[tokio::test]
+    async fn checksum_changes_when_content_changes() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap1 = store.read().await.unwrap();
+
+        let _snap2 = store
+            .update_midi(Some(Midi::new("new-midi", None)), &snap1.checksum)
+            .await
+            .unwrap();
+        let snap3 = store.read().await.unwrap();
+        assert_ne!(snap1.checksum, snap3.checksum);
+    }
+
+    #[tokio::test]
+    async fn update_with_correct_checksum_succeeds_and_persists() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path.clone());
+        let snap = store.read().await.unwrap();
+
+        let new_snap = store
+            .update_midi(Some(Midi::new("updated-midi", None)), &snap.checksum)
+            .await
+            .unwrap();
+
+        // Verify in-memory state.
+        let read_snap = store.read().await.unwrap();
+        assert_eq!(read_snap.checksum, new_snap.checksum);
+
+        // Verify persisted to disk.
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("updated-midi"));
+    }
+
+    #[tokio::test]
+    async fn update_with_stale_checksum_returns_error() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let result = store
+            .update_midi(Some(Midi::new("new-midi", None)), "stale-checksum")
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ConfigError::StaleChecksum {
+                expected,
+                actual: _,
+            } => {
+                assert_eq!(expected, "stale-checksum");
+            }
+            other => panic!("expected StaleChecksum, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribers_notified_on_mutation() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let mut rx = store.subscribe();
+
+        let snap = store.read().await.unwrap();
+        store
+            .update_midi(Some(Midi::new("midi-device", None)), &snap.checksum)
+            .await
+            .unwrap();
+
+        // Should receive the notification.
+        let result = rx.try_recv();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn concurrent_reads_dont_block() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = std::sync::Arc::new(ConfigStore::new(player, path));
+
+        let store1 = store.clone();
+        let store2 = store.clone();
+
+        let (r1, r2) = tokio::join!(
+            tokio::spawn(async move { store1.read().await.unwrap().checksum }),
+            tokio::spawn(async move { store2.read().await.unwrap().checksum }),
+        );
+        assert_eq!(r1.unwrap(), r2.unwrap());
+    }
+
+    #[tokio::test]
+    async fn add_and_remove_profile() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        // Add a profile.
+        let new_profile = Profile::new(Some("new-host".to_string()), None, None, None);
+        let snap = store
+            .add_profile(new_profile, &snap.checksum)
+            .await
+            .unwrap();
+        assert_eq!(snap.config.all_profiles().len(), 2);
+
+        // Remove the added profile.
+        let snap = store.remove_profile(1, &snap.checksum).await.unwrap();
+        assert_eq!(snap.config.all_profiles().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn update_profile_at_index() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        let updated = Profile::new(Some("updated-host".to_string()), None, None, None);
+        let snap = store
+            .update_profile(0, updated, &snap.checksum)
+            .await
+            .unwrap();
+        assert_eq!(
+            snap.config.all_profiles()[0].hostname(),
+            Some("updated-host")
+        );
+    }
+
+    #[tokio::test]
+    async fn update_profile_out_of_bounds_returns_error() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        let profile = Profile::new(Some("host".to_string()), None, None, None);
+        let result = store.update_profile(99, profile, &snap.checksum).await;
+        match result.unwrap_err() {
+            ConfigError::InvalidProfileIndex { index, len } => {
+                assert_eq!(index, 99);
+                assert_eq!(len, 1);
+            }
+            other => panic!("expected InvalidProfileIndex, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_profile_out_of_bounds_returns_error() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        let result = store.remove_profile(5, &snap.checksum).await;
+        match result.unwrap_err() {
+            ConfigError::InvalidProfileIndex { index, len } => {
+                assert_eq!(index, 5);
+                assert_eq!(len, 1);
+            }
+            other => panic!("expected InvalidProfileIndex, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_audio_stores_new_audio() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        let snap = store
+            .update_audio(
+                Some(super::super::audio::Audio::new("new-audio-device")),
+                &snap.checksum,
+            )
+            .await
+            .unwrap();
+
+        // Verify via serialized YAML (setters modify top-level fields).
+        let (yaml, _) = store.read_yaml().await.unwrap();
+        assert!(yaml.contains("new-audio-device"));
+
+        // Clear audio.
+        let snap = store.update_audio(None, &snap.checksum).await.unwrap();
+        let (yaml, _) = store.read_yaml().await.unwrap();
+        // After clearing, the top-level audio key should be gone,
+        // but the profile's audio should still be there.
+        assert!(!yaml.contains("new-audio-device"));
+        drop(snap);
+    }
+
+    #[tokio::test]
+    async fn update_dmx_stores_new_dmx() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        let dmx = super::super::dmx::Dmx::new(
+            None,
+            None,
+            Some(9090),
+            vec![super::super::dmx::Universe::new(1, "test".to_string())],
+            None,
+        );
+        let snap = store.update_dmx(Some(dmx), &snap.checksum).await.unwrap();
+
+        let (yaml, _) = store.read_yaml().await.unwrap();
+        assert!(yaml.contains("9090"));
+
+        // Clear DMX.
+        let snap = store.update_dmx(None, &snap.checksum).await.unwrap();
+        let (yaml, _) = store.read_yaml().await.unwrap();
+        assert!(!yaml.contains("9090"));
+        drop(snap);
+    }
+
+    #[tokio::test]
+    async fn update_controllers_stores_and_clears() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path);
+        let snap = store.read().await.unwrap();
+
+        let controllers = vec![Controller::Grpc(
+            super::super::controller::GrpcController::new(5000),
+        )];
+        let snap = store
+            .update_controllers(controllers, &snap.checksum)
+            .await
+            .unwrap();
+
+        let (yaml, _) = store.read_yaml().await.unwrap();
+        assert!(yaml.contains("5000"));
+
+        // Empty vec clears controllers (maps to None).
+        let snap = store
+            .update_controllers(vec![], &snap.checksum)
+            .await
+            .unwrap();
+        let (yaml, _) = store.read_yaml().await.unwrap();
+        assert!(!yaml.contains("5000"));
+        drop(snap);
+    }
+
+    #[tokio::test]
+    async fn disk_persistence_round_trip() {
+        let player = make_player(basic_yaml());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, basic_yaml()).unwrap();
+
+        let store = ConfigStore::new(player, path.clone());
+        let snap = store.read().await.unwrap();
+
+        // Mutate via store — add a profile with a distinctive hostname.
+        let profile = Profile::new(Some("round-trip-host".to_string()), None, None, None);
+        store.add_profile(profile, &snap.checksum).await.unwrap();
+
+        // Deserialize from disk independently.
+        let reloaded = Player::deserialize(&path).unwrap();
+        let hostnames: Vec<_> = reloaded
+            .all_profiles()
+            .iter()
+            .filter_map(|p| p.hostname())
+            .collect();
+        assert!(
+            hostnames.contains(&"round-trip-host"),
+            "expected round-trip-host in {:?}",
+            hostnames
+        );
+    }
+
+    #[test]
+    fn sha256_checksum_deterministic() {
+        let yaml = "songs: songs\nprofiles:\n  - audio:\n      device: test\n";
+        let c1 = compute_checksum(yaml);
+        let c2 = compute_checksum(yaml);
+        assert_eq!(c1, c2);
+        // SHA-256 produces a 64-char hex string.
+        assert_eq!(c1.len(), 64);
+        assert!(c1.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Different content produces different checksum.
+        let c3 = compute_checksum("different content");
+        assert_ne!(c1, c3);
+    }
+}

--- a/src/config/trackmappings.rs
+++ b/src/config/trackmappings.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 /// The mappings of tracks to output channels.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct TrackMappings {
     // The individual track mappings.
     #[serde(flatten)]

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -22,10 +22,13 @@ use crate::{
     player::Player,
     proto::player::v1::{
         player_service_server::{PlayerService, PlayerServiceServer},
-        Cue, GetActiveEffectsRequest, GetActiveEffectsResponse, GetCuesRequest, GetCuesResponse,
-        NextRequest, NextResponse, PlayFromRequest, PlayRequest, PlayResponse, PreviousRequest,
-        PreviousResponse, StatusRequest, StatusResponse, StopRequest, StopResponse,
-        StopSamplesRequest, StopSamplesResponse, SwitchToPlaylistRequest, SwitchToPlaylistResponse,
+        AddProfileRequest, Cue, GetActiveEffectsRequest, GetActiveEffectsResponse,
+        GetConfigRequest, GetConfigResponse, GetCuesRequest, GetCuesResponse, NextRequest,
+        NextResponse, PlayFromRequest, PlayRequest, PlayResponse, PreviousRequest,
+        PreviousResponse, RemoveProfileRequest, StatusRequest, StatusResponse, StopRequest,
+        StopResponse, StopSamplesRequest, StopSamplesResponse, SwitchToPlaylistRequest,
+        SwitchToPlaylistResponse, UpdateAudioRequest, UpdateConfigResponse,
+        UpdateControllersRequest, UpdateDmxRequest, UpdateMidiRequest, UpdateProfileRequest,
         FILE_DESCRIPTOR_SET,
     },
 };
@@ -81,7 +84,6 @@ impl super::Driver for Driver {
         let player = self.player.clone();
 
         tokio::spawn(async move {
-            let player = player.clone();
             let reflection_service = tonic_reflection::server::Builder::configure()
                 .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
                 .build_v1()
@@ -92,9 +94,14 @@ impl super::Driver for Driver {
                 info!("Starting gRPC server");
             }
 
+            let player_server = match player.config_store() {
+                Some(store) => PlayerServer::with_config_store(player, store),
+                None => PlayerServer::new(player),
+            };
+
             Server::builder()
                 .add_service(reflection_service)
-                .add_service(PlayerServiceServer::new(PlayerServer::new(player.clone())))
+                .add_service(PlayerServiceServer::new(player_server))
                 .serve(addr)
                 .await
                 .map_err(io::Error::other)
@@ -106,12 +113,28 @@ impl super::Driver for Driver {
 pub(crate) struct PlayerServer {
     /// The player.
     player: Arc<Player>,
+    /// Mutable configuration store for runtime config changes.
+    config_store: Option<Arc<crate::config::ConfigStore>>,
 }
 
 impl PlayerServer {
     /// Creates a new PlayerServer wrapping the given player.
     pub(crate) fn new(player: Arc<Player>) -> Self {
-        Self { player }
+        Self {
+            player,
+            config_store: None,
+        }
+    }
+
+    /// Creates a new PlayerServer with a config store.
+    pub(crate) fn with_config_store(
+        player: Arc<Player>,
+        config_store: Arc<crate::config::ConfigStore>,
+    ) -> Self {
+        Self {
+            player,
+            config_store: Some(config_store),
+        }
     }
 
     /// Converts a play/play_from result into a gRPC response.
@@ -127,6 +150,35 @@ impl PlayerServer {
             Err(e) => Err(Status::failed_precondition(e.to_string())),
         }
     }
+
+    /// Returns a reference to the config store or a NOT_FOUND error.
+    #[allow(clippy::result_large_err)]
+    fn require_config_store(&self) -> Result<&crate::config::ConfigStore, Status> {
+        self.config_store
+            .as_deref()
+            .ok_or_else(|| Status::unimplemented("config store not available"))
+    }
+}
+
+/// Converts a ConfigError to a gRPC Status.
+fn config_error_to_status(e: config::ConfigError) -> Status {
+    match e {
+        config::ConfigError::StaleChecksum { .. } => Status::failed_precondition(e.to_string()),
+        config::ConfigError::InvalidProfileIndex { .. } => Status::out_of_range(e.to_string()),
+        _ => Status::internal(e.to_string()),
+    }
+}
+
+/// Converts a ConfigSnapshot to an UpdateConfigResponse by serializing to YAML.
+fn snapshot_to_update_response(
+    snapshot: config::store::ConfigSnapshot,
+) -> Result<Response<UpdateConfigResponse>, Status> {
+    let yaml = crate::util::to_yaml_string(&snapshot.config)
+        .map_err(|e| Status::internal(format!("serialization error: {}", e)))?;
+    Ok(Response::new(UpdateConfigResponse {
+        yaml,
+        checksum: snapshot.checksum,
+    }))
 }
 
 #[tonic::async_trait]
@@ -273,6 +325,136 @@ impl PlayerService for PlayerServer {
     ) -> Result<Response<StopSamplesResponse>, Status> {
         self.player.stop_samples();
         Ok(Response::new(StopSamplesResponse {}))
+    }
+
+    async fn get_config(
+        &self,
+        _: Request<GetConfigRequest>,
+    ) -> Result<Response<GetConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let (yaml, checksum) = store.read_yaml().await.map_err(config_error_to_status)?;
+        Ok(Response::new(GetConfigResponse { yaml, checksum }))
+    }
+
+    async fn update_audio(
+        &self,
+        request: Request<UpdateAudioRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let audio: Option<config::Audio> = if req.audio_json.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::from_str(&req.audio_json)
+                    .map_err(|e| Status::invalid_argument(format!("invalid audio JSON: {}", e)))?,
+            )
+        };
+        let snapshot = store
+            .update_audio(audio, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
+    }
+
+    async fn update_midi(
+        &self,
+        request: Request<UpdateMidiRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let midi: Option<config::Midi> = if req.midi_json.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::from_str(&req.midi_json)
+                    .map_err(|e| Status::invalid_argument(format!("invalid MIDI JSON: {}", e)))?,
+            )
+        };
+        let snapshot = store
+            .update_midi(midi, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
+    }
+
+    async fn update_dmx(
+        &self,
+        request: Request<UpdateDmxRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let dmx: Option<config::Dmx> = if req.dmx_json.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::from_str(&req.dmx_json)
+                    .map_err(|e| Status::invalid_argument(format!("invalid DMX JSON: {}", e)))?,
+            )
+        };
+        let snapshot = store
+            .update_dmx(dmx, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
+    }
+
+    async fn update_controllers(
+        &self,
+        request: Request<UpdateControllersRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let controllers: Vec<config::Controller> = serde_json::from_str(&req.controllers_json)
+            .map_err(|e| Status::invalid_argument(format!("invalid controllers JSON: {}", e)))?;
+        let snapshot = store
+            .update_controllers(controllers, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
+    }
+
+    async fn add_profile(
+        &self,
+        request: Request<AddProfileRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let profile: config::Profile = serde_json::from_str(&req.profile_json)
+            .map_err(|e| Status::invalid_argument(format!("invalid profile JSON: {}", e)))?;
+        let snapshot = store
+            .add_profile(profile, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
+    }
+
+    async fn update_profile(
+        &self,
+        request: Request<UpdateProfileRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let profile: config::Profile = serde_json::from_str(&req.profile_json)
+            .map_err(|e| Status::invalid_argument(format!("invalid profile JSON: {}", e)))?;
+        let snapshot = store
+            .update_profile(req.index as usize, profile, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
+    }
+
+    async fn remove_profile(
+        &self,
+        request: Request<RemoveProfileRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let store = self.require_config_store()?;
+        let req = request.into_inner();
+        let snapshot = store
+            .remove_profile(req.index as usize, &req.expected_checksum)
+            .await
+            .map_err(config_error_to_status)?;
+        snapshot_to_update_response(snapshot)
     }
 }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -134,6 +134,8 @@ pub struct Player {
     stop_run: Arc<AtomicBool>,
     /// The logging span.
     span: Span,
+    /// Mutable configuration store for runtime config changes.
+    config_store: Arc<parking_lot::Mutex<Option<Arc<config::ConfigStore>>>>,
 }
 
 impl Player {
@@ -296,6 +298,7 @@ impl Player {
             join: Arc::new(Mutex::new(None)),
             stop_run: Arc::new(AtomicBool::new(false)),
             span: span!(Level::INFO, "player"),
+            config_store: Arc::new(parking_lot::Mutex::new(None)),
         })
     }
 
@@ -431,6 +434,16 @@ impl Player {
         if let Some(ref engine) = self.dmx_engine {
             engine.set_broadcast_tx(tx);
         }
+    }
+
+    /// Sets the config store on the player. Called once after startup.
+    pub fn set_config_store(&self, store: Arc<config::ConfigStore>) {
+        *self.config_store.lock() = Some(store);
+    }
+
+    /// Returns the config store, if one has been set.
+    pub fn config_store(&self) -> Option<Arc<config::ConfigStore>> {
+        self.config_store.lock().clone()
     }
 
     /// Reports status as MIDI events.
@@ -1775,6 +1788,7 @@ mod test {
             join: Arc::new(Mutex::new(None)),
             stop_run: Arc::new(AtomicBool::new(false)),
             span: span!(Level::INFO, "test"),
+            config_store: Arc::new(parking_lot::Mutex::new(None)),
         };
 
         assert!(player.audio_device().is_none());
@@ -2314,6 +2328,33 @@ mod test {
         let player =
             make_test_player_with_config(Some(config::Audio::new("mock-device")), None, None)?;
         assert!(player.midi_device().is_none());
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_config_store_getter_setter() -> Result<(), Box<dyn Error>> {
+        let player = make_test_player()?;
+
+        // Initially None.
+        assert!(player.config_store().is_none());
+
+        // Set a config store.
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "songs: songs\n")?;
+        let cfg = config::Player::deserialize(&path)?;
+        let store = std::sync::Arc::new(config::ConfigStore::new(cfg, path));
+        player.set_config_store(store.clone());
+
+        // Now it should be Some.
+        let retrieved = player.config_store();
+        assert!(retrieved.is_some());
+
+        // Should be the same Arc (read_yaml returns same checksum).
+        let (_, checksum1) = store.read_yaml().await?;
+        let (_, checksum2) = retrieved.unwrap().read_yaml().await?;
+        assert_eq!(checksum1, checksum2);
+
         Ok(())
     }
 }

--- a/src/proto/player/v1/player.proto
+++ b/src/proto/player/v1/player.proto
@@ -139,6 +139,83 @@ message StopSamplesRequest {}
 // StopSamplesResponse is the response message after stopping triggered samples.
 message StopSamplesResponse {}
 
+// GetConfigRequest is the message for requesting the current configuration.
+message GetConfigRequest {}
+
+// GetConfigResponse is the response containing the current configuration.
+message GetConfigResponse {
+    // The full configuration as a YAML string.
+    string yaml = 1;
+    // Checksum of the current configuration for optimistic concurrency.
+    string checksum = 2;
+}
+
+// UpdateAudioRequest is the message for updating the audio configuration.
+message UpdateAudioRequest {
+    // The audio configuration as a JSON string.
+    string audio_json = 1;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 2;
+}
+
+// UpdateMidiRequest is the message for updating the MIDI configuration.
+message UpdateMidiRequest {
+    // The MIDI configuration as a JSON string.
+    string midi_json = 1;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 2;
+}
+
+// UpdateDmxRequest is the message for updating the DMX configuration.
+message UpdateDmxRequest {
+    // The DMX configuration as a JSON string.
+    string dmx_json = 1;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 2;
+}
+
+// UpdateControllersRequest is the message for updating the controllers configuration.
+message UpdateControllersRequest {
+    // The controllers configuration as a JSON string (array).
+    string controllers_json = 1;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 2;
+}
+
+// AddProfileRequest is the message for adding a new profile.
+message AddProfileRequest {
+    // The profile as a JSON string.
+    string profile_json = 1;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 2;
+}
+
+// UpdateProfileRequest is the message for updating a profile at a specific index.
+message UpdateProfileRequest {
+    // The index of the profile to update.
+    uint32 index = 1;
+    // The profile as a JSON string.
+    string profile_json = 2;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 3;
+}
+
+// RemoveProfileRequest is the message for removing a profile at a specific index.
+message RemoveProfileRequest {
+    // The index of the profile to remove.
+    uint32 index = 1;
+    // Expected checksum for optimistic concurrency.
+    string expected_checksum = 2;
+}
+
+// UpdateConfigResponse is the response after a configuration mutation.
+message UpdateConfigResponse {
+    // The full configuration as a YAML string after the update.
+    string yaml = 1;
+    // New checksum after the update.
+    string checksum = 2;
+}
+
 // PlayerService is a service for controlling the mtrack player.
 service PlayerService {
     // Play will play the current song in the playlist if no other songs
@@ -172,4 +249,28 @@ service PlayerService {
 
     // StopSamples will stop all triggered samples that are currently playing.
     rpc StopSamples(StopSamplesRequest) returns (StopSamplesResponse);
+
+    // GetConfig returns the current configuration as YAML with a checksum.
+    rpc GetConfig(GetConfigRequest) returns (GetConfigResponse);
+
+    // UpdateAudio updates the audio configuration section.
+    rpc UpdateAudio(UpdateAudioRequest) returns (UpdateConfigResponse);
+
+    // UpdateMidi updates the MIDI configuration section.
+    rpc UpdateMidi(UpdateMidiRequest) returns (UpdateConfigResponse);
+
+    // UpdateDmx updates the DMX configuration section.
+    rpc UpdateDmx(UpdateDmxRequest) returns (UpdateConfigResponse);
+
+    // UpdateControllers updates the controllers configuration.
+    rpc UpdateControllers(UpdateControllersRequest) returns (UpdateConfigResponse);
+
+    // AddProfile adds a new hardware profile.
+    rpc AddProfile(AddProfileRequest) returns (UpdateConfigResponse);
+
+    // UpdateProfile updates a profile at a specific index.
+    rpc UpdateProfile(UpdateProfileRequest) returns (UpdateConfigResponse);
+
+    // RemoveProfile removes a profile at a specific index.
+    rpc RemoveProfile(RemoveProfileRequest) returns (UpdateConfigResponse);
 }

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -16,7 +16,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, post, put},
     Json, Router,
 };
 use serde_json::json;
@@ -44,6 +44,16 @@ pub fn router() -> Router<WebUiState> {
             get(get_lighting_file).put(put_lighting_file),
         )
         .route("/lighting/validate", post(validate_lighting))
+        .route("/config/store", get(get_config_store))
+        .route("/config/audio", put(put_config_audio))
+        .route("/config/midi", put(put_config_midi))
+        .route("/config/dmx", put(put_config_dmx))
+        .route("/config/controllers", put(put_config_controllers))
+        .route("/config/profiles", post(post_config_profile))
+        .route(
+            "/config/profiles/{index}",
+            put(put_config_profile).delete(delete_config_profile),
+        )
 }
 
 /// GET /api/config — returns the raw YAML content of the player config file.
@@ -338,6 +348,360 @@ async fn validate_config(body: String) -> impl IntoResponse {
             Json(json!({"valid": false, "errors": errors})),
         )
             .into_response(),
+    }
+}
+
+/// Helper to convert a ConfigError into an HTTP response.
+fn config_store_error_response(e: config::ConfigError) -> axum::response::Response {
+    match e {
+        config::ConfigError::StaleChecksum { .. } => {
+            (StatusCode::CONFLICT, Json(json!({"error": e.to_string()}))).into_response()
+        }
+        config::ConfigError::InvalidProfileIndex { .. } => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+        _ => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+/// Helper to convert a ConfigSnapshot into a JSON response.
+fn config_snapshot_response(
+    snapshot: config::store::ConfigSnapshot,
+    status: StatusCode,
+) -> axum::response::Response {
+    match crate::util::to_yaml_string(&snapshot.config) {
+        Ok(yaml) => (
+            status,
+            Json(json!({"yaml": yaml, "checksum": snapshot.checksum})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("serialization error: {}", e)})),
+        )
+            .into_response(),
+    }
+}
+
+/// Returns the config store from the player, or an error response.
+#[allow(clippy::result_large_err)]
+fn require_config_store(
+    state: &WebUiState,
+) -> Result<std::sync::Arc<crate::config::ConfigStore>, axum::response::Response> {
+    state.player.config_store().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "config store not available"})),
+        )
+            .into_response()
+    })
+}
+
+/// GET /api/config/store — returns config YAML + checksum via the ConfigStore.
+async fn get_config_store(State(state): State<WebUiState>) -> impl IntoResponse {
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.read_yaml().await {
+        Ok((yaml, checksum)) => (
+            StatusCode::OK,
+            Json(json!({"yaml": yaml, "checksum": checksum})),
+        )
+            .into_response(),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// PUT /api/config/audio — update audio config section.
+async fn put_config_audio(
+    State(state): State<WebUiState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        }
+    };
+
+    let audio: Option<config::Audio> = match body.get("audio") {
+        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
+            Ok(a) => Some(a),
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid audio: {}", e)})),
+                )
+                    .into_response()
+            }
+        },
+        _ => None,
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.update_audio(audio, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::OK),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// PUT /api/config/midi — update MIDI config section.
+async fn put_config_midi(
+    State(state): State<WebUiState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        }
+    };
+
+    let midi: Option<config::Midi> = match body.get("midi") {
+        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
+            Ok(m) => Some(m),
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid midi: {}", e)})),
+                )
+                    .into_response()
+            }
+        },
+        _ => None,
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.update_midi(midi, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::OK),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// PUT /api/config/dmx — update DMX config section.
+async fn put_config_dmx(
+    State(state): State<WebUiState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        }
+    };
+
+    let dmx: Option<config::Dmx> = match body.get("dmx") {
+        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
+            Ok(d) => Some(d),
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid dmx: {}", e)})),
+                )
+                    .into_response()
+            }
+        },
+        _ => None,
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.update_dmx(dmx, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::OK),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// PUT /api/config/controllers — update controllers config.
+async fn put_config_controllers(
+    State(state): State<WebUiState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        }
+    };
+
+    let controllers: Vec<config::Controller> = match body.get("controllers") {
+        Some(v) => match serde_json::from_value(v.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid controllers: {}", e)})),
+                )
+                    .into_response()
+            }
+        },
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing controllers field"})),
+            )
+                .into_response()
+        }
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.update_controllers(controllers, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::OK),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// POST /api/config/profiles — add a new profile.
+async fn post_config_profile(
+    State(state): State<WebUiState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        }
+    };
+
+    let profile: config::Profile = match body.get("profile") {
+        Some(v) => match serde_json::from_value(v.clone()) {
+            Ok(p) => p,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid profile: {}", e)})),
+                )
+                    .into_response()
+            }
+        },
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing profile field"})),
+            )
+                .into_response()
+        }
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.add_profile(profile, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::CREATED),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// PUT /api/config/profiles/:index — update profile at index.
+async fn put_config_profile(
+    State(state): State<WebUiState>,
+    Path(index): Path<usize>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        }
+    };
+
+    let profile: config::Profile = match body.get("profile") {
+        Some(v) => match serde_json::from_value(v.clone()) {
+            Ok(p) => p,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("invalid profile: {}", e)})),
+                )
+                    .into_response()
+            }
+        },
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing profile field"})),
+            )
+                .into_response()
+        }
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.update_profile(index, profile, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::OK),
+        Err(e) => config_store_error_response(e),
+    }
+}
+
+/// DELETE /api/config/profiles/:index?expected_checksum=... — remove profile at index.
+async fn delete_config_profile(
+    State(state): State<WebUiState>,
+    Path(index): Path<usize>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let checksum = match params.get("expected_checksum") {
+        Some(c) => c.to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum query parameter"})),
+            )
+                .into_response()
+        }
+    };
+
+    let store = match require_config_store(&state) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match store.remove_profile(index, &checksum).await {
+        Ok(snapshot) => config_snapshot_response(snapshot, StatusCode::OK),
+        Err(e) => config_store_error_response(e),
     }
 }
 
@@ -2059,5 +2423,55 @@ show "test" {
             .as_str()
             .unwrap()
             .contains("Failed to scan for lighting files"));
+    }
+
+    #[tokio::test]
+    async fn get_config_store_without_store_returns_503() {
+        let (state, _dir) = test_state();
+        // No config store set on player — should return SERVICE_UNAVAILABLE.
+        let app = router().with_state(state);
+
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/config/store")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn get_config_store_with_store_returns_yaml_and_checksum() {
+        let (state, _dir) = test_state();
+
+        // Set up a config store on the player.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("store-config.yaml");
+        std::fs::write(&path, "songs: songs\n").unwrap();
+        let cfg = crate::config::Player::deserialize(&path).unwrap();
+        let store = std::sync::Arc::new(crate::config::ConfigStore::new(cfg, path));
+        state.player.set_config_store(store);
+
+        let app = router().with_state(state);
+
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/config/store")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(parsed["yaml"].as_str().unwrap().contains("songs"));
+        assert!(!parsed["checksum"].as_str().unwrap().is_empty());
     }
 }

--- a/src/webui/server.rs
+++ b/src/webui/server.rs
@@ -209,7 +209,12 @@ async fn grpc_web_handler(
         method, uri, content_type
     );
 
-    let grpc_svc = PlayerServiceServer::new(PlayerServer::new(state.player.clone()));
+    let grpc_svc = match state.player.config_store() {
+        Some(store) => {
+            PlayerServiceServer::new(PlayerServer::with_config_store(state.player.clone(), store))
+        }
+        None => PlayerServiceServer::new(PlayerServer::new(state.player.clone())),
+    };
     let grpc_web = GrpcWebLayer::new().layer(grpc_svc);
 
     match grpc_web.oneshot(request).await {
@@ -621,9 +626,12 @@ mod test {
 
     #[tokio::test]
     async fn server_serves_css_asset() {
+        let css_file = WebUiAssets::iter()
+            .find(|f| f.ends_with(".css"))
+            .expect("no CSS asset found in embedded files");
         let (_handle, base_url, _dir) = start_test_server().await;
 
-        let resp = reqwest::get(format!("{}/assets/index-Cf9m096F.css", base_url))
+        let resp = reqwest::get(format!("{}/{}", base_url, css_file))
             .await
             .unwrap();
         assert_eq!(resp.status(), 200);
@@ -643,9 +651,12 @@ mod test {
 
     #[tokio::test]
     async fn server_serves_js_asset() {
+        let js_file = WebUiAssets::iter()
+            .find(|f| f.ends_with(".js"))
+            .expect("no JS asset found in embedded files");
         let (_handle, base_url, _dir) = start_test_server().await;
 
-        let resp = reqwest::get(format!("{}/assets/index-SLiPmHn5.js", base_url))
+        let resp = reqwest::get(format!("{}/{}", base_url, js_file))
             .await
             .unwrap();
         assert_eq!(resp.status(), 200);


### PR DESCRIPTION
In order to lower the barrier to entry for mtrack, we need a way of controling configuration without hand crafting a bunch of YAML. This is the beginning work to this: this adds the ability for us to serialize our various config structs along with the basic gRPC interface.

I was debating whether to go with something along the lines of sqlite for a backend instead of raw YAML. I'd like to stick with the current config based method because it allows for deterministic rebuilding of mtrack state without worrying about:

1. Doing any manual imports/dumps/etc.
2. Keeping track of an errant sqlite file.
3. Dealing with synchronization issues between YAML and sqlite.

The goal here is that users can basically point to a directory on disk as a bare minimum and we can then create config, songs, playlists, etc.