### PR TITLE
Fix MIDI playback bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web UI asset tests now discover embedded filenames dynamically instead of hardcoding
   hashed filenames that change with every Svelte build.
 
+## [0.10.2] - 2026-03-14
+
+### Fixed
+
+- **Songs without MIDI freeze playback**: When a MIDI device was configured but a song had no
+  MIDI file, the MIDI subsystem returned without signaling readiness, preventing the playback
+  clock from starting. All subsystems (audio, DMX, MIDI) would spin indefinitely waiting for
+  the clock, resulting in no audio or lighting output.
+
 ## [0.10.1] - 2026-03-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -186,6 +186,15 @@ impl super::Device for Device {
         let span = span!(Level::INFO, "play song (midir)");
         let _enter = span.enter();
 
+        let midi_playback = match song.midi_playback() {
+            Some(midi_playback) => midi_playback,
+            None => {
+                info!(song = song.name(), "Song has no MIDI sheet.");
+                let _ = ready_tx.send(());
+                return Ok(());
+            }
+        };
+
         let output_port = match self.output_port.as_ref() {
             Some(output_port) => output_port,
             None => {
@@ -194,14 +203,6 @@ impl super::Device for Device {
                     "No MIDI output device configured, cannot play song."
                 );
                 let _ = ready_tx.send(());
-                return Ok(());
-            }
-        };
-
-        let midi_playback = match song.midi_playback() {
-            Some(midi_playback) => midi_playback,
-            None => {
-                info!(song = song.name(), "Song has no MIDI sheet.");
                 return Ok(());
             }
         };
@@ -1438,7 +1439,7 @@ mod test {
             let cancel = CancelHandle::new();
             let (ready_tx, _ready_rx) = std::sync::mpsc::channel::<()>();
             let clock = PlaybackClock::wall();
-            // Even with no output port, the no-output-port check happens first
+            // The no-MIDI-sheet check happens before the output-port check
             let result = <Device as crate::midi::Device>::play_from(
                 &device,
                 song,
@@ -1448,6 +1449,34 @@ mod test {
                 clock,
             );
             assert!(result.is_ok());
+        }
+
+        #[test]
+        fn play_from_without_midi_playback_sends_ready() {
+            // When a MIDI device exists but the song has no MIDI sheet,
+            // play_from must still send the ready signal so the playback
+            // clock starts. Without this, all subsystems (audio, DMX)
+            // spin forever waiting for the clock.
+            let device = Device::new_default("test".to_string());
+            let (_tmp_dir, song) = make_song();
+            assert!(song.midi_playback().is_none());
+
+            let cancel = CancelHandle::new();
+            let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+            let clock = PlaybackClock::wall();
+            let result = <Device as crate::midi::Device>::play_from(
+                &device,
+                song,
+                cancel,
+                ready_tx,
+                Duration::ZERO,
+                clock,
+            );
+            assert!(result.is_ok());
+            assert!(
+                ready_rx.try_recv().is_ok(),
+                "play_from must send ready signal even when the song has no MIDI playback"
+            );
         }
     }
 


### PR DESCRIPTION
During MIDI playback, it looks like if a song doesn't have a MIDI file and also has a MIDI hardware device configured, playback will freeze. This has been fixed.