### PR TITLE
Multiple playlists, playlist management in the UI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sections, reducing visual clutter. Each tab shows a green dot when that section is enabled.
 - **Song creation UI**: Songs can now be created from the web UI song browser with a name
   and optional configuration.
+- **Multiple playlist support**: The player now supports multiple user-defined playlists
+  stored as individual YAML files in a `playlists/` directory (default: `{config_dir}/playlists/`).
+  Playlists are named after their filename stem. The `all_songs` playlist remains always
+  present and auto-generated. Switching to `all_songs` is session-only (not persisted across
+  restarts), acting as a temporary escape hatch. The persisted active playlist is stored in
+  `mtrack.yaml` via the `active_playlist` field (defaults to `"playlist"` for backward
+  compatibility). MIDI/OSC `Playlist` action returns to the persisted active playlist,
+  regardless of its name.
+- **Playlist REST API**: Five new endpoints for playlist CRUD:
+  `GET /api/playlists` (list all with song count and active status),
+  `GET /api/playlists/{name}` (songs + available songs),
+  `PUT /api/playlists/{name}` (create or update),
+  `DELETE /api/playlists/{name}` (delete, refuses `all_songs`),
+  `POST /api/playlists/{name}/activate` (switch active playlist).
+  Legacy `/api/playlist` GET/PUT endpoints remain as backward-compatible aliases.
+- **Playlist editor UI**: The web UI playlist page is now a full editor with a left panel
+  for browsing, creating, and deleting playlists, and a right panel for editing song order
+  (reorder, add, remove) with a searchable available-songs list. Playlists can be activated
+  directly from the editor.
+- **Dashboard playlist selector**: The dashboard playlist card now shows a dropdown of all
+  available playlists instead of a hardcoded Playlist/All Songs toggle. The available
+  playlists and active playlist name are broadcast via WebSocket.
 
 ### Changed
 
@@ -110,6 +132,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be updated immediately.
 - The systemd service template now uses `$MTRACK_PATH` instead of `$MTRACK_CONFIG` to reflect
   the new directory-or-file semantics.
+- The `Player` struct now uses a `HashMap<String, Arc<Playlist>>` internally instead of
+  separate `playlist` / `all_songs` / `use_all_songs` fields. `switch_to_playlist()` accepts
+  any playlist name (not just `"playlist"` or `"all_songs"`). The gRPC `SwitchToPlaylist` RPC
+  accepts arbitrary playlist names — invalid names return `NOT_FOUND` instead of
+  `UNIMPLEMENTED`.
 
 - **Mutable configuration store**: A new `ConfigStore` wraps the player configuration in a
   `tokio::sync::RwLock`, enabling runtime config mutations with optimistic concurrency control

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -177,14 +177,19 @@ pub async fn start(
 
     let songs = songs::get_all_songs(&songs_path)?;
 
-    // Resolve playlist — gracefully handle missing
-    let mut playlist_path = playlist_path
+    // Resolve playlists directory from config, defaulting to {config_dir}/playlists/.
+    let playlists_dir = player_config
+        .playlists_dir(player_path)
+        .or_else(|| player_path.parent().map(|p| p.join("playlists")));
+
+    // Resolve legacy playlist path.
+    let mut legacy_playlist_path = playlist_path
         .as_ref()
         .map(PathBuf::from)
         .or(player_config.playlist());
 
-    // Make playlist path absolute if relative
-    if let Some(ref mut pp) = playlist_path {
+    // Make legacy playlist path absolute if relative.
+    if let Some(ref mut pp) = legacy_playlist_path {
         if !pp.is_absolute() {
             *pp = if let Some(parent) = player_path.parent() {
                 parent.join(&pp)
@@ -199,29 +204,17 @@ pub async fn start(
         }
     }
 
-    let playlist = if let Some(ref pp) = playlist_path {
-        match config::Playlist::deserialize(pp.as_path()) {
-            Ok(playlist_config) => {
-                match Playlist::new("playlist", &playlist_config, songs.clone()) {
-                    Ok(pl) => pl,
-                    Err(e) => {
-                        info!("Playlist references missing songs ({}); using all songs", e);
-                        crate::playlist::from_songs(songs.clone())?
-                    }
-                }
-            }
-            Err(_) => {
-                info!("Playlist file not found; using all songs");
-                crate::playlist::from_songs(songs.clone())?
-            }
-        }
-    } else {
-        info!("No playlist configured; using all songs");
-        crate::playlist::from_songs(songs.clone())?
-    };
+    // Load all playlists from directory + legacy file.
+    let playlists = crate::player::load_playlists(
+        playlists_dir.as_deref(),
+        legacy_playlist_path.as_deref(),
+        songs.clone(),
+    )?;
 
-    // Default playlist_path for web UI (so config writes have somewhere to go)
-    let playlist_path = playlist_path.unwrap_or_else(|| {
+    let active_playlist = player_config.active_playlist().to_string();
+
+    // Default legacy_playlist_path for web UI backward compat (so config writes have somewhere to go).
+    let legacy_playlist_path = legacy_playlist_path.unwrap_or_else(|| {
         player_path
             .parent()
             .unwrap_or(Path::new("."))
@@ -229,8 +222,8 @@ pub async fn start(
     });
 
     let player = Arc::new(crate::player::Player::new(
-        songs,
-        playlist,
+        playlists,
+        active_playlist,
         &player_config,
         player_path.parent(),
     )?);
@@ -257,7 +250,8 @@ pub async fn start(
             broadcast_tx,
             config_path: player_path.to_path_buf(),
             songs_path: player_config.songs(player_path),
-            playlist_path: playlist_path.clone(),
+            playlists_dir: playlists_dir.clone(),
+            legacy_playlist_path: Some(legacy_playlist_path.clone()),
             waveform_cache: crate::webui::state::new_waveform_cache(),
             calibration: std::sync::Arc::new(parking_lot::Mutex::new(None)),
         };

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -29,6 +29,10 @@ use super::error::ConfigError;
 use std::error::Error;
 use tracing::{error, info, warn};
 
+fn default_active_playlist() -> String {
+    "playlist".to_string()
+}
+
 /// The configuration for the multitrack player.
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Player {
@@ -60,6 +64,11 @@ pub struct Player {
     status_events: Option<StatusEvents>,
     /// The path to the playlist.
     playlist: Option<String>,
+    /// Directory containing playlist YAML files.
+    playlists_dir: Option<String>,
+    /// The active playlist name (persisted across restarts).
+    #[serde(default = "default_active_playlist")]
+    active_playlist: String,
     /// The path to the song definitions.
     songs: String,
     /// Inline sample definitions.
@@ -90,6 +99,8 @@ impl Default for Player {
             profiles_dir: None,
             status_events: None,
             playlist: None,
+            playlists_dir: None,
+            active_playlist: default_active_playlist(),
             songs: "songs".to_string(),
             samples: HashMap::new(),
             samples_file: None,
@@ -127,6 +138,8 @@ impl Player {
             profiles_dir: None,
             status_events: None,
             playlist: None,
+            playlists_dir: None,
+            active_playlist: default_active_playlist(),
             songs: songs.to_string(),
             samples: HashMap::new(),
             samples_file: None,
@@ -404,6 +417,28 @@ impl Player {
     /// Gets the path to the playlist.
     pub fn playlist(&self) -> Option<PathBuf> {
         self.playlist.as_ref().map(PathBuf::from)
+    }
+
+    /// Gets the playlists directory, resolved relative to the given config path.
+    pub fn playlists_dir(&self, config_path: &Path) -> Option<PathBuf> {
+        let dir_str = self.playlists_dir.as_ref()?;
+        let dir_path = PathBuf::from(dir_str);
+        if dir_path.is_absolute() {
+            Some(dir_path)
+        } else {
+            let config_dir = config_path.parent().unwrap_or(Path::new("."));
+            Some(config_dir.join(dir_path))
+        }
+    }
+
+    /// Gets the active playlist name.
+    pub fn active_playlist(&self) -> &str {
+        &self.active_playlist
+    }
+
+    /// Sets the active playlist name (for config store mutations).
+    pub fn set_active_playlist(&mut self, name: String) {
+        self.active_playlist = name;
     }
 
     /// Sets the songs path (relative or absolute).

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -321,6 +321,19 @@ impl ConfigStore {
         })
         .await
     }
+
+    /// Sets the active playlist name without requiring a checksum.
+    /// This is called internally when switching playlists, not from the
+    /// config editor UI, so optimistic concurrency isn't needed.
+    pub async fn set_active_playlist(&self, name: String) -> Result<(), ConfigError> {
+        let mut guard = self.inner.write().await;
+        guard.set_active_playlist(name);
+        let new_yaml =
+            to_yaml_string(&*guard).map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+        atomic_write(&self.path, &new_yaml).map_err(ConfigError::StoreIo)?;
+        let _ = self.change_tx.send(());
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -87,7 +87,9 @@ mod test {
     };
     use tracing::error;
 
-    use crate::{config, player::Player, playlist::Playlist, songs, testutil::eventually};
+    use crate::{
+        config, player::Player, playlist, playlist::Playlist, songs, testutil::eventually,
+    };
 
     use super::Driver;
 
@@ -163,10 +165,10 @@ mod test {
                             player.stop().await;
                         }
                         TestEvent::AllSongs => {
-                            player.switch_to_all_songs().await;
+                            player.switch_to_playlist("all_songs").await.unwrap();
                         }
                         TestEvent::Playlist => {
-                            player.switch_to_playlist().await;
+                            player.switch_to_playlist("playlist").await.unwrap();
                         }
                         TestEvent::Close => return Ok(()),
                     }
@@ -179,13 +181,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_controller_new_with_grpc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), playlist);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -211,13 +220,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_controller_new_empty_config() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), playlist);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -241,13 +257,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_controller_new_with_osc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), playlist);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -272,13 +295,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_controller() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), playlist);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -385,13 +415,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_controller_shutdown() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), playlist);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -33,32 +33,6 @@ use crate::{
     },
 };
 
