### PR TITLE
Rename legacy DMX MIDI to MIDI DMX.

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,9 +37,9 @@
 - [Running on Startup (systemd)](deployment/systemd.md)
 - [Service Hardening](deployment/security.md)
 
-# Legacy
+# DMX
 
-- [MIDI-Based DMX System](legacy/midi-dmx.md)
+- [MIDI-Based DMX](dmx/midi-dmx.md)
 
 # Reference
 

--- a/docs/src/dmx/midi-dmx.md
+++ b/docs/src/dmx/midi-dmx.md
@@ -1,20 +1,27 @@
-# MIDI-Based DMX System
+# MIDI-Based DMX
 
-> **Note**: The new tag-based lighting system (described in the [lighting overview](../lighting/overview.md)) is the recommended approach for most users. The MIDI-based DMX system is still supported for specific use cases requiring direct channel control.
+mtrack supports two approaches to lighting control: the **tag-based DSL system** (described in
+the [lighting overview](../lighting/overview.md)) and the **MIDI-based DMX system** described
+here. Both can be used independently or together in the same project.
+
+> **Tip**: If you're starting fresh, the DSL-based system is recommended for most users.
+> It provides venue-agnostic shows, high-level effects, and integrates with the web UI's
+> visual timeline editor. The MIDI-based system is best suited for workflows that require
+> direct per-channel DMX control or integration with DAW-authored MIDI lighting data.
 
 ## When to Use Each System
 
-**Use the New Tag-Based System when:**
+**Use the Tag-Based DSL System when:**
 - You want venue-agnostic lighting shows
-- You prefer high-level effect definitions
-- You want intelligent fixture selection
-- You're creating new lighting shows
+- You prefer high-level effect definitions (static, cycle, chase, strobe, etc.)
+- You want intelligent fixture selection via logical groups
+- You want to use the timeline editor for visual cue authoring
 
 **Use the MIDI-Based DMX System when:**
-- You have existing MIDI-based lighting shows
-- You need precise channel-level control
-- You're integrating with existing MIDI workflows
-- You prefer direct DMX channel programming
+- You need precise per-channel DMX control
+- You're integrating with existing MIDI workflows or DAWs
+- You prefer programming lights as MIDI data
+- You want to use live MIDI controllers for real-time DMX control
 
 ## Basic DMX Information
 
@@ -23,9 +30,9 @@ fed into one or more DMX channels. Each DMX channel can be set from `0` to `255`
 DMX channels: 1 for red, 1 for green, 1 for blue. In order to set the color of the light, you would have to supply these channels with
 data representing the color that you want. DMX data is arranged into universes, where 1 universe consists of 512 channels of DMX data.
 
-## Configuring mtrack for Legacy DMX Playback
+## Configuring mtrack for MIDI DMX Playback
 
