### PR TITLE
Start controller init after hardware init.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-03-20
+
+### Fixed
+
+- **Controller startup timing**: MIDI controllers (and any controller that depends on
+  hardware devices) failed to start because controllers were initialized before async
+  hardware discovery completed. Controllers are now started at the end of hardware
+  initialization, after all devices are ready. This also affects hardware reloads —
+  controllers are re-created with each reload cycle.
+- **`Player::new()` returns `Arc<Player>`**: Since the player spawns async init tasks
+  that require `Arc` access, `new()` now returns `Arc<Player>` directly instead of
+  requiring callers to wrap it.
+
 ## [0.11.0] - 2026-03-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -217,12 +217,12 @@ pub async fn start(
             .join("playlist.yaml")
     });
 
-    let player = Arc::new(crate::player::Player::new(
+    let player = crate::player::Player::new(
         playlists,
         active_playlist,
         &player_config,
         player_path.parent(),
-    )?);
+    )?;
     player.set_config_store(config_store);
 
     // Create the state watch channel upfront. The sampler will be started
@@ -265,14 +265,6 @@ pub async fn start(
             }
         }
     };
-
-    let hostname = config::resolve_hostname();
-    let controllers = player_config
-        .profiles(&hostname)
-        .first()
-        .map(|p| p.controllers().to_vec())
-        .unwrap_or_default();
-    player.start_controllers(controllers);
 
     if tui_mode {
         crate::tui::run(player.clone(), state_rx).await?;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -253,7 +253,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), playlist);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -265,7 +265,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
 
         // Use port 0 to let the OS pick an available port.
@@ -292,7 +292,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), playlist);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -304,7 +304,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
 
         // Empty config vec should produce a controller with no drivers.
@@ -329,7 +329,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), playlist);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -341,7 +341,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
 
         let osc_config = config::OscController::new();
@@ -367,7 +367,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), playlist);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -379,7 +379,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let playlist = player.get_playlist();
         let binding = player
@@ -484,7 +484,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), playlist);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -496,7 +496,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
 
         let driver = Arc::new(TestDriver::new(player.clone(), TestEvent::Unset));

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -524,7 +524,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -536,7 +536,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let binding = player
             .audio_device()
@@ -702,7 +702,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -714,7 +714,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let device = player.audio_device().expect("audio device").to_mock()?;
 

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -236,7 +236,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -248,7 +248,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let playlist = player.get_playlist();
         let binding = player

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -465,7 +465,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -477,7 +477,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let binding = player
             .audio_device()
@@ -636,7 +636,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -648,7 +648,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let _player = player;
 
@@ -766,7 +766,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -778,7 +778,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let _player = player;
 
@@ -1051,22 +1051,20 @@ mod test {
                 playlist::from_songs(songs.clone()).unwrap(),
             );
             playlists.insert("playlist".to_string(), pl);
-            let player = Arc::new(
-                Player::new(
-                    playlists,
-                    "playlist".to_string(),
-                    &config::Player::new(
-                        vec![],
-                        Some(config::Audio::new("mock-device")),
-                        Some(config::Midi::new("mock-midi-device", None)),
-                        None,
-                        HashMap::new(),
-                        "assets/songs",
-                    ),
+            let player = Player::new(
+                playlists,
+                "playlist".to_string(),
+                &config::Player::new(
+                    vec![],
+                    Some(config::Audio::new("mock-device")),
+                    Some(config::Midi::new("mock-midi-device", None)),
                     None,
-                )
-                .unwrap(),
-            );
+                    HashMap::new(),
+                    "assets/songs",
+                ),
+                None,
+            )
+            .unwrap();
             player.await_hardware_ready().await;
             player
         }
@@ -1163,7 +1161,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -1175,7 +1173,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
         let binding = player
             .audio_device()
@@ -1258,7 +1256,7 @@ mod test {
             playlist::from_songs(songs.clone())?,
         );
         playlists.insert("playlist".to_string(), pl);
-        let player = Arc::new(Player::new(
+        let player = Player::new(
             playlists,
             "playlist".to_string(),
             &config::Player::new(
@@ -1270,7 +1268,7 @@ mod test {
                 "assets/songs",
             ),
             None,
-        )?);
+        )?;
         player.await_hardware_ready().await;
 
         // Find a free port.

--- a/src/player.rs
+++ b/src/player.rs
@@ -193,7 +193,7 @@ impl Player {
         active_playlist: String,
         config: &config::Player,
         base_path: Option<&Path>,
-    ) -> Result<Player, Box<dyn Error>> {
+    ) -> Result<Arc<Player>, Box<dyn Error>> {
         let devices = PlayerDevices {
             audio: None,
             mappings: None,
@@ -203,7 +203,12 @@ impl Player {
             trigger_engine: None,
         };
 
-        let player = Self::new_with_devices(devices, playlists, active_playlist, base_path)?;
+        let player = Arc::new(Self::new_with_devices(
+            devices,
+            playlists,
+            active_playlist,
+            base_path,
+        )?);
 
         // Mark as not ready — async init will set to true when complete.
         // Use send_modify() because send() is a no-op when no receivers exist yet.
@@ -228,7 +233,11 @@ impl Player {
     ///   Phase 1: Audio + DMX (parallel)
     ///   Phase 2: MIDI (needs DMX), Sample engine (needs Audio) — parallel
     ///   Phase 3: Trigger engine (needs Sample engine), status reporting
-    async fn init_hardware_async(&self, config: config::Player, base_path: Option<PathBuf>) {
+    async fn init_hardware_async(
+        self: &Arc<Self>,
+        config: config::Player,
+        base_path: Option<PathBuf>,
+    ) {
         let cancel = self.init_cancel.lock().clone();
 
         let hostname = config::resolve_hostname();
@@ -441,6 +450,9 @@ impl Player {
                 ));
             }
         }
+
+        // Start controllers now that all hardware is ready.
+        self.start_controllers(profile.controllers().to_vec());
 
         self.init_done_tx.send_modify(|v| *v = true);
         info!("Hardware initialization complete");
@@ -733,7 +745,7 @@ impl Player {
     /// Rejects the request if the player is currently playing. Cancels any
     /// in-flight init, resets hardware to empty, and spawns a new async init
     /// round. Returns immediately — does not wait for devices to be found.
-    pub async fn reload_hardware(&self) -> Result<(), Box<dyn Error>> {
+    pub async fn reload_hardware(self: &Arc<Self>) -> Result<(), Box<dyn Error>> {
         if self.is_playing().await {
             return Err("Cannot reload hardware during playback".into());
         }
@@ -2020,7 +2032,7 @@ mod test {
         audio: Option<config::Audio>,
         midi: Option<config::Midi>,
         dmx: Option<config::Dmx>,
-    ) -> Result<Player, Box<dyn Error>> {
+    ) -> Result<Arc<Player>, Box<dyn Error>> {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
         let playlist = Playlist::new(
             "playlist",
@@ -2038,7 +2050,7 @@ mod test {
     }
 
     /// Helper to create a player with the standard test assets (audio + MIDI).
-    async fn make_test_player() -> Result<Player, Box<dyn Error>> {
+    async fn make_test_player() -> Result<Arc<Player>, Box<dyn Error>> {
         make_test_player_with_config(
             Some(config::Audio::new("mock-device")),
             Some(config::Midi::new("mock-midi-device", None)),


### PR DESCRIPTION
Since controllers can use hardware (like MIDI devices), we need to start the controllers after the hardware init. This bug was introduced because we now initialize hardware asynchronously.