### PR TITLE
Add bulk song import, delete to UI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This enables the timeline editor to play any song from any position in a single call.
 - **`Playlist::navigate_to(name)`**: New method sets the playlist position to the song
   matching the given name, returning the song if found.
+- **Bulk song import**: New `POST /api/browse/bulk-import` endpoint scans all
+  subdirectories of a given path and creates `song.yaml` in each one that doesn't
+  already have one. Audio, MIDI, and lighting files are auto-detected per directory.
+  The song browser's import UI now shows an "Import All Subdirectories" button when
+  viewing a directory that contains subdirectories, with a results summary showing
+  created, skipped, and failed imports.
 
 ### Changed
 

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -102,7 +102,7 @@ impl Default for Player {
             playlist: None,
             playlists_dir: None,
             active_playlist: default_active_playlist(),
-            songs: "songs".to_string(),
+            songs: ".".to_string(),
             samples: HashMap::new(),
             samples_file: None,
             sample_triggers: Vec::new(),

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -50,7 +50,8 @@ pub fn router() -> Router<WebUiState> {
             "/songs/{name}",
             get(songs_api::get_song)
                 .post(songs_api::post_song)
-                .put(songs_api::put_song),
+                .put(songs_api::put_song)
+                .delete(songs_api::delete_song),
         )
         .route(
             "/songs/{name}/tracks/{filename}",
@@ -68,6 +69,7 @@ pub fn router() -> Router<WebUiState> {
             "/browse/create-song",
             post(browse::create_song_in_directory),
         )
+        .route("/browse/bulk-import", post(browse::bulk_import))
         .route(
             "/playlist",
             get(playlists::get_playlist).put(playlists::put_playlist),

--- a/src/webui/api/browse.rs
+++ b/src/webui/api/browse.rs
@@ -317,6 +317,163 @@ pub(super) struct CreateSongInDirRequest {
     name: Option<String>,
 }
 
+/// POST /api/browse/bulk-import — scans subdirectories of a parent directory and creates
+/// song.yaml in each one that contains audio files. Skips subdirectories that already
+/// have song.yaml. Returns a summary of created, skipped, and failed directories.
+pub(super) async fn bulk_import(
+    State(state): State<WebUiState>,
+    Json(body): Json<BulkImportRequest>,
+) -> impl IntoResponse {
+    let config_canonical = match state.config_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve config path: {}", e)})),
+            )
+                .into_response();
+        }
+    };
+    let root_canonical = match config_canonical.parent() {
+        Some(p) => p.to_path_buf(),
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "Unable to determine config root directory"})),
+            )
+                .into_response();
+        }
+    };
+
+    let relative = body.path.strip_prefix('/').unwrap_or(&body.path);
+    let target_dir = if relative.is_empty() {
+        root_canonical.clone()
+    } else {
+        root_canonical.join(relative)
+    };
+
+    let dir_canonical = match target_dir.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Directory not found: {}", body.path)})),
+            )
+                .into_response();
+        }
+    };
+
+    if !dir_canonical.starts_with(&root_canonical) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "Access denied: path is outside the project directory"})),
+        )
+            .into_response();
+    }
+
+    if !dir_canonical.is_dir() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Path is not a directory"})),
+        )
+            .into_response();
+    }
+
+    let mut created: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+    let mut failed: Vec<serde_json::Value> = Vec::new();
+
+    // codeql[rust/path-injection] dir_canonical is canonicalized and verified
+    // via starts_with(root_canonical) above, preventing path traversal.
+    let read_dir = match std::fs::read_dir(&dir_canonical) {
+        Ok(rd) => rd,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to read directory: {}", e)})),
+            )
+                .into_response();
+        }
+    };
+
+    let mut subdirs: Vec<std::path::PathBuf> = read_dir
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.is_dir()
+                && !path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_none_or(|n| n.starts_with('.'))
+            {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    subdirs.sort();
+
+    for subdir in &subdirs {
+        let dir_name = subdir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Skip if song.yaml already exists
+        if subdir.join("song.yaml").exists() {
+            skipped.push(dir_name);
+            continue;
+        }
+
+        // Try to initialize a song from this directory
+        match songs::Song::initialize(subdir) {
+            Ok(song) => {
+                let mut config = song.get_config();
+                // Use directory name as song name
+                config.set_name(&dir_name);
+                let config_path = subdir.join("song.yaml");
+                match config.save(&config_path) {
+                    Ok(()) => created.push(dir_name),
+                    Err(e) => failed.push(json!({
+                        "name": dir_name,
+                        "error": format!("Failed to save: {}", e),
+                    })),
+                }
+            }
+            Err(_) => {
+                // No audio files or failed to scan — skip silently
+                skipped.push(dir_name);
+            }
+        }
+    }
+
+    // Refresh the player's song state once after all imports
+    if !created.is_empty() {
+        state.player.reload_songs(
+            &state.songs_path,
+            state.playlists_dir.as_deref(),
+            state.legacy_playlist_path.as_deref(),
+        );
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "created": created,
+            "skipped": skipped,
+            "failed": failed,
+        })),
+    )
+        .into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct BulkImportRequest {
+    path: String,
+}
+
 #[cfg(test)]
 mod test {
     use super::super::router;
@@ -576,5 +733,132 @@ mod test {
         // Within groups, sorted alphabetically
         assert_eq!(entries[0]["name"], "aaa_dir");
         assert_eq!(entries[1]["name"], "zzz_dir");
+    }
+
+    #[tokio::test]
+    async fn bulk_import_creates_songs() {
+        let (state, _dir) = test_state();
+        let parent = _dir.path().join("songs");
+        std::fs::create_dir_all(&parent).unwrap();
+
+        // Two subdirectories with audio, one without, one already has song.yaml
+        let song_a = parent.join("Alpha");
+        std::fs::create_dir_all(&song_a).unwrap();
+        std::fs::write(song_a.join("track.wav"), create_test_wav()).unwrap();
+
+        let song_b = parent.join("Beta");
+        std::fs::create_dir_all(&song_b).unwrap();
+        std::fs::write(song_b.join("track.wav"), create_test_wav()).unwrap();
+
+        let song_c = parent.join("Gamma");
+        std::fs::create_dir_all(&song_c).unwrap();
+        // No audio files — still gets a song.yaml (empty tracks)
+
+        let song_d = parent.join("Delta");
+        std::fs::create_dir_all(&song_d).unwrap();
+        std::fs::write(song_d.join("track.wav"), create_test_wav()).unwrap();
+        std::fs::write(song_d.join("song.yaml"), "name: Delta\ntracks: []\n").unwrap();
+        // Already has song.yaml — should be skipped
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .method("POST")
+                    .uri("/browse/bulk-import")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"path": "/songs"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        let created: Vec<&str> = parsed["created"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        let skipped: Vec<&str> = parsed["skipped"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+
+        assert!(
+            created.contains(&"Alpha"),
+            "Alpha should be created: {:?}",
+            created
+        );
+        assert!(
+            created.contains(&"Beta"),
+            "Beta should be created: {:?}",
+            created
+        );
+        assert!(
+            created.contains(&"Gamma"),
+            "Gamma should be created (empty): {:?}",
+            created
+        );
+        assert!(
+            skipped.contains(&"Delta"),
+            "Delta should be skipped (existing): {:?}",
+            skipped
+        );
+
+        // Verify song.yaml was actually created
+        assert!(song_a.join("song.yaml").exists());
+        assert!(song_b.join("song.yaml").exists());
+        assert!(song_c.join("song.yaml").exists());
+    }
+
+    #[tokio::test]
+    async fn bulk_import_nonexistent_path() {
+        let (state, _dir) = test_state();
+        let app = router().with_state(state);
+
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .method("POST")
+                    .uri("/browse/bulk-import")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"path": "/nonexistent"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn bulk_import_empty_directory() {
+        let (state, _dir) = test_state();
+        let parent = _dir.path().join("empty_parent");
+        std::fs::create_dir_all(&parent).unwrap();
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .method("POST")
+                    .uri("/browse/bulk-import")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"path": "/empty_parent"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(parsed["created"].as_array().unwrap().is_empty());
     }
 }

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -260,6 +260,81 @@ pub(super) struct ImportFileRequest {
     filename: Option<String>,
 }
 
+/// DELETE /api/songs/:name — removes a song by deleting its song.yaml.
+///
+/// The song's audio, MIDI, and lighting files are left in place. Only the
+/// song.yaml config file is removed, which unregisters the song from the player.
+pub(super) async fn delete_song(
+    State(state): State<WebUiState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Look up the song in the player's registry to find its base path.
+    let all_songs = state.player.get_all_songs_playlist();
+    let song = match all_songs.get_song(&name) {
+        Some(song) => song,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Song '{}' not found", name)})),
+            )
+                .into_response();
+        }
+    };
+
+    let config_path = song.base_path().join("song.yaml");
+
+    // Verify the resolved path is under the songs directory to prevent path traversal.
+    let songs_canonical = match state.songs_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
+            )
+                .into_response();
+        }
+    };
+    let config_canonical = match config_path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "song.yaml not found for this song"})),
+            )
+                .into_response();
+        }
+    };
+    if !config_canonical.starts_with(&songs_canonical) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "song path is outside the songs directory"})),
+        )
+            .into_response();
+    }
+
+    // codeql[rust/path-injection] Path verified via canonicalize + starts_with above.
+    if let Err(e) = std::fs::remove_file(&config_canonical) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to delete song.yaml: {}", e)})),
+        )
+            .into_response();
+    }
+
+    // Refresh the player's song state.
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
+
+    (
+        StatusCode::OK,
+        Json(json!({"status": "deleted", "name": name})),
+    )
+        .into_response()
+}
+
 /// GET /api/songs/:name/waveform — returns waveform peaks for a song.
 ///
 /// Uses the shared waveform cache; computes on demand if not cached.
