### PR TITLE
Use safe path.

### DIFF
--- a/src/webui.rs
+++ b/src/webui.rs
@@ -14,5 +14,6 @@
 
 pub mod api;
 pub mod config_io;
+pub mod safe_path;
 pub mod server;
 pub mod state;

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -174,7 +174,8 @@ pub fn router() -> Router<WebUiState> {
 
 /// Validates that a filename has a supported audio extension (for sample uploads).
 fn validate_sample_filename(filename: &str) -> Result<(), Box<axum::response::Response>> {
-    if filename.contains("..") || filename.contains('/') || filename.contains('\\') {
+    use super::safe_path::SafePath;
+    if SafePath::validate_name(filename).is_err() {
         return Err(Box::new(
             (
                 StatusCode::BAD_REQUEST,

--- a/src/webui/api/browse.rs
+++ b/src/webui/api/browse.rs
@@ -20,8 +20,52 @@ use axum::{
 };
 use serde_json::json;
 
+use super::super::safe_path::{SafePath, VerifiedRoot};
 use super::super::server::WebUiState;
 use crate::songs;
+
+/// Resolves the project root (parent of config_path) as a VerifiedRoot.
+fn project_root(state: &WebUiState) -> Result<VerifiedRoot, Box<axum::response::Response>> {
+    let config_canonical = state.config_path.canonicalize().map_err(|e| {
+        Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Failed to resolve config path: {}", e)})),
+            )
+                .into_response(),
+        )
+    })?;
+    let parent = config_canonical.parent().ok_or_else(|| {
+        Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "Unable to determine config root directory"})),
+            )
+                .into_response(),
+        )
+    })?;
+    VerifiedRoot::new(parent).map_err(|e| Box::new(e.into_response()))
+}
+
+/// Resolves a project-relative path (e.g. "/songs") under the project root.
+fn resolve_browse_path(
+    root: &VerifiedRoot,
+    path: &str,
+) -> Result<SafePath, Box<axum::response::Response>> {
+    if path.is_empty() || path == "/" {
+        return Ok(root.as_safe_path());
+    }
+    let relative = path.strip_prefix('/').unwrap_or(path);
+    SafePath::resolve(&root.as_path().join(relative), root).map_err(|_| {
+        Box::new(
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Not a directory: {}", path)})),
+            )
+                .into_response(),
+        )
+    })
+}
 
 /// GET /api/browse?path=... — lists files and directories at a filesystem path.
 ///
@@ -32,70 +76,24 @@ pub(super) async fn browse_directory(
     State(state): State<WebUiState>,
     Query(params): Query<BrowseParams>,
 ) -> impl IntoResponse {
-    // The browsable root is the directory containing mtrack.yaml.
-    // Canonicalize config_path first to handle relative paths (e.g., "mtrack.yaml").
-    let config_canonical = match state.config_path.canonicalize() {
+    let root = match project_root(&state) {
+        Ok(r) => r,
+        Err(e) => return *e,
+    };
+    let dir_safe = match resolve_browse_path(&root, &params.path) {
         Ok(p) => p,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve config path: {}", e)})),
-            )
-                .into_response();
-        }
+        Err(e) => return *e,
     };
-
-    let root_canonical = match config_canonical.parent() {
-        Some(p) => p.to_path_buf(),
-        None => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "Unable to determine config root directory"})),
-            )
-                .into_response();
-        }
-    };
-
-    // Resolve the requested path. Paths from the frontend are project-relative
-    // (e.g., "/" = project root, "/songs" = songs subdirectory).
-    let requested = if params.path.is_empty() || params.path == "/" {
-        root_canonical.clone()
-    } else {
-        // Strip leading "/" and join with root to get absolute path.
-        let relative = params.path.strip_prefix('/').unwrap_or(&params.path);
-        root_canonical.join(relative)
-    };
-
-    // Canonicalize the requested path and verify it's under the root before
-    // touching the filesystem, preventing path traversal attacks.
-    let dir_canonical = match requested.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Not a directory: {}", params.path)})),
-            )
-                .into_response();
-        }
-    };
-
-    if !dir_canonical.starts_with(&root_canonical) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(json!({
-                "error": "Access denied: path is outside the project directory",
-            })),
-        )
-            .into_response();
-    }
-
-    if !dir_canonical.is_dir() {
+    if !dir_safe.is_dir() {
         return (
             StatusCode::NOT_FOUND,
             Json(json!({"error": format!("Not a directory: {}", params.path)})),
         )
             .into_response();
     }
+
+    let root_canonical = root.as_path().to_path_buf();
+    let dir_canonical = dir_safe.as_path().to_path_buf();
 
     // Convert an absolute path to a project-relative path (e.g., "/songs/foo").
     let to_relative = |abs: &std::path::Path| -> String {
@@ -202,62 +200,22 @@ pub(super) async fn create_song_in_directory(
     State(state): State<WebUiState>,
     Json(body): Json<CreateSongInDirRequest>,
 ) -> impl IntoResponse {
-    // Resolve the project root (same logic as browse_directory).
-    let config_canonical = match state.config_path.canonicalize() {
+    let root = match project_root(&state) {
+        Ok(r) => r,
+        Err(e) => return *e,
+    };
+    let dir_safe = match resolve_browse_path(&root, &body.path) {
         Ok(p) => p,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve config path: {}", e)})),
-            )
-                .into_response();
-        }
+        Err(e) => return *e,
     };
-    let root_canonical = match config_canonical.parent() {
-        Some(p) => p.to_path_buf(),
-        None => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "Unable to determine config root directory"})),
-            )
-                .into_response();
-        }
-    };
-
-    // Resolve the target directory from the project-relative path.
-    let relative = body.path.strip_prefix('/').unwrap_or(&body.path);
-    let target_dir = if relative.is_empty() {
-        root_canonical.clone()
-    } else {
-        root_canonical.join(relative)
-    };
-
-    let dir_canonical = match target_dir.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Directory not found: {}", body.path)})),
-            )
-                .into_response();
-        }
-    };
-
-    if !dir_canonical.starts_with(&root_canonical) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(json!({"error": "Access denied: path is outside the project directory"})),
-        )
-            .into_response();
-    }
-
-    if !dir_canonical.is_dir() {
+    if !dir_safe.is_dir() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Path is not a directory"})),
         )
             .into_response();
     }
