### PR TITLE
Morningstar MIDI Controller support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Morningstar SysEx integration**: mtrack can now automatically push the current song name
+  to a Morningstar MIDI controller (MC3, MC6, MC8, MC6 Pro, MC8 Pro, MC4 Pro) via SysEx
+  when songs change. Configured via an optional `morningstar` block on the MIDI controller,
+  this eliminates the need for hand-maintained per-song program change mappings. Supports
+  short/long preset names, configurable preset slots, save-to-flash, and custom model IDs.
+- **Morningstar configuration in web UI**: The MIDI controller section in the hardware profile
+  editor now includes a Morningstar preset naming panel with model selection, preset number,
+  name type, and save-to-flash options.
+- **Song change notifier system**: New `SongChangeNotifier` trait on the player enables
+  pluggable reactions to song changes. The Morningstar integration is the first consumer;
+  the trait is generic and supports multiple concurrent notifiers.
+
+### Changed
+
+- **Player method refactoring**: Converted several static `Player` methods (`emit_midi_event`,
+  `prev_and_emit`, `next_and_emit`, `report_status`) to instance methods, reducing parameter
+  passing and simplifying call sites. Playlist navigation now uses a `PlaylistDirection` enum
+  instead of function pointers.
+
 ## [0.11.2] - 2026-03-21
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ gen-proto:
 
 ## Build the Svelte frontend (generates protobuf bindings first)
 build-ui: gen-proto
-	cd $(SVELTE_DIR) && npm run build
+	cd $(SVELTE_DIR) && npm ci && npm run build
 
 ## Build the Rust binary
 build-rust:

--- a/docs/src/configuration/hardware-profiles.md
+++ b/docs/src/configuration/hardware-profiles.md
@@ -126,3 +126,84 @@ dmx:
 
 Files are sorted by filename for deterministic ordering. Use numeric prefixes
 (e.g., `01-pi-a.yaml`, `02-pi-b.yaml`, `99-fallback.yaml`) to control priority.
+
+## Controllers
+
+Controllers (gRPC, OSC, MIDI) are defined per-profile under the `controllers` key.
+They are initialized after all hardware devices are ready.
+
+```yaml
+profiles:
+  - hostname: my-host
+    audio:
+      device: "Behringer WING"
+      track_mappings:
+        click: [1]
+    midi:
+      device: "Behringer WING"
+    controllers:
+      - kind: grpc
+      - kind: osc
+        port: 43235
+      - kind: midi
+        play:
+          type: control_change
+          channel: 16
+          controller: 100
+          value: 0
+        prev:
+          type: control_change
+          channel: 16
+          controller: 100
+          value: 1
+        next:
+          type: control_change
+          channel: 16
+          controller: 100
+          value: 2
+        stop:
+          type: control_change
+          channel: 16
+          controller: 100
+          value: 3
+        all_songs:
+          type: control_change
+          channel: 16
+          controller: 100
+          value: 4
+        playlist:
+          type: control_change
+          channel: 16
+          controller: 100
+          value: 5
+```
+
+### Morningstar Integration
+
+If you use a Morningstar MIDI controller (MC3, MC6, MC8, MC6 Pro, MC8 Pro, MC4 Pro),
+mtrack can automatically push the current song name to the controller's display via
+SysEx whenever the song changes. Add a `morningstar` block to your MIDI controller
+configuration:
+
+```yaml
+controllers:
+  - kind: midi
+    play: { type: control_change, channel: 16, controller: 100, value: 0 }
+    # ... other MIDI events ...
+    morningstar:
+      model: mc4pro     # Controller model (mc3, mc6, mc8, mc6pro, mc8pro, mc4pro)
+      # save: false     # Save to flash (default: false = temporary, resets on power cycle)
+```
+
+The `model` field determines the SysEx device ID and the bank name length
+(16 chars for MC3, 24 for MC6/MC8, 32 for Pro models). Names are automatically
+truncated or padded to fit.
+
+For unlisted models, use a custom device ID:
+
+```yaml
+    morningstar:
+      model:
+        custom:
+          model_id: 15   # SysEx device ID byte (0-127)
+```

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -238,6 +238,21 @@ controllers:
     controller: 100
     value: 5
 
+  # Optional: Morningstar controller integration. When configured, mtrack will
+  # automatically update the current bank name on the controller via SysEx
+  # whenever the current song changes. This eliminates the need for per-song
+  # program change mappings.
+  morningstar:
+    # The Morningstar controller model. Determines the device ID byte and the
+    # required name length in the SysEx message.
+    # Supported values: mc3, mc6, mc8, mc6pro, mc8pro, mc4pro
+    # For unlisted models, use: { custom: { model_id: <0-127> } }
+    model: mc4pro
+
+    # Whether to save the bank name to flash (true) or keep it temporary (false).
+    # Temporary names reset on power cycle. Default: false.
+    # save: false
+
 # Mappings of track names to output channels.
 track_mappings:
   click:

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,8 +34,11 @@ pub mod trigger;
 
 pub use self::audio::{Audio, ResamplerType, StreamBufferSize};
 pub use self::controller::Controller;
+pub use self::controller::CustomModel;
 pub use self::controller::GrpcController;
 pub use self::controller::MidiController;
+pub use self::controller::MorningstarConfig;
+pub use self::controller::MorningstarModel;
 pub use self::controller::OscController;
 pub use self::controller::DEFAULT_GRPC_PORT;
 pub use self::dmx::Dmx;

--- a/src/config/controller.rs
+++ b/src/config/controller.rs
@@ -80,6 +80,9 @@ pub struct MidiController {
     all_songs: midi::Event,
     /// The MIDI event to look for to switch back to the current playlist.
     playlist: midi::Event,
+    /// Optional Morningstar controller integration for automatic preset naming.
+    #[serde(default)]
+    morningstar: Option<MorningstarConfig>,
 }
 
 impl MidiController {
@@ -99,6 +102,7 @@ impl MidiController {
             stop,
             all_songs,
             playlist,
+            morningstar: None,
         }
     }
     /// Gets the play event.