@@ -438,7 +513,9 @@ pub(super) async fn post_song(
             .into_response();
     }
 
-    // Validate the YAML can be deserialized as a song config
+    // Validate the YAML can be deserialized as a song config.
+    // codeql[rust/path-injection] tmp.path() is an OS-generated tempfile path, not from user input.
+    // The user-controlled `body` is written as file *content*, not used as a path.
     let tmp = match tempfile::Builder::new().suffix(".yaml").tempfile() {
         Ok(t) => t,
         Err(e) => {
@@ -464,7 +541,16 @@ pub(super) async fn post_song(
             .into_response();
     }
 
-    match config_io::atomic_write(&config_path, &body) {
+    // Re-verify the song directory is under the songs root (breaks CodeQL taint chain).
+    let dir_verified = match verify_under_songs_dir(&song_dir, &state.songs_path) {
+        Ok(p) => p,
+        Err(e) => return *e,
+    };
+    // codeql[rust/path-injection] dir_verified is canonicalized and containment-checked;
+    // "song.yaml" is a constant suffix.
+    let config_verified = dir_verified.join("song.yaml");
+
+    match config_io::atomic_write(&config_verified, &body) {
         Ok(()) => {
             state.player.reload_songs(
                 &state.songs_path,
@@ -502,7 +588,7 @@ pub(super) async fn put_song(
             .into_response();
     }
 
-    // Canonicalize songs_path and verify the song directory stays within it.
+    // Verify the songs root is valid first (500 if not).
     let songs_canonical = match state.songs_path.canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -513,28 +599,14 @@ pub(super) async fn put_song(
                 .into_response();
         }
     };
-    let song_dir = songs_canonical.join(&name);
-    if !song_dir.is_dir() {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": format!("Song not found: {}", name)})),
-        )
-            .into_response();
-    }
-    // codeql[rust/path-injection] Path verified via canonicalize + starts_with.
-    let song_dir = match song_dir.canonicalize() {
-        Ok(p) if p.starts_with(&songs_canonical) => p,
-        Ok(_) => {
+
+    // Canonicalize and verify containment before any filesystem access.
+    let song_dir = match verify_under_songs_dir(&songs_canonical.join(&name), &state.songs_path) {
+        Ok(p) if p.is_dir() => p,
+        _ => {
             return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid song name"})),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve song path: {}", e)})),
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Song not found: {}", name)})),
             )
                 .into_response();
         }
@@ -760,6 +832,44 @@ pub(super) fn ensure_song_dir(
     }
 
     Ok(song_canonical)
+}
+
+/// Canonicalizes a path and verifies it is contained within the songs directory.
+/// Returns the canonical path on success, or an error response on failure.
+/// This breaks the CodeQL taint chain by producing a fresh canonical path
+/// verified against the songs root.
+fn verify_under_songs_dir(
+    path: &std::path::Path,
+    songs_path: &std::path::Path,
+) -> Result<std::path::PathBuf, Box<axum::response::Response>> {
+    let songs_canonical = songs_path.canonicalize().map_err(|e| {
+        Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
+            )
+                .into_response(),
+        )
+    })?;
+    let canonical = path.canonicalize().map_err(|e| {
+        Box::new(
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Path not found: {}", e)})),
+            )
+                .into_response(),
+        )
+    })?;
+    if !canonical.starts_with(&songs_canonical) {
+        return Err(Box::new(
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({"error": "Path is outside the songs directory"})),
+            )
+                .into_response(),
+        ));
+    }
+    Ok(canonical)
 }
 
 /// Generates song.yaml for a song directory if one doesn't already exist.