+    let dir_canonical = dir_safe.as_path().to_path_buf();
 
     let config_path = dir_canonical.join("song.yaml");
     if config_path.exists() {
@@ -324,60 +282,22 @@ pub(super) async fn bulk_import(
     State(state): State<WebUiState>,
     Json(body): Json<BulkImportRequest>,
 ) -> impl IntoResponse {
-    let config_canonical = match state.config_path.canonicalize() {
+    let root = match project_root(&state) {
+        Ok(r) => r,
+        Err(e) => return *e,
+    };
+    let dir_safe = match resolve_browse_path(&root, &body.path) {
         Ok(p) => p,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve config path: {}", e)})),
-            )
-                .into_response();
-        }
+        Err(e) => return *e,
     };
-    let root_canonical = match config_canonical.parent() {
-        Some(p) => p.to_path_buf(),
-        None => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "Unable to determine config root directory"})),
-            )
-                .into_response();
-        }
-    };
-
-    let relative = body.path.strip_prefix('/').unwrap_or(&body.path);
-    let target_dir = if relative.is_empty() {
-        root_canonical.clone()
-    } else {
-        root_canonical.join(relative)
-    };
-
-    let dir_canonical = match target_dir.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Directory not found: {}", body.path)})),
-            )
-                .into_response();
-        }
-    };
-
-    if !dir_canonical.starts_with(&root_canonical) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(json!({"error": "Access denied: path is outside the project directory"})),
-        )
-            .into_response();
-    }
-
-    if !dir_canonical.is_dir() {
+    if !dir_safe.is_dir() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Path is not a directory"})),
         )
             .into_response();
     }
+    let dir_canonical = dir_safe.as_path().to_path_buf();
 
     let mut created: Vec<String> = Vec::new();
     let mut skipped: Vec<String> = Vec::new();

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -88,38 +88,14 @@ pub(super) async fn get_lighting_file(
     State(state): State<WebUiState>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // Prevent path traversal
-    if name.contains("..") {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid path"})),
-        )
-            .into_response();
-    }
+    use super::super::safe_path::{SafePath, VerifiedRoot};
 
-    let file_path = state.songs_path.join(&name);
-
-    // Ensure the resolved path is still under songs_path
-    match file_path.canonicalize() {
-        Ok(canonical) => {
-            let base = match state.songs_path.canonicalize() {
-                Ok(b) => b,
-                Err(e) => {
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": format!("Failed to resolve base path: {}", e)})),
-                    )
-                        .into_response();
-                }
-            };
-            if !canonical.starts_with(&base) {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": "Path outside allowed directory"})),
-                )
-                    .into_response();
-            }
-        }
+    let root = match VerifiedRoot::new(&state.songs_path) {
+        Ok(r) => r,
+        Err(e) => return e.into_response(),
+    };
+    let safe = match SafePath::resolve(&state.songs_path.join(&name), &root) {
+        Ok(p) => p,
         Err(_) => {
             return (
                 StatusCode::NOT_FOUND,
@@ -127,10 +103,9 @@ pub(super) async fn get_lighting_file(
             )
                 .into_response();
         }
-    }
+    };
 
-    // codeql[rust/path-injection] file_path is validated via canonicalize + starts_with above.
-    match std::fs::read_to_string(&file_path) {
+    match std::fs::read_to_string(safe.as_path()) {
         Ok(content) => (
             StatusCode::OK,
             [("content-type", "text/plain; charset=utf-8")],
@@ -151,38 +126,39 @@ pub(super) async fn put_lighting_file(
     Path(name): Path<String>,
     body: String,
 ) -> impl IntoResponse {
-    if name.contains("..") {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid path"})),
-        )
-            .into_response();
-    }
+    use super::super::safe_path::{SafePath, SafePathError, VerifiedRoot};
 
-    let file_path = state.songs_path.join(&name);
+    let root = match VerifiedRoot::new(&state.songs_path) {
+        Ok(r) => r,
+        Err(e) => return e.into_response(),
+    };
 
-    // Validate path is within songs directory
-    // For new files the parent must exist and be within the base
-    let parent = match file_path.parent() {
-        Some(p) => p,
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid file path"})),
-            )
-                .into_response();
+    // Resolve the file path under the songs root. For existing files, SafePath::resolve
+    // canonicalizes and verifies containment. For new files, resolve the parent directory
+    // and join the filename to it.
+    let candidate = root.as_path().join(&name);
+    let verified_path = match SafePath::resolve(&candidate, &root) {
+        Ok(p) => p.as_path().to_path_buf(),
+        Err(_) => {
+            // File doesn't exist — resolve the parent and join the filename.
+            let (parent, filename) = match (candidate.parent(), candidate.file_name()) {
+                (Some(p), Some(f)) => (p, f),
+                _ => return SafePathError::InvalidName.into_response(),
+            };
+            let safe_parent = match SafePath::resolve(parent, &root) {
+                Ok(p) => p,
+                Err(e) => return e.into_response(),
+            };
+            safe_parent.as_path().join(filename)
         }
     };
-    if let Err(e) = config_io::validate_path_within(&state.songs_path, parent) {
-        return (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response();
-    }
 
     // Validate the DSL content
     if let Err(errors) = config_io::validate_light_show(&body) {
         return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
     }
 
-    match config_io::atomic_write(&file_path, &body) {
+    match config_io::atomic_write(&verified_path, &body) {
         Ok(()) => (StatusCode::OK, Json(json!({"status": "saved"}))).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response(),
     }
@@ -220,77 +196,19 @@ fn resolve_lighting_dir(
     override_dir: Option<&str>,
     default: &str,
 ) -> Result<std::path::PathBuf, axum::response::Response> {
+    use super::super::safe_path::{SafePath, VerifiedRoot};
+
     let project_root = config_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
-    // Canonicalize the project root so all derived paths are anchored to a
-    // verified absolute base, preventing path traversal via the dir override.
-    let root_canonical = project_root.canonicalize().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to resolve project root: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let root = VerifiedRoot::new(project_root).map_err(|e| e.into_response())?;
+
     let relative = match override_dir {
         Some(d) if !d.is_empty() => d,
         _ => default,
     };
-    // Reject absolute overrides — directories must be relative to the project root.
-    if std::path::Path::new(relative).is_absolute() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Directory must be a relative path"})),
-        )
-            .into_response());
-    }
-    let resolved = root_canonical.join(relative);
-    // If the directory already exists, canonicalize and verify containment.
-    if resolved.exists() {
-        let canonical = resolved.canonicalize().map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve directory: {}", e)})),
-            )
-                .into_response()
-        })?;
-        if !canonical.starts_with(&root_canonical) {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Directory must be within the project root"})),
-            )
-                .into_response());
-        }
-        Ok(canonical)
-    } else {
-        // Directory doesn't exist yet — verify no ".." components escape the root
-        // by checking lexically. The directory will be created later if needed.
-        let mut normalized = root_canonical.clone();
-        for component in std::path::Path::new(relative).components() {
-            match component {
-                std::path::Component::Normal(c) => normalized.push(c),
-                std::path::Component::ParentDir => {
-                    normalized.pop();
-                    if !normalized.starts_with(&root_canonical) {
-                        return Err((
-                            StatusCode::BAD_REQUEST,
-                            Json(json!({"error": "Directory must be within the project root"})),
-                        )
-                            .into_response());
-                    }
-                }
-                std::path::Component::CurDir => {}
-                _ => {
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        Json(json!({"error": "Invalid directory path"})),
-                    )
-                        .into_response());
-                }
-            }
-        }
-        Ok(normalized)
-    }
+
+    SafePath::validate_relative(relative, &root).map_err(|e| e.into_response())
 }
 
 /// Query parameters for lighting endpoints — allows overriding the directory.