@@ -129,6 +133,11 @@ impl MidiController {
     /// Gets the playlist event.
     pub fn playlist(&self) -> Result<LiveEvent<'static>, Box<dyn Error>> {
         self.playlist.to_midi_event()
+    }
+
+    /// Gets the optional Morningstar configuration.
+    pub fn morningstar(&self) -> Option<&MorningstarConfig> {
+        self.morningstar.as_ref()
     }
 }
 
@@ -289,6 +298,89 @@ impl OscController {
     pub fn playlist_current_song_elapsed(&self) -> &str {
         &self.playlist_current_song_elapsed
     }
+}
+
+/// Configuration for Morningstar MIDI controller integration.
+///
+/// When present, mtrack will send SysEx messages to update the current bank
+/// name on the controller whenever the current song changes.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct MorningstarConfig {
+    /// The Morningstar controller model.
+    model: MorningstarModel,
+    /// Whether to save the name to flash (true) or keep it temporary (false).
+    #[serde(default)]
+    save: bool,
+}
+
+impl MorningstarConfig {
+    #[cfg(test)]
+    pub fn new(model: MorningstarModel, save: bool) -> MorningstarConfig {
+        MorningstarConfig { model, save }
+    }
+
+    /// Returns the device model ID byte for the SysEx message.
+    pub fn model_id(&self) -> u8 {
+        self.model.device_id()
+    }
+
+    /// Returns whether to save to flash.
+    pub fn save(&self) -> bool {
+        self.save
+    }
+
+    /// Returns the required bank name length for this model.
+    /// Names must be padded with spaces to exactly this length.
+    pub fn name_length(&self) -> usize {
+        self.model.name_length()
+    }
+}
+
+/// Morningstar controller model.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum MorningstarModel {
+    MC3,
+    MC6,
+    MC8,
+    #[serde(rename = "mc6pro")]
+    MC6Pro,
+    #[serde(rename = "mc8pro")]
+    MC8Pro,
+    #[serde(rename = "mc4pro")]
+    MC4Pro,
+    Custom(CustomModel),
+}
+
+impl MorningstarModel {
+    /// Returns the SysEx device ID byte for this model.
+    fn device_id(&self) -> u8 {
+        match self {
+            MorningstarModel::MC3 => 0x05,
+            MorningstarModel::MC6 => 0x03,
+            MorningstarModel::MC8 => 0x04,
+            MorningstarModel::MC6Pro => 0x06,
+            MorningstarModel::MC8Pro => 0x08,
+            MorningstarModel::MC4Pro => 0x09,
+            MorningstarModel::Custom(c) => c.model_id,
+        }
+    }
+
+    /// Returns the required bank name length for this model.
+    fn name_length(&self) -> usize {
+        match self {
+            MorningstarModel::MC3 => 16,
+            MorningstarModel::MC6 | MorningstarModel::MC8 => 24,
+            MorningstarModel::MC6Pro | MorningstarModel::MC8Pro | MorningstarModel::MC4Pro => 32,
+            MorningstarModel::Custom(_) => 32,
+        }
+    }
+}
+
+/// Custom Morningstar model with explicit device ID.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct CustomModel {
+    pub model_id: u8,
 }
 
 #[cfg(test)]

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -17,7 +17,7 @@ use midly::live::LiveEvent;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{error, info, span, Level};
 
-use crate::{config, midi::Device, player::Player};
+use crate::{config, midi, midi::Device, player::Player};
 
 /// Recognized MIDI controller actions.
 #[derive(Debug, PartialEq)]
@@ -76,18 +76,27 @@ impl Driver {
         player: Arc<Player>,
     ) -> Result<Arc<Self>, Box<dyn Error>> {
         match player.midi_device() {
-            Some(midi_device) => Ok(Arc::new(Driver {
-                player,
-                midi_device,
-                events: MidiEvents {
-                    play: config.play()?,
-                    prev: config.prev()?,
-                    next: config.next()?,
-                    stop: config.stop()?,
-                    all_songs: config.all_songs()?,
-                    playlist: config.playlist()?,
-                },
-            })),
+            Some(midi_device) => {
+                if let Some(ms) = config.morningstar() {
+                    info!("Registering Morningstar song change notifier");
+                    player.add_song_change_notifier(Arc::new(midi::morningstar::Notifier::new(
+                        ms.clone(),
+                        midi_device.clone(),
+                    )));
+                }
+                Ok(Arc::new(Driver {
+                    player,
+                    midi_device,
+                    events: MidiEvents {
+                        play: config.play()?,
+                        prev: config.prev()?,
+                        next: config.next()?,
+                        stop: config.stop()?,
+                        all_songs: config.all_songs()?,
+                        playlist: config.playlist()?,
+                    },
+                }))
+            }
             None => Err("No MIDI device to use for MIDI configuration".into()),
         }
     }
@@ -132,6 +141,11 @@ impl super::Driver for Driver {
                         return Ok(());
                     }
                 };