--- a/src/webui/svelte/src/components/songs/ImportSongs.svelte
+++ b/src/webui/svelte/src/components/songs/ImportSongs.svelte
@@ -16,7 +16,9 @@
   import {
     browseDirectory,
     createSongInDirectory,
+    bulkImportSongs,
     type BrowseEntry,
+    type BulkImportResult,
   } from "../../lib/api/songs";
 
   interface Props {
@@ -26,7 +28,7 @@
 
   let { onimported, oncancel }: Props = $props();
 
-  type Step = "browse" | "confirm";
+  type Step = "browse" | "confirm" | "bulk-result";
   let step = $state<Step>("browse");
 
   // Browse state
@@ -41,6 +43,11 @@
   let songName = $state("");
   let createError = $state("");
   let creating = $state(false);
+
+  // Bulk import state
+  let bulkImporting = $state(false);
+  let bulkResult = $state<BulkImportResult | null>(null);
+  let bulkError = $state("");
 
   async function navigate(path?: string) {
     loading = true;
@@ -129,6 +136,22 @@
       createError = e instanceof Error ? e.message : "Failed to create song";
     } finally {
       creating = false;
+    }
+  }
+
+  let canBulkImport = $derived(dirEntries.length > 0);
+
+  async function handleBulkImport() {
+    bulkImporting = true;
+    bulkError = "";
+    bulkResult = null;
+    try {
+      bulkResult = await bulkImportSongs(currentPath);
+      step = "bulk-result";
+    } catch (e) {
+      bulkError = e instanceof Error ? e.message : "Bulk import failed";
+    } finally {
+      bulkImporting = false;
     }
   }
 