@@ -302,12 +220,8 @@ pub(super) struct LightingDirQuery {
 /// Validates that a fixture type or venue name is safe for use as a filename.
 #[allow(clippy::result_large_err)]
 fn validate_lighting_name(name: &str) -> Result<(), axum::response::Response> {
-    if name.is_empty()
-        || name.contains("..")
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains('\0')
-    {
+    use super::super::safe_path::SafePath;
+    if SafePath::validate_name(name).is_err() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Invalid name"})),
@@ -962,7 +876,13 @@ mod test {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let status = response.status();
+        assert!(
+            status == StatusCode::FORBIDDEN
+                || status == StatusCode::BAD_REQUEST
+                || status == StatusCode::NOT_FOUND,
+            "expected rejection for symlink escape, got {status}"
+        );
     }
 
     #[tokio::test]
@@ -1134,7 +1054,13 @@ show "test" {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let status = response.status();
+        assert!(
+            status == StatusCode::FORBIDDEN
+                || status == StatusCode::BAD_REQUEST
+                || status == StatusCode::NOT_FOUND,
+            "expected rejection for symlink escape, got {status}"
+        );
     }
 
     #[tokio::test]
@@ -1258,10 +1184,14 @@ show "test" {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = response_body(response).await;
-        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert!(parsed["error"].as_str().unwrap().contains("Invalid path"));
+        // Path traversal: expect rejection (NOT_FOUND, FORBIDDEN, or BAD_REQUEST).
+        let status = response.status();
+        assert!(
+            status == StatusCode::NOT_FOUND
+                || status == StatusCode::FORBIDDEN
+                || status == StatusCode::BAD_REQUEST,
+            "expected rejection, got {status}"
+        );
     }
 
     #[tokio::test]
@@ -1337,10 +1267,13 @@ show "test" {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = response_body(response).await;
-        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert!(parsed["error"].as_str().unwrap().contains("Invalid path"));
+        let status = response.status();
+        assert!(
+            status == StatusCode::NOT_FOUND
+                || status == StatusCode::FORBIDDEN
+                || status == StatusCode::BAD_REQUEST,
+            "expected rejection for path traversal, got {status}"
+        );
     }
 
     #[tokio::test]

--- a/src/webui/api/playlists.rs
+++ b/src/webui/api/playlists.rs
@@ -105,13 +105,8 @@ pub(super) async fn validate_playlist(body: String) -> impl IntoResponse {
 /// Validates a playlist name for use in file paths.
 #[allow(clippy::result_large_err)]
 fn validate_playlist_name(name: &str) -> Result<(), axum::response::Response> {
-    if name.is_empty()
-        || name == "all_songs"
-        || name.contains("..")
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains('\0')
-    {
+    use super::super::safe_path::SafePath;
+    if name == "all_songs" || SafePath::validate_name(name).is_err() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Invalid playlist name"})),
@@ -135,59 +130,25 @@ fn require_playlists_dir(state: &WebUiState) -> Result<PathBuf, axum::response::
 
 /// Resolves a playlist file path within the playlists directory, verifying
 /// that the result does not escape the directory via symlinks or other tricks.
-/// The playlists directory must exist before calling this function.
-/// Returns the validated path or an error response.
+/// Uses SafePath for containment verification.
 #[allow(clippy::result_large_err)]
 fn resolve_playlist_path(
     playlists_dir: &std::path::Path,
     name: &str,
     ext: &str,
 ) -> Result<PathBuf, axum::response::Response> {
-    // Canonicalize the directory itself (must exist) so the resulting path
-    // is anchored to a verified absolute base.
-    let dir_canonical = playlists_dir.canonicalize().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to resolve playlists dir: {}", e)})),
-        )
-            .into_response()
-    })?;
-    let file_path = dir_canonical.join(format!("{}.{}", name, ext));
-    // If the file already exists, canonicalize it and verify it stayed inside.
-    // This catches symlink escapes.
+    use super::super::safe_path::VerifiedRoot;
+
+    let root = VerifiedRoot::new(playlists_dir).map_err(|e| e.into_response())?;
+    // Name is pre-validated by validate_playlist_name (no "..", "/", "\", null).
+    // Joining a validated filename to a canonical root is safe.
+    let file_path = root.as_path().join(format!("{}.{}", name, ext));
     if file_path.exists() {
-        let canonical = file_path.canonicalize().map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve path: {}", e)})),
-            )
-                .into_response()
-        })?;
-        if !canonical.starts_with(&dir_canonical) {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid playlist path"})),
-            )
-                .into_response());
-        }
-        Ok(canonical)
+        // Verify existing file hasn't escaped via symlink.
+        let safe = super::super::safe_path::SafePath::resolve(&file_path, &root)
+            .map_err(|e| e.into_response())?;
+        Ok(safe.as_path().to_path_buf())
     } else {
-        // File doesn't exist yet. Verify the parent of the constructed path
-        // is still the canonical directory (defense in depth beyond name validation).
-        let parent = file_path.parent().ok_or_else(|| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid playlist path"})),
-            )
-                .into_response()
-        })?;
-        if parent != dir_canonical {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid playlist path"})),
-            )
-                .into_response());
-        }
         Ok(file_path)
     }
 }

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -31,12 +31,8 @@ use config::Config;
 /// Validates a profile filename for use in file paths.
 #[allow(clippy::result_large_err)]
 fn validate_profile_filename(name: &str) -> Result<(), axum::response::Response> {
-    if name.is_empty()
-        || name.contains("..")
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains('\0')
-    {
+    use super::super::safe_path::SafePath;
+    if SafePath::validate_name(name).is_err() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Invalid profile filename"})),
@@ -60,51 +56,23 @@ fn require_profiles_dir(state: &WebUiState) -> Result<PathBuf, axum::response::R
 
 /// Resolves a profile file path within the profiles directory, verifying
 /// that the result does not escape the directory via symlinks or other tricks.
+/// Uses SafePath for containment verification.
 #[allow(clippy::result_large_err)]
 fn resolve_profile_path(
     profiles_dir: &std::path::Path,
     name: &str,
     ext: &str,
 ) -> Result<PathBuf, axum::response::Response> {
-    let dir_canonical = profiles_dir.canonicalize().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to resolve profiles dir: {}", e)})),
-        )
-            .into_response()
-    })?;
-    let file_path = dir_canonical.join(format!("{}.{}", name, ext));
+    use super::super::safe_path::VerifiedRoot;
+
+    let root = VerifiedRoot::new(profiles_dir).map_err(|e| e.into_response())?;
+    // Name is pre-validated by validate_profile_filename (no "..", "/", "\", null).
+    let file_path = root.as_path().join(format!("{}.{}", name, ext));
     if file_path.exists() {
-        let canonical = file_path.canonicalize().map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve path: {}", e)})),
-            )
-                .into_response()
-        })?;
-        if !canonical.starts_with(&dir_canonical) {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid profile path"})),
-            )
-                .into_response());
-        }
-        Ok(canonical)
+        let safe = super::super::safe_path::SafePath::resolve(&file_path, &root)
+            .map_err(|e| e.into_response())?;
+        Ok(safe.as_path().to_path_buf())
     } else {
-        let parent = file_path.parent().ok_or_else(|| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid profile path"})),
-            )
-                .into_response()
-        })?;
-        if parent != dir_canonical {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid profile path"})),
-            )
-                .into_response());
-        }
         Ok(file_path)
     }
 }

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -158,7 +158,9 @@ pub(super) async fn import_file_to_song(
     Path(name): Path<String>,
     Json(body): Json<ImportFileRequest>,
 ) -> impl IntoResponse {
-    // Determine the project root (same as the browse endpoint).
+    use super::super::safe_path::{SafePath, VerifiedRoot};
+
+    // Determine the project root (parent of mtrack.yaml).
     let config_canonical = match state.config_path.canonicalize() {
         Ok(p) => p,
         Err(e) => {
@@ -170,7 +172,10 @@ pub(super) async fn import_file_to_song(
         }
     };
     let project_root = match config_canonical.parent() {
-        Some(p) => p.to_path_buf(),
+        Some(p) => match VerifiedRoot::new(p) {
+            Ok(r) => r,
+            Err(e) => return e.into_response(),
+        },
         None => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -180,26 +185,18 @@ pub(super) async fn import_file_to_song(
         }
     };
 
-    // Canonicalize the source path to resolve symlinks and verify it exists.
-    // codeql[rust/path-injection] Path is canonicalized and verified against project_root below.
-    let source_canonical = match std::path::Path::new(&body.path).canonicalize() {
+    // Resolve the source file path under the project root.
+    let source = match SafePath::resolve(std::path::Path::new(&body.path), &project_root) {
         Ok(p) => p,
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Source file does not exist or is invalid"})),
+                Json(json!({"error": "Source file does not exist or is outside the project directory"})),
             )
                 .into_response();
         }
     };
-    if !source_canonical.starts_with(&project_root) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Source path is outside the project directory"})),
-        )
-            .into_response();
-    }
-    if !source_canonical.is_file() {
+    if !source.is_file() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({"error": "Source path is not a file"})),
@@ -210,7 +207,7 @@ pub(super) async fn import_file_to_song(
     let filename = body
         .filename
         .as_deref()
-        .or_else(|| source_canonical.file_name().and_then(|n| n.to_str()))
+        .or_else(|| source.file_name().and_then(|n| n.to_str()))
         .unwrap_or("unknown");
 
     if let Err(e) = validate_track_filename(filename) {
@@ -224,8 +221,8 @@ pub(super) async fn import_file_to_song(
 
     // codeql[rust/path-injection] dest_path is under song_dir (verified by resolve_or_create_song_dir),
     // filename is validated by validate_track_filename (no .. or / allowed).
-    let dest_path = song_dir.join(filename);
-    if let Err(e) = std::fs::copy(&source_canonical, &dest_path) {
+    let dest_path = song_dir.join_filename(filename);
+    if let Err(e) = std::fs::copy(&source, &dest_path) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("Failed to copy file: {}", e)})),
@@ -281,52 +278,22 @@ pub(super) async fn delete_song(
         }
     }
 