-In order to use legacy light shows, you'll need to set up OLA on your playback device and map your DMX devices into DMX universes. I recommend
+In order to use MIDI-based light shows, you'll need to set up OLA on your playback device and map your DMX devices into DMX universes. I recommend
 following [this tutorial](https://www.openlighting.org/ola/getting-started/). mtrack assumes that OLA is running on the same device.
 
 mtrack can be configured to stream DMX data to OLA universes. This can be done through the mtrack configuration file when using `mtrack start`
@@ -36,7 +43,7 @@ The `dmx-universe-config` argument format is:
 universe=1,name=light-show;universe=2,name=another-light-show
 ```
 
-Legacy light shows can be defined in `Song` files and consist of an array of "universe names" and MIDI files. These universe names correlate to the
+MIDI-based light shows are defined in `Song` files and consist of an array of "universe names" and MIDI files. These universe names correlate to the
 names used in the mtrack configuration. For instance, a song with a light show with a universe name of `light-show` will play on the mtrack
 universe with the equivalent name.
 

--- a/docs/src/getting-started/song-repository.md
+++ b/docs/src/getting-started/song-repository.md
@@ -15,7 +15,7 @@ A song comprises of:
 
 - One or more audio files.
 - An optional MIDI file.
-- One or more light shows (using `.light` DSL files, or legacy MIDI files interpreted as DMX).
+- One or more light shows (using `.light` DSL files, or MIDI files interpreted as DMX).
 - A song definition (`song.yaml`).
 
 The audio files must all be the same sample rate. They do not need to be the same length. mtrack
@@ -91,7 +91,7 @@ $ mtrack songs --init /mnt/song-storage
 This creates a `song.yaml` in each subfolder of `/mnt/song-storage`. The name of the
 subfolder determines the song's name. Audio files are used as tracks (stereo and multichannel
 files are split into per-channel tracks). MIDI files are used as MIDI playback, and files
-prefixed with `dmx_` are treated as legacy light shows. `.light` files are auto-detected as
+prefixed with `dmx_` are treated as MIDI DMX light shows. `.light` files are auto-detected as
 DSL lighting shows.
 
 ## Directory Structure

--- a/docs/src/interfaces/web-ui.md
+++ b/docs/src/interfaces/web-ui.md
@@ -43,7 +43,7 @@ The dashboard is the landing page, providing an at-a-glance view of the player s
 ## Song Browser
 
 The song browser lists all songs in the repository, grouped by directory. Each song shows its
-duration, track count, and badges for MIDI, lighting DSL, and legacy MIDI DMX files.
+duration, track count, and badges for MIDI, lighting DSL, and MIDI DMX files.
 
 ![Song browser](../images/song-browser.png)
 

--- a/docs/src/lighting/overview.md
+++ b/docs/src/lighting/overview.md
@@ -1,17 +1,34 @@
 # Light Shows
 
-Light shows and DMX playback are now supported through the use of the [Open Lighting Architecture](https://www.openlighting.org/).
-The lighting system has been significantly enhanced with a new tag-based group resolution system that enables venue-agnostic lighting shows.
+mtrack supports programmable lighting control via DMX through the
+[Open Lighting Architecture](https://www.openlighting.org/). There are two approaches
+to authoring light shows:
 
-## New Lighting System Features
+- **DSL-based lighting** (recommended) — A tag-based system with a custom lighting DSL,
+  a visual timeline editor, and venue-agnostic shows. This is the primary lighting system
+  and the focus of this documentation.
+- **MIDI-based DMX** — Direct per-channel DMX control via MIDI files. Useful for precise
+  channel programming or integration with DAW workflows. See the
+  [MIDI-Based DMX](../dmx/midi-dmx.md) section.
 
-The new lighting system provides:
+Both systems can be used independently or combined in the same project. For most users,
+the DSL system is the better starting point — it provides high-level effect definitions,
+works across different venues without modification, and integrates with the web UI's
+timeline editor for visual cue authoring with real-time playback preview.
 
-- **Venue-Agnostic Songs**: Songs use logical groups instead of specific fixture names
-- **Tag-Based Group Resolution**: Fixtures are tagged with capabilities and roles
-- **Intelligent Selection**: System automatically chooses optimal fixtures based on constraints
-- **Venue Portability**: Same lighting show works across different venues
-- **Performance Optimization**: Cached group resolutions for fast lookups
+## DSL Lighting Features
+
+- **Venue-Agnostic Shows**: Songs use logical groups instead of specific fixture names,
+  so the same show works across different venues.
+- **Tag-Based Group Resolution**: Fixtures are tagged with capabilities and roles.
+  The system automatically selects optimal fixtures based on constraints.
+- **Effects Engine**: Built-in effects (static, cycle, chase, strobe, pulse, dimmer,
+  rainbow) with layering, blend modes, and timing control.
+- **Timeline Editor**: Visual DAW-style cue authoring in the web UI with integrated
+  audio playback and real-time stage preview.
+- **Sequences**: Reusable cue patterns that can be referenced from multiple shows.
+- **Tempo-Aware Cueing**: Cues can be placed at measure/beat positions with automatic
+  tempo change support.
 
 ## Configuration Structure
 
@@ -31,7 +48,7 @@ The system supports several constraint types for group resolution:
 - **`MinCount`**: Minimum number of fixtures required
 - **`MaxCount`**: Maximum number of fixtures allowed
 - **`FallbackTo`**: Fallback to another group if primary group fails (e.g., `"all_lights"`)
-- **`AllowEmpty`**: Allow group to be empty if no fixtures match (graceful degradation, e.g., `true`)
+- **`AllowEmpty`**: Allow group to be empty if no fixtures match (graceful degradation)
 
 ## Benefits
 
@@ -39,10 +56,13 @@ The system supports several constraint types for group resolution:
 2. **Intelligent Selection**: System prefers premium fixtures when available, falls back to standard
 3. **Flexible Constraints**: Support for complex requirement combinations
 4. **Clear Error Handling**: Know exactly what's missing when requirements aren't met
-5. **Performance**: Cached resolutions for fast lookups
+5. **Visual Authoring**: Timeline editor with playback preview and stage visualization
 6. **Maintainable**: Easy to add new venues and fixture types
 
-## Migration Path
+## Getting Started
 
-- **Gradual adoption** - can mix old and new group definitions
-- **Venue-defined groups** - venue-defined groups are still supported alongside logical groups
+1. Define fixture types and venues (see [Configuration](configuration.md))
+2. Create a `.light` file for your song (see [Effects Reference](effects.md) and
+   [Cueing Features](cueing.md))
+3. Reference the light file in your song's `song.yaml`
+4. Use the web UI's timeline editor to visually author and preview your show

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -13,7 +13,7 @@
 //
 
 pub mod engine;
-pub mod legacy_store;
+pub mod midi_dmx_store;
 pub mod ola_client;
 pub mod universe;
 pub mod watcher;

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -26,7 +26,7 @@ use std::{
     time::Duration,
 };
 
-use super::legacy_store::LegacyDmxStore;
+use super::midi_dmx_store::MidiDmxStore;
 use super::ola_client::OlaClient;
 use ola::DmxBuffer;
 use tracing::{debug, error, info, span, warn, Level};
@@ -89,10 +89,10 @@ fn classify_midi_dmx_action(
 /// universe(s) that should be sent to our DMX interface(s).
 pub struct Engine {
     dimming_speed_modifier: f64,
-    /// How long to wait before starting legacy MIDI DMX playback.
+    /// How long to wait before starting MIDI DMX DMX playback.
     playback_delay: Duration,
     universes: HashMap<u16, Universe>,
-    /// Mapping from universe names to IDs for legacy MIDI system
+    /// Mapping from universe names to IDs for MIDI DMX system
     universe_name_to_id: HashMap<String, u16>,
     cancel_handle: CancelHandle,
     client_handle: Option<JoinHandle<()>>,
@@ -117,12 +117,12 @@ pub struct Engine {
     broadcast_tx: Mutex<Option<tokio::sync::broadcast::Sender<String>>>,
     /// Handle to the current file watcher (dropped/replaced per-song)
     watcher_handle: Mutex<Option<super::watcher::WatcherHandle>>,
-    /// Lockless store for legacy MIDI DMX values with built-in interpolation.
+    /// Lockless store for MIDI DMX DMX values with built-in interpolation.
     /// RwLock protects structural changes (register_slot); hot-path reads
     /// (write/tick/iter_active) take a cheap read lock while atomics handle data.
-    legacy_store: Arc<parking_lot::RwLock<LegacyDmxStore>>,
-    /// Active legacy MIDI playbacks dispatched from the effects loop.
-    legacy_midi_playbacks: Mutex<Vec<LegacyMidiPlayback>>,
+    midi_dmx_store: Arc<parking_lot::RwLock<MidiDmxStore>>,
+    /// Active MIDI DMX playbacks dispatched from the effects loop.
+    midi_dmx_playbacks: Mutex<Vec<MidiDmxPlayback>>,
     /// Heartbeat counter incremented by the effects loop each frame.
     /// Used by barrier threads to detect if the effects loop has died.
     effects_loop_heartbeat: Arc<AtomicU64>,
@@ -135,8 +135,8 @@ pub struct Engine {
     update_subphase: Arc<AtomicU64>,
 }
 
-/// A legacy MIDI light show being played back from the effects loop.
-struct LegacyMidiPlayback {
+/// A MIDI DMX light show being played back from the effects loop.
+struct MidiDmxPlayback {
     precomputed: PrecomputedMidi,
     cursor: usize,
     universe_id: u16,
@@ -183,7 +183,7 @@ impl Engine {
             })
             .collect();
 
-        // Create mapping from universe names to IDs for legacy MIDI system
+        // Create mapping from universe names to IDs for MIDI DMX system
         let universe_name_to_id: HashMap<String, u16> = config
             .universes()
             .into_iter()
@@ -217,7 +217,7 @@ impl Engine {
         let timeline_finished = Arc::new(AtomicBool::new(true));
         let timeline_cancel_handle: Arc<Mutex<Option<CancelHandle>>> = Arc::new(Mutex::new(None));
 
-        let legacy_store = Arc::new(parking_lot::RwLock::new(LegacyDmxStore::new()));
+        let midi_dmx_store = Arc::new(parking_lot::RwLock::new(MidiDmxStore::new()));
 
         Ok(Engine {
             dimming_speed_modifier: config.dimming_speed_modifier(),
@@ -237,8 +237,8 @@ impl Engine {
             timeline_cancel_handle,
             broadcast_tx: Mutex::new(None),
             watcher_handle: Mutex::new(None),
-            legacy_store,
-            legacy_midi_playbacks: Mutex::new(Vec::new()),
+            midi_dmx_store,
+            midi_dmx_playbacks: Mutex::new(Vec::new()),
             effects_loop_heartbeat: Arc::new(AtomicU64::new(0)),
             effects_loop_phase: Arc::new(AtomicU64::new(0)),
             update_subphase,
@@ -323,16 +323,16 @@ impl Engine {
     /// effects update, timeline update, and finished-check.
     ///
     /// Phase values (stored in `effects_loop_phase` for diagnostics):
-    ///   1 = legacy store tick, 2 = MIDI advance, 3 = update effects,
+    ///   1 = MIDI DMX store tick, 2 = MIDI advance, 3 = update effects,
     ///   4 = update song lighting, 5 = timeline finished check, 0 = idle.
     fn effects_loop_tick(&self) {
-        // Tick the legacy store to interpolate dimming values
+        // Tick the MIDI DMX store to interpolate dimming values
         self.effects_loop_phase.store(1, Ordering::Relaxed);
-        self.legacy_store.read().tick();
+        self.midi_dmx_store.read().tick();
 
-        // Advance legacy MIDI playback cursors and dispatch events
+        // Advance MIDI DMX playback cursors and dispatch events
         self.effects_loop_phase.store(2, Ordering::Relaxed);
-        self.advance_legacy_midi_playbacks();
+        self.advance_midi_dmx_playbacks();
 
         // Update effects engine and apply to universes
         self.effects_loop_phase.store(3, Ordering::Relaxed);
@@ -347,7 +347,7 @@ impl Engine {
             error!("Error updating song lighting: {}", e);
         }
 
-        // Check if all lighting has finished (DSL timeline cues + legacy MIDI playbacks)
+        // Check if all lighting has finished (DSL timeline cues + MIDI DMX playbacks)
         // and notify the waiting thread if so
         self.effects_loop_phase.store(5, Ordering::Relaxed);
         if !self.timeline_finished.load(Ordering::Relaxed) {
@@ -355,9 +355,9 @@ impl Engine {
                 let timeline = self.current_song_timeline.lock();
                 timeline.as_ref().is_none_or(|tl| tl.is_finished())
             };
-            let legacy_done = self.legacy_playbacks_finished();
+            let midi_dmx_done = self.midi_dmx_playbacks_finished();
 
-            if timeline_done && legacy_done {
+            if timeline_done && midi_dmx_done {
                 info!("Lighting timeline finished. Notifying barrier.");
                 self.timeline_finished.store(true, Ordering::Relaxed);
                 // Notify the cancel handle so wait() returns
@@ -460,7 +460,7 @@ impl Engine {
                 }
             }
         } else {
-            // Clear lighting state from previous song so legacy songs
+            // Clear lighting state from previous song so MIDI DMX songs
             // don't inherit a stale tempo map or timeline.
             {
                 let mut effect_engine = dmx_engine.effect_engine.lock();
@@ -533,12 +533,12 @@ impl Engine {
             return Ok(());
         }
 
-        // Build legacy MIDI playbacks and store them for effects-loop dispatch.
+        // Build MIDI DMX playbacks and store them for effects-loop dispatch.
         // Drain the map to take ownership of MidiSheets (avoids cloning event vecs).
         // This must happen BEFORE resetting timeline_finished to avoid a race where
         // the effects loop sees empty playbacks + no timeline and sets finished=true.
         {
-            let mut playbacks = dmx_engine.legacy_midi_playbacks.lock();
+            let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
             playbacks.clear();
             for (universe_name, (midi_sheet, channels)) in dmx_midi_sheets.drain() {
                 let midi_channels = HashSet::from_iter(channels);
@@ -549,7 +549,7 @@ impl Engine {
                 let events = midi_sheet.precomputed.into_events();
                 // Seek cursor past start_time
                 let cursor = events.partition_point(|e| e.time < start_time);
-                playbacks.push(LegacyMidiPlayback {
+                playbacks.push(MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor,
                     universe_id,
@@ -629,22 +629,22 @@ impl Engine {
         // Stop the lighting timeline for this song, but effects continue processing
         dmx_engine.stop_lighting_timeline();
 
-        // Clear legacy MIDI playbacks
-        dmx_engine.legacy_midi_playbacks.lock().clear();
+        // Clear MIDI DMX playbacks
+        dmx_engine.midi_dmx_playbacks.lock().clear();
 
         info!("DMX playback stopped.");
 
         Ok(())
     }
 
-    /// Advances all legacy MIDI playback cursors to the current song time,
+    /// Advances all MIDI DMX playback cursors to the current song time,
     /// dispatching events via handle_midi_event_by_id.
-    fn advance_legacy_midi_playbacks(&self) {
+    fn advance_midi_dmx_playbacks(&self) {
         let song_time = match self.get_song_time().checked_sub(self.playback_delay) {
             Some(t) => t,
             None => return, // Still within the playback delay period
         };
-        let mut playbacks = self.legacy_midi_playbacks.lock();
+        let mut playbacks = self.midi_dmx_playbacks.lock();
         for playback in playbacks.iter_mut() {
             let events = playback.precomputed.events();
             while playback.cursor < events.len() && events[playback.cursor].time <= song_time {
@@ -659,9 +659,9 @@ impl Engine {
         }
     }
 
-    /// Returns true if all legacy MIDI playbacks have finished.
-    fn legacy_playbacks_finished(&self) -> bool {
-        let playbacks = self.legacy_midi_playbacks.lock();
+    /// Returns true if all MIDI DMX playbacks have finished.
+    fn midi_dmx_playbacks_finished(&self) -> bool {
+        let playbacks = self.midi_dmx_playbacks.lock();
         playbacks.iter().all(|p| p.cursor >= p.precomputed.len())
     }
 
@@ -703,21 +703,21 @@ impl Engine {
         if let Some(universe) = self.universes.get(&universe_id) {
             universe.update_dim_speed(dimming_duration);
         }
-        // Mirror dim rate to legacy store
+        // Mirror dim rate to MIDI DMX store
         let rate = if dimming_duration.is_zero() {
             1.0
         } else {
             dimming_duration.as_secs_f64() * super::universe::TARGET_HZ
         };
-        self.legacy_store.read().set_dim_rate(universe_id, rate);
+        self.midi_dmx_store.read().set_dim_rate(universe_id, rate);
     }
 
     /// Updates the given universe by ID.
     /// Mapped channels (those with registered fixtures) go through the lockless
-    /// LegacyDmxStore for interpolation and EffectEngine injection. Unmapped
+    /// MidiDmxStore for interpolation and EffectEngine injection. Unmapped
     /// channels go directly to the Universe for backward compatibility.
     fn update_universe_by_id(&self, universe_id: u16, channel: u16, value: u8, dim: bool) {
-        let store = self.legacy_store.read();
+        let store = self.midi_dmx_store.read();
         if store.lookup(universe_id, channel).is_some() {
             // Mapped channel → lockless store (interpolation + EffectEngine injection)
             store.write(universe_id, channel, value, dim);
@@ -789,24 +789,24 @@ impl Engine {
             let lighting_system = lighting_system.lock();
             let fixture_infos = lighting_system.get_current_venue_fixtures()?;
             let mut effect_engine = self.effect_engine.lock();
-            let mut legacy_store = self.legacy_store.write();
+            let mut midi_dmx_store = self.midi_dmx_store.write();
 
             for fixture_info in &fixture_infos {
-                // Register slots in the legacy store for each fixture channel
+                // Register slots in the MIDI DMX store for each fixture channel
                 for (channel_name, &offset) in &fixture_info.channels {
                     let dmx_channel = fixture_info.address + offset - 1;
-                    legacy_store.register_slot(
+                    midi_dmx_store.register_slot(
                         fixture_info.universe,
                         dmx_channel,
                         &fixture_info.name,
                         channel_name,
                     );
                 }
-                legacy_store.register_universe(fixture_info.universe);
+                midi_dmx_store.register_universe(fixture_info.universe);
             }
 
-            // Set the legacy store reference on the EffectEngine
-            effect_engine.set_legacy_store(self.legacy_store.clone());
+            // Set the MIDI DMX store reference on the EffectEngine
+            effect_engine.set_midi_dmx_store(self.midi_dmx_store.clone());
 
             for fixture_info in fixture_infos {
                 effect_engine.register_fixture(fixture_info);
@@ -1034,7 +1034,7 @@ impl Engine {
                 let current_phase = phase.load(Ordering::Relaxed);
                 let phase_name = match current_phase {
                     0 => "idle",
-                    1 => "legacy_store_tick",
+                    1 => "midi_dmx_store_tick",
                     2 => "midi_advance",
                     3 => "update_effects",
                     4 => "update_song_lighting",
@@ -1048,7 +1048,7 @@ impl Engine {
                     2 => "acquire_effect_lock",
                     10 => "fast_path_check",
                     20 => "state_setup",
-                    30 => "legacy_inject",
+                    30 => "midi_dmx_inject",
                     40 => "effect_sort",
                     50 => "effect_process",
                     60 => "completed_effects",
@@ -1511,7 +1511,7 @@ mod test {
     }
 
     #[test]
-    fn test_legacy_midi_channel_filtering() -> Result<(), Box<dyn Error>> {
+    fn test_midi_dmx_channel_filtering() -> Result<(), Box<dyn Error>> {
         let (engine, _cancel_handle) = create_engine()?;
 
         assert_eq!(engine.get_universe(5).unwrap().get_dim_speed(), 1.0);
@@ -1526,7 +1526,7 @@ mod test {
 
         assert_eq!(engine.get_universe(5).unwrap().get_dim_speed(), 44.0);
 
-        // Verify channel filtering via legacy playback dispatch.
+        // Verify channel filtering via MIDI DMX playback dispatch.
         // Build a playback with channel filter = {5}.
         use crate::midi::playback::{PrecomputedMidi, TimedMidiEvent};
         let events = vec![TimedMidiEvent {
@@ -1540,8 +1540,8 @@ mod test {
         let mut midi_channels = HashSet::new();
         midi_channels.insert(5);
         {
-            let mut playbacks = engine.legacy_midi_playbacks.lock();
-            playbacks.push(super::LegacyMidiPlayback {
+            let mut playbacks = engine.midi_dmx_playbacks.lock();
+            playbacks.push(super::MidiDmxPlayback {
                 precomputed,
                 cursor: 0,
                 universe_id: 5,
@@ -1551,13 +1551,13 @@ mod test {
 
         // Advance playbacks — channel 6 should be excluded
         engine.update_song_time(std::time::Duration::from_secs(1));
-        engine.advance_legacy_midi_playbacks();
+        engine.advance_midi_dmx_playbacks();
 
         // Dim speed should still be 44.0, not reset to 0.0
         assert_eq!(engine.get_universe(5).unwrap().get_dim_speed(), 44.0);
 
         // Cleanup
-        engine.legacy_midi_playbacks.lock().clear();
+        engine.midi_dmx_playbacks.lock().clear();
 
         Ok(())
     }
@@ -1979,17 +1979,17 @@ mod test {
     }
 
     #[test]
-    fn test_legacy_song_clears_dsl_state() -> Result<(), Box<dyn std::error::Error>> {
-        // After a DSL song, a legacy song (MIDI-based light shows) must clear the
+    fn test_midi_dmx_song_clears_dsl_state() -> Result<(), Box<dyn std::error::Error>> {
+        // After a DSL song, a MIDI DMX song (MIDI-based light shows) must clear the
         // tempo map and timeline left behind.
         let (engine, cancel_handle) = create_engine()?;
         seed_lighting_state(&engine);
 
-        // Create a legacy song with a MIDI-based light show pointing to a
+        // Create a MIDI DMX song with a MIDI-based light show pointing to a
         // non-matching universe so the (empty) MIDI file is never parsed.
         let assets_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("assets");
         let song_config = crate::config::Song::new(
-            "Legacy Song",
+            "MIDI DMX Song",
             None,
             None,
             None,
@@ -2022,7 +2022,7 @@ mod test {
     }
 
     #[test]
-    fn test_legacy_midi_mirrors_to_effect_engine() -> Result<(), Box<dyn Error>> {
+    fn test_midi_dmx_mirrors_to_effect_engine() -> Result<(), Box<dyn Error>> {
         let (engine, _cancel_handle) = create_engine()?;
 
         // Register a fixture: universe 5 (matching create_engine), address 1
@@ -2041,9 +2041,9 @@ mod test {
             None,
         );
 
-        // Register slots in the legacy store
+        // Register slots in the MIDI DMX store
         {
-            let mut store = engine.legacy_store.write();
+            let mut store = engine.midi_dmx_store.write();
             store.register_slot(5, 1, "test_fixture", "dimmer");
             store.register_slot(5, 2, "test_fixture", "red");
             store.register_slot(5, 3, "test_fixture", "green");
@@ -2053,11 +2053,11 @@ mod test {
 
         {
             let mut effect_engine = engine.effect_engine.lock();
-            effect_engine.set_legacy_store(engine.legacy_store.clone());
+            effect_engine.set_midi_dmx_store(engine.midi_dmx_store.clone());
             effect_engine.register_fixture(fixture_info);
         }
 
-        // Send a legacy MIDI NoteOn: key=0 → DMX channel 1 (dimmer), vel=127 → value=254
+        // Send a MIDI DMX NoteOn: key=0 → DMX channel 1 (dimmer), vel=127 → value=254
         engine.handle_midi_event(
             "universe1".to_string(),
             midly::MidiMessage::NoteOn {
@@ -2068,7 +2068,7 @@ mod test {
 
         // Tick the store to interpolate (instant since NoteOn uses dim=true but
         // default dim_rate=1.0 so rate calculation produces a single-tick transition)
-        engine.legacy_store.read().tick();
+        engine.midi_dmx_store.read().tick();
 
         // Verify the EffectEngine has the value after update
         {
@@ -2096,7 +2096,7 @@ mod test {
     }
 
     #[test]
-    fn test_legacy_midi_unmapped_channel_no_mirror() -> Result<(), Box<dyn Error>> {
+    fn test_midi_dmx_unmapped_channel_no_mirror() -> Result<(), Box<dyn Error>> {
         let (engine, _cancel_handle) = create_engine()?;
 
         // Register a fixture with a small channel range (address 1, 4 channels)
@@ -2115,9 +2115,9 @@ mod test {
             None,
         );
 
-        // Register slots for channels 1-4 in the legacy store
+        // Register slots for channels 1-4 in the MIDI DMX store
         {
-            let mut store = engine.legacy_store.write();
+            let mut store = engine.midi_dmx_store.write();
             store.register_slot(5, 1, "test_fixture", "dimmer");
             store.register_slot(5, 2, "test_fixture", "red");
             store.register_slot(5, 3, "test_fixture", "green");
@@ -2127,7 +2127,7 @@ mod test {
 
         {
             let mut effect_engine = engine.effect_engine.lock();
-            effect_engine.set_legacy_store(engine.legacy_store.clone());
+            effect_engine.set_midi_dmx_store(engine.midi_dmx_store.clone());
             effect_engine.register_fixture(fixture_info);
         }
 
@@ -2149,7 +2149,7 @@ mod test {
         );
 
         // Tick and update
-        engine.legacy_store.read().tick();
+        engine.midi_dmx_store.read().tick();
 
         // EffectEngine should NOT have any state for this unmapped channel
         {
@@ -2394,14 +2394,14 @@ mod test {
         }
     }
 
-    mod legacy_playbacks_finished_tests {
+    mod midi_dmx_playbacks_finished_tests {
         use super::*;
         use crate::midi::playback::{PrecomputedMidi, TimedMidiEvent};
 
         #[test]
         fn no_playbacks_means_finished() -> Result<(), Box<dyn Error>> {
             let (engine, _cancel_handle) = create_engine()?;
-            assert!(engine.legacy_playbacks_finished());
+            assert!(engine.midi_dmx_playbacks_finished());
             Ok(())
         }
 
@@ -2417,15 +2417,15 @@ mod test {
                 },
             }];
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
-                playbacks.push(super::super::LegacyMidiPlayback {
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor: 0,
                     universe_id: 5,
                     midi_channels: HashSet::new(),
                 });
             }
-            assert!(!engine.legacy_playbacks_finished());
+            assert!(!engine.midi_dmx_playbacks_finished());
             Ok(())
         }
 
@@ -2442,15 +2442,15 @@ mod test {
             }];
             let len = events.len();
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
-                playbacks.push(super::super::LegacyMidiPlayback {
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor: len,
                     universe_id: 5,
                     midi_channels: HashSet::new(),
                 });
             }
-            assert!(engine.legacy_playbacks_finished());
+            assert!(engine.midi_dmx_playbacks_finished());
             Ok(())
         }
 
@@ -2466,28 +2466,28 @@ mod test {
                 },
             };
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
                 // Finished playback
-                playbacks.push(super::super::LegacyMidiPlayback {
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(vec![event.clone()]),
                     cursor: 1,
                     universe_id: 5,
                     midi_channels: HashSet::new(),
                 });
                 // Unfinished playback
-                playbacks.push(super::super::LegacyMidiPlayback {
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(vec![event]),
                     cursor: 0,
                     universe_id: 5,
                     midi_channels: HashSet::new(),
                 });
             }
-            assert!(!engine.legacy_playbacks_finished());
+            assert!(!engine.midi_dmx_playbacks_finished());
             Ok(())
         }
     }
 
-    mod advance_legacy_playbacks_tests {
+    mod advance_midi_dmx_playbacks_tests {
         use super::*;
         use crate::midi::playback::{PrecomputedMidi, TimedMidiEvent};
 
@@ -2512,8 +2512,8 @@ mod test {
                 },
             }];
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
-                playbacks.push(super::super::LegacyMidiPlayback {
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor: 0,
                     universe_id: 5,
@@ -2523,10 +2523,10 @@ mod test {
 
             // Song time = 1s, delay = 2s → checked_sub returns None → no advance
             engine.update_song_time(std::time::Duration::from_secs(1));
-            engine.advance_legacy_midi_playbacks();
+            engine.advance_midi_dmx_playbacks();
 
             // Cursor should still be at 0
-            let playbacks = engine.legacy_midi_playbacks.lock();
+            let playbacks = engine.midi_dmx_playbacks.lock();
             assert_eq!(playbacks[0].cursor, 0);
             Ok(())
         }
@@ -2552,8 +2552,8 @@ mod test {
                 },
             }];
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
-                playbacks.push(super::super::LegacyMidiPlayback {
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor: 0,
                     universe_id: 5,
@@ -2563,9 +2563,9 @@ mod test {
 
             // Song time = 2s, delay = 1s → effective time = 1s → should advance
             engine.update_song_time(std::time::Duration::from_secs(2));
-            engine.advance_legacy_midi_playbacks();
+            engine.advance_midi_dmx_playbacks();
 
-            let playbacks = engine.legacy_midi_playbacks.lock();
+            let playbacks = engine.midi_dmx_playbacks.lock();
             assert_eq!(playbacks[0].cursor, 1);
             Ok(())
         }
@@ -2593,8 +2593,8 @@ mod test {
                 },
             ];
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
-                playbacks.push(super::super::LegacyMidiPlayback {
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor: 0,
                     universe_id: 5,
@@ -2604,9 +2604,9 @@ mod test {
 
             // At 1s, only the first event (at 500ms) should be dispatched
             engine.update_song_time(std::time::Duration::from_secs(1));
-            engine.advance_legacy_midi_playbacks();
+            engine.advance_midi_dmx_playbacks();
 
-            let playbacks = engine.legacy_midi_playbacks.lock();
+            let playbacks = engine.midi_dmx_playbacks.lock();
             assert_eq!(
                 playbacks[0].cursor, 1,
                 "should advance past first event only"
@@ -2637,8 +2637,8 @@ mod test {
                 },
             ];
             {
-                let mut playbacks = engine.legacy_midi_playbacks.lock();
-                playbacks.push(super::super::LegacyMidiPlayback {
+                let mut playbacks = engine.midi_dmx_playbacks.lock();
+                playbacks.push(super::super::MidiDmxPlayback {
                     precomputed: PrecomputedMidi::from_events(events),
                     cursor: 0,
                     universe_id: 5,
@@ -2647,10 +2647,10 @@ mod test {
             }
 
             engine.update_song_time(std::time::Duration::from_secs(1));
-            engine.advance_legacy_midi_playbacks();
+            engine.advance_midi_dmx_playbacks();
 
             // Both events should be dispatched
-            let playbacks = engine.legacy_midi_playbacks.lock();
+            let playbacks = engine.midi_dmx_playbacks.lock();
             assert_eq!(playbacks[0].cursor, 2);
             Ok(())
         }
@@ -3135,11 +3135,11 @@ mod test {
         }
 
         #[test]
-        fn dimming_mirrors_to_legacy_store() -> Result<(), Box<dyn Error>> {
+        fn dimming_mirrors_to_midi_dmx_store() -> Result<(), Box<dyn Error>> {
             let (engine, _cancel_handle) = create_engine()?;
 
-            // Register universe in legacy store
-            engine.legacy_store.write().register_universe(5);
+            // Register universe in MIDI DMX store
+            engine.midi_dmx_store.write().register_universe(5);
 
             // Send a ProgramChange to set dimming
             engine.handle_midi_event_by_id(
@@ -3149,9 +3149,9 @@ mod test {
                 },
             );
 
-            // Legacy store should have the mirrored rate
+            // MIDI DMX store should have the mirrored rate
             // Just verify it doesn't panic — the rate value depends on the dimming_speed_modifier
-            let _store = engine.legacy_store.read();
+            let _store = engine.midi_dmx_store.read();
             Ok(())
         }
 
@@ -3523,13 +3523,13 @@ mod test {
         }
 
         #[test]
-        fn play_legacy_song_with_unmatched_universe() -> Result<(), Box<dyn Error>> {
+        fn play_midi_dmx_song_with_unmatched_universe() -> Result<(), Box<dyn Error>> {
             let (engine, cancel_handle) = create_engine()?;
             Engine::start_persistent_effects_loop(engine.clone());
 
             let assets_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("assets");
             let song_config = crate::config::Song::new(
-                "Legacy Song",
+                "MIDI DMX Song",
                 None,
                 None,
                 None,
@@ -3561,14 +3561,14 @@ mod test {
         }
 
         #[test]
-        fn play_legacy_song_multiple_unmatched_universes() -> Result<(), Box<dyn Error>> {
+        fn play_midi_dmx_song_multiple_unmatched_universes() -> Result<(), Box<dyn Error>> {
             // Test the empty barrier thread path with multiple unmatched universes
             let (engine, cancel_handle) = create_engine()?;
             Engine::start_persistent_effects_loop(engine.clone());
 
             let assets_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("assets");
             let song_config = crate::config::Song::new(
-                "Legacy Multi",
+                "MIDI DMX Multi",
                 None,
                 None,
                 None,
@@ -4209,7 +4209,7 @@ mod test {
         }
     }
 
-    mod play_matched_legacy_tests {
+    mod play_matched_midi_dmx_tests {
         use super::*;
 
         /// Create a minimal valid MIDI file (Type 0, 1 track)
@@ -4233,7 +4233,7 @@ mod test {
         }
 
         #[test]
-        fn play_legacy_song_with_matching_universe() -> Result<(), Box<dyn Error>> {
+        fn play_midi_dmx_song_with_matching_universe() -> Result<(), Box<dyn Error>> {
             // Create engine with universe "universe1" mapped to ID 5
             let (engine, cancel_handle) = create_engine()?;
             Engine::start_persistent_effects_loop(engine.clone());
@@ -4243,7 +4243,7 @@ mod test {
             create_valid_midi_file(&midi_path);
 
             let song_config = crate::config::Song::new(
-                "Legacy Matched",
+                "MIDI DMX Matched",
                 None,
                 None,
                 None,
@@ -4275,7 +4275,7 @@ mod test {
         }
 
         #[test]
-        fn play_legacy_song_matched_with_start_time() -> Result<(), Box<dyn Error>> {
+        fn play_midi_dmx_song_matched_with_start_time() -> Result<(), Box<dyn Error>> {
             let (engine, cancel_handle) = create_engine()?;
             Engine::start_persistent_effects_loop(engine.clone());
 
@@ -4284,7 +4284,7 @@ mod test {
             create_valid_midi_file(&midi_path);
 
             let song_config = crate::config::Song::new(
-                "Legacy Seek",
+                "MIDI DMX Seek",
                 None,
                 None,
                 None,
@@ -4379,8 +4379,8 @@ mod test {
         }
 
         #[test]
-        fn play_two_matched_legacy_universes() -> Result<(), Box<dyn Error>> {
-            // Engine with two universes to cover the second legacy barrier thread (line 713-714)
+        fn play_two_matched_midi_dmx_universes() -> Result<(), Box<dyn Error>> {
+            // Engine with two universes to cover the second MIDI DMX barrier thread (line 713-714)
             let config = config::Dmx::new(
                 None,
                 None,
@@ -4440,8 +4440,8 @@ mod test {
         }
 
         #[test]
-        fn play_dsl_and_legacy_combined() -> Result<(), Box<dyn Error>> {
-            // Song with both DSL and legacy light shows
+        fn play_dsl_and_midi_dmx_combined() -> Result<(), Box<dyn Error>> {
+            // Song with both DSL and MIDI DMX light shows
             let config = config::Dmx::new(
                 None,
                 None,

--- a/src/dmx/midi_dmx_store.rs
+++ b/src/dmx/midi_dmx_store.rs
@@ -49,16 +49,16 @@ impl Slot {
     }
 }
 
-/// Lockless store for legacy MIDI DMX values. MIDI events write atomically;
+/// Lockless store for MIDI DMX values. MIDI events write atomically;
 /// the effects loop calls `tick()` each frame to interpolate, then reads
 /// interpolated values for injection into the EffectEngine.
-impl Default for LegacyDmxStore {
+impl Default for MidiDmxStore {
     fn default() -> Self {
         Self::new()
     }
 }
 
-pub struct LegacyDmxStore {
+pub struct MidiDmxStore {
     /// Pre-allocated slots indexed by position.
     slots: Vec<Slot>,
     /// (universe_id, dmx_channel) → slot index.
@@ -76,7 +76,7 @@ pub struct LegacyDmxStore {
     interpolating: AtomicBool,
 }
 
-impl LegacyDmxStore {
+impl MidiDmxStore {
     /// Creates an empty store.
     pub fn new() -> Self {
         Self {
@@ -243,8 +243,8 @@ impl LegacyDmxStore {
 mod tests {
     use super::*;
 
-    fn create_test_store() -> LegacyDmxStore {
-        let mut store = LegacyDmxStore::new();
+    fn create_test_store() -> MidiDmxStore {
+        let mut store = MidiDmxStore::new();
         store.register_slot(1, 10, "wash1", "dimmer");
         store.register_slot(1, 11, "wash1", "red");
         store.register_slot(1, 12, "wash1", "green");
@@ -442,14 +442,14 @@ mod tests {
 
     #[test]
     fn test_default_trait() {
-        let store = LegacyDmxStore::default();
+        let store = MidiDmxStore::default();
         assert_eq!(store.iter_active().count(), 0);
         assert_eq!(store.generation(), 0);
     }
 
     #[test]
     fn test_multiple_universes() {
-        let mut store = LegacyDmxStore::new();
+        let mut store = MidiDmxStore::new();
         store.register_slot(1, 1, "fixture_a", "dimmer");
         store.register_slot(2, 1, "fixture_b", "dimmer");
         store.register_universe(1);

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -29,7 +29,7 @@ use super::effects::*;
 use super::tempo::TempoMap;
 use tracing::debug;
 
-use crate::dmx::legacy_store::LegacyDmxStore;
+use crate::dmx::midi_dmx_store::MidiDmxStore;
 
 /// The main effects engine that manages and processes lighting effects
 pub struct EffectEngine {
@@ -65,11 +65,11 @@ pub struct EffectEngine {
     /// Only built during tests for validation; not needed in production.
     #[cfg(test)]
     dmx_to_fixture_map: HashMap<(u16, u16), (String, String)>,
-    /// Reference to the legacy DMX store for reading interpolated values each frame.
-    legacy_store: Option<Arc<parking_lot::RwLock<LegacyDmxStore>>>,
+    /// Reference to the MIDI DMX store for reading interpolated values each frame.
+    midi_dmx_store: Option<Arc<parking_lot::RwLock<MidiDmxStore>>>,
     /// Cached DmxCommands from the last update() — returned when nothing has changed.
     cached_commands: Vec<DmxCommand>,
-    /// Last-seen legacy store generation (used to detect when recomputation can be skipped).
+    /// Last-seen MIDI DMX store generation (used to detect when recomputation can be skipped).
     last_store_generation: u32,
     /// Set when engine state is mutated outside of update() (e.g. clear_layer,
     /// stop_all_effects). Forces the next update() to do a full recomputation
@@ -77,7 +77,7 @@ pub struct EffectEngine {
     cache_dirty: bool,
     /// Sub-phase indicator for update() progress. Shared via Arc so external
     /// code (heartbeat checker) can read it without holding the effect_engine lock.
-    /// 0=idle, 10=fast_path, 20=state_setup, 30=legacy_inject, 40=effect_sort,
+    /// 0=idle, 10=fast_path, 20=state_setup, 30=midi_dmx_inject, 40=effect_sort,
     /// 50=effect_process, 60=completed_effects, 70=persist_state, 80=dmx_generate.
     update_subphase: Arc<AtomicU64>,
 }
@@ -106,7 +106,7 @@ impl EffectEngine {
             last_song_time: None,
             #[cfg(test)]
             dmx_to_fixture_map: HashMap::new(),
-            legacy_store: None,
+            midi_dmx_store: None,
             cached_commands: Vec::new(),
             last_store_generation: 0,
             cache_dirty: false,
@@ -298,9 +298,9 @@ impl EffectEngine {
         self.dmx_to_fixture_map.get(&(universe, dmx_channel))
     }
 
-    /// Set the legacy DMX store reference for reading interpolated MIDI values.
-    pub fn set_legacy_store(&mut self, store: Arc<parking_lot::RwLock<LegacyDmxStore>>) {
-        self.legacy_store = Some(store);
+    /// Set the MIDI DMX store reference for reading interpolated MIDI values.
+    pub fn set_midi_dmx_store(&mut self, store: Arc<parking_lot::RwLock<MidiDmxStore>>) {
+        self.midi_dmx_store = Some(store);
     }
 
     /// Start an effect
@@ -393,7 +393,7 @@ impl EffectEngine {
         self.engine_elapsed += dt;
         self.last_song_time = song_time;
 
-        // Fast path for legacy-only frames: when no DSL effects are running and
+        // Fast path for MIDI-DMX-only frames: when no DSL effects are running and
         // no permanent state exists, generate DmxCommands directly from the store.
         // This skips all HashMap cloning, fixture state rebuilding, and the full
         // merge pipeline — significant savings during active MIDI playback.
@@ -403,7 +403,7 @@ impl EffectEngine {
             && self.fixture_states.is_empty()
         {
             let store_gen = self
-                .legacy_store
+                .midi_dmx_store
                 .as_ref()
                 .map(|s| s.read().generation())
                 .unwrap_or(0);
@@ -419,7 +419,7 @@ impl EffectEngine {
             let mut commands = Vec::new();
             self.last_merged_states.clear();
 
-            if let Some(ref store) = self.legacy_store {
+            if let Some(ref store) = self.midi_dmx_store {
                 let store = store.read();
                 for (slot_idx, normalized_value) in store.iter_active() {
                     let (fixture_name, channel_name) = store.fixture_info(slot_idx);
@@ -460,7 +460,7 @@ impl EffectEngine {
         if !self.cache_dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
         {
             let store_gen = self
-                .legacy_store
+                .midi_dmx_store
                 .as_ref()
                 .map(|s| s.read().generation())
                 .unwrap_or(0);
@@ -485,7 +485,7 @@ impl EffectEngine {
         }
 
         // Track which channels come from permanent effects to preserve them later.
-        // This MUST be computed before injecting direct values so that legacy MIDI
+        // This MUST be computed before injecting direct values so that MIDI DMX
         // channel states are not accidentally persisted as permanent effect state.
         let mut permanent_channels: HashMap<String, std::collections::HashSet<String>> =
             current_fixture_states
@@ -495,9 +495,9 @@ impl EffectEngine {
 
         self.update_subphase.store(30, Ordering::Relaxed);
 
-        // Inject legacy MIDI values from the lockless store (lowest priority).
+        // Inject MIDI DMX values from the lockless store (lowest priority).
         // Only set channels that aren't already claimed by persisted permanent effects.
-        if let Some(ref store) = self.legacy_store {
+        if let Some(ref store) = self.midi_dmx_store {
             let store = store.read();
             for (slot_idx, normalized_value) in store.iter_active() {
                 let (fixture_name, channel_name) = store.fixture_info(slot_idx);
@@ -846,8 +846,8 @@ impl EffectEngine {
         self.last_merged_states = merged_states.clone();
 
         // Convert fixture states to DMX commands.
-        // All commands pass through — legacy MIDI values are now handled via the
-        // LegacyDmxStore → EffectEngine injection path (no suppression needed).
+        // All commands pass through — MIDI DMX values are now handled via the
+        // MidiDmxStore → EffectEngine injection path (no suppression needed).
         let mut commands = Vec::new();
         for (fixture_name, fixture_state) in merged_states {
             if let Some(fixture_info) = self.fixture_registry.get(&fixture_name) {
@@ -859,7 +859,7 @@ impl EffectEngine {
         // subsequent frames where nothing changes.
         self.cached_commands = commands.clone();
         self.last_store_generation = self
-            .legacy_store
+            .midi_dmx_store
             .as_ref()
             .map(|s| s.read().generation())
             .unwrap_or(0);
@@ -921,10 +921,10 @@ impl EffectEngine {
         self.fixture_states.clear();
         self.channel_locks.clear();
         self.last_merged_states.clear();
-        // Clear legacy MIDI values so they don't bleed into the next song.
-        // Uses a read lock because LegacyDmxStore uses interior mutability
+        // Clear MIDI DMX values so they don't bleed into the next song.
+        // Uses a read lock because MidiDmxStore uses interior mutability
         // (atomics) — no write lock needed.
-        if let Some(ref store) = self.legacy_store {
+        if let Some(ref store) = self.midi_dmx_store {
             store.read().clear();
         }
         self.cache_dirty = true;

--- a/src/lighting/engine/tests/direct_value_tests.rs
+++ b/src/lighting/engine/tests/direct_value_tests.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use super::common::create_test_fixture;
-use crate::dmx::legacy_store::LegacyDmxStore;
+use crate::dmx::midi_dmx_store::MidiDmxStore;
 use crate::lighting::effects::{EffectType, FixtureInfo};
 use crate::lighting::engine::EffectEngine;
 use crate::lighting::EffectInstance;
@@ -20,11 +20,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Helper: create a LegacyDmxStore with slots matching create_test_fixture("wash1", 1, 1).
+/// Helper: create a MidiDmxStore with slots matching create_test_fixture("wash1", 1, 1).
 /// The fixture has channels dimmer=1, red=2, green=3, blue=4, white=5, strobe=6
 /// at universe 1, address 1, so DMX channels are 1–6.
-fn create_store_for_wash1() -> Arc<parking_lot::RwLock<LegacyDmxStore>> {
-    let mut store = LegacyDmxStore::new();
+fn create_store_for_wash1() -> Arc<parking_lot::RwLock<MidiDmxStore>> {
+    let mut store = MidiDmxStore::new();
     store.register_slot(1, 1, "wash1", "dimmer"); // address 1 + offset 1 - 1 = 1
     store.register_slot(1, 2, "wash1", "red"); // address 1 + offset 2 - 1 = 2
     store.register_slot(1, 3, "wash1", "green"); // address 1 + offset 3 - 1 = 3
@@ -86,16 +86,16 @@ fn test_reverse_map_construction() {
 }
 
 #[test]
-fn test_legacy_store_values_in_merged_states() {
+fn test_midi_dmx_store_values_in_merged_states() {
     let mut engine = EffectEngine::new();
 
     let fixture = create_test_fixture("wash1", 1, 1);
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
-    // Write values via the store (simulating legacy MIDI writes)
+    // Write values via the store (simulating MIDI DMX writes)
     // Values are in 0–255 DMX scale
     {
         let s = store.read();
@@ -128,8 +128,8 @@ fn test_legacy_store_values_in_merged_states() {
 }
 
 #[test]
-fn test_legacy_store_values_generate_dmx_commands() {
-    // With the new single-path architecture, legacy values flow through the
+fn test_midi_dmx_store_values_generate_dmx_commands() {
+    // With the new single-path architecture, MIDI DMX values flow through the
     // EffectEngine and generate DmxCommands (no suppression).
     let mut engine = EffectEngine::new();
 
@@ -137,7 +137,7 @@ fn test_legacy_store_values_generate_dmx_commands() {
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
     // Write red value via the store
     {
@@ -154,22 +154,22 @@ fn test_legacy_store_values_generate_dmx_commands() {
         .find(|cmd| cmd.universe == 1 && cmd.channel == 2);
     assert!(
         red_cmd.is_some(),
-        "DMX command for legacy channel (universe 1, channel 2) should be generated"
+        "DMX command for MIDI DMX channel (universe 1, channel 2) should be generated"
     );
     assert_eq!(red_cmd.unwrap().value, 255);
 }
 
 #[test]
-fn test_legacy_store_values_overridden_by_effects() {
+fn test_midi_dmx_store_values_overridden_by_effects() {
     let mut engine = EffectEngine::new();
 
     let fixture = create_test_fixture("wash1", 1, 1);
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
-    // Set legacy store value for red = 128 (0.502 normalized)
+    // Set MIDI DMX store value for red = 128 (0.502 normalized)
     {
         let s = store.read();
         s.write(1, 2, 128, false);
@@ -196,26 +196,26 @@ fn test_legacy_store_values_overridden_by_effects() {
 
     let _commands = engine.update(Duration::from_millis(23), None).unwrap();
 
-    // The effect should override the legacy store value
+    // The effect should override the MIDI DMX store value
     let states = engine.get_fixture_states();
     let wash1_state = states.get("wash1").unwrap();
     assert!(
         (wash1_state.channels.get("red").unwrap().value - 1.0).abs() < f64::EPSILON,
-        "effect should override legacy store value: got {}",
+        "effect should override MIDI DMX store value: got {}",
         wash1_state.channels.get("red").unwrap().value
     );
 }
 
 #[test]
-fn test_legacy_store_values_update_across_frames() {
-    // Regression test: legacy values must reflect new MIDI writes on subsequent frames.
+fn test_midi_dmx_store_values_update_across_frames() {
+    // Regression test: MIDI DMX values must reflect new MIDI writes on subsequent frames.
     let mut engine = EffectEngine::new();
 
     let fixture = create_test_fixture("wash1", 1, 1);
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
     // Frame 1: set red = 128 (~0.502)
     {
@@ -282,8 +282,8 @@ fn test_legacy_store_values_update_across_frames() {
 }
 
 #[test]
-fn test_legacy_store_values_not_persisted_as_permanent() {
-    // Legacy values should NOT be saved into fixture_states (permanent storage).
+fn test_midi_dmx_store_values_not_persisted_as_permanent() {
+    // MIDI DMX values should NOT be saved into fixture_states (permanent storage).
     // They must be re-injected fresh each frame from the store.
     let mut engine = EffectEngine::new();
 
@@ -291,7 +291,7 @@ fn test_legacy_store_values_not_persisted_as_permanent() {
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
     // Set and process one frame
     {
@@ -316,14 +316,14 @@ fn test_legacy_store_values_not_persisted_as_permanent() {
 }
 
 #[test]
-fn test_clear_legacy_store() {
+fn test_clear_midi_dmx_store() {
     let mut engine = EffectEngine::new();
 
     let fixture = create_test_fixture("wash1", 1, 1);
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
     // Write values
     {
@@ -336,7 +336,7 @@ fn test_clear_legacy_store() {
     // Clear the store
     store.read().clear();
 
-    // After update, no legacy values should appear
+    // After update, no MIDI DMX values should appear
     let _commands = engine.update(Duration::from_millis(23), None).unwrap();
     let states = engine.get_fixture_states();
 
@@ -350,14 +350,14 @@ fn test_clear_legacy_store() {
 }
 
 #[test]
-fn test_stop_all_effects_clears_legacy_store() {
+fn test_stop_all_effects_clears_midi_dmx_store() {
     let mut engine = EffectEngine::new();
 
     let fixture = create_test_fixture("wash1", 1, 1);
     engine.register_fixture(fixture);
 
     let store = create_store_for_wash1();
-    engine.set_legacy_store(store.clone());
+    engine.set_midi_dmx_store(store.clone());
 
     // Write values
     {
@@ -371,7 +371,7 @@ fn test_stop_all_effects_clears_legacy_store() {
     let states = engine.get_fixture_states();
     assert!(states.contains_key("wash1"), "wash1 should have state");
 
-    // stop_all_effects should clear the legacy store
+    // stop_all_effects should clear the MIDI DMX store
     engine.stop_all_effects();
 
     let _commands = engine.update(Duration::from_millis(23), None).unwrap();

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -264,9 +264,9 @@ impl LightingSystem {
                     return self.resolve_logical_group_graceful(&fallback_group);
                 }
 
-                // Try legacy group system as final fallback
-                if let Ok(legacy_group) = self.get_group(group_name) {
-                    return legacy_group.fixtures().to_vec();
+                // Try venue group system as final fallback
+                if let Ok(venue_group) = self.get_group(group_name) {
+                    return venue_group.fixtures().to_vec();
                 }
                 Vec::new()
             }
@@ -1239,7 +1239,7 @@ mod tests {
     }
 
     #[test]
-    fn test_graceful_with_legacy_group_fallback() {
+    fn test_graceful_with_venue_group_fallback() {
         let mut system = LightingSystem::new();
 
         let mut fixtures = HashMap::new();
@@ -1254,23 +1254,27 @@ mod tests {
             ),
         );
 
-        // Create venue with a legacy group definition
+        // Create venue with a venue group definition
         let mut groups = HashMap::new();
         groups.insert(
-            "legacy_wash".to_string(),
-            Group::new("legacy_wash".to_string(), vec!["Wash1".to_string()]),
+            "venue_wash".to_string(),
+            Group::new("venue_wash".to_string(), vec!["Wash1".to_string()]),
         );
 
         let venue = Venue::new("Test Venue".to_string(), fixtures, groups);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
-        // Don't define legacy_wash as a logical group - it should fall through to legacy
-        let results = system.resolve_logical_group_graceful("legacy_wash");
-        assert_eq!(results.len(), 1, "Legacy fallback should return 1 fixture");
+        // Don't define venue_wash as a logical group - it should fall through to venue groups
+        let results = system.resolve_logical_group_graceful("venue_wash");
+        assert_eq!(
+            results.len(),
+            1,
+            "Venue group fallback should return 1 fixture"
+        );
         assert!(
             results.contains(&"Wash1".to_string()),
-            "Legacy fallback should contain Wash1"
+            "Venue group fallback should contain Wash1"
         );
     }
 }

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -2660,7 +2660,7 @@ mod test {
         ];
         fs::write(song_dir.join("song.mid"), &midi_bytes)?;
 
-        // Legacy DMX light show file (dmx_ prefix)
+        // MIDI DMX light show file (dmx_ prefix)
         fs::write(song_dir.join("dmx_light.mid"), &midi_bytes)?;
 
         // DSL lighting show file
@@ -2681,11 +2681,11 @@ mod test {
             "Expected MIDI playback from song.mid"
         );
 
-        // Should have one legacy light show from dmx_light.mid.
+        // Should have one MIDI DMX light show from dmx_light.mid.
         assert_eq!(
             song.light_shows().len(),
             1,
-            "Expected one legacy light show from dmx_light.mid"
+            "Expected one MIDI DMX light show from dmx_light.mid"
         );
 
         // Should have one DSL lighting show from show.light.

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -57,8 +57,8 @@ pub(super) async fn get_songs(State(state): State<WebUiState>) -> impl IntoRespo
                 })
                 .collect();
 
-            // Collect legacy MIDI DMX file paths relative to the songs root.
-            let legacy_lighting_files: Vec<String> = song
+            // Collect MIDI DMX file paths relative to the songs root.
+            let midi_dmx_files: Vec<String> = song
                 .light_shows()
                 .iter()
                 .filter_map(|show| {
@@ -81,7 +81,7 @@ pub(super) async fn get_songs(State(state): State<WebUiState>) -> impl IntoRespo
                 "has_lighting": !song.light_shows().is_empty() || !song.dsl_lighting_shows().is_empty(),
                 "base_dir": base_dir,
                 "lighting_files": lighting_files,
-                "legacy_lighting_files": legacy_lighting_files,
+                "midi_dmx_files": midi_dmx_files,
             })
         })
         .collect();
@@ -1953,7 +1953,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn get_songs_includes_legacy_lighting_files() {
+    async fn get_songs_includes_midi_dmx_files() {
         let (mut state, _dir) = test_state();
         state.songs_path = state.songs_path.canonicalize().unwrap();
 
@@ -1999,14 +1999,14 @@ mod test {
             .iter()
             .find(|s| s["name"] == "LegacySong")
             .expect("LegacySong should be in the response");
-        let legacy_files = legacy_song["legacy_lighting_files"].as_array().unwrap();
+        let legacy_files = legacy_song["midi_dmx_files"].as_array().unwrap();
         assert!(
             !legacy_files.is_empty(),
-            "legacy_lighting_files should be populated"
+            "midi_dmx_files should be populated"
         );
         assert!(
             legacy_files[0].as_str().unwrap().contains("dmx_show.mid"),
-            "legacy_lighting_files should contain the dmx MIDI file path"
+            "midi_dmx_files should contain the dmx MIDI file path"
         );
     }
 

--- a/src/webui/svelte/src/components/songs/SongDetail.svelte
+++ b/src/webui/svelte/src/components/songs/SongDetail.svelte
@@ -385,7 +385,7 @@
         {#if song && song.lighting_files.length > 0}
           <span class="badge lighting">LIGHT</span>
         {/if}
-        {#if song && song.legacy_lighting_files.length > 0}
+        {#if song && song.midi_dmx_files.length > 0}
           <span class="badge midi-dmx">MIDI DMX</span>
         {/if}
       </div>

--- a/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
@@ -481,8 +481,8 @@
 
     <div class="file-info">
       {lightFiles.length} DSL
-      {#if song.legacy_lighting_files.length > 0}
-        + {song.legacy_lighting_files.length} MIDI DMX
+      {#if song.midi_dmx_files.length > 0}
+        + {song.midi_dmx_files.length} MIDI DMX
       {/if}
       <button class="btn btn-sm" onclick={addLightFile}>+ DSL</button>
       <button class="btn btn-sm" onclick={() => (showMidiDmxModal = true)}>
@@ -581,11 +581,11 @@
         >
       </div>
       <div class="modal-body">
-        {#if song.legacy_lighting_files.length > 0}
+        {#if song.midi_dmx_files.length > 0}
           <div class="modal-section">
             <span class="modal-section-label">Current Files</span>
             <div class="midi-dmx-files">
-              {#each song.legacy_lighting_files as lf (lf)}
+              {#each song.midi_dmx_files as lf (lf)}
                 <span class="midi-dmx-file" title={lf}
                   >{lf.replace(/^.*\//, "")}</span
                 >

--- a/src/webui/svelte/src/components/songs/SongList.svelte
+++ b/src/webui/svelte/src/components/songs/SongList.svelte
@@ -245,7 +245,7 @@
                   {#if song.lighting_files.length > 0}
                     <span class="badge lighting">LIGHT</span>
                   {/if}
-                  {#if song.legacy_lighting_files.length > 0}
+                  {#if song.midi_dmx_files.length > 0}
                     <span class="badge midi-dmx">MIDI DMX</span>
                   {/if}
                 </div>

--- a/src/webui/svelte/src/lib/api/songs.ts
+++ b/src/webui/svelte/src/lib/api/songs.ts
@@ -29,7 +29,7 @@ export interface SongSummary {
   /** DSL lighting file paths relative to the songs root */
   lighting_files: string[];
   /** MIDI DMX file paths relative to the songs root */
-  legacy_lighting_files: string[];
+  midi_dmx_files: string[];
 }
 
 export interface WaveformTrack {

--- a/src/webui/svelte/src/pages/LightingEditor.svelte
+++ b/src/webui/svelte/src/pages/LightingEditor.svelte
@@ -86,7 +86,7 @@
   let sequenceNames = $derived(mergedLightFile.sequences.map((s) => s.name));
 
   let uploading = $state(false);
-  let showLegacyModal = $state(false);
+  let showMidiDmxModal = $state(false);
   let showFileBrowser = $state(false);
 
   // --- Data loading ---
@@ -451,7 +451,7 @@
                 {#if song.lighting_files.length > 0}
                   <span class="lighting-dot dsl" title="DSL lighting"></span>
                 {:else if song.has_lighting}
-                  <span class="lighting-dot legacy" title="Legacy MIDI lighting"
+                  <span class="lighting-dot midi-dmx" title="MIDI DMX lighting"
                   ></span>
                 {/if}
               </span>
@@ -492,12 +492,12 @@
 
         <div class="file-info">
           {lightFiles.length} DSL
-          {#if selectedSong && selectedSong.legacy_lighting_files.length > 0}
-            + {selectedSong.legacy_lighting_files.length} legacy
+          {#if selectedSong && selectedSong.midi_dmx_files.length > 0}
+            + {selectedSong.midi_dmx_files.length} MIDI DMX
           {/if}
           <button class="btn btn-sm" onclick={addLightFile}>+ DSL</button>
-          <button class="btn btn-sm" onclick={() => (showLegacyModal = true)}>
-            Legacy DMX...
+          <button class="btn btn-sm" onclick={() => (showMidiDmxModal = true)}>
+            MIDI DMX...
           </button>
         </div>
 
@@ -586,13 +586,13 @@
   </div>
 </div>
 
-{#if showLegacyModal && selectedSong}
+{#if showMidiDmxModal && selectedSong}
   <div
     class="modal-overlay"
-    onclick={() => (showLegacyModal = false)}
-    onkeydown={(e) => e.key === "Escape" && (showLegacyModal = false)}
+    onclick={() => (showMidiDmxModal = false)}
+    onkeydown={(e) => e.key === "Escape" && (showMidiDmxModal = false)}
     role="dialog"
-    aria-label="Legacy MIDI DMX Files"
+    aria-label="MIDI DMX Files"
     tabindex="-1"
   >
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -603,27 +603,27 @@
       role="document"
     >
       <div class="modal-header">
-        <h3>Legacy MIDI DMX Files</h3>
+        <h3>MIDI DMX Files</h3>
         <span class="modal-song">{selectedSongName}</span>
-        <button class="btn btn-sm" onclick={() => (showLegacyModal = false)}>
+        <button class="btn btn-sm" onclick={() => (showMidiDmxModal = false)}>
           Close
         </button>
       </div>
 
       <div class="modal-body">
-        {#if selectedSong.legacy_lighting_files.length > 0}
+        {#if selectedSong.midi_dmx_files.length > 0}
           <div class="modal-section">
             <span class="modal-section-label">Current Files</span>
-            <div class="legacy-files">
-              {#each selectedSong.legacy_lighting_files as lf (lf)}
-                <span class="legacy-file" title={lf}>
+            <div class="midi-dmx-files">
+              {#each selectedSong.midi_dmx_files as lf (lf)}
+                <span class="midi-dmx-file" title={lf}>
                   {lf.replace(/^.*\//, "")}
                 </span>
               {/each}
             </div>
           </div>
         {:else}
-          <p class="muted">No legacy MIDI DMX files.</p>
+          <p class="muted">No MIDI DMX files.</p>
         {/if}
 
         <div class="modal-section">
@@ -781,7 +781,7 @@
   .lighting-dot.dsl {
     background: var(--accent);
   }
-  .lighting-dot.legacy {
+  .lighting-dot.midi-dmx {
     background: var(--text-dim);
     border: 1px solid var(--text-muted);
     width: 5px;
@@ -895,12 +895,12 @@
     letter-spacing: 0.5px;
     font-weight: 600;
   }
-  .legacy-files {
+  .midi-dmx-files {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
   }
-  .legacy-file {
+  .midi-dmx-file {
     font-size: 12px;
     font-family: var(--mono);
     color: var(--text-muted);


### PR DESCRIPTION
I don't think the legacy DMX MIDI light shows are going anywhere, so It's been renamed in the docs and code to treat this as a first class feature as opposed to referring to it as legacy.