+
+                // Check for Morningstar SysEx ack responses.
+                if midi::morningstar::check_ack(&raw_event) {
+                    continue;
+                }
 
                 // Process triggered samples (synchronous, minimal latency)
                 player.process_sample_trigger(&raw_event);

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -23,6 +23,7 @@ use crate::{
 pub(crate) mod beat_clock;
 pub(crate) mod midir;
 pub(crate) mod mock;
+pub mod morningstar;
 pub(crate) mod playback;
 mod transform;
 
@@ -49,6 +50,9 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
 
     /// Emits an event.
     fn emit(&self, midi_event: Option<LiveEvent<'static>>) -> Result<(), Box<dyn Error>>;
+
+    /// Sends raw SysEx bytes to the MIDI output.
+    fn emit_sysex(&self, bytes: &[u8]) -> Result<(), Box<dyn Error>>;
 
     #[cfg(test)]
     fn to_mock(&self) -> Result<Arc<mock::Device>, Box<dyn Error>>;

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -379,6 +379,28 @@ impl super::Device for Device {
         Ok(())
     }
 
+    fn emit_sysex(&self, bytes: &[u8]) -> Result<(), Box<dyn Error>> {
+        let span = span!(Level::INFO, "emit_sysex (midir)");
+        let _enter = span.enter();
+
+        let output_port = match &self.output_port {
+            Some(output_port) => output_port,
+            None => {
+                warn!("No MIDI output device configured, cannot emit SysEx.");
+                return Ok(());
+            }
+        };
+
+        let output = MidiOutput::new("mtrack emit sysex output")?;
+
+        debug!(device = self.name, len = bytes.len(), "Emitting SysEx.");
+
+        let mut connection = output.connect(output_port, "mtrack player")?;
+        connection.send(bytes)?;
+
+        Ok(())
+    }
+
     #[cfg(test)]
     fn to_mock(&self) -> Result<Arc<super::mock::Device>, Box<dyn Error>> {
         Err("not a mock".into())

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -36,6 +36,7 @@ pub struct Device {
     closed: Arc<AtomicBool>,
     event: Arc<Mutex<Vec<u8>>>,
     emit_called: Arc<Mutex<Option<Vec<u8>>>>,
+    sysex_called: Arc<Mutex<Option<Vec<u8>>>>,
     event_thread: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
@@ -48,6 +49,7 @@ impl Device {
             barrier: Arc::new(Barrier::new(2)),
             event: Arc::new(Mutex::new(Vec::new())),
             emit_called: Arc::new(Mutex::new(None)),
+            sysex_called: Arc::new(Mutex::new(None)),
             event_thread: Arc::new(Mutex::new(None)),
         }
     }
@@ -83,6 +85,20 @@ impl Device {
             .lock()
             .expect("unable to get emit called lock");
         *emit_called = None;
+    }
+
+    #[cfg(test)]
+    /// Gets the last SysEx bytes emitted.
+    pub fn get_emitted_sysex(&self) -> Option<Vec<u8>> {
+        let sysex = self.sysex_called.lock().expect("unable to get sysex lock");
+        sysex.clone()
+    }
+
+    #[cfg(test)]
+    /// Resets the last emitted SysEx to none.
+    pub fn reset_emitted_sysex(&self) {
+        let mut sysex = self.sysex_called.lock().expect("unable to get sysex lock");
+        *sysex = None;
     }
 }
 
@@ -201,6 +217,13 @@ impl super::Device for Device {
             *emit_called = Some(buf);
         }
 
+        Ok(())
+    }
+
+    /// Sends raw SysEx bytes.
+    fn emit_sysex(&self, bytes: &[u8]) -> Result<(), Box<dyn Error>> {
+        let mut sysex = self.sysex_called.lock().expect("unable to get sysex lock");
+        *sysex = Some(bytes.to_vec());
         Ok(())
     }
 

--- a/src/midi/morningstar.rs
+++ b/src/midi/morningstar.rs
@@ -1,0 +1,401 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+use std::sync::Arc;
+
+use tracing::{error, info, warn};
+
+use crate::config::MorningstarConfig;
+use crate::songs::Song;
+
+/// Implements `SongChangeNotifier` for Morningstar controllers.
+/// Captures the MIDI device at construction time and sends a SysEx
+/// preset-name update whenever the current song changes.
+pub struct Notifier {
+    config: MorningstarConfig,
+    device: Arc<dyn super::Device>,
+}
+
+impl Notifier {
+    pub fn new(config: MorningstarConfig, device: Arc<dyn super::Device>) -> Notifier {
+        Notifier { config, device }
+    }
+}
+
+impl crate::player::SongChangeNotifier for Notifier {
+    fn notify(&self, song: &Song) {
+        let sysex = build_update_bank_name(&self.config, song.name());
+        if let Err(e) = self.device.emit_sysex(&sysex) {
+            error!("Error emitting Morningstar bank name SysEx: {:?}", e);
+        }
+    }
+}
+
+/// Morningstar SysEx manufacturer ID prefix.
+const MANUFACTURER_ID: [u8; 3] = [0x00, 0x21, 0x24];
+
+/// Checks if a raw MIDI message is a Morningstar SysEx acknowledgement and
+/// logs the result. Returns true if the message was a Morningstar ack (so
+/// callers can skip further processing if desired).
+pub fn check_ack(raw_event: &[u8]) -> bool {
+    // Minimum ack length: F0 + 3 mfr + model + 00 + 70 + 7F + ack + ... + checksum + F7
+    if raw_event.len() < 10 {
+        return false;
+    }
+    if raw_event[0] != 0xF0 || raw_event[1..4] != MANUFACTURER_ID {
+        return false;
+    }
+    // op2 = 0x7F indicates an ack response
+    if raw_event[7] != 0x7F {
+        return false;
+    }
+
+    let ack_code = raw_event[8];
+    match ack_code {
+        0x00 => info!("Morningstar SysEx acknowledged (success)"),
+        0x01 => warn!("Morningstar SysEx rejected: wrong model ID"),
+        0x02 => warn!("Morningstar SysEx rejected: wrong checksum"),
+        0x03 => warn!("Morningstar SysEx rejected: wrong payload size"),
+        code => warn!(code, "Morningstar SysEx rejected: unknown ack code"),
+    }
+
+    true
+}
+
+/// Builds the SysEx message to update the current bank name on a Morningstar controller.
+///
+/// Message format:
+/// `F0 00 21 24 <model_id> 00 70 10 00 <save_flag> 00 00 00 <txn_id=00> 00 00 <name_bytes...> <checksum> F7`
+///
+/// - op2: 0x10 (update current bank name)
+/// - save_flag: 0x7F (save to flash) or 0x00 (temporary)
+/// - checksum: XOR of all bytes from F0 through last name byte, AND 0x7F
+/// - Name is truncated or padded with spaces to the model's required length.
+pub fn build_update_bank_name(config: &MorningstarConfig, name: &str) -> Vec<u8> {
+    let name_len = config.name_length();
+    let padded = format!("{:<width$}", name, width = name_len);
+    // Truncate if longer than required (format! won't truncate).
+    let padded: String = padded.chars().take(name_len).collect();
+
+    let save_flag: u8 = if config.save() { 0x7F } else { 0x00 };
+
+    let mut msg: Vec<u8> = Vec::with_capacity(16 + name_len + 2);
+
+    // Header
+    msg.push(0xF0); // SysEx start
+    msg.push(0x00); // Morningstar manufacturer ID byte 1
+    msg.push(0x21); // Morningstar manufacturer ID byte 2
+    msg.push(0x24); // Morningstar manufacturer ID byte 3
+    msg.push(config.model_id()); // Device model ID
+    msg.push(0x00); // ignore
+    msg.push(0x70); // opcode 1
+    msg.push(0x10); // opcode 2: update current bank name
+    msg.push(0x00); // opcode 3
+    msg.push(save_flag); // opcode 4: save flag
+    msg.push(0x00); // opcode 5
+    msg.push(0x00); // opcode 6
+    msg.push(0x00); // opcode 7
+    msg.push(0x00); // transaction ID
+    msg.push(0x00); // ignore
+    msg.push(0x00); // ignore
+
+    // Name bytes (padded to model's required length)
+    for b in padded.as_bytes() {
+        msg.push(*b);
+    }
+
+    // Checksum: XOR of all bytes so far, masked to 7 bits
+    let checksum = msg.iter().fold(0u8, |acc, &b| acc ^ b) & 0x7F;
+    msg.push(checksum);
+
+    // SysEx end
+    msg.push(0xF7);
+
+    msg
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::MorningstarModel;
+
+    fn make_config(model: MorningstarModel, save: bool) -> MorningstarConfig {
+        MorningstarConfig::new(model, save)
+    }
+
+    #[test]
+    fn basic_message_structure() {
+        let config = make_config(MorningstarModel::MC6Pro, false);
+        let msg = build_update_bank_name(&config, "Test");
+
+        assert_eq!(msg[0], 0xF0);
+        assert_eq!(&msg[1..4], &[0x00, 0x21, 0x24]);
+        assert_eq!(msg[4], 0x06); // MC6Pro model ID
+        assert_eq!(msg[6], 0x70); // opcode 1
+        assert_eq!(msg[7], 0x10); // opcode 2: update current bank name
+        assert_eq!(msg[8], 0x00); // opcode 3
+        assert_eq!(msg[9], 0x00); // save flag (false)
+        assert_eq!(*msg.last().unwrap(), 0xF7);
+    }
+
+    #[test]
+    fn save_flag_set() {
+        let config = make_config(MorningstarModel::MC4Pro, true);
+        let msg = build_update_bank_name(&config, "X");
+
+        assert_eq!(msg[9], 0x7F);
+    }
+
+    #[test]
+    fn name_bytes_padded_with_spaces() {
+        let config = make_config(MorningstarModel::MC4Pro, false);
+        let msg = build_update_bank_name(&config, "ABC");
+
+        // Name starts at index 16 (14 header + 2 ignore bytes)
+        assert_eq!(msg[16], b'A');
+        assert_eq!(msg[17], b'B');
+        assert_eq!(msg[18], b'C');
+        // Remaining 29 bytes should be spaces (MC4Pro = 32 char name)
+        for i in 19..48 {
+            assert_eq!(msg[i], b' ', "byte {} should be space padding", i);
+        }
+        // Total: 16 header + 32 name + checksum + F7 = 50
+        assert_eq!(msg.len(), 50);
+    }
+
+    #[test]
+    fn truncation_at_model_limit() {
+        let config = make_config(MorningstarModel::MC4Pro, false);
+        let long_name = "A".repeat(50);
+        let msg = build_update_bank_name(&config, &long_name);
+
+        // 16 header bytes + 32 name bytes + checksum + F7 = 50
+        assert_eq!(msg.len(), 50);
+        for i in 16..48 {
+            assert_eq!(msg[i], b'A');
+        }
+    }
+
+    #[test]
+    fn mc3_uses_16_char_name() {
+        let config = make_config(MorningstarModel::MC3, false);
+        let msg = build_update_bank_name(&config, "Hi");
+
+        // 16 header + 16 name + checksum + F7 = 34
+        assert_eq!(msg.len(), 34);
+        assert_eq!(msg[16], b'H');
+        assert_eq!(msg[17], b'i');
+        // Rest is space padding
+        for i in 18..32 {
+            assert_eq!(msg[i], b' ');
+        }
+    }
+
+    #[test]
+    fn mc6_uses_24_char_name() {
+        let config = make_config(MorningstarModel::MC6, false);
+        let msg = build_update_bank_name(&config, "Test");
+
+        // 16 header + 24 name + checksum + F7 = 42
+        assert_eq!(msg.len(), 42);
+    }
+
+    #[test]
+    fn checksum_is_correct() {
+        let config = make_config(MorningstarModel::MC4Pro, false);
+        let msg = build_update_bank_name(&config, "Hi");
+
+        let checksum_idx = msg.len() - 2;
+        let expected = msg[..checksum_idx].iter().fold(0u8, |acc, &b| acc ^ b) & 0x7F;
+        assert_eq!(msg[checksum_idx], expected);
+    }
+
+    #[test]
+    fn checksum_masked_to_7_bits() {
+        let config = make_config(MorningstarModel::MC4Pro, false);
+        let msg = build_update_bank_name(&config, "~~~~~");
+
+        let checksum_idx = msg.len() - 2;
+        assert!(msg[checksum_idx] <= 0x7F);
+    }
+
+    #[test]
+    fn all_model_ids() {
+        let models = vec![
+            (MorningstarModel::MC3, 0x05),
+            (MorningstarModel::MC6, 0x03),
+            (MorningstarModel::MC8, 0x04),
+            (MorningstarModel::MC6Pro, 0x06),
+            (MorningstarModel::MC8Pro, 0x08),
+            (MorningstarModel::MC4Pro, 0x09),
+            (
+                MorningstarModel::Custom(crate::config::CustomModel { model_id: 0x0A }),
+                0x0A,
+            ),
+        ];
+
+        for (model, expected_id) in models {
+            let config = make_config(model, false);
+            let msg = build_update_bank_name(&config, "X");
+            assert_eq!(msg[4], expected_id, "Model ID mismatch");
+        }
+    }
+
+    #[test]
+    fn empty_name_padded_to_model_length() {
+        let config = make_config(MorningstarModel::MC4Pro, false);
+        let msg = build_update_bank_name(&config, "");
+
+        // 16 header + 32 spaces + checksum + F7 = 50
+        assert_eq!(msg.len(), 50);
+        for i in 16..48 {
+            assert_eq!(msg[i], b' ');
+        }
+    }
+
+    #[test]
+    fn exactly_32_chars_not_truncated() {
+        let config = make_config(MorningstarModel::MC4Pro, false);
+        let name = "A".repeat(32);
+        let msg = build_update_bank_name(&config, &name);
+
+        // 16 + 32 + 1 + 1 = 50
+        assert_eq!(msg.len(), 50);
+        // No padding needed — name fills the slot exactly
+        for i in 16..48 {
+            assert_eq!(msg[i], b'A');
+        }
+    }
+
+    #[test]
+    fn config_deserialization() {
+        use config::Config;
+        use config::File;
+        use config::FileFormat;
+
+        let yaml = r#"
+            model: mc4pro
+            save: true
+        "#;
+
+        let config: MorningstarConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.model_id(), 0x09);
+        assert!(config.save());
+    }
+
+    #[test]
+    fn config_deserialization_defaults() {
+        use config::Config;
+        use config::File;
+        use config::FileFormat;
+
+        let yaml = r#"
+            model: mc6pro
+        "#;
+
+        let config: MorningstarConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.model_id(), 0x06);
+        assert!(!config.save());
+    }
+
+    #[test]
+    fn config_deserialization_custom_model() {
+        use config::Config;
+        use config::File;
+        use config::FileFormat;
+
+        let yaml = r#"
+            model:
+              custom:
+                model_id: 15
+        "#;
+
+        let config: MorningstarConfig = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert_eq!(config.model_id(), 15);
+    }
+
+    mod check_ack_tests {
+        use super::*;
+
+        fn make_ack(ack_code: u8) -> Vec<u8> {
+            // F0 00 21 24 <model> 00 70 7F <ack> 00 00 00 00 <txn> 00 00 <checksum> F7
+            vec![
+                0xF0, 0x00, 0x21, 0x24, 0x09, 0x00, 0x70, 0x7F, ack_code, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0xF7,
+            ]
+        }
+
+        #[test]
+        fn recognizes_success_ack() {
+            assert!(check_ack(&make_ack(0x00)));
+        }
+
+        #[test]
+        fn recognizes_wrong_model_id() {
+            assert!(check_ack(&make_ack(0x01)));
+        }
+
+        #[test]
+        fn recognizes_wrong_checksum() {
+            assert!(check_ack(&make_ack(0x02)));
+        }
+
+        #[test]
+        fn recognizes_wrong_payload_size() {
+            assert!(check_ack(&make_ack(0x03)));
+        }
+
+        #[test]
+        fn ignores_non_sysex() {
+            assert!(!check_ack(&[0x90, 0x3C, 0x64]));
+        }
+
+        #[test]
+        fn ignores_wrong_manufacturer() {
+            assert!(!check_ack(&[
+                0xF0, 0x00, 0x00, 0x00, 0x09, 0x00, 0x70, 0x7F, 0x00, 0xF7,
+            ]));
+        }
+
+        #[test]
+        fn ignores_non_ack_sysex() {
+            // op2 = 0x10 (bank name update), not 0x7F (ack)
+            assert!(!check_ack(&[
+                0xF0, 0x00, 0x21, 0x24, 0x09, 0x00, 0x70, 0x10, 0x00, 0xF7,
+            ]));
+        }
+
+        #[test]
+        fn ignores_too_short() {
+            assert!(!check_ack(&[0xF0, 0x00, 0x21, 0x24]));
+        }
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,6 +13,7 @@
 //
 use midly::live::LiveEvent;
 use parking_lot::RwLock;
+use std::fmt;
 use std::{
     collections::HashMap,
     error::Error,
@@ -42,6 +43,21 @@ use crate::{
     songs::Song,
 };
 
+/// Direction for playlist navigation.
+enum PlaylistDirection {
+    Next,
+    Prev,
+}
+
+impl fmt::Display for PlaylistDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PlaylistDirection::Next => write!(f, "next"),
+            PlaylistDirection::Prev => write!(f, "previous"),
+        }
+    }
+}
+
 /// Holds the ingredients for constructing a per-song `PlaybackClock`.
 /// When an audio device is present, clocks are derived from its hardware
 /// sample counter. Otherwise, clocks fall back to `Instant::now()`.