-    // Look up the song in the player's registry to find its base path.
-    let all_songs = state.player.get_all_songs_playlist();
-    let song = match all_songs.get_song(&name) {
-        Some(song) => song,
-        None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Song '{}' not found", name)})),
-            )
-                .into_response();
-        }
+    // Resolve the song directory through the registry with path verification.
+    let song_dir = match resolve_song_dir(&state.player, &state.songs_path, &name) {
+        Ok(p) => p,
+        Err(e) => return *e,
     };
 
-    let config_path = song.base_path().join("song.yaml");
-
-    // Verify the resolved path is under the songs directory to prevent path traversal.
-    let songs_canonical = match state.songs_path.canonicalize() {
-        Ok(p) => p,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
-            )
-                .into_response();
-        }
-    };
-    let config_canonical = match config_path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "song.yaml not found for this song"})),
-            )
-                .into_response();
-        }
-    };
-    if !config_canonical.starts_with(&songs_canonical) {
+    let config_path = song_dir.join_filename("song.yaml");
+    if !config_path.exists() {
         return (
-            StatusCode::FORBIDDEN,
-            Json(json!({"error": "song path is outside the songs directory"})),
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "song.yaml not found for this song"})),
         )
             .into_response();
     }
 
-    // codeql[rust/path-injection] Path verified via canonicalize + starts_with above.
-    if let Err(e) = std::fs::remove_file(&config_canonical) {
+    if let Err(e) = std::fs::remove_file(&config_path) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("Failed to delete song.yaml: {}", e)})),
@@ -519,80 +486,19 @@ pub(super) async fn post_song(
     Path(name): Path<String>,
     body: String,
 ) -> impl IntoResponse {
-    // Allow slashes in the name for nested directory creation (e.g. "Artist/Album/Song"),
-    // but reject traversal attempts.
-    if name.is_empty() || name.contains("..") || name.contains('\\') || name.contains('\0') {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid song name"})),
-        )
-            .into_response();
-    }
+    use super::super::safe_path::{SafePath, VerifiedRoot};
 