@@ -231,6 +254,17 @@
         </div>
         <div class="footer-actions">
           <button class="btn" onclick={oncancel}>Cancel</button>
+          {#if canBulkImport}
+            <button
+              class="btn"
+              onclick={handleBulkImport}
+              disabled={bulkImporting}
+            >
+              {bulkImporting
+                ? "Importing..."
+                : `Import All Subdirectories (${dirEntries.length})`}
+            </button>
+          {/if}
           <button
             class="btn btn-primary"
             onclick={selectDirectory}
@@ -239,6 +273,9 @@
             Use This Directory
           </button>
         </div>
+        {#if bulkError}
+          <div class="error-msg" style="margin-top: 6px">{bulkError}</div>
+        {/if}
       </div>
     </div>
   </div>
@@ -273,6 +310,64 @@
       >
         {creating ? "Creating..." : "Create Song"}
       </button>
+    </div>
+  </div>
+{:else if step === "bulk-result" && bulkResult}
+  <div class="import-section">
+    <div class="import-header">
+      <h3>Bulk Import Complete</h3>
+    </div>
+    <div class="bulk-result">
+      {#if bulkResult.created.length > 0}
+        <div class="result-group">
+          <span class="result-label created"
+            >Created ({bulkResult.created.length})</span
+          >
+          <div class="result-list">
+            {#each bulkResult.created as name (name)}
+              <span class="result-item">{name}</span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+      {#if bulkResult.skipped.length > 0}
+        <div class="result-group">
+          <span class="result-label skipped"
+            >Skipped ({bulkResult.skipped.length})</span
+          >
+          <div class="result-list">
+            {#each bulkResult.skipped as name (name)}
+              <span class="result-item dimmed">{name}</span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+      {#if bulkResult.failed.length > 0}
+        <div class="result-group">
+          <span class="result-label failed"
+            >Failed ({bulkResult.failed.length})</span
+          >
+          <div class="result-list">
+            {#each bulkResult.failed as item (item.name)}
+              <span class="result-item error">{item.name}: {item.error}</span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+      {#if bulkResult.created.length === 0 && bulkResult.failed.length === 0}
+        <p class="hint">
+          No new songs were found to import. All subdirectories either already
+          have a song.yaml or contain no audio files.
+        </p>
+      {/if}
+    </div>
+    <div class="configure-actions">
+      <button class="btn" onclick={() => (step = "browse")}>Back</button>
+      {#if bulkResult.created.length > 0}
+        <button class="btn btn-primary" onclick={onimported}>Done</button>
+      {:else}
+        <button class="btn" onclick={oncancel}>Close</button>
+      {/if}
     </div>
   </div>
 {/if}
@@ -454,5 +549,57 @@
     display: flex;
     gap: 8px;
     justify-content: flex-end;
+  }
+  .bulk-result {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-card);
+    padding: 12px 16px;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .result-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .result-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .result-label.created {
+    color: var(--green);
+  }
+  .result-label.skipped {
+    color: var(--text-muted);
+  }
+  .result-label.failed {
+    color: var(--red);
+  }
+  .result-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .result-item {
+    font-size: 13px;
+    font-family: var(--mono);
+    background: rgba(255, 255, 255, 0.04);
+    padding: 2px 8px;
+    border-radius: 3px;
+    border: 1px solid var(--border);
+  }
+  .result-item.dimmed {
+    opacity: 0.5;
+  }
+  .result-item.error {
+    color: var(--red);
+    border-color: rgba(239, 68, 68, 0.3);
   }
 </style>

--- a/src/webui/svelte/src/components/songs/SongList.svelte
+++ b/src/webui/svelte/src/components/songs/SongList.svelte
@@ -16,6 +16,7 @@
   import {
     fetchSongs,
     fetchWaveform,
+    deleteSong,
     type SongSummary,
     type WaveformData,
   } from "../../lib/api/songs";
@@ -135,6 +136,27 @@
     showImport = false;
     load();
   }
+
+  async function handleDelete(e: MouseEvent, name: string) {
+    e.stopPropagation();
+    if (
+      !confirm(
+        `Remove "${name}" from the song registry?\n\nThis only deletes song.yaml — audio and other files are kept.`,
+      )
+    )
+      return;
+    try {
+      const res = await deleteSong(name);
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        alert(data?.error ?? `Delete failed (${res.status})`);
+        return;
+      }
+      load();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Delete failed");
+    }
+  }
 </script>
 
 {#if showImport}
@@ -239,6 +261,14 @@
                     : ""}</span
                 >
               </div>
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <span
+                class="song-delete"
+                role="button"
+                tabindex="-1"
+                title="Remove from registry"
+                onclick={(e) => handleDelete(e, song.name)}>&#10005;</span
+              >
             </button>
           {/each}
         {/if}
@@ -348,9 +378,25 @@
     font-size: 12px;
     color: var(--text-dim);
   }
+  .song-delete {
+    opacity: 0;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 13px;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: opacity 0.15s;
+  }
+  .song-row:hover .song-delete {
+    opacity: 1;
+  }
+  .song-delete:hover {
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--red);
+  }
   .song-row {
     display: grid;
-    grid-template-columns: 1fr minmax(80px, 160px) auto;
+    grid-template-columns: 1fr minmax(80px, 160px) auto auto;
     align-items: center;
     gap: 12px;
     padding: 8px 14px;
@@ -425,7 +471,7 @@
       gap: 4px;
     }
     .song-row {
-      grid-template-columns: 1fr auto;
+      grid-template-columns: 1fr auto auto;
     }
     .song-waveform {
       display: none;

--- a/src/webui/svelte/src/lib/api/songs.ts
+++ b/src/webui/svelte/src/lib/api/songs.ts
@@ -97,6 +97,10 @@ export async function importFileToSong(
   );
 }
 
+export async function deleteSong(name: string): Promise<Response> {
+  return fetch(`/api/songs/${encodeURIComponent(name)}`, { method: "DELETE" });
+}
+
 export async function fetchWaveform(name: string): Promise<WaveformData> {
   const res = await get(`/songs/${encodeURIComponent(name)}/waveform`);
   if (!res.ok) throw new Error(`Failed to fetch waveform: ${res.status}`);
@@ -143,4 +147,24 @@ export async function createSongInDirectory(
   name?: string,
 ): Promise<Response> {
   return post("/browse/create-song", JSON.stringify({ path: dirPath, name }));
+}
+
+export interface BulkImportResult {
+  created: string[];
+  skipped: string[];
+  failed: { name: string; error: string }[];
+}
+
+export async function bulkImportSongs(
+  dirPath: string,
+): Promise<BulkImportResult> {
+  const res = await post(
+    "/browse/bulk-import",
+    JSON.stringify({ path: dirPath }),
+  );
+  if (!res.ok) {
+    const data = await res.json().catch(() => null);
+    throw new Error(data?.error ?? `Bulk import failed: ${res.status}`);
+  }
+  return res.json();
 }


### PR DESCRIPTION
Bulk song imports and song deletions are now added to the UI. Bulk song imports make a number of assumptions about the data found and require audio to be on the local file system. The expectation is that a bulk import will make sane assumptions and then it's up to the user to customize songs.