@@ -69,6 +85,14 @@ impl ClockSource {
     }
 }
 
+/// Notified when the current song changes. Implementations capture whatever
+/// device handles they need at construction time, keeping the player unaware
+/// of protocol-specific details.
+pub trait SongChangeNotifier: Send + Sync {
+    /// Called when the player advances to a new song.
+    fn notify(&self, song: &Song);
+}
+
 /// Groups all hardware device state so it can be atomically swapped on reload.
 #[derive(Clone)]
 struct HardwareState {
@@ -79,6 +103,8 @@ struct HardwareState {
     sample_engine: Option<Arc<RwLock<SampleEngine>>>,
     trigger_engine: Option<Arc<TriggerEngine>>,
     clock_source: ClockSource,
+    /// Notifiers invoked on every song change.
+    song_change_notifiers: Vec<Arc<dyn SongChangeNotifier>>,
     /// The hostname of the active hardware profile (None if no profile matched).
     profile_name: Option<String>,
     /// The resolved machine hostname used for profile matching.
@@ -424,10 +450,15 @@ impl Player {
             self.hardware.write().trigger_engine = Some(te.clone());
         }
 
+        // Start controllers now that all hardware is ready.
+        self.start_controllers(profile.controllers().to_vec());
+
         // MIDI post-init: emit initial track event + start status reporting.
+        // This runs after start_controllers so that song change notifiers
+        // (e.g. Morningstar) are registered before the first song fires.
         if midi_result.is_some() {
             if let Some(song) = self.get_playlist().current() {
-                Player::emit_midi_event(midi_result.clone(), song);
+                self.emit_song_change(&song);
             }
 
             let status_events = match StatusEvents::new(config.status_events()) {
@@ -439,20 +470,12 @@ impl Player {
             };
 
             if let Some(status_events) = status_events {
-                let midi_device = midi_result.clone().expect("MIDI device must be present");
-                let join = self.join.clone();
-                let span = self.span.clone();
-                tokio::spawn(Player::report_status(
-                    span,
-                    midi_device,
-                    join,
-                    status_events,
-                ));
+                let player = self.clone();
+                tokio::spawn(async move {
+                    player.report_status(status_events).await;
+                });
             }
         }
-
-        // Start controllers now that all hardware is ready.
-        self.start_controllers(profile.controllers().to_vec());
 
         self.init_done_tx.send_modify(|v| *v = true);
         info!("Hardware initialization complete");
@@ -529,6 +552,7 @@ impl Player {
             sample_engine: devices.sample_engine,
             trigger_engine: devices.trigger_engine,
             clock_source,
+            song_change_notifiers: Vec::new(),
             profile_name: None,
             hostname: None,
         };
@@ -588,6 +612,11 @@ impl Player {
     /// Gets the MIDI device currently in use by the player.
     pub fn midi_device(&self) -> Option<Arc<dyn midi::Device>> {
         self.hardware.read().midi_device.clone()
+    }
+
+    /// Adds a notifier that will be called on every song change.
+    pub fn add_song_change_notifier(&self, notifier: Arc<dyn SongChangeNotifier>) {
+        self.hardware.write().song_change_notifiers.push(notifier);
     }
 
     /// Returns a snapshot of all hardware subsystem statuses.
@@ -772,6 +801,7 @@ impl Player {
             sample_engine: None,
             trigger_engine: None,
             clock_source: ClockSource::Wall,
+            song_change_notifiers: Vec::new(),
             profile_name: None,
             hostname: None,
         };
@@ -843,17 +873,17 @@ impl Player {
     }
 
     /// Reports status as MIDI events.
-    async fn report_status(
-        span: Span,
-        midi_device: Arc<dyn midi::Device>,
-        join: Arc<Mutex<Option<PlayHandles>>>,
-        status_events: StatusEvents,
-    ) {
-        let _enter = span.enter();
+    async fn report_status(&self, status_events: StatusEvents) {
+        let _enter = self.span.enter();
         info!("Reporting status");
 
-        let midi_device = midi_device.clone();
-        let join = join.clone();
+        let midi_device = self
+            .hardware
+            .read()
+            .midi_device
+            .clone()
+            .expect("MIDI device must be present for status reporting");
+        let join = self.join.clone();
 
         // This thread will run until the process is terminated.
         let _join_handle = tokio::spawn(async move {
@@ -1025,10 +1055,8 @@ impl Player {
         });
 
         {
-            let join_mutex = self.join.clone();
-            let stop_run = self.stop_run.clone();
+            let player = self.clone();
             let song = song.clone();
-            let midi_device = hw.midi_device.clone();
             tokio::spawn(async move {
                 let result = match play_rx.await {
                     Ok(Ok(())) => PlaybackResult::Success,
@@ -1053,16 +1081,18 @@ impl Player {
                 }
 
                 // Natural finish: advance playlist and clean up.
-                let mut join = join_mutex.lock().await;
-                Player::next_and_emit(midi_device.clone(), playlist);
+                let mut join = player.join.lock().await;
+                if let Some(song) = playlist.next() {
+                    player.emit_song_change(&song);
+                }
 
                 {
-                    let mut play_start_time = play_start_time.lock().await;
+                    let mut play_start_time = player.play_start_time.lock().await;
                     *play_start_time = None;
                 }
 
                 *join = None;
-                stop_run.store(false, Ordering::Relaxed);
+                player.stop_run.store(false, Ordering::Relaxed);
             });
         }
 
@@ -1235,30 +1265,30 @@ impl Player {
         }
     }
 
-    /// Navigates the playlist using the given function, returning the current song
-    /// if the player is active. Returns `None` if the playlist is empty.
+    /// Navigates the playlist in the given direction, emitting the song-change
+    /// event. Returns the current song if the player is active.
     ///
     /// Holds the join lock across the entire operation to prevent a concurrent
     /// `play_from()` from starting between the is-playing check and the
     /// playlist position advance.
-    async fn navigate<F>(&self, action: &str, nav_fn: F) -> Option<Arc<Song>>
-    where
-        F: FnOnce(Option<Arc<dyn midi::Device>>, Arc<Playlist>) -> Option<Arc<Song>>,
-    {
+    async fn navigate(&self, direction: PlaylistDirection) -> Option<Arc<Song>> {
         let join = self.join.lock().await;
         if join.is_some() {
             let current = self.get_playlist().current();
             if let Some(ref song) = current {
                 info!(
                     current_song = song.name(),
-                    "Can't go to {}, player is active.", action
+                    "Can't go to {}, player is active.", direction
                 );
             }
             return current;
         }
         let playlist = self.get_playlist();
-        let midi_device = self.hardware.read().midi_device.clone();
-        let song = nav_fn(midi_device, playlist)?;
+        let song = match direction {
+            PlaylistDirection::Next => playlist.next()?,
+            PlaylistDirection::Prev => playlist.prev()?,
+        };
+        self.emit_song_change(&song);
         drop(join);
         self.load_song_samples(&song);
         Some(song)
@@ -1266,12 +1296,12 @@ impl Player {
 
     /// Next goes to the next entry in the playlist.
     pub async fn next(&self) -> Option<Arc<Song>> {
-        self.navigate("next", Player::next_and_emit).await
+        self.navigate(PlaylistDirection::Next).await
     }
 
     /// Prev goes to the previous entry in the playlist.
     pub async fn prev(&self) -> Option<Arc<Song>> {
-        self.navigate("previous", Player::prev_and_emit).await
+        self.navigate(PlaylistDirection::Prev).await
     }
 
     /// Stop will stop a song if a song is playing.
@@ -1350,8 +1380,7 @@ impl Player {
         }
 
         if let Some(song) = self.get_playlist().current() {
-            let midi_device = self.hardware.read().midi_device.clone();
-            Player::emit_midi_event(midi_device, song);
+            self.emit_song_change(&song);
         }
 
         Ok(())
@@ -1493,33 +1522,20 @@ impl Player {
             .map(|engine| engine.format_active_effects())
     }
 
-    /// Goes to the previous song and emits the MIDI event associated if one exists.
-    fn prev_and_emit(
-        midi_device: Option<Arc<dyn midi::Device>>,
-        playlist: Arc<Playlist>,
-    ) -> Option<Arc<Song>> {
-        let song = playlist.prev()?;
-        Player::emit_midi_event(midi_device, song.clone());
-        Some(song)
-    }
+    /// Emits the per-song MIDI event and notifies all song-change notifiers.
+    fn emit_song_change(&self, song: &Song) {
+        let hw = self.hardware.read();
+        let midi_device = hw.midi_device.clone();
+        let notifiers = hw.song_change_notifiers.clone();
+        drop(hw);
 
-    /// Goes to the next song and emits the MIDI event associated if one exists.
-    fn next_and_emit(
-        midi_device: Option<Arc<dyn midi::Device>>,
-        playlist: Arc<Playlist>,
-    ) -> Option<Arc<Song>> {
-        let song = playlist.next()?;
-        Player::emit_midi_event(midi_device, song.clone());
-        Some(song)
-    }
-
-    /// Emits a MIDI event for the given song if possible.
-    fn emit_midi_event(midi_device: Option<Arc<dyn midi::Device>>, song: Arc<Song>) {
-        if let Some(midi_device) = midi_device.clone() {
-            let midi_event = song.midi_event();
-            if let Err(e) = midi_device.emit(midi_event) {
+        if let Some(ref device) = midi_device {
+            if let Err(e) = device.emit(song.midi_event()) {
                 error!("Error emitting MIDI event: {:?}", e);
             }
+        }
+        for notifier in &notifiers {
+            notifier.notify(song);
         }
     }
 }
@@ -2832,10 +2848,13 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn emit_midi_event_no_device() {
-        let song = Arc::new(Song::new_for_test("test", &[]));
-        Player::emit_midi_event(None, song);
+    #[tokio::test(flavor = "multi_thread")]
+    async fn emit_song_change_no_device() -> Result<(), Box<dyn Error>> {
+        let player = make_test_player_with_config(None, None, None).await?;
+        let song = Song::new_for_test("test", &[]);
+        // Should not panic when no MIDI device is configured.
+        player.emit_song_change(&song);
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2869,16 +2888,11 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_prev_and_emit_no_midi() -> Result<(), Box<dyn Error>> {
-        let songs = songs::get_all_songs(Path::new("assets/songs"))?;
-        let playlist = Playlist::new(
-            "test",
-            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
-            songs.clone(),
-        )?;
+    async fn test_navigate_no_midi() -> Result<(), Box<dyn Error>> {
+        let player = make_test_player_with_config(None, None, None).await?;
 
-        Player::next_and_emit(None, playlist.clone());
-        let song = Player::prev_and_emit(None, playlist).unwrap();
+        player.next().await;
+        let song = player.prev().await.unwrap();
         assert_eq!(song.name(), "Song 1");
         Ok(())
     }

--- a/src/webui/svelte/src/components/config/ControllersSection.svelte
+++ b/src/webui/svelte/src/components/config/ControllersSection.svelte
@@ -104,6 +104,74 @@
   function toggleOscAdvanced(i: number) {
     showOscAdvanced[i] = !showOscAdvanced[i];
   }
+
+  // Morningstar helpers
+  const morningstarModels = [
+    { value: "mc3", label: "MC3" },
+    { value: "mc6", label: "MC6" },
+    { value: "mc8", label: "MC8" },
+    { value: "mc6pro", label: "MC6 Pro" },
+    { value: "mc8pro", label: "MC8 Pro" },
+    { value: "mc4pro", label: "MC4 Pro" },
+    { value: "custom", label: "Custom" },
+  ];
+
+  function toggleMorningstar(i: number) {
+    if (controllers[i].morningstar) {
+      delete controllers[i].morningstar;
+    } else {
+      controllers[i].morningstar = { model: "mc4pro" };
+    }
+    onchange();
+  }
+
+  function updateMorningstarField(i: number, key: string, value: any) {
+    if (!controllers[i].morningstar) return;
+    if (value === undefined || value === "") {
+      delete controllers[i].morningstar[key];
+    } else {
+      controllers[i].morningstar[key] = value;
+    }
+    onchange();
+  }
+
+  function getMorningstarModel(ctrl: any): string {
+    const ms = ctrl.morningstar;
+    if (!ms?.model) return "mc4pro";
+    if (typeof ms.model === "string") return ms.model;
+    if (typeof ms.model === "object" && ms.model.custom) return "custom";
+    return "mc4pro";
+  }
+
+  function setMorningstarModel(i: number, value: string) {
+    if (!controllers[i].morningstar) return;
+    if (value === "custom") {
+      const existingId =
+        typeof controllers[i].morningstar.model === "object"
+          ? (controllers[i].morningstar.model.custom?.model_id ?? 0)
+          : 0;
+      controllers[i].morningstar.model = { custom: { model_id: existingId } };
+    } else {
+      controllers[i].morningstar.model = value;
+    }
+    onchange();
+  }
+
+  function getCustomModelId(ctrl: any): number {
+    const model = ctrl.morningstar?.model;
+    if (typeof model === "object" && model.custom) {
+      return model.custom.model_id ?? 0;
+    }
+    return 0;
+  }
+
+  function setCustomModelId(i: number, value: number) {
+    if (!controllers[i].morningstar) return;
+    controllers[i].morningstar.model = {
+      custom: { model_id: value },
+    };
+    onchange();
+  }
 </script>
 
 <div class="section-fields">
@@ -216,6 +284,84 @@
         {/if}
       {:else if ctrl.kind === "midi"}
         <div class="note">{$t("controllers.midiNote")}</div>
+
+        <div class="morningstar-section">
+          <label class="checkbox-label">
+            <input
+              type="checkbox"
+              checked={!!ctrl.morningstar}
+              onchange={() => toggleMorningstar(i)}
+            />
+            {$t("controllers.morningstarEnable")}
+            <Tooltip text={$t("tooltips.controllers.morningstar")} />
+          </label>
+
+          {#if ctrl.morningstar}
+            <div class="morningstar-fields">
+              <div class="field">
+                <label for="ms-model-{i}"
+                  >{$t("controllers.morningstarModel")}
+                  <Tooltip
+                    text={$t("tooltips.controllers.morningstarModel")}
+                  /></label
+                >
+                <select
+                  id="ms-model-{i}"
+                  class="input"
+                  value={getMorningstarModel(ctrl)}
+                  onchange={(e) =>
+                    setMorningstarModel(
+                      i,
+                      (e.target as HTMLSelectElement).value,
+                    )}
+                >
+                  {#each morningstarModels as m (m.value)}
+                    <option value={m.value}>{m.label}</option>
+                  {/each}
+                </select>
+              </div>
+
+              {#if getMorningstarModel(ctrl) === "custom"}
+                <div class="field">
+                  <label for="ms-custom-id-{i}"
+                    >{$t("controllers.morningstarCustomModelId")}
+                    <Tooltip
+                      text={$t("tooltips.controllers.morningstarCustomModelId")}
+                    /></label
+                  >
+                  <input
+                    id="ms-custom-id-{i}"
+                    type="number"
+                    class="input"
+                    min="0"
+                    max="127"
+                    value={getCustomModelId(ctrl)}
+                    onchange={(e) =>
+                      setCustomModelId(
+                        i,
+                        parseInt((e.target as HTMLInputElement).value) || 0,
+                      )}
+                  />
+                </div>
+              {/if}
+
+              <label class="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={ctrl.morningstar.save ?? false}
+                  onchange={(e) =>
+                    updateMorningstarField(
+                      i,
+                      "save",
+                      (e.target as HTMLInputElement).checked || undefined,
+                    )}
+                />
+                {$t("controllers.morningstarSave")}
+                <Tooltip text={$t("tooltips.controllers.morningstarSave")} />
+              </label>
+            </div>
+          {/if}
+        </div>
       {/if}
     </div>
   {/each}
@@ -303,6 +449,28 @@
     font-size: 13px;
     color: var(--text-dim);
     font-style: italic;
+  }
+  .morningstar-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .morningstar-fields {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    padding: 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text-muted);
+    cursor: pointer;
   }
   @media (max-width: 600px) {
     .osc-paths {

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -240,6 +240,11 @@
   "controllers.showOscPaths": "Show OSC Path Overrides",
   "controllers.hideOscPaths": "Hide OSC Path Overrides",
   "controllers.midiNote": "Edit MIDI controllers in raw YAML.",
+  "controllers.morningstar": "Morningstar",
+  "controllers.morningstarEnable": "Enable Morningstar bank naming",
+  "controllers.morningstarModel": "Model",
+  "controllers.morningstarSave": "Save to flash",
+  "controllers.morningstarCustomModelId": "Device ID",
   "controllers.addGrpc": "Add gRPC",
   "controllers.addOsc": "Add OSC",
 
@@ -656,6 +661,10 @@
   "tooltips.controllers.grpcPort": "TCP port for the gRPC control server. The web UI and other clients connect to this port. Default is 43234.",
   "tooltips.controllers.oscPort": "UDP port to listen for incoming OSC messages. Default is 43235.",
   "tooltips.controllers.broadcastAddresses": "IP addresses to broadcast OSC status updates to (e.g. '192.168.1.255:43235'). Enables external apps like TouchOSC to receive state updates.",
+  "tooltips.controllers.morningstar": "Automatically push the current song name to a Morningstar MIDI controller via SysEx when songs change.",
+  "tooltips.controllers.morningstarModel": "The Morningstar controller model. Determines the device ID byte in the SysEx message.",
+  "tooltips.controllers.morningstarSave": "When enabled, the bank name is saved to flash. When disabled, the name is temporary and resets on power cycle.",
+  "tooltips.controllers.morningstarCustomModelId": "The SysEx device ID byte for a custom/unlisted Morningstar model (0-127).",
 
   "tooltips.samples.outputChannels": "Device output channels for this sample, as comma-separated numbers (e.g. '1, 2'). If both output channels and output track are empty, uses the default stereo output.",
   "tooltips.samples.outputTrack": "Name of a track mapping (defined in Audio settings) to route this sample's output. Overrides output channels if set.",


### PR DESCRIPTION
Special support for Morningstar MIDI Controllers that support custom naming has been added. Additionally, a refactor of Player has been done so that fewer of the Player's functions are static. Frankly, this has been done because it's very annoying to get a song display while having to making dozens of different banks with a song title corresponding to each bank to simulate switching between songs. Now I can maintain one bank and I get the song name automatically.