-    let songs_canonical = match state.songs_path.canonicalize() {
-        Ok(p) => p,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
-            )
-                .into_response();
-        }
+    let root = match VerifiedRoot::new(&state.songs_path) {
+        Ok(r) => r,
+        Err(e) => return e.into_response(),
     };
 
-    // Create the directory segment by segment, verifying containment at each step.
-    // This ensures canonicalize+starts_with before every filesystem op.
-    let mut song_dir = songs_canonical.clone();
-    for segment in name.split('/') {
-        let segment = validate_path_segment(segment);
-        let segment = match segment {
-            Some(s) => s,
-            None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": "Invalid song path"})),
-                )
-                    .into_response();
-            }
-        };
-        // song_dir here is canonical (from previous iteration or songs_canonical).
-        // Join the validated segment, then try to canonicalize. If it fails
-        // (doesn't exist yet), create it via the canonical parent + segment.
-        let next = song_dir.join(&segment);
-        song_dir = match next.canonicalize() {
-            Ok(p) if p.starts_with(&songs_canonical) => p,
-            Ok(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": "Invalid song path"})),
-                )
-                    .into_response();
-            }
-            Err(_) => {
-                // Doesn't exist — create via the verified canonical parent.
-                let new_dir = song_dir.join(&segment);
-                if let Err(e) = std::fs::create_dir(&new_dir) {
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": format!("Failed to create directory: {}", e)})),
-                    )
-                        .into_response();
-                }
-                match new_dir.canonicalize() {
-                    Ok(p) if p.starts_with(&songs_canonical) => p,
-                    _ => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            Json(json!({"error": "Invalid song path"})),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-        };
-    }
+    let song_dir = match SafePath::create_dir_nested(&name, &root) {
+        Ok(p) => p,
+        Err(e) => return e.into_response(),
+    };
 