-// Playlist name constants.
-const PLAYLIST_NAME: &str = "playlist";
-const ALL_SONGS_NAME: &str = "all_songs";
-
-/// Recognized playlist switch targets.
-#[derive(Debug, PartialEq)]
-enum PlaylistTarget {
-    Playlist,
-    AllSongs,
-}
-
-/// Classifies a playlist name string into a known target, or returns an error Status.
-#[allow(clippy::result_large_err)]
-fn classify_playlist_name(name: &str) -> Result<PlaylistTarget, Status> {
-    if name == PLAYLIST_NAME {
-        Ok(PlaylistTarget::Playlist)
-    } else if name == ALL_SONGS_NAME {
-        Ok(PlaylistTarget::AllSongs)
-    } else {
-        Err(Status::unimplemented(format!(
-            "only {} and {} are supported for now",
-            ALL_SONGS_NAME, PLAYLIST_NAME
-        )))
-    }
-}
-
 /// A controller that controls a player using gRPC.
 pub struct Driver {
     /// The player.
@@ -264,10 +238,17 @@ impl PlayerService for PlayerServer {
         &self,
         request: Request<SwitchToPlaylistRequest>,
     ) -> Result<Response<SwitchToPlaylistResponse>, Status> {
-        match classify_playlist_name(&request.into_inner().playlist_name)? {
-            PlaylistTarget::Playlist => self.player.switch_to_playlist().await,
-            PlaylistTarget::AllSongs => self.player.switch_to_all_songs().await,
-        }
+        let playlist_name = request.into_inner().playlist_name;
+        self.player
+            .switch_to_playlist(&playlist_name)
+            .await
+            .map_err(|e| {
+                if e.contains("not found") {
+                    Status::not_found(e)
+                } else {
+                    Status::failed_precondition(e)
+                }
+            })?;
         Ok(Response::new(SwitchToPlaylistResponse {}))
     }
 
@@ -495,10 +476,8 @@ mod test {
 
     use crate::{
         config,
-        controller::{
-            grpc::{Driver, ALL_SONGS_NAME, PLAYLIST_NAME},
-            Driver as _,
-        },
+        controller::{grpc::Driver, Driver as _},
+        playlist,
         playlist::Playlist,
         proto::player::v1::{
             player_service_client::PlayerServiceClient, NextRequest, PlayRequest, PreviousRequest,
@@ -513,13 +492,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_grpc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -589,7 +575,7 @@ mod test {
         println!("Switch to AllSongs");
         let _ = client
             .switch_to_playlist(SwitchToPlaylistRequest {
-                playlist_name: ALL_SONGS_NAME.to_string(),
+                playlist_name: "all_songs".to_string(),
             })
             .await?;
         assert_eq!(player.get_playlist().current().unwrap().name(), "Song 1");
@@ -619,7 +605,7 @@ mod test {
 
         let _ = client
             .switch_to_playlist(SwitchToPlaylistRequest {
-                playlist_name: PLAYLIST_NAME.to_string(),
+                playlist_name: "playlist".to_string(),
             })
             .await?;
         println!("Switch to Playlist");
@@ -684,13 +670,20 @@ mod test {
         Box<dyn Error>,
     > {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -774,7 +767,7 @@ mod test {
             .await;
         assert!(result.is_err());
         let status = result.unwrap_err();
-        assert_eq!(status.code(), tonic::Code::Unimplemented);
+        assert_eq!(status.code(), tonic::Code::NotFound);
 
         Ok(())
     }
@@ -928,44 +921,5 @@ mod test {
         client.stop(StopRequest {}).await?;
         eventually(|| !device.is_playing(), "Song never stopped");
         Ok(())
-    }
-
-    mod classify_playlist_name_tests {
-        use super::super::{classify_playlist_name, PlaylistTarget};
-
-        #[test]
-        fn recognizes_playlist() {
-            assert_eq!(
-                classify_playlist_name("playlist").unwrap(),
-                PlaylistTarget::Playlist
-            );
-        }
-
-        #[test]
-        fn recognizes_all_songs() {
-            assert_eq!(
-                classify_playlist_name("all_songs").unwrap(),
-                PlaylistTarget::AllSongs
-            );
-        }
-
-        #[test]
-        fn unknown_name_returns_error() {
-            let result = classify_playlist_name("nonexistent");
-            assert!(result.is_err());
-            let status = result.unwrap_err();
-            assert_eq!(status.code(), tonic::Code::Unimplemented);
-        }
-
-        #[test]
-        fn empty_name_returns_error() {
-            assert!(classify_playlist_name("").is_err());
-        }
-
-        #[test]
-        fn case_sensitive() {
-            assert!(classify_playlist_name("Playlist").is_err());
-            assert!(classify_playlist_name("ALL_SONGS").is_err());
-        }
     }
 }

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -159,8 +159,17 @@ impl super::Driver for Driver {
                     MidiAction::Stop => {
                         player.stop().await;
                     }
-                    MidiAction::AllSongs => player.switch_to_all_songs().await,
-                    MidiAction::Playlist => player.switch_to_playlist().await,
+                    MidiAction::AllSongs => {
+                        if let Err(e) = player.switch_to_playlist("all_songs").await {
+                            error!("Failed to switch to all_songs: {}", e);
+                        }
+                    }
+                    MidiAction::Playlist => {
+                        let name = player.persisted_playlist_name();
+                        if let Err(e) = player.switch_to_playlist(&name).await {
+                            error!("Failed to switch to playlist {}: {}", name, e);
+                        }
+                    }
                     MidiAction::Unrecognized => {}
                 }
             }
@@ -177,6 +186,7 @@ mod test {
         controller::Controller,
         midi::Device,
         player::Player,
+        playlist,
         playlist::Playlist,
         songs,
         testutil::eventually,
@@ -215,13 +225,20 @@ mod test {
         unrecognized_event.write(&mut unrecognized_buf)?;
 
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -351,8 +351,17 @@ impl Driver {
             OscAction::Stop => {
                 player.stop().await;
             }
-            OscAction::AllSongs => player.switch_to_all_songs().await,
-            OscAction::Playlist => player.switch_to_playlist().await,
+            OscAction::AllSongs => {
+                if let Err(e) = player.switch_to_playlist("all_songs").await {
+                    error!("Failed to switch to all_songs: {}", e);
+                }
+            }
+            OscAction::Playlist => {
+                let name = player.persisted_playlist_name();
+                if let Err(e) = player.switch_to_playlist(&name).await {
+                    error!("Failed to switch to playlist {}: {}", name, e);
+                }
+            }
             OscAction::StopSamples => player.stop_samples(),
             OscAction::Unrecognized => return Ok(false),
         }
@@ -432,6 +441,7 @@ mod test {
     use crate::{
         config,
         controller::osc::{Driver, STATUS_PLAYING, STATUS_STOPPED},
+        playlist,
         playlist::Playlist,
         songs,
         testutil::{eventually, eventually_async},
@@ -442,13 +452,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_osc() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -606,13 +623,20 @@ mod test {
     async fn test_osc_client_tracking() -> Result<(), Box<dyn Error>> {
         // Set up a player (not used directly, but needed for Driver initialization)
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -729,13 +753,20 @@ mod test {
     async fn test_osc_multiple_clients() -> Result<(), Box<dyn Error>> {
         // Test that multiple clients can connect and all receive broadcasts
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -1006,15 +1037,22 @@ mod test {
 
         async fn make_player() -> Arc<Player> {
             let songs = songs::get_all_songs(Path::new("assets/songs")).unwrap();
+            let pl = Playlist::new(
+                "playlist",
+                &config::Playlist::deserialize(Path::new("assets/playlist.yaml")).unwrap(),
+                songs.clone(),
+            )
+            .unwrap();
+            let mut playlists = HashMap::new();
+            playlists.insert(
+                "all_songs".to_string(),
+                playlist::from_songs(songs.clone()).unwrap(),
+            );
+            playlists.insert("playlist".to_string(), pl);
             let player = Arc::new(
                 Player::new(
-                    songs.clone(),
-                    Playlist::new(
-                        "playlist",
-                        &config::Playlist::deserialize(Path::new("assets/playlist.yaml")).unwrap(),
-                        songs,
-                    )
-                    .unwrap(),
+                    playlists,
+                    "playlist".to_string(),
                     &config::Player::new(
                         vec![],
                         Some(config::Audio::new("mock-device")),
@@ -1112,13 +1150,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_osc_monitor_events() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -1200,13 +1245,20 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_osc_monitor_events_with_multicast() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Arc::new(Player::new(
+        let pl = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone())?,
+        );
+        playlists.insert("playlist".to_string(), pl);
+        let player = Arc::new(Player::new(
+            playlists,
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),

--- a/src/player.rs
+++ b/src/player.rs
@@ -121,14 +121,13 @@ pub struct Player {
     hardware: Arc<parking_lot::RwLock<HardwareState>>,
     /// Base path for resolving sample/DMX config files. None in test paths.
     base_path: Option<PathBuf>,
-    /// The playlist to use. Behind a RwLock so it can be refreshed when the
-    /// active playlist was auto-generated from all songs (zero-config mode).
-    playlist: Arc<parking_lot::RwLock<Arc<Playlist>>>,
-    /// The all songs playlist. Behind a RwLock so it can be refreshed at runtime
-    /// (e.g., after importing a song via the web UI).
-    all_songs: Arc<parking_lot::RwLock<Arc<Playlist>>>,
-    /// Switches between the playlist and the all songs playlist.
-    use_all_songs: Arc<AtomicBool>,
+    /// All playlists keyed by name. Always includes "all_songs".
+    playlists: Arc<parking_lot::RwLock<HashMap<String, Arc<Playlist>>>>,
+    /// The name of the currently active playlist.
+    active_playlist: Arc<parking_lot::RwLock<String>>,
+    /// The persisted active playlist name (last non-all_songs choice). Used by
+    /// MIDI/OSC `Playlist` action to return to the user's "real" playlist.
+    persisted_playlist: Arc<parking_lot::RwLock<String>>,
     /// The time that the last play action occurred.
     play_start_time: Arc<Mutex<Option<SystemTime>>>,
     /// Keeps track of the player joins. There should only be one task on here at a time.
@@ -161,8 +160,8 @@ impl Player {
     /// `await_hardware_ready()` to wait for init to complete (mainly useful
     /// in tests).
     pub fn new(
-        songs: Arc<Songs>,
-        playlist: Arc<Playlist>,
+        playlists: HashMap<String, Arc<Playlist>>,
+        active_playlist: String,
         config: &config::Player,
         base_path: Option<&Path>,
     ) -> Result<Player, Box<dyn Error>> {
@@ -175,7 +174,7 @@ impl Player {
             trigger_engine: None,
         };
 
-        let player = Self::new_with_devices(devices, playlist, songs, base_path)?;
+        let player = Self::new_with_devices(devices, playlists, active_playlist, base_path)?;
 
         // Mark as not ready — async init will set to true when complete.
         // Use send_modify() because send() is a no-op when no receivers exist yet.
@@ -453,8 +452,8 @@ impl Player {
     /// and can be called directly in tests with mock devices.
     pub fn new_with_devices(
         devices: PlayerDevices,
-        playlist: Arc<Playlist>,
-        songs: Arc<Songs>,
+        playlists: HashMap<String, Arc<Playlist>>,
+        active_playlist: String,
         base_path: Option<&Path>,
     ) -> Result<Player, Box<dyn Error>> {
         // Store the clock source so each song can create a fresh PlaybackClock.
@@ -482,12 +481,25 @@ impl Player {
 
         let (init_done_tx, _init_done_rx) = tokio::sync::watch::channel(true);
 
+        // Resolve the active playlist: use the requested name if it exists, else fall back to all_songs.
+        let resolved_active = if playlists.contains_key(&active_playlist) {
+            active_playlist
+        } else {
+            "all_songs".to_string()
+        };
+
         Ok(Player {
             hardware: Arc::new(parking_lot::RwLock::new(hw)),
             base_path: base_path.map(Path::to_path_buf),
-            playlist: Arc::new(parking_lot::RwLock::new(playlist)),
-            all_songs: Arc::new(parking_lot::RwLock::new(playlist::from_songs(songs)?)),
-            use_all_songs: Arc::new(AtomicBool::new(false)),
+            playlists: Arc::new(parking_lot::RwLock::new(playlists)),
+            active_playlist: Arc::new(parking_lot::RwLock::new(resolved_active.clone())),
+            persisted_playlist: Arc::new(parking_lot::RwLock::new(
+                if resolved_active == "all_songs" {
+                    "playlist".to_string()
+                } else {
+                    resolved_active
+                },
+            )),
             play_start_time: Arc::new(Mutex::new(None)),
             join: Arc::new(Mutex::new(None)),
             stop_run: Arc::new(AtomicBool::new(false)),
@@ -1111,31 +1123,63 @@ impl Player {
         Some(song)
     }
 
-    /// Switches the active playlist if the player is idle.
-    async fn switch_playlist(&self, use_all_songs: bool, label: &str) {
+    /// Switches the active playlist by name. Returns an error if the name
+    /// doesn't exist in the map or if the player is currently playing.
+    /// Switching to "all_songs" is session-only (not persisted to config).
+    pub async fn switch_to_playlist(&self, name: &str) -> Result<(), String> {
         if let Some(current) = self.if_playing_then_current_song().await {
             info!(
                 current_song = current.name(),
-                "Can't switch to {}, player is active.", label
+                "Can't switch to {}, player is active.", name
             );
-            return;
+            return Err("Cannot switch playlist while playing".to_string());
         }
 
-        self.use_all_songs.store(use_all_songs, Ordering::Relaxed);
+        // Validate the name exists.
+        {
+            let playlists = self.playlists.read();
+            if !playlists.contains_key(name) {
+                return Err(format!("Playlist '{}' not found", name));
+            }
+        }
+
+        *self.active_playlist.write() = name.to_string();
+
+        // Persist the choice to the config store, unless it's "all_songs" (session-only).
+        if name != "all_songs" {
+            *self.persisted_playlist.write() = name.to_string();
+            if let Some(store) = self.config_store() {
+                if let Err(e) = store.set_active_playlist(name.to_string()).await {
+                    warn!("Failed to persist active playlist: {}", e);
+                }
+            }
+        }
+
         if let Some(song) = self.get_playlist().current() {
             let midi_device = self.hardware.read().midi_device.clone();
             Player::emit_midi_event(midi_device, song);
         }
+
+        Ok(())
     }
 
-    /// Switch to the all songs playlist.
-    pub async fn switch_to_all_songs(&self) {
-        self.switch_playlist(true, "all songs").await;
+    /// Returns the persisted active playlist name (the last non-all_songs choice).
+    /// This is what MIDI/OSC `Playlist` action uses to "go back to my real playlist".
+    pub fn persisted_playlist_name(&self) -> String {
+        self.persisted_playlist.read().clone()
     }
 
-    /// Switch to the regular playlist.
-    pub async fn switch_to_playlist(&self) {
-        self.switch_playlist(false, "playlist").await;
+    /// Returns a sorted list of all playlist names.
+    pub fn list_playlists(&self) -> Vec<String> {
+        let playlists = self.playlists.read();
+        let mut names: Vec<String> = playlists.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Returns a snapshot of all playlists.
+    pub fn playlists_snapshot(&self) -> HashMap<String, Arc<Playlist>> {
+        self.playlists.read().clone()
     }
 
     /// Returns the track-to-output-channel mappings, if audio is configured.
@@ -1145,27 +1189,43 @@ impl Player {
 
     /// Returns the song registry from the all-songs playlist.
     pub fn songs(&self) -> Arc<Songs> {
-        self.all_songs.read().registry().clone()
+        let playlists = self.playlists.read();
+        playlists
+            .get("all_songs")
+            .expect("all_songs must always be present")
+            .registry()
+            .clone()
     }
 
     /// Gets the all-songs playlist (every song in the registry).
     pub fn get_all_songs_playlist(&self) -> Arc<Playlist> {
-        self.all_songs.read().clone()
+        let playlists = self.playlists.read();
+        playlists
+            .get("all_songs")
+            .expect("all_songs must always be present")
+            .clone()
     }
 
     /// Gets the current playlist used by the player.
     pub fn get_playlist(&self) -> Arc<Playlist> {
-        if self.use_all_songs.load(Ordering::Relaxed) {
-            return self.all_songs.read().clone();
-        }
-
-        self.playlist.read().clone()
+        let name = self.active_playlist.read().clone();
+        let playlists = self.playlists.read();
+        playlists
+            .get(&name)
+            .or_else(|| playlists.get("all_songs"))
+            .expect("all_songs must always be present")
+            .clone()
     }
 
     /// Reinitializes all song-related state by rescanning songs from disk and
-    /// rebuilding both playlists. Call this after any mutation that affects songs
+    /// rebuilding all playlists. Call this after any mutation that affects songs
     /// (import, create, config edit, etc.).
-    pub fn reload_songs(&self, songs_path: &std::path::Path, playlist_path: &std::path::Path) {
+    pub fn reload_songs(
+        &self,
+        songs_path: &std::path::Path,
+        playlists_dir: Option<&std::path::Path>,
+        legacy_playlist_path: Option<&std::path::Path>,
+    ) {
         let new_songs = match songs::get_all_songs(songs_path) {
             Ok(s) => s,
             Err(e) => {
@@ -1174,29 +1234,24 @@ impl Player {
             }
         };
 
-        // Rebuild all-songs playlist.
-        let new_all_songs = match playlist::from_songs(new_songs.clone()) {
-            Ok(p) => p,
-            Err(e) => {
-                warn!("Failed to rebuild all-songs playlist: {}", e);
-                return;
-            }
-        };
-
-        // Rebuild the main playlist from its config file, falling back to all-songs.
-        let new_playlist = match config::Playlist::deserialize(playlist_path) {
-            Ok(playlist_config) => match Playlist::new("playlist", &playlist_config, new_songs) {
+        let new_playlists =
+            match load_playlists(playlists_dir, legacy_playlist_path, new_songs.clone()) {
                 Ok(p) => p,
                 Err(e) => {
-                    info!("Playlist references missing songs ({}); using all songs", e);
-                    new_all_songs.clone()
+                    warn!("Failed to rebuild playlists: {}", e);
+                    return;
                 }
-            },
-            Err(_) => new_all_songs.clone(),
-        };
+            };
 
-        *self.playlist.write() = new_playlist;
-        *self.all_songs.write() = new_all_songs;
+        // Preserve active playlist name if it still exists; fall back to all_songs.
+        {
+            let mut active = self.active_playlist.write();
+            if !new_playlists.contains_key(active.as_str()) {
+                *active = "all_songs".to_string();
+            }
+        }
+
+        *self.playlists.write() = new_playlists;
         info!("Reloaded song state");
     }
 
@@ -1438,6 +1493,90 @@ fn resolve_playback_outcome(
     }
 }
 
+/// Loads all playlists from a directory and/or legacy playlist path.
+/// Always includes the computed "all_songs" playlist.
+pub fn load_playlists(
+    playlists_dir: Option<&Path>,
+    legacy_playlist_path: Option<&Path>,
+    songs: Arc<Songs>,
+) -> Result<HashMap<String, Arc<Playlist>>, Box<dyn Error>> {
+    let mut playlists = HashMap::new();
+
+    // Always create all_songs.
+    playlists.insert(
+        "all_songs".to_string(),
+        playlist::from_songs(songs.clone())?,
+    );
+
+    // Load playlists from directory.
+    if let Some(dir) = playlists_dir {
+        if dir.is_dir() {
+            let mut entries: Vec<_> = std::fs::read_dir(dir)?
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path().is_file()
+                        && e.path()
+                            .extension()
+                            .is_some_and(|ext| ext == "yaml" || ext == "yml")
+                })
+                .collect();
+            entries.sort_by_key(|e| e.file_name());
+
+            for entry in entries {
+                let path = entry.path();
+                let name = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+                    .to_string();
+                if name.is_empty() || name == "all_songs" {
+                    continue;
+                }
+                match config::Playlist::deserialize(&path) {
+                    Ok(playlist_config) => {
+                        match Playlist::new(&name, &playlist_config, songs.clone()) {
+                            Ok(pl) => {
+                                info!(name = %name, "Loaded playlist from directory");
+                                playlists.insert(name, pl);
+                            }
+                            Err(e) => {
+                                warn!(name = %name, error = %e, "Playlist references missing songs, skipping");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(path = ?path, error = %e, "Failed to parse playlist file, skipping");
+                    }
+                }
+            }
+        }
+    }
+
+    // Load legacy playlist file as name "playlist" (if not already loaded from dir).
+    if let Some(legacy_path) = legacy_playlist_path {
+        if !playlists.contains_key("playlist") {
+            match config::Playlist::deserialize(legacy_path) {
+                Ok(playlist_config) => {
+                    match Playlist::new("playlist", &playlist_config, songs.clone()) {
+                        Ok(pl) => {
+                            info!("Loaded legacy playlist");
+                            playlists.insert("playlist".to_string(), pl);
+                        }
+                        Err(e) => {
+                            info!("Legacy playlist references missing songs ({}); skipping", e);
+                        }
+                    }
+                }
+                Err(_) => {
+                    info!("Legacy playlist file not found or invalid; skipping");
+                }
+            }
+        }
+    }
+
+    Ok(playlists)
+}
+
 #[cfg(test)]
 mod test {
     use std::{collections::HashMap, error::Error, fs, path::Path, sync::Arc};
@@ -1451,16 +1590,31 @@ mod test {
 
     use super::*;
 
+    /// Test helper: builds a playlists map from a single playlist + songs registry.
+    fn test_playlists(
+        playlist: Arc<Playlist>,
+        songs: Arc<Songs>,
+    ) -> HashMap<String, Arc<Playlist>> {
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs).unwrap(),
+        );
+        playlists.insert("playlist".to_string(), playlist);
+        playlists
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_player() -> Result<(), Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let player = Player::new(
+            test_playlists(playlist, songs.clone()),
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -1494,7 +1648,7 @@ mod test {
         assert_eq!(player.get_playlist().current().unwrap().name(), "Song 1");
 
         println!("Switch to AllSongs");
-        player.switch_to_all_songs().await;
+        player.switch_to_playlist("all_songs").await.unwrap();
         assert_eq!(player.get_playlist().current().unwrap().name(), "Song 1");
 
         player.next().await;
@@ -1526,7 +1680,7 @@ mod test {
 
         assert!(midi_device.get_emitted_event().is_none());
 
-        player.switch_to_playlist().await;
+        player.switch_to_playlist("playlist").await.unwrap();
         println!("Switch to Playlist");
         assert_eq!(player.get_playlist().current().unwrap().name(), "Song 1");
 
@@ -1643,8 +1797,8 @@ mod test {
 
         // Create player with DMX engine that has lighting config
         let player = Player::new(
-            songs,
-            playlist,
+            test_playlists(playlist, songs.clone()),
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -1675,13 +1829,14 @@ mod test {
         dmx: Option<config::Dmx>,
     ) -> Result<Player, Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let player = Player::new(
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
             songs.clone(),
-            Playlist::new(
-                "playlist",
-                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-                songs,
-            )?,
+        )?;
+        let player = Player::new(
+            test_playlists(playlist, songs),
+            "playlist".to_string(),
             &config::Player::new(vec![], audio, midi, dmx, HashMap::new(), "assets/songs"),
             None,
         )?;
@@ -1805,9 +1960,9 @@ mod test {
         let player = make_test_player().await?;
 
         assert_eq!(player.get_playlist().name(), "playlist");
-        player.switch_to_all_songs().await;
+        player.switch_to_playlist("all_songs").await.unwrap();
         assert_eq!(player.get_playlist().name(), "all_songs");
-        player.switch_to_playlist().await;
+        player.switch_to_playlist("playlist").await.unwrap();
         assert_eq!(player.get_playlist().name(), "playlist");
 
         Ok(())
@@ -1914,8 +2069,8 @@ mod test {
 
         // Create player with DMX engine that has lighting config
         let player = Player::new(
-            songs,
-            playlist,
+            test_playlists(playlist, songs.clone()),
+            "playlist".to_string(),
             &config::Player::new(
                 vec![],
                 Some(config::Audio::new("mock-device")),
@@ -2022,7 +2177,7 @@ mod test {
         player.get_playlist().next(); // Song 3
         player.get_playlist().next(); // Song 5
                                       // Use the all songs playlist to reach Song 2 more easily.
-        player.switch_to_all_songs().await;
+        player.switch_to_playlist("all_songs").await.unwrap();
         // all_songs starts at Song 1, navigate to Song 2.
         player.get_playlist().next(); // Song 10
         player.get_playlist().next(); // Song 2
@@ -2083,7 +2238,12 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
-        let player = Player::new_with_devices(devices, playlist, songs, None)?;
+        let player = Player::new_with_devices(
+            devices,
+            test_playlists(playlist, songs),
+            "playlist".to_string(),
+            None,
+        )?;
 
         assert!(player.audio_device().is_none());
         assert!(player.midi_device().is_none());
@@ -2171,12 +2331,16 @@ mod test {
         player.play().await?;
         eventually(|| device.is_playing(), "Song never started playing");
 
-        // Attempt switch while playing — should be a no-op.
-        player.switch_to_all_songs().await;
+        // Attempt switch while playing — should return error.
+        let result = player.switch_to_playlist("all_songs").await;
+        assert!(
+            result.is_err(),
+            "switch_to_playlist should fail while playing"
+        );
         assert_eq!(
             player.get_playlist().name(),
             "playlist",
-            "switch_to_all_songs should be a no-op while playing"
+            "playlist should not change while playing"
         );
 
         player.stop().await;
@@ -2411,7 +2575,12 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
-        Player::new_with_devices(devices, playlist, songs, None)
+        Player::new_with_devices(
+            devices,
+            test_playlists(playlist, songs),
+            "playlist".to_string(),
+            None,
+        )
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2464,17 +2633,21 @@ mod test {
             .expect("audio device should be present");
         let device = binding.to_mock()?;
 
-        player.switch_to_all_songs().await;
+        player.switch_to_playlist("all_songs").await.unwrap();
         assert_eq!(player.get_playlist().name(), "all_songs");
 
         player.play().await?;
         eventually(|| device.is_playing(), "Song never started playing");
 
-        player.switch_to_playlist().await;
+        let result = player.switch_to_playlist("playlist").await;
+        assert!(
+            result.is_err(),
+            "switch_to_playlist should fail while playing"
+        );
         assert_eq!(
             player.get_playlist().name(),
             "all_songs",
-            "switch_to_playlist should be a no-op while playing"
+            "playlist should not change while playing"
         );
 
         player.stop().await;
@@ -2513,7 +2686,12 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
-        let player = Player::new_with_devices(devices, playlist, songs, None)?;
+        let player = Player::new_with_devices(
+            devices,
+            test_playlists(playlist, songs),
+            "test".to_string(),
+            None,
+        )?;
         assert!(player.audio_device().is_none());
         assert!(player.midi_device().is_none());
         assert!(player.dmx_engine().is_none());
@@ -2565,7 +2743,12 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
-        let player = Player::new_with_devices(devices, playlist, songs, None)?;
+        let player = Player::new_with_devices(
+            devices,
+            test_playlists(playlist, songs),
+            "playlist".to_string(),
+            None,
+        )?;
 
         player.process_sample_trigger(&[0x90, 60, 127]);
         player.stop_samples();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -153,11 +153,12 @@ impl App {
                 Action::None
             }
             KeyCode::Char('a') => {
-                self.player.switch_to_all_songs().await;
+                let _ = self.player.switch_to_playlist("all_songs").await;
                 Action::None
             }
             KeyCode::Char('l') => {
-                self.player.switch_to_playlist().await;
+                let name = self.player.persisted_playlist_name();
+                let _ = self.player.switch_to_playlist(&name).await;
                 Action::None
             }
             _ => Action::None,
@@ -216,7 +217,7 @@ mod tests {
         let songs = Arc::new(Songs::new(map));
         let playlist_config =
             config::Playlist::new(&song_names.iter().map(|s| s.to_string()).collect::<Vec<_>>());
-        let playlist = playlist::Playlist::new("test", &playlist_config, songs.clone()).unwrap();
+        let pl = playlist::Playlist::new("test", &playlist_config, songs.clone()).unwrap();
         let devices = PlayerDevices {
             audio: None,
             mappings: None,
@@ -225,7 +226,13 @@ mod tests {
             sample_engine: None,
             trigger_engine: None,
         };
-        Arc::new(Player::new_with_devices(devices, playlist, songs, None).unwrap())
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone()).unwrap(),
+        );
+        playlists.insert(pl.name().to_string(), pl);
+        Arc::new(Player::new_with_devices(devices, playlists, "test".to_string(), None).unwrap())
     }
 
     fn test_app(song_names: &[&str]) -> App {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -398,8 +398,7 @@ mod tests {
             let songs = std::sync::Arc::new(Songs::new(map));
             let playlist_config =
                 config::Playlist::new(&["Song A".to_string(), "Song B".to_string()]);
-            let playlist =
-                playlist::Playlist::new("My Set", &playlist_config, songs.clone()).unwrap();
+            let pl = playlist::Playlist::new("My Set", &playlist_config, songs.clone()).unwrap();
             let devices = PlayerDevices {
                 audio: None,
                 mappings: None,
@@ -408,8 +407,20 @@ mod tests {
                 sample_engine: None,
                 trigger_engine: None,
             };
+            let mut playlists = HashMap::new();
+            playlists.insert(
+                "all_songs".to_string(),
+                playlist::from_songs(songs.clone()).unwrap(),
+            );
+            playlists.insert(pl.name().to_string(), pl);
             let player = std::sync::Arc::new(
-                crate::player::Player::new_with_devices(devices, playlist, songs, None).unwrap(),
+                crate::player::Player::new_with_devices(
+                    devices,
+                    playlists,
+                    "My Set".to_string(),
+                    None,
+                )
+                .unwrap(),
             );
             let (_tx, state_rx) =
                 watch::channel(std::sync::Arc::new(crate::state::StateSnapshot::default()));

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -22,6 +22,8 @@ use axum::{
 };
 use serde_json::json;
 
+use std::path::PathBuf;
+
 use tracing::warn;
 
 use super::config_io;
@@ -47,6 +49,14 @@ pub fn router() -> Router<WebUiState> {
         .route("/browse/create-song", post(create_song_in_directory))
         .route("/playlist", get(get_playlist).put(put_playlist))
         .route("/playlist/validate", post(validate_playlist))
+        .route("/playlists", get(get_playlists))
+        .route(
+            "/playlists/{name}",
+            get(get_playlist_by_name)
+                .put(put_playlist_by_name)
+                .delete(delete_playlist_by_name),
+        )
+        .route("/playlists/{name}/activate", post(activate_playlist))
         .route("/lighting", get(get_lighting_files))
         .route(
             "/lighting/{name}",
@@ -628,9 +638,11 @@ async fn create_song_in_directory(
     match song_config.save(&config_path) {
         Ok(()) => {
             // Refresh the player's all-songs playlist so newly imported songs appear.
-            state
-                .player
-                .reload_songs(&state.songs_path, &state.playlist_path);
+            state.player.reload_songs(
+                &state.songs_path,
+                state.playlists_dir.as_deref(),
+                state.legacy_playlist_path.as_deref(),
+            );
             (
                 StatusCode::CREATED,
                 Json(json!({"status": "created", "path": config_path.to_string_lossy()})),
@@ -651,9 +663,28 @@ struct CreateSongInDirRequest {
     name: Option<String>,
 }
 
-/// GET /api/playlist — returns the playlist config as JSON.
+/// Resolves the path for the legacy `/api/playlist` endpoints.
+/// Prefers `legacy_playlist_path`, falls back to `playlists_dir/playlist.yaml`.
+fn resolve_legacy_playlist_path(state: &WebUiState) -> Option<PathBuf> {
+    if let Some(ref p) = state.legacy_playlist_path {
+        return Some(p.clone());
+    }
+    state
+        .playlists_dir
+        .as_ref()
+        .map(|d| d.join("playlist.yaml"))
+}
+
+/// GET /api/playlist — returns the playlist config as JSON (backward compat).
 async fn get_playlist(State(state): State<WebUiState>) -> impl IntoResponse {
-    match config::Playlist::deserialize(&state.playlist_path) {
+    let Some(path) = resolve_legacy_playlist_path(&state) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "No playlist configured"})),
+        )
+            .into_response();
+    };
+    match config::Playlist::deserialize(&path) {
         Ok(playlist) => match serde_json::to_value(&playlist) {
             Ok(json_val) => (StatusCode::OK, Json(json_val)).into_response(),
             Err(e) => (
@@ -1680,9 +1711,11 @@ async fn post_song(
 
     match config_io::atomic_write(&config_path, &body) {
         Ok(()) => {
-            state
-                .player
-                .reload_songs(&state.songs_path, &state.playlist_path);
+            state.player.reload_songs(
+                &state.songs_path,
+                state.playlists_dir.as_deref(),
+                state.legacy_playlist_path.as_deref(),
+            );
             (
                 StatusCode::CREATED,
                 Json(json!({"status": "created", "song": name})),
@@ -1701,7 +1734,12 @@ async fn put_song(
     Path(name): Path<String>,
     body: String,
 ) -> impl IntoResponse {
-    if name.contains("..") || name.contains('/') || name.contains('\\') {
+    if name.is_empty()
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+    {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Invalid song name"})),
@@ -1709,7 +1747,18 @@ async fn put_song(
             .into_response();
     }
 
-    let song_dir = state.songs_path.join(&name);
+    // Canonicalize songs_path and verify the song directory stays within it.
+    let songs_canonical = match state.songs_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
+            )
+                .into_response();
+        }
+    };
+    let song_dir = songs_canonical.join(&name);
     if !song_dir.is_dir() {
         return (
             StatusCode::NOT_FOUND,
@@ -1717,6 +1766,24 @@ async fn put_song(
         )
             .into_response();
     }
+    // codeql[rust/path-injection] Path verified via canonicalize + starts_with.
+    let song_dir = match song_dir.canonicalize() {
+        Ok(p) if p.starts_with(&songs_canonical) => p,
+        Ok(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "Invalid song name"})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve song path: {}", e)})),
+            )
+                .into_response();
+        }
+    };
 
     let config_path = song_dir.join("song.yaml");
 
@@ -1759,8 +1826,13 @@ fn ensure_song_dir(
     songs_path: &std::path::Path,
     name: &str,
 ) -> Result<std::path::PathBuf, Box<axum::response::Response>> {
-    // Reject path traversal
-    if name.contains("..") || name.contains('/') || name.contains('\\') {
+    // Reject path traversal characters.
+    if name.is_empty()
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+    {
         return Err(Box::new(
             (
                 StatusCode::BAD_REQUEST,
@@ -1770,7 +1842,19 @@ fn ensure_song_dir(
         ));
     }
 
-    let song_dir = songs_path.join(name);
+    // Canonicalize the songs directory so all derived paths are anchored to a
+    // verified absolute base.
+    let songs_canonical = songs_path.canonicalize().map_err(|e| {
+        Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
+            )
+                .into_response(),
+        )
+    })?;
+
+    let song_dir = songs_canonical.join(name);
 
     if !song_dir.exists() {
         std::fs::create_dir_all(&song_dir).map_err(|e| {
@@ -1784,7 +1868,28 @@ fn ensure_song_dir(
         })?;
     }
 
-    Ok(song_dir)
+    // Canonicalize the result and verify containment within songs directory.
+    // codeql[rust/path-injection] Path verified via canonicalize + starts_with.
+    let song_canonical = song_dir.canonicalize().map_err(|e| {
+        Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve song directory: {}", e)})),
+            )
+                .into_response(),
+        )
+    })?;
+    if !song_canonical.starts_with(&songs_canonical) {
+        return Err(Box::new(
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "Invalid song name"})),
+            )
+                .into_response(),
+        ));
+    }
+
+    Ok(song_canonical)
 }
 
 /// Generates song.yaml for a song directory if one doesn't already exist.
@@ -1964,9 +2069,11 @@ async fn upload_track_single(
     }
 
     ensure_song_config(&song_dir).map_err(|e| *e)?;
-    state
-        .player
-        .reload_songs(&state.songs_path, &state.playlist_path);
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
 
     Ok((
         StatusCode::OK,
@@ -2035,9 +2142,11 @@ async fn upload_tracks_multipart(
     }
 
     ensure_song_config(&song_dir).map_err(|e| *e)?;
-    state
-        .player
-        .reload_songs(&state.songs_path, &state.playlist_path);
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
 
     Ok((
         StatusCode::OK,
@@ -2049,13 +2158,20 @@ async fn upload_tracks_multipart(
     ))
 }
 
-/// PUT /api/playlist — validates and atomically writes the playlist.
+/// PUT /api/playlist — validates and atomically writes the playlist (backward compat).
 async fn put_playlist(State(state): State<WebUiState>, body: String) -> impl IntoResponse {
+    let Some(path) = resolve_legacy_playlist_path(&state) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "No playlist configured"})),
+        )
+            .into_response();
+    };
     if let Err(errors) = config_io::validate_playlist(&body) {
         return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
     }
 
-    match config_io::atomic_write(&state.playlist_path, &body) {
+    match config_io::atomic_write(&path, &body) {
         Ok(()) => (StatusCode::OK, Json(json!({"status": "saved"}))).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response(),
     }
@@ -2070,6 +2186,289 @@ async fn validate_playlist(body: String) -> impl IntoResponse {
             Json(json!({"valid": false, "errors": errors})),
         )
             .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Playlist CRUD endpoints
+// ---------------------------------------------------------------------------
+
+/// Validates a playlist name for use in file paths.
+#[allow(clippy::result_large_err)]
+fn validate_playlist_name(name: &str) -> Result<(), axum::response::Response> {
+    if name.is_empty()
+        || name == "all_songs"
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Invalid playlist name"})),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Returns the playlists directory, or an error response if not configured.
+#[allow(clippy::result_large_err)]
+fn require_playlists_dir(state: &WebUiState) -> Result<PathBuf, axum::response::Response> {
+    state.playlists_dir.clone().ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "No playlists directory configured"})),
+        )
+            .into_response()
+    })
+}
+
+/// Resolves a playlist file path within the playlists directory, verifying
+/// that the result does not escape the directory via symlinks or other tricks.
+/// The playlists directory must exist before calling this function.
+/// Returns the validated path or an error response.
+#[allow(clippy::result_large_err)]
+fn resolve_playlist_path(
+    playlists_dir: &std::path::Path,
+    name: &str,
+    ext: &str,
+) -> Result<PathBuf, axum::response::Response> {
+    // Canonicalize the directory itself (must exist) so the resulting path
+    // is anchored to a verified absolute base.
+    let dir_canonical = playlists_dir.canonicalize().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to resolve playlists dir: {}", e)})),
+        )
+            .into_response()
+    })?;
+    let file_path = dir_canonical.join(format!("{}.{}", name, ext));
+    // If the file already exists, canonicalize it and verify it stayed inside.
+    // This catches symlink escapes.
+    if file_path.exists() {
+        let canonical = file_path.canonicalize().map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve path: {}", e)})),
+            )
+                .into_response()
+        })?;
+        if !canonical.starts_with(&dir_canonical) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "Invalid playlist path"})),
+            )
+                .into_response());
+        }
+        Ok(canonical)
+    } else {
+        // File doesn't exist yet. Verify the parent of the constructed path
+        // is still the canonical directory (defense in depth beyond name validation).
+        let parent = file_path.parent().ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "Invalid playlist path"})),
+            )
+                .into_response()
+        })?;
+        if parent != dir_canonical {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "Invalid playlist path"})),
+            )
+                .into_response());
+        }
+        Ok(file_path)
+    }
+}
+
+/// GET /api/playlists — list all playlists with name, song count, and active status.
+async fn get_playlists(State(state): State<WebUiState>) -> impl IntoResponse {
+    let playlists = state.player.list_playlists();
+    let active = {
+        let active_playlist = state.player.get_playlist();
+        active_playlist.name().to_string()
+    };
+    let items: Vec<serde_json::Value> = playlists
+        .iter()
+        .map(|name| {
+            let playlist_map = state.player.playlists_snapshot();
+            let song_count = playlist_map.get(name).map(|p| p.songs().len()).unwrap_or(0);
+            json!({
+                "name": name,
+                "song_count": song_count,
+                "is_active": name == &active,
+            })
+        })
+        .collect();
+    (StatusCode::OK, Json(json!(items))).into_response()
+}
+
+/// GET /api/playlists/:name — get a playlist's songs and available songs.
+async fn get_playlist_by_name(
+    State(state): State<WebUiState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let playlists = state.player.playlists_snapshot();
+    let Some(pl) = playlists.get(&name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("Playlist '{}' not found", name)})),
+        )
+            .into_response();
+    };
+    let all_songs: Vec<String> = state
+        .player
+        .songs()
+        .sorted_list()
+        .iter()
+        .map(|s| s.name().to_string())
+        .collect();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "name": name,
+            "songs": pl.songs(),
+            "available_songs": all_songs,
+        })),
+    )
+        .into_response()
+}
+
+#[derive(serde::Deserialize)]
+struct PlaylistBody {
+    songs: Vec<String>,
+}
+
+/// PUT /api/playlists/:name — create or update a playlist.
+async fn put_playlist_by_name(
+    State(state): State<WebUiState>,
+    Path(name): Path<String>,
+    Json(body): Json<PlaylistBody>,
+) -> impl IntoResponse {
+    validate_playlist_name(&name)?;
+    let playlists_dir = require_playlists_dir(&state)?;
+
+    // Write the playlist YAML file.
+    let playlist_config = config::Playlist::new(&body.songs);
+    let yaml = match crate::util::to_yaml_string(&playlist_config) {
+        Ok(y) => y,
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to serialize playlist: {}", e)})),
+            )
+                .into_response());
+        }
+    };
+
+    // Ensure the playlists directory exists.
+    if let Err(e) = std::fs::create_dir_all(&playlists_dir) {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to create playlists directory: {}", e)})),
+        )
+            .into_response());
+    }
+
+    // codeql[rust/path-injection] name is validated by validate_playlist_name; path is
+    // verified via canonicalize + starts_with containment in resolve_playlist_path.
+    let file_path = resolve_playlist_path(&playlists_dir, &name, "yaml")?;
+    if let Err(e) = config_io::atomic_write(&file_path, &yaml) {
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response());
+    }
+
+    // Reload songs to pick up the new playlist.
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
+
+    Ok::<_, axum::response::Response>(
+        (
+            StatusCode::OK,
+            Json(json!({"status": "saved", "name": name})),
+        )
+            .into_response(),
+    )
+}
+
+/// DELETE /api/playlists/:name — delete a playlist.
+async fn delete_playlist_by_name(
+    State(state): State<WebUiState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    validate_playlist_name(&name)?;
+    let playlists_dir = require_playlists_dir(&state)?;
+
+    // codeql[rust/path-injection] name is validated by validate_playlist_name; path is
+    // verified via canonicalize + starts_with containment in resolve_playlist_path.
+    let file_path = resolve_playlist_path(&playlists_dir, &name, "yaml")?;
+    if !file_path.is_file() {
+        // Also check .yml extension.
+        let yml_path = resolve_playlist_path(&playlists_dir, &name, "yml")?;
+        if yml_path.is_file() {
+            std::fs::remove_file(&yml_path).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": format!("Failed to delete file: {}", e)})),
+                )
+                    .into_response()
+            })?;
+        } else {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Playlist '{}' not found", name)})),
+            )
+                .into_response());
+        }
+    } else {
+        std::fs::remove_file(&file_path).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to delete file: {}", e)})),
+            )
+                .into_response()
+        })?;
+    }
+
+    // Reload songs to remove the playlist.
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
+
+    Ok::<_, axum::response::Response>(
+        (
+            StatusCode::OK,
+            Json(json!({"status": "deleted", "name": name})),
+        )
+            .into_response(),
+    )
+}
+
+/// POST /api/playlists/:name/activate — switch the active playlist.
+async fn activate_playlist(
+    State(state): State<WebUiState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    match state.player.switch_to_playlist(&name).await {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({"status": "activated", "name": name})),
+        )
+            .into_response(),
+        Err(e) => {
+            let status = if e.contains("not found") {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::CONFLICT
+            };
+            (status, Json(json!({"error": e}))).into_response()
+        }
     }
 }
 
