### PR TITLE
Bin crate uses the lib crate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod audio;
 pub mod build_info;
 pub mod calibrate;
+pub mod cli;
 pub(crate) mod clock;
 pub mod config;
 pub mod controller;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,31 +11,8 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-mod audio;
-mod build_info;
-mod calibrate;
-mod cli;
-mod clock;
-mod config;
-mod controller;
-mod dmx;
-mod lighting;
-mod midi;
-mod player;
-mod playlist;
-mod playsync;
-mod proto;
-mod samples;
-mod songs;
-mod state;
-#[cfg(test)]
-mod testutil;
-mod thread_priority;
-mod trigger;
-mod tui;
-mod util;
-mod verify;
-mod webui;
+use mtrack::cli;
+use mtrack::tui;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
The mtrack binary now uses the library. This creates a more idiomatic split. Additionally, this should reduce build times and test times in CI.