-    let config_path = song_dir.join("song.yaml");
+    let config_path = song_dir.join_filename("song.yaml");
     if config_path.exists() {
         return (
             StatusCode::CONFLICT,
@@ -629,16 +535,7 @@ pub(super) async fn post_song(
             .into_response();
     }
 
-    // Re-verify the song directory is under the songs root (breaks CodeQL taint chain).
-    let dir_verified = match verify_under_songs_dir(&song_dir, &state.songs_path) {
-        Ok(p) => p,
-        Err(e) => return *e,
-    };
-    // codeql[rust/path-injection] dir_verified is canonicalized and containment-checked;
-    // "song.yaml" is a constant suffix.
-    let config_verified = dir_verified.join("song.yaml");
-
-    match config_io::atomic_write(&config_verified, &body) {
+    match config_io::atomic_write(&config_path, &body) {
         Ok(()) => {
             state.player.reload_songs(
                 &state.songs_path,
@@ -663,34 +560,13 @@ pub(super) async fn put_song(
     Path(name): Path<String>,
     body: String,
 ) -> impl IntoResponse {
-    if name.is_empty()
-        || name.contains("..")
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains('\0')
-    {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid song name"})),
-        )
-            .into_response();
-    }
-
-    // Verify the songs root is resolvable (500 if misconfigured).
-    if let Err(e) = state.songs_path.canonicalize() {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
-        )
-            .into_response();
-    }
     // Look up the song in the registry to get its actual path (handles nested dirs).
     let song_dir = match resolve_song_dir(&state.player, &state.songs_path, &name) {
         Ok(p) => p,
         Err(e) => return *e,
     };
 
-    let config_path = song_dir.join("song.yaml");
+    let config_path = song_dir.join_filename("song.yaml");
 
     // Validate the YAML can be deserialized as a song config
     let tmp = match tempfile::Builder::new().suffix(".yaml").tempfile() {
@@ -737,7 +613,7 @@ pub(super) async fn upload_track_single(
     let song_dir =
         resolve_or_create_song_dir(&state.player, &state.songs_path, &name).map_err(|e| *e)?;
 
-    let file_path = song_dir.join(&filename);
+    let file_path = song_dir.join_filename(&filename);
     let replaced = file_path.exists();
     if let Err(e) = std::fs::write(&file_path, &body) {
         return Err((
@@ -802,7 +678,7 @@ pub(super) async fn upload_tracks_multipart(
                 .into_response()
         })?;
 
-        let file_path = song_dir.join(&filename);
+        let file_path = song_dir.join_filename(&filename);
         std::fs::write(&file_path, &data).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -843,32 +719,34 @@ pub(super) async fn upload_tracks_multipart(
 // Song helper functions
 // ---------------------------------------------------------------------------
 
-/// Ensures a song directory exists and returns its path.
-/// Creates the directory if it doesn't exist. Returns an error response if the
-/// song name is invalid or the directory can't be created.
-/// Resolves a song directory by checking the player's registry (handles
-/// nested directories like `artist/album/song`). Returns NOT_FOUND if the
-/// song isn't registered.
+use super::super::safe_path::{SafePath, VerifiedRoot};
+
+/// Resolves an existing song directory by checking the player's registry first
+/// (handles nested paths like `artist/album/song`), then falling back to a
+/// direct path join. Returns an error response if the song isn't found.
 pub(super) fn resolve_song_dir(
     player: &crate::player::Player,
     songs_path: &std::path::Path,
     name: &str,
-) -> Result<std::path::PathBuf, Box<axum::response::Response>> {
-    let all_songs = player.get_all_songs_playlist();
-    if let Some(song) = all_songs.get_song(name) {
-        let dir = song.base_path().to_path_buf();
-        if dir.is_dir() {
-            return verify_under_songs_dir(&dir, songs_path);
+) -> Result<SafePath, Box<axum::response::Response>> {
+    let root = VerifiedRoot::new(songs_path).map_err(|e| Box::new(e.into_response()))?;
+
+    // Check the registry first — handles songs in nested subdirectories.
+    if let Some(song) = player.get_all_songs_playlist().get_song(name) {
+        if let Ok(safe) = SafePath::resolve(song.base_path(), &root) {
+            if safe.is_dir() {
+                return Ok(safe);
+            }
         }
     }
+
     // Fall back to direct join for songs not yet in registry but on disk.
-    // Verify via canonicalize + starts_with before any filesystem access.
-    let candidate = songs_path.join(name);
-    if let Ok(verified) = verify_under_songs_dir(&candidate, songs_path) {
-        if verified.is_dir() {
-            return Ok(verified);
+    if let Ok(safe) = root.resolve(name) {
+        if safe.is_dir() {
+            return Ok(safe);
         }
     }
+
     Err(Box::new(
         (
             StatusCode::NOT_FOUND,
@@ -878,107 +756,20 @@ pub(super) fn resolve_song_dir(
     ))
 }
 
-/// Resolves a song directory from the registry, falling back to `ensure_song_dir`
-/// to create it if the song isn't registered (for uploads to new songs).
+/// Resolves a song directory from the registry, falling back to creating it
+/// if the song isn't registered (for uploads to new songs).
 pub(super) fn resolve_or_create_song_dir(
     player: &crate::player::Player,
     songs_path: &std::path::Path,
     name: &str,
-) -> Result<std::path::PathBuf, Box<axum::response::Response>> {
-    // Check the registry first — handles songs in nested subdirectories.
+) -> Result<SafePath, Box<axum::response::Response>> {
     if let Ok(dir) = resolve_song_dir(player, songs_path, name) {
         return Ok(dir);
     }
-    // Not found — create at songs_path/name (for new songs).
-    ensure_song_dir(songs_path, name)
+    let root = VerifiedRoot::new(songs_path).map_err(|e| Box::new(e.into_response()))?;
+    SafePath::create_dir(&root.as_safe_path(), name, &root).map_err(|e| Box::new(e.into_response()))
 }
 
-pub(super) fn ensure_song_dir(
-    songs_path: &std::path::Path,
-    name: &str,
-) -> Result<std::path::PathBuf, Box<axum::response::Response>> {
-    // Reject path traversal characters.
-    if name.is_empty()
-        || name.contains("..")
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains('\0')
-    {
-        return Err(Box::new(
-            (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid song name"})),
-            )
-                .into_response(),
-        ));
-    }
-
-    // Canonicalize the songs directory so all derived paths are anchored to a
-    // verified absolute base.
-    let songs_canonical = songs_path.canonicalize().map_err(|e| {
-        Box::new(
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
-            )
-                .into_response(),
-        )
-    })?;
-
-    // codeql[rust/path-injection] name is validated above: no empty, no "..", no "/", no "\", no null.
-    // Joining a single validated segment to a canonical base cannot escape the directory.
-    let song_dir = songs_canonical.join(name);
-
-    if !song_dir.exists() {
-        std::fs::create_dir_all(&song_dir).map_err(|e| {
-            Box::new(
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("Failed to create song directory: {}", e)})),
-                )
-                    .into_response(),
-            )
-        })?;
-    }
-
-    // Canonicalize the result and verify containment within songs directory.
-    // codeql[rust/path-injection] Path verified via canonicalize + starts_with.
-    let song_canonical = song_dir.canonicalize().map_err(|e| {
-        Box::new(
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve song directory: {}", e)})),
-            )
-                .into_response(),
-        )
-    })?;
-    if !song_canonical.starts_with(&songs_canonical) {
-        return Err(Box::new(
-            (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "Invalid song name"})),
-            )
-                .into_response(),
-        ));
-    }
-
-    Ok(song_canonical)
-}
-
-/// Validates a single path segment for use in directory creation.
-/// Returns None if the segment is invalid (empty, "..", contains "\" or null).
-/// Returns a new owned String to break CodeQL taint from the original input.
-fn validate_path_segment(s: &str) -> Option<String> {
-    if s.is_empty() || s == ".." || s.contains('\\') || s.contains('\0') {
-        return None;
-    }
-    Some(s.to_string())
-}
-
-/// Canonicalizes a path and verifies it is contained within the songs directory.
-/// Returns the canonical path on success, or an error response on failure.
-/// This breaks the CodeQL taint chain by producing a fresh canonical path
-/// verified against the songs root.
 /// Removes a song name from all playlist YAML files on disk.
 /// Silently skips files that can't be read or written.
 fn remove_song_from_playlists(
@@ -1028,40 +819,6 @@ fn remove_song_from_playlists(
     }
 }
 
-fn verify_under_songs_dir(
-    path: &std::path::Path,
-    songs_path: &std::path::Path,
-) -> Result<std::path::PathBuf, Box<axum::response::Response>> {
-    let songs_canonical = songs_path.canonicalize().map_err(|e| {
-        Box::new(
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to resolve songs path: {}", e)})),
-            )
-                .into_response(),
-        )
-    })?;
-    let canonical = path.canonicalize().map_err(|e| {
-        Box::new(
-            (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Path not found: {}", e)})),
-            )
-                .into_response(),
-        )
-    })?;
-    if !canonical.starts_with(&songs_canonical) {
-        return Err(Box::new(
-            (
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "Path is outside the songs directory"})),
-            )
-                .into_response(),
-        ));
-    }
-    Ok(canonical)
-}
-
 /// Generates song.yaml for a song directory if one doesn't already exist.
 /// If song.yaml already exists, it is left untouched so that manual edits
 /// (track names, lighting config, etc.) are preserved.
@@ -1096,7 +853,7 @@ pub(super) fn ensure_song_config(
 
 /// Validates that a track filename has a supported extension.
 pub(super) fn validate_track_filename(filename: &str) -> Result<(), Box<axum::response::Response>> {
-    if filename.contains("..") || filename.contains('/') || filename.contains('\\') {
+    if SafePath::validate_name(filename).is_err() {
         return Err(Box::new(
             (
                 StatusCode::BAD_REQUEST,

--- a/src/webui/config_io.rs
+++ b/src/webui/config_io.rs
@@ -74,24 +74,6 @@ pub fn validate_light_show(content: &str) -> Result<(), Vec<String>> {
     Ok(())
 }
 
-/// Validates that a resolved path is under the given base directory.
-/// Returns the canonical path if valid, or an error if the path would escape.
-pub fn validate_path_within(base: &Path, requested: &Path) -> Result<std::path::PathBuf, String> {
-    let canonical = requested
-        .canonicalize()
-        .map_err(|e| format!("Cannot resolve path {}: {}", requested.display(), e))?;
-
-    let canonical_base = base
-        .canonicalize()
-        .map_err(|e| format!("Cannot resolve base path {}: {}", base.display(), e))?;
-
-    if !canonical.starts_with(&canonical_base) {
-        return Err("Path outside allowed directory".to_string());
-    }
-
-    Ok(canonical)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,42 +116,6 @@ show "test" {
     fn test_validate_playlist_valid() {
         let yaml = "songs:\n  - song1\n  - song2\n";
         assert!(validate_playlist(yaml).is_ok());
-    }
-
-    #[test]
-    fn test_validate_path_within() {
-        let dir = tempfile::tempdir().unwrap();
-        let sub = dir.path().join("sub");
-        std::fs::create_dir(&sub).unwrap();
-        let file = sub.join("test.txt");
-        std::fs::write(&file, "test").unwrap();
-
-        // Valid path within base
-        assert!(validate_path_within(dir.path(), &file).is_ok());
-
-        // Path traversal attempt
-        let bad_path = dir
-            .path()
-            .join("sub")
-            .join("..")
-            .join("..")
-            .join("etc")
-            .join("passwd");
-        assert!(validate_path_within(dir.path(), &bad_path).is_err());
-    }
-
-    #[test]
-    fn test_validate_path_within_outside_base() {
-        // Create two separate tempdirs so the canonical path exists but is
-        // not under the base directory.
-        let base_dir = tempfile::tempdir().unwrap();
-        let other_dir = tempfile::tempdir().unwrap();
-        let outside_file = other_dir.path().join("secret.txt");
-        std::fs::write(&outside_file, "secret").unwrap();
-
-        let result = validate_path_within(base_dir.path(), &outside_file);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Path outside allowed directory");
     }
 
     #[test]

--- a/src/webui/safe_path.rs
+++ b/src/webui/safe_path.rs
@@ -1,0 +1,357 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Verified filesystem paths that are guaranteed to be under a trusted root.
+//!
+//! `SafePath` can only be constructed through methods that canonicalize the path
+//! and verify it is contained within a specified root directory. This prevents
+//! path traversal attacks and centralizes the validation logic that was previously
+//! duplicated across every API handler.
+
+use std::path::{Path, PathBuf};
+
+/// A canonicalized path that has been verified to reside under a trusted root directory.
+///
+/// Cannot be constructed directly — use [`SafePath::resolve`], [`SafePath::create_dir`],
+/// or [`SafePath::create_dir_nested`] to obtain one.
+#[derive(Debug, Clone)]
+pub struct SafePath {
+    path: PathBuf,
+}
+
+impl SafePath {
+    /// Returns the verified canonical path.
+    pub fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Joins a filename to this verified path. Safe for both constant filenames
+    /// (e.g. "song.yaml") and user-provided filenames that have been validated
+    /// via `SafePath::validate_name()`.
+    pub fn join_filename(&self, name: &str) -> PathBuf {
+        self.path.join(name)
+    }
+
+    /// Returns true if the path is a directory.
+    pub fn is_dir(&self) -> bool {
+        self.path.is_dir()
+    }
+
+    /// Resolves an existing path under the given root.
+    /// The path must exist and must resolve to a location within the root.
+    pub fn resolve(path: &Path, root: &VerifiedRoot) -> Result<Self, SafePathError> {
+        let canonical = path.canonicalize().map_err(|_| SafePathError::NotFound)?;
+        if !canonical.starts_with(root.as_path()) {
+            return Err(SafePathError::OutsideRoot);
+        }
+        Ok(SafePath { path: canonical })
+    }
+
+    /// Creates a single directory under the given root and returns the verified path.
+    /// The name must be a single path segment (no slashes).
+    pub fn create_dir(
+        parent: &SafePath,
+        name: &str,
+        root: &VerifiedRoot,
+    ) -> Result<Self, SafePathError> {
+        if name.is_empty()
+            || name.contains("..")
+            || name.contains('/')
+            || name.contains('\\')
+            || name.contains('\0')
+        {
+            return Err(SafePathError::InvalidName);
+        }
+        let target = parent.path.join(name);
+        if !target.exists() {
+            std::fs::create_dir(&target).map_err(SafePathError::Io)?;
+        }
+        let canonical = target.canonicalize().map_err(|_| SafePathError::NotFound)?;
+        if !canonical.starts_with(root.as_path()) {
+            // Clean up if a symlink caused escape.
+            let _ = std::fs::remove_dir(&target);
+            return Err(SafePathError::OutsideRoot);
+        }
+        Ok(SafePath { path: canonical })
+    }
+
+    /// Validates a single path segment (filename or directory name) is safe.
+    /// Rejects empty strings, "..", and path separators.
+    pub fn validate_name(name: &str) -> Result<(), SafePathError> {
+        if name.is_empty()
+            || name.contains("..")
+            || name.contains('/')
+            || name.contains('\\')
+            || name.contains('\0')
+        {
+            return Err(SafePathError::InvalidName);
+        }
+        Ok(())
+    }
+
+    /// Validates a relative path under the root without creating anything.
+    /// If the full path exists, it's resolved and verified. If it doesn't exist,
+    /// each segment is checked for traversal (no "..", "\", null) and the
+    /// constructed path is returned without filesystem modification.
+    /// Use this for read-only operations where the directory may not exist.
+    pub fn validate_relative(
+        relative: &str,
+        root: &VerifiedRoot,
+    ) -> Result<PathBuf, SafePathError> {
+        if relative.is_empty()
+            || relative.contains("..")
+            || relative.contains('\\')
+            || relative.contains('\0')
+        {
+            return Err(SafePathError::InvalidName);
+        }
+        if std::path::Path::new(relative).is_absolute() {
+            return Err(SafePathError::InvalidName);
+        }
+        let resolved = root.as_path().join(relative);
+        if resolved.exists() {
+            let safe = SafePath::resolve(&resolved, root)?;
+            Ok(safe.path)
+        } else {
+            Ok(resolved)
+        }
+    }
+
+    /// Creates a nested directory path (e.g. "Artist/Album/Song") segment by segment,
+    /// verifying containment at each step.
+    pub fn create_dir_nested(name: &str, root: &VerifiedRoot) -> Result<Self, SafePathError> {
+        if name.is_empty() || name.contains("..") || name.contains('\\') || name.contains('\0') {
+            return Err(SafePathError::InvalidName);
+        }
+        let mut current = SafePath {
+            path: root.as_path().to_path_buf(),
+        };
+        for segment in name.split('/') {
+            if segment.is_empty() {
+                continue; // skip double slashes
+            }
+            current = SafePath::create_dir(&current, segment, root)?;
+        }
+        Ok(current)
+    }
+}
+
+impl AsRef<Path> for SafePath {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::ops::Deref for SafePath {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// A canonicalized root directory used as the trust anchor for path verification.
+#[derive(Debug, Clone)]
+pub struct VerifiedRoot {
+    path: PathBuf,
+}
+
+impl VerifiedRoot {
+    /// Creates a VerifiedRoot by canonicalizing the given path.
+    pub fn new(path: &Path) -> Result<Self, SafePathError> {
+        let canonical = path
+            .canonicalize()
+            .map_err(|_| SafePathError::RootNotFound)?;
+        Ok(VerifiedRoot { path: canonical })
+    }
+
+    /// Returns the canonical root path.
+    pub fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Convenience: resolve an existing path relative to this root.
+    pub fn resolve(&self, relative: &str) -> Result<SafePath, SafePathError> {
+        SafePath::resolve(&self.path.join(relative), self)
+    }
+
+    /// Convenience: create a SafePath pointing at the root itself.
+    pub fn as_safe_path(&self) -> SafePath {
+        SafePath {
+            path: self.path.clone(),
+        }
+    }
+}
+
+/// Errors from SafePath operations.
+#[derive(Debug)]
+pub enum SafePathError {
+    /// The path does not exist.
+    NotFound,
+    /// The root directory could not be resolved.
+    RootNotFound,
+    /// The resolved path is outside the trusted root.
+    OutsideRoot,
+    /// The provided name contains invalid characters.
+    InvalidName,
+    /// A filesystem operation failed.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for SafePathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SafePathError::NotFound => write!(f, "Path not found"),
+            SafePathError::RootNotFound => write!(f, "Root directory not found"),
+            SafePathError::OutsideRoot => write!(f, "Path is outside the allowed directory"),
+            SafePathError::InvalidName => write!(f, "Invalid path name"),
+            SafePathError::Io(e) => write!(f, "I/O error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for SafePathError {}
+
+impl SafePathError {
+    /// Convert to an axum response with appropriate HTTP status code.
+    pub fn into_response(self) -> axum::response::Response {
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::Json;
+        let (status, msg) = match &self {
+            SafePathError::NotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            SafePathError::RootNotFound => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            SafePathError::OutsideRoot => (StatusCode::FORBIDDEN, self.to_string()),
+            SafePathError::InvalidName => (StatusCode::BAD_REQUEST, self.to_string()),
+            SafePathError::Io(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+        };
+        (status, Json(serde_json::json!({"error": msg}))).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_existing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("child");
+        std::fs::create_dir(&sub).unwrap();
+
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let safe = SafePath::resolve(&sub, &root).unwrap();
+        assert!(safe.is_dir());
+    }
+
+    #[test]
+    fn resolve_outside_root_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let result = SafePath::resolve(other.path(), &root);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn create_dir_single_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let parent = root.as_safe_path();
+
+        let safe = SafePath::create_dir(&parent, "newsong", &root).unwrap();
+        assert!(safe.is_dir());
+        assert!(safe.as_path().ends_with("newsong"));
+    }
+
+    #[test]
+    fn create_dir_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let parent = root.as_safe_path();
+
+        assert!(SafePath::create_dir(&parent, "..", &root).is_err());
+        assert!(SafePath::create_dir(&parent, "a/b", &root).is_err());
+        assert!(SafePath::create_dir(&parent, "", &root).is_err());
+    }
+
+    #[test]
+    fn create_dir_nested_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+
+        let safe = SafePath::create_dir_nested("Artist/Album/Song", &root).unwrap();
+        assert!(safe.is_dir());
+        assert!(safe.as_path().ends_with("Song"));
+        assert!(dir.path().join("Artist/Album/Song").exists());
+    }
+
+    #[test]
+    fn create_dir_nested_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+
+        assert!(SafePath::create_dir_nested("Artist/../../../etc", &root).is_err());
+    }
+
+    #[test]
+    fn join_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let safe = root.as_safe_path();
+
+        let joined = safe.join_filename("song.yaml");
+        assert!(joined.ends_with("song.yaml"));
+    }
+
+    #[test]
+    fn resolve_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("songs");
+        std::fs::create_dir(&sub).unwrap();
+
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let safe = root.resolve("songs").unwrap();
+        assert!(safe.is_dir());
+    }
+
+    #[test]
+    fn validate_relative_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("fixtures");
+        std::fs::create_dir(&sub).unwrap();
+
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let path = SafePath::validate_relative("fixtures", &root).unwrap();
+        assert!(path.is_dir());
+    }
+
+    #[test]
+    fn validate_relative_nonexistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        let path = SafePath::validate_relative("does_not_exist", &root).unwrap();
+        // Returns the path without creating it
+        assert!(!path.exists());
+        assert!(path.ends_with("does_not_exist"));
+    }
+
+    #[test]
+    fn validate_relative_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = VerifiedRoot::new(dir.path()).unwrap();
+        assert!(SafePath::validate_relative("../escape", &root).is_err());
+        assert!(SafePath::validate_relative("/absolute", &root).is_err());
+    }
+}


### PR DESCRIPTION
Rather than play whack-a-mole with CodeQL, let's try to move everything into a SafePath module so that we have a single point we can use to sanitize incoming paths.