@@ -2807,9 +3206,16 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
+        let mut playlists = std::collections::HashMap::new();
+        playlists.insert("all_songs".to_string(), all_songs_playlist);
         let player = std::sync::Arc::new(
-            crate::player::Player::new_with_devices(devices, all_songs_playlist, songs, None)
-                .unwrap(),
+            crate::player::Player::new_with_devices(
+                devices,
+                playlists,
+                "all_songs".to_string(),
+                None,
+            )
+            .unwrap(),
         );
 
         let (broadcast_tx, _) = broadcast::channel(16);
@@ -2822,7 +3228,8 @@ mod test {
             broadcast_tx,
             config_path,
             songs_path,
-            playlist_path,
+            playlists_dir: Some(dir.path().to_path_buf()),
+            legacy_playlist_path: Some(playlist_path),
             waveform_cache: super::super::state::new_waveform_cache(),
             calibration: std::sync::Arc::new(parking_lot::Mutex::new(None)),
         };
@@ -3026,7 +3433,8 @@ mod test {
     #[tokio::test]
     async fn get_playlist_missing_file() {
         let (mut state, _dir) = test_state();
-        state.playlist_path = std::path::PathBuf::from("/nonexistent/playlist.yaml");
+        state.legacy_playlist_path = Some(std::path::PathBuf::from("/nonexistent/playlist.yaml"));
+        state.playlists_dir = None;
         let app = router().with_state(state);
 
         let response = app
@@ -3083,7 +3491,7 @@ mod test {
     #[tokio::test]
     async fn put_playlist_valid() {
         let (state, _dir) = test_state();
-        let playlist_path = state.playlist_path.clone();
+        let playlist_path = state.legacy_playlist_path.clone().unwrap();
         let app = router().with_state(state);
 
         let response = app
@@ -3472,7 +3880,7 @@ show "test" {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]
@@ -3509,9 +3917,11 @@ show "test" {
         .unwrap();
 
         // Reload the player's registry from disk so the new song is visible.
-        state
-            .player
-            .reload_songs(&state.songs_path, &state.playlist_path);
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
 
         let app = router().with_state(state);
 
@@ -3544,9 +3954,11 @@ show "test" {
         let song_yaml = "name: MySong\ntracks:\n  - name: track1\n    file: track1.wav\n";
         std::fs::write(song_dir.join("song.yaml"), song_yaml).unwrap();
 
-        state
-            .player
-            .reload_songs(&state.songs_path, &state.playlist_path);
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
         let app = router().with_state(state);
 
         let response = app
@@ -3580,9 +3992,11 @@ show "test" {
         .unwrap();
 
         // Load the song into the player's registry while the config exists.
-        state
-            .player
-            .reload_songs(&state.songs_path, &state.playlist_path);
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
 
         // Now remove the config so get_song can't read it.
         std::fs::rename(song_dir.join("song.yaml"), song_dir.join("song.bak")).unwrap();
@@ -3617,9 +4031,11 @@ show "test" {
         // Use .yml extension
         std::fs::write(song_dir.join("song.yml"), song_yaml).unwrap();
 
-        state
-            .player
-            .reload_songs(&state.songs_path, &state.playlist_path);
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
         let app = router().with_state(state);
         let response = app
             .oneshot(
@@ -3709,9 +4125,11 @@ show "test" {
         .unwrap();
 
         // get_all_songs discovers config.yaml (any non-media-extension file)
-        state
-            .player
-            .reload_songs(&state.songs_path, &state.playlist_path);
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
         let app = router().with_state(state);
         let response = app
             .oneshot(
@@ -3745,9 +4163,11 @@ show "test" {
         )
         .unwrap();
 
-        state
-            .player
-            .reload_songs(&state.songs_path, &state.playlist_path);
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
         let app = router().with_state(state);
         let response = app
             .oneshot(
@@ -3973,7 +4393,8 @@ show "test" {
     #[tokio::test]
     async fn get_playlist_error_body_contains_message() {
         let (mut state, _dir) = test_state();
-        state.playlist_path = std::path::PathBuf::from("/nonexistent/playlist.yaml");
+        state.legacy_playlist_path = Some(std::path::PathBuf::from("/nonexistent/playlist.yaml"));
+        state.playlists_dir = None;
         let app = router().with_state(state);
 
         let response = app
@@ -4167,7 +4588,9 @@ show "test" {
     #[tokio::test]
     async fn put_playlist_write_failure_returns_500() {
         let (mut state, _dir) = test_state();
-        state.playlist_path = std::path::PathBuf::from("/nonexistent/dir/playlist.yaml");
+        state.legacy_playlist_path =
+            Some(std::path::PathBuf::from("/nonexistent/dir/playlist.yaml"));
+        state.playlists_dir = None;
         let app = router().with_state(state);
 
         let response = app
@@ -4188,7 +4611,7 @@ show "test" {
     }
 
     #[tokio::test]
-    async fn put_song_songs_dir_failure_returns_404() {
+    async fn put_song_songs_dir_failure_returns_500() {
         let (mut state, _dir) = test_state();
         state.songs_path = std::path::PathBuf::from("/nonexistent/songs");
         let app = router().with_state(state);
@@ -4204,7 +4627,7 @@ show "test" {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/src/webui/server.rs
+++ b/src/webui/server.rs
@@ -69,8 +69,10 @@ pub struct WebUiState {
     pub config_path: PathBuf,
     /// Resolved path to the songs directory.
     pub songs_path: PathBuf,
-    /// Resolved path to the playlist file.
-    pub playlist_path: PathBuf,
+    /// Resolved path to the playlists directory (if configured).
+    pub playlists_dir: Option<PathBuf>,
+    /// Resolved path to the legacy playlist file (for backward compat).
+    pub legacy_playlist_path: Option<PathBuf>,
     /// Shared waveform cache (sent to each WebSocket client on connect).
     pub waveform_cache: ws_state::WaveformCache,
     /// Active calibration session (at most one at a time).
@@ -503,8 +505,16 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
-        let player =
-            Arc::new(crate::player::Player::new_with_devices(devices, pl, songs, None).unwrap());
+        let mut playlists = std::collections::HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone()).unwrap(),
+        );
+        playlists.insert(pl.name().to_string(), pl);
+        let player = Arc::new(
+            crate::player::Player::new_with_devices(devices, playlists, "test".to_string(), None)
+                .unwrap(),
+        );
 
         let (broadcast_tx, _) = broadcast::channel(16);
         let (_state_tx, state_rx) =
@@ -516,7 +526,8 @@ mod test {
             broadcast_tx,
             config_path,
             songs_path,
-            playlist_path,
+            playlists_dir: None,
+            legacy_playlist_path: Some(playlist_path),
             waveform_cache: ws_state::new_waveform_cache(),
             calibration: Arc::new(parking_lot::Mutex::new(None)),
         };

--- a/src/webui/state.rs
+++ b/src/webui/state.rs
@@ -91,6 +91,9 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
             (String::new(), 0, vec![])
         };
 
+        let available_playlists = player.list_playlists();
+        let persisted_playlist_name = player.persisted_playlist_name();
+
         let msg = json!({
             "type": "playback",
             "is_playing": is_playing,
@@ -101,6 +104,8 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
             "playlist_position": playlist_position,
             "playlist_songs": playlist_songs,
             "tracks": tracks,
+            "available_playlists": available_playlists,
+            "persisted_playlist_name": persisted_playlist_name,
         });
 
         let _ = tx.send(msg.to_string());
@@ -783,7 +788,16 @@ mod test {
             sample_engine: None,
             trigger_engine: None,
         };
-        Arc::new(crate::player::Player::new_with_devices(devices, pl, songs, None).unwrap())
+        let mut playlists = HashMap::new();
+        playlists.insert(
+            "all_songs".to_string(),
+            playlist::from_songs(songs.clone()).unwrap(),
+        );
+        playlists.insert(pl.name().to_string(), pl);
+        Arc::new(
+            crate::player::Player::new_with_devices(devices, playlists, "test".to_string(), None)
+                .unwrap(),
+        )
     }
 
     #[test]

--- a/src/webui/svelte/src/components/cards/PlaylistCard.svelte
+++ b/src/webui/svelte/src/components/cards/PlaylistCard.svelte
@@ -24,26 +24,25 @@
     }
   }
 
-  let isPlaylistMode = $derived($playbackStore.playlist_name === "playlist");
+  let playlists = $derived($playbackStore.available_playlists);
+  let currentPlaylist = $derived($playbackStore.playlist_name);
 </script>
 
 <div class="card">
   <div class="card-header">
     <span class="card-title">Playlist</span>
-    <div class="btn-group">
-      <button
-        class="btn"
-        class:active={isPlaylistMode}
-        onclick={() => switchPlaylist("playlist")}>Playlist</button
+    {#if playlists.length > 0}
+      <select
+        class="playlist-select"
+        value={currentPlaylist}
+        onchange={(e) => switchPlaylist(e.currentTarget.value)}
       >
-      <button
-        class="btn"
-        class:active={!isPlaylistMode}
-        onclick={() => switchPlaylist("all_songs")}>All Songs</button
-      >
-    </div>
+        {#each playlists as name (name)}
+          <option value={name}>{name}</option>
+        {/each}
+      </select>
+    {/if}
   </div>
-  <div class="playlist-name">{$playbackStore.playlist_name}</div>
   <ul class="playlist-songs">
     {#each $playbackStore.playlist_songs as song, i (song)}
       <li class:current={i === $playbackStore.playlist_position}>{song}</li>
@@ -52,11 +51,14 @@
 </div>
 
 <style>
-  .playlist-name {
-    font-size: 13px;
-    font-weight: 600;
+  .playlist-select {
+    font-size: 12px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text);
-    margin-bottom: 8px;
+    cursor: pointer;
   }
   .playlist-songs {
     list-style: none;

--- a/src/webui/svelte/src/lib/api/config.ts
+++ b/src/webui/svelte/src/lib/api/config.ts
@@ -355,3 +355,59 @@ export async function deleteVenue(name: string, dir?: string): Promise<void> {
     throw new Error(data.error || `Failed to delete venue: ${res.status}`);
   }
 }
+
+// ---- Playlist CRUD ----
+
+export interface PlaylistInfo {
+  name: string;
+  song_count: number;
+  is_active: boolean;
+}
+
+export interface PlaylistData {
+  name: string;
+  songs: string[];
+  available_songs: string[];
+}
+
+export async function fetchPlaylists(): Promise<PlaylistInfo[]> {
+  const res = await get("/playlists");
+  if (!res.ok) throw new Error(`Failed to fetch playlists: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchPlaylist(name: string): Promise<PlaylistData> {
+  const res = await get(`/playlists/${encodeURIComponent(name)}`);
+  if (!res.ok) throw new Error(`Failed to fetch playlist: ${res.status}`);
+  return res.json();
+}
+
+export async function savePlaylist(
+  name: string,
+  songs: string[],
+): Promise<void> {
+  const res = await put(
+    `/playlists/${encodeURIComponent(name)}`,
+    JSON.stringify({ songs }),
+  );
+  if (!res.ok) {
+    const d = await res.json().catch(() => ({}));
+    throw new Error(d.error || `Failed to save playlist: ${res.status}`);
+  }
+}
+
+export async function deletePlaylist(name: string): Promise<void> {
+  const res = await del(`/playlists/${encodeURIComponent(name)}`);
+  if (!res.ok) {
+    const d = await res.json().catch(() => ({}));
+    throw new Error(d.error || `Failed to delete playlist: ${res.status}`);
+  }
+}
+
+export async function activatePlaylist(name: string): Promise<void> {
+  const res = await post(`/playlists/${encodeURIComponent(name)}/activate`);
+  if (!res.ok) {
+    const d = await res.json().catch(() => ({}));
+    throw new Error(d.error || `Failed to activate playlist: ${res.status}`);
+  }
+}

--- a/src/webui/svelte/src/lib/ws/stores.ts
+++ b/src/webui/svelte/src/lib/ws/stores.ts
@@ -31,6 +31,8 @@ export interface PlaybackState {
   playlist_position: number;
   playlist_songs: string[];
   tracks: TrackInfo[];
+  available_playlists: string[];
+  persisted_playlist_name: string;
 }
 
 export interface FixtureChannels {
@@ -71,6 +73,8 @@ export const playbackStore = writable<PlaybackState>({
   playlist_position: 0,
   playlist_songs: [],
   tracks: [],
+  available_playlists: [],
+  persisted_playlist_name: "",
 });
 
 export const fixtureStore = writable<Record<string, FixtureChannels>>({});
@@ -106,6 +110,8 @@ on("playback", (msg) => {
     playlist_position: m.playlist_position,
     playlist_songs: m.playlist_songs,
     tracks: m.tracks ?? [],
+    available_playlists: m.available_playlists ?? [],
+    persisted_playlist_name: m.persisted_playlist_name ?? "",
   });
 });
 

--- a/src/webui/svelte/src/pages/PlaylistEditor.svelte
+++ b/src/webui/svelte/src/pages/PlaylistEditor.svelte
@@ -12,7 +12,499 @@
      * this program. If not, see <https://www.gnu.org/licenses/>.
      *
      * -->
-<div class="page-placeholder">
-  <h2>Playlist Editor</h2>
-  <p>Coming in Phase 2.</p>
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  import {
+    fetchPlaylists,
+    fetchPlaylist,
+    savePlaylist,
+    deletePlaylist,
+    activatePlaylist,
+    type PlaylistInfo,
+    type PlaylistData,
+  } from "../lib/api/config";
+
+  let playlists = $state<PlaylistInfo[]>([]);
+  let selected = $state<string | null>(null);
+  let detail = $state<PlaylistData | null>(null);
+  let editSongs = $state<string[]>([]);
+  let loading = $state(true);
+  let error = $state("");
+  let saving = $state(false);
+  let dirty = $state(false);
+  let newName = $state("");
+  let showNewInput = $state(false);
+  let searchQuery = $state("");
+  let confirmDelete = $state<string | null>(null);
+
+  let availableSongs = $derived(
+    detail
+      ? detail.available_songs.filter(
+          (s) =>
+            !editSongs.includes(s) &&
+            s.toLowerCase().includes(searchQuery.toLowerCase()),
+        )
+      : [],
+  );
+
+  async function loadPlaylists() {
+    try {
+      loading = true;
+      error = "";
+      playlists = await fetchPlaylists();
+    } catch (e: any) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function selectPlaylist(name: string) {
+    try {
+      error = "";
+      detail = await fetchPlaylist(name);
+      selected = name;
+      editSongs = [...detail.songs];
+      dirty = false;
+      searchQuery = "";
+    } catch (e: any) {
+      error = e.message;
+    }
+  }
+
+  async function handleSave() {
+    if (!selected) return;
+    try {
+      saving = true;
+      error = "";
+      await savePlaylist(selected, editSongs);
+      dirty = false;
+      await loadPlaylists();
+      // Re-fetch to get updated available_songs
+      detail = await fetchPlaylist(selected);
+    } catch (e: any) {
+      error = e.message;
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleActivate(name: string) {
+    try {
+      error = "";
+      await activatePlaylist(name);
+      await loadPlaylists();
+    } catch (e: any) {
+      error = e.message;
+    }
+  }
+
+  async function handleDelete(name: string) {
+    try {
+      error = "";
+      await deletePlaylist(name);
+      if (selected === name) {
+        selected = null;
+        detail = null;
+        editSongs = [];
+      }
+      confirmDelete = null;
+      await loadPlaylists();
+    } catch (e: any) {
+      error = e.message;
+    }
+  }
+
+  async function handleCreate() {
+    const name = newName.trim();
+    if (!name) return;
+    try {
+      error = "";
+      await savePlaylist(name, []);
+      newName = "";
+      showNewInput = false;
+      await loadPlaylists();
+      await selectPlaylist(name);
+    } catch (e: any) {
+      error = e.message;
+    }
+  }
+
+  function addSong(song: string) {
+    editSongs = [...editSongs, song];
+    dirty = true;
+  }
+
+  function removeSong(index: number) {
+    editSongs = editSongs.filter((_, i) => i !== index);
+    dirty = true;
+  }
+
+  function moveSong(from: number, to: number) {
+    if (to < 0 || to >= editSongs.length) return;
+    const songs = [...editSongs];
+    const [item] = songs.splice(from, 1);
+    songs.splice(to, 0, item);
+    editSongs = songs;
+    dirty = true;
+  }
+
+  loadPlaylists();
+</script>
+
+<div class="playlist-editor">
+  <div class="panel list-panel">
+    <div class="panel-header">
+      <h3>Playlists</h3>
+      <button class="btn btn-sm" onclick={() => (showNewInput = !showNewInput)}>
+        {showNewInput ? "Cancel" : "New"}
+      </button>
+    </div>
+
+    {#if showNewInput}
+      <div class="new-playlist-form">
+        <input
+          type="text"
+          class="input"
+          placeholder="Playlist name"
+          bind:value={newName}
+          onkeydown={(e) => e.key === "Enter" && handleCreate()}
+        />
+        <button class="btn btn-primary btn-sm" onclick={handleCreate}
+          >Create</button
+        >
+      </div>
+    {/if}
+
+    {#if loading}
+      <p class="muted">Loading...</p>
+    {:else if playlists.length === 0}
+      <p class="muted">No playlists found.</p>
+    {:else}
+      <ul class="playlist-list">
+        {#each playlists as pl (pl.name)}
+          <li
+            class:selected={selected === pl.name}
+            class:all-songs={pl.name === "all_songs"}
+          >
+            <button
+              class="playlist-item"
+              onclick={() => pl.name !== "all_songs" && selectPlaylist(pl.name)}
+              disabled={pl.name === "all_songs"}
+            >
+              <span class="pl-name">{pl.name}</span>
+              <span class="pl-count">{pl.song_count} songs</span>
+            </button>
+            <div class="pl-actions">
+              {#if pl.is_active}
+                <span class="badge">active</span>
+              {:else if pl.name !== "all_songs"}
+                <button
+                  class="btn-icon"
+                  title="Activate"
+                  onclick={() => handleActivate(pl.name)}
+                >
+                  &#9654;
+                </button>
+              {/if}
+              {#if pl.name !== "all_songs"}
+                {#if confirmDelete === pl.name}
+                  <button
+                    class="btn-icon danger"
+                    onclick={() => handleDelete(pl.name)}
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    class="btn-icon"
+                    onclick={() => (confirmDelete = null)}
+                  >
+                    Cancel
+                  </button>
+                {:else}
+                  <button
+                    class="btn-icon"
+                    title="Delete"
+                    onclick={() => (confirmDelete = pl.name)}
+                  >
+                    &#10005;
+                  </button>
+                {/if}
+              {/if}
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+
+  <div class="panel detail-panel">
+    {#if error}
+      <div class="error-banner">{error}</div>
+    {/if}
+
+    {#if !selected}
+      <p class="muted center">
+        Select a playlist to edit, or create a new one.
+      </p>
+    {:else if detail}
+      <div class="panel-header">
+        <h3>{selected}</h3>
+        <button
+          class="btn btn-primary btn-sm"
+          onclick={handleSave}
+          disabled={!dirty || saving}
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+
+      <div class="song-columns">
+        <div class="song-col">
+          <h4>Playlist Songs ({editSongs.length})</h4>
+          {#if editSongs.length === 0}
+            <p class="muted">
+              No songs in this playlist. Add songs from the right.
+            </p>
+          {:else}
+            <ul class="song-list">
+              {#each editSongs as song, i (song + i)}
+                <li>
+                  <div class="reorder-btns">
+                    <button
+                      class="btn-icon small"
+                      disabled={i === 0}
+                      onclick={() => moveSong(i, i - 1)}>&#9650;</button
+                    >
+                    <button
+                      class="btn-icon small"
+                      disabled={i === editSongs.length - 1}
+                      onclick={() => moveSong(i, i + 1)}>&#9660;</button
+                    >
+                  </div>
+                  <span class="song-name">{song}</span>
+                  <button
+                    class="btn-icon"
+                    title="Remove"
+                    onclick={() => removeSong(i)}
+                  >
+                    &#10005;
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+
+        <div class="song-col">
+          <h4>Available Songs</h4>
+          <input
+            type="text"
+            class="input"
+            placeholder="Search songs..."
+            bind:value={searchQuery}
+          />
+          <ul class="song-list available">
+            {#each availableSongs as song (song)}
+              <li>
+                <span class="song-name">{song}</span>
+                <button
+                  class="btn-icon"
+                  title="Add"
+                  onclick={() => addSong(song)}>+</button
+                >
+              </li>
+            {/each}
+          </ul>
+        </div>
+      </div>
+    {/if}
+  </div>
 </div>
+
+<style>
+  .playlist-editor {
+    display: flex;
+    gap: 16px;
+    height: calc(100vh - 120px);
+  }
+  .panel {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    overflow-y: auto;
+  }
+  .list-panel {
+    width: 300px;
+    flex-shrink: 0;
+  }
+  .detail-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+  .panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+  .panel-header h3 {
+    margin: 0;
+    font-size: 16px;
+  }
+  .new-playlist-form {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .new-playlist-form .input {
+    flex: 1;
+  }
+  .muted {
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+  .center {
+    text-align: center;
+    margin-top: 40px;
+  }
+  .error-banner {
+    background: rgba(220, 38, 38, 0.15);
+    color: #ef4444;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+    margin-bottom: 12px;
+  }
+
+  /* Playlist list */
+  .playlist-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .playlist-list li {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 6px;
+    padding: 2px;
+  }
+  .playlist-list li.selected {
+    background: rgba(91, 91, 214, 0.12);
+  }
+  .playlist-list li.all-songs {
+    opacity: 0.6;
+  }
+  .playlist-item {
+    flex: 1;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: none;
+    border: none;
+    color: var(--text);
+    padding: 8px;
+    font-size: 13px;
+    cursor: pointer;
+    border-radius: 4px;
+    text-align: left;
+  }
+  .playlist-item:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.04);
+  }
+  .playlist-item:disabled {
+    cursor: default;
+  }
+  .pl-count {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+  .pl-actions {
+    display: flex;
+    gap: 2px;
+    align-items: center;
+  }
+  .badge {
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--accent);
+    color: white;
+  }
+  .btn-icon {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 12px;
+    padding: 4px 6px;
+    border-radius: 4px;
+  }
+  .btn-icon:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text);
+  }
+  .btn-icon.danger {
+    color: #ef4444;
+    font-size: 11px;
+  }
+  .btn-icon.small {
+    font-size: 10px;
+    padding: 1px 4px;
+    line-height: 1;
+  }
+
+  /* Song columns */
+  .song-columns {
+    display: flex;
+    gap: 16px;
+    flex: 1;
+    min-height: 0;
+  }
+  .song-col {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .song-col h4 {
+    margin: 0 0 8px 0;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .song-col .input {
+    margin-bottom: 8px;
+  }
+  .song-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+  .song-list li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 4px;
+  }
+  .song-list li:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+  .song-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .reorder-btns {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+</style>


### PR DESCRIPTION
Multiple playlists are now possible in mtrack. Additionally, playlist management is now supported in the UI. It's possible to go into the UI and create multiple playlists and switch between them as needed. MIDI and OSC will switch between the "active" playlist and the "all_songs" playlist.