### PR TITLE
Whole song looping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Song looping with crossfade**: Songs can now be configured to loop indefinitely by
+  setting `loop_playback: true` in song.yaml. Audio crossfades seamlessly at loop boundaries
+  (100ms linear fade), MIDI restarts from the beginning, and the lighting/DMX timeline resets
+  cleanly. During a looping song, pressing Play or Next breaks out of the loop, advances the
+  playlist, and auto-plays the next song. Stop cancels everything as usual.
+- **Beat grid detection from click tracks**: Audio click tracks (tracks named "click") are
+  analyzed offline to detect beat positions and measure boundaries. The result is a `BeatGrid`
+  with absolute beat times and accented-beat indices, stored in a per-song disk cache
+  (`.mtrack-cache.json`) alongside waveform peaks. Accent classification uses a pluggable
+  `AccentClassifier` trait — the default `ZcrClassifier` separates click sounds by
+  zero-crossing rate (timbral differences), with `AmplitudeClassifier` as an alternative.
+  Beat grid data is exposed via gRPC proto and displayed in the web UI (measure/beat position
+  during playback, beat/measure counts in song detail).
+- **Song analysis disk cache**: Computed song data (waveform peaks, beat grids) is now persisted
+  to `.mtrack-cache.json` in each song's directory. The cache uses file mtime+size for
+  invalidation — if an audio file changes, its cached data is recomputed on next access.
+  This eliminates redundant waveform computation on restarts.
+- **Audio crossfade primitives**: New `CrossfadeCurve` enum (Linear, EqualPower) and
+  `GainEnvelope` struct for applying time-varying gain to audio sources. The mixer's
+  `ActiveSource` now supports an optional gain envelope, applied per-block during mixing.
+  Sources with a completed fade-out envelope are automatically finished. These primitives
+  support both song looping and future song-to-song crossfade transitions.
 - **Morningstar SysEx integration**: mtrack can now automatically push the current song name
   to a Morningstar MIDI controller (MC3, MC6, MC8, MC6 Pro, MC8 Pro, MC4 Pro) via SysEx
   when songs change. Configured via an optional `morningstar` block on the MIDI controller,

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use std::any::Any;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{error::Error, fmt, sync::Arc, time::Duration};
 
 use crate::config;
@@ -45,6 +45,7 @@ pub fn next_source_id() -> u64 {
 /// Type alias for the channel sender used to add sources to the mixer.
 pub type SourceSender = crossbeam_channel::Sender<mixer::ActiveSource>;
 
+#[allow(clippy::too_many_arguments)]
 pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Plays the given song through the audio interface, starting from a specific time.
     /// The `ready_tx` sender signals that setup is complete. The implementation should
@@ -58,6 +59,7 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
         ready_tx: std::sync::mpsc::Sender<()>,
         clock: crate::clock::PlaybackClock,
         start_time: Duration,
+        loop_break: Arc<AtomicBool>,
     ) -> Result<(), Box<dyn Error>>;
 
     /// Gets the mixer for adding triggered samples.
@@ -181,6 +183,7 @@ mod test {
                 _ready_tx: std::sync::mpsc::Sender<()>,
                 _clock: crate::clock::PlaybackClock,
                 _start_time: Duration,
+                _loop_break: Arc<AtomicBool>,
             ) -> Result<(), Box<dyn Error>> {
                 Ok(())
             }

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -996,6 +996,7 @@ impl AudioDevice for Device {
         ready_tx: std::sync::mpsc::Sender<()>,
         clock: crate::clock::PlaybackClock,
         start_time: Duration,
+        loop_break: Arc<AtomicBool>,
     ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (cpal)");
         let _enter = span.enter();
@@ -1062,6 +1063,23 @@ impl AudioDevice for Device {
             return Err("No sources found in song".into());
         }
 
+        // If there are already sources in the mixer (fading out from a previous
+        // song), apply a fade-in envelope to the new sources for a smooth crossfade.
+        let has_existing_sources = {
+            let sources = self.output_manager.mixer.get_active_sources();
+            let guard = sources.read();
+            !guard.is_empty()
+        };
+        let fade_in_envelope = if has_existing_sources {
+            let crossfade_samples = (0.1 * self.output_manager.mixer.sample_rate() as f64) as u64;
+            Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+                crossfade_samples,
+                crate::audio::crossfade::CrossfadeCurve::Linear,
+            )))
+        } else {
+            None
+        };
+
         // Create sources and track their finish flags (no locks needed for monitoring)
         let mut source_finish_flags = Vec::new();
 
@@ -1074,14 +1092,14 @@ impl AudioDevice for Device {
             let active_source = MixerActiveSource {
                 id: current_source_id,
                 source,
-                track_mappings: mappings.clone(), // Clone for each source
-                channel_mappings: Vec::new(),     // Will be precomputed in add_source
+                track_mappings: mappings.clone(),
+                channel_mappings: Vec::new(),
                 cached_source_channel_count: source_channel_count,
-                cancel_handle: cancel_handle.clone(), // Clone for each source
+                cancel_handle: cancel_handle.clone(),
                 is_finished,
-                start_at_sample: None,  // Song sources play immediately
-                cancel_at_sample: None, // Song sources don't have scheduled cancellation
-                gain_envelope: None,
+                start_at_sample: None,
+                cancel_at_sample: None,
+                gain_envelope: fade_in_envelope.clone(),
             };
 
             self.output_manager.add_source(active_source)?;
@@ -1117,6 +1135,103 @@ impl AudioDevice for Device {
         });
 
         cancel_handle.wait(finished);
+
+        // Loop if the song has loop_playback and we haven't been told to stop.
+        while song.loop_playback()
+            && !cancel_handle.is_cancelled()
+            && !loop_break.load(Ordering::Relaxed)
+        {
+            info!(song = song.name(), "Audio loop: creating crossfade sources");
+
+            let crossfade_samples = (0.1 * self.output_manager.mixer.sample_rate() as f64) as u64;
+
+            // Fade out any remaining sources from previous iteration.
+            let current_ids: Vec<u64> = {
+                let sources = self.output_manager.mixer.get_active_sources();
+                let guard = sources.read();
+                guard.iter().map(|s| s.lock().id).collect()
+            };
+            if !current_ids.is_empty() {
+                let fade_out = Arc::new(crate::audio::crossfade::GainEnvelope::fade_out(
+                    crossfade_samples,
+                    crate::audio::crossfade::CrossfadeCurve::Linear,
+                ));
+                self.output_manager
+                    .mixer
+                    .set_gain_envelope(&current_ids, fade_out);
+            }
+
+            // Create new sources at t=0 with fade-in.
+            let new_sources = match song.create_channel_mapped_sources_from(
+                &playback_context,
+                Duration::ZERO,
+                mappings,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(err = e.as_ref(), "Failed to create loop audio sources");
+                    break;
+                }
+            };
+
+            let fade_in = Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+                crossfade_samples,
+                crate::audio::crossfade::CrossfadeCurve::Linear,
+            ));
+
+            let mut new_finish_flags = Vec::new();
+            for source in new_sources {
+                let source_id = crate::audio::next_source_id();
+                let source_channel_count = source.source_channel_count();
+                let is_finished = Arc::new(AtomicBool::new(false));
+                new_finish_flags.push(is_finished.clone());
+
+                let active_source = MixerActiveSource {
+                    id: source_id,
+                    source,
+                    track_mappings: mappings.clone(),
+                    channel_mappings: Vec::new(),
+                    cached_source_channel_count: source_channel_count,
+                    cancel_handle: cancel_handle.clone(),
+                    is_finished,
+                    start_at_sample: None,
+                    cancel_at_sample: None,
+                    gain_envelope: Some(fade_in.clone()),
+                };
+
+                if let Err(e) = self.output_manager.add_source(active_source) {
+                    error!(err = %e, "Failed to add loop source to mixer");
+                    break;
+                }
+            }
+
+            if new_finish_flags.is_empty() {
+                break;
+            }
+
+            // Wait for new sources to finish or cancel/loop_break.
+            let loop_finished = Arc::new(AtomicBool::new(false));
+            let loop_finished_monitor = loop_finished.clone();
+            let cancel_for_monitor = cancel_handle.clone();
+            let loop_break_for_monitor = loop_break.clone();
+            let monitor_flags = new_finish_flags;
+
+            thread::spawn(move || loop {
+                if cancel_for_monitor.is_cancelled()
+                    || loop_break_for_monitor.load(Ordering::Relaxed)
+                {
+                    break;
+                }
+                if monitor_flags.iter().all(|f| f.load(Ordering::Relaxed)) {
+                    loop_finished_monitor.store(true, Ordering::Relaxed);
+                    cancel_for_monitor.notify();
+                    break;
+                }
+                thread::sleep(Duration::from_millis(10));
+            });
+
+            cancel_handle.wait(loop_finished);
+        }
 
         Ok(())
     }

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -167,6 +167,22 @@ impl AudioMixer {
         });
     }
 
+    /// Sets a gain envelope on all active sources matching the given IDs.
+    /// Used to attach fade-out envelopes to running sources during loop crossfades.
+    pub fn set_gain_envelope(
+        &self,
+        source_ids: &[u64],
+        envelope: Arc<crate::audio::crossfade::GainEnvelope>,
+    ) {
+        let sources = self.active_sources.read();
+        for source_arc in sources.iter() {
+            let mut source = source_arc.lock();
+            if source_ids.contains(&source.id) {
+                source.gain_envelope = Some(envelope.clone());
+            }
+        }
+    }
+
     /// Processes one frame of audio mixing with performance monitoring (test only)
     /// This is the core mixing logic extracted from the CPAL callback
     /// Minimizes lock duration by cloning Arc references and processing without holding the lock
@@ -317,8 +333,16 @@ impl AudioMixer {
         for active_source_arc in sources_to_process.iter() {
             let mut active_source = active_source_arc.lock();
 
+            // Sources with an active fade-out envelope should continue playing
+            // until the fade completes, even if cancelled. This allows crossfade
+            // transitions to complete smoothly when breaking out of a loop.
+            let has_active_fade_out = active_source
+                .gain_envelope
+                .as_ref()
+                .is_some_and(|env| env.end_gain() == 0.0 && !env.is_finished());
+
             if active_source.is_finished.load(Ordering::Relaxed)
-                || active_source.cancel_handle.is_cancelled()
+                || (active_source.cancel_handle.is_cancelled() && !has_active_fade_out)
             {
                 debug!(
                     source_id = active_source.id,

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -60,6 +60,7 @@ impl crate::audio::Device for Device {
         ready_tx: std::sync::mpsc::Sender<()>,
         clock: crate::clock::PlaybackClock,
         start_time: Duration,
+        _loop_break: Arc<AtomicBool>,
     ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();
@@ -187,6 +188,7 @@ mod tests {
                 ready_tx,
                 clock_clone,
                 Duration::from_millis(0),
+                Arc::new(AtomicBool::new(false)),
             );
         });
 
@@ -228,6 +230,7 @@ mod tests {
                 ready_tx,
                 clock_clone,
                 Duration::from_secs(1), // Start offset > duration → remaining = 0
+                Arc::new(AtomicBool::new(false)),
             );
         });
 
@@ -266,6 +269,7 @@ mod tests {
                 ready_tx,
                 clock_clone,
                 Duration::from_millis(0),
+                Arc::new(AtomicBool::new(false)),
             );
         });
 

--- a/src/config/song.rs
+++ b/src/config/song.rs
@@ -50,6 +50,9 @@ pub struct Song {
     /// Song-specific sample trigger mappings (overrides global triggers with same MIDI event).
     #[serde(default)]
     sample_triggers: Vec<SampleTrigger>,
+    /// Whether this song should loop when it finishes playing.
+    #[serde(default)]
+    loop_playback: bool,
 }
 
 impl Song {
@@ -77,6 +80,7 @@ impl Song {
             tracks,
             samples,
             sample_triggers,
+            loop_playback: false,
         }
     }
 
@@ -188,6 +192,11 @@ impl Song {
     /// Gets the tracks associated with the song.
     pub fn tracks(&self) -> &Vec<Track> {
         &self.tracks
+    }
+
+    /// Returns whether this song should loop when it finishes playing.
+    pub fn loop_playback(&self) -> bool {
+        self.loop_playback
     }
 
     /// Gets the song-specific samples configuration.

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -195,7 +195,7 @@ impl PlayerService for PlayerServer {
         &self,
         _: Request<PreviousRequest>,
     ) -> Result<Response<PreviousResponse>, Status> {
-        if self.player.is_playing().await {
+        if self.player.is_playing().await && !self.player.is_current_song_looping() {
             return Err(Status::failed_precondition("can't navigate while playing"));
         }
         let current_song = self
@@ -221,7 +221,7 @@ impl PlayerService for PlayerServer {
     }
 
     async fn next(&self, _: Request<NextRequest>) -> Result<Response<NextResponse>, Status> {
-        if self.player.is_playing().await {
+        if self.player.is_playing().await && !self.player.is_current_song_looping() {
             return Err(Status::failed_precondition("can't navigate while playing"));
         }
         let current_song = self

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -408,6 +408,7 @@ impl Engine {
         ready_tx: std::sync::mpsc::Sender<()>,
         start_time: Duration,
         clock: crate::clock::PlaybackClock,
+        loop_break: Arc<AtomicBool>,
     ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (dmx)");
         let _enter = span.enter();
@@ -618,18 +619,75 @@ impl Engine {
         }
 
         // Song playback finished - signal the song time tracker to stop.
-        // We use timeline_finished flag (not cancel) so we don't cancel audio/MIDI.
         dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
 
-        // Wait for song time tracker to finish (will exit now that timeline_finished is set)
         if let Err(e) = song_time_tracker.join() {
             error!("Error waiting for song time tracker to stop: {:?}", e);
         }
 
-        // Stop the lighting timeline for this song, but effects continue processing
-        dmx_engine.stop_lighting_timeline();
+        // Loop if the song has loop_playback enabled.
+        while song.loop_playback()
+            && !cancel_handle.is_cancelled()
+            && !loop_break.load(Ordering::Relaxed)
+        {
+            info!(
+                song = song.name(),
+                "DMX loop: restarting timeline from beginning"
+            );
 
-        // Clear MIDI DMX playbacks
+            // Reset state for new loop iteration.
+            dmx_engine.update_song_time(Duration::ZERO);
+            dmx_engine.start_lighting_timeline_at(Duration::ZERO);
+
+            // Reset MIDI DMX playback cursors to the beginning.
+            {
+                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
+                for playback in playbacks.iter_mut() {
+                    playback.cursor = 0;
+                }
+            }
+
+            dmx_engine.timeline_finished.store(false, Ordering::Relaxed);
+
+            // Start a new song time tracker for this loop iteration.
+            let loop_time_tracker = Self::start_song_time_tracker_from(
+                dmx_engine.clone(),
+                cancel_handle.clone(),
+                Duration::ZERO,
+                clock.clone(),
+            );
+
+            // Wait for timeline to finish again.
+            let loop_watcher = {
+                let cancel_handle = cancel_handle.clone();
+                let timeline_finished = dmx_engine.timeline_finished.clone();
+                let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
+                let phase = dmx_engine.effects_loop_phase.clone();
+                let subphase = dmx_engine.update_subphase.clone();
+                thread::spawn(move || {
+                    Self::wait_for_timeline_with_heartbeat(
+                        &cancel_handle,
+                        timeline_finished,
+                        &heartbeat,
+                        &phase,
+                        &subphase,
+                    );
+                })
+            };
+
+            if let Err(e) = loop_watcher.join() {
+                error!("Error while joining loop timeline watcher: {:?}", e);
+            }
+
+            dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
+
+            if let Err(e) = loop_time_tracker.join() {
+                error!("Error waiting for loop time tracker to stop: {:?}", e);
+            }
+        }
+
+        // Final cleanup.
+        dmx_engine.stop_lighting_timeline();
         dmx_engine.midi_dmx_playbacks.lock().clear();
 
         info!("DMX playback stopped.");
@@ -1191,7 +1249,7 @@ mod test {
         collections::HashSet,
         error::Error,
         net::{Ipv4Addr, SocketAddr, TcpListener},
-        sync::Arc,
+        sync::{atomic::AtomicBool, Arc},
     };
 
     use midly::num::u7;
@@ -1677,6 +1735,7 @@ mod test {
             ready_tx,
             std::time::Duration::ZERO,
             clock,
+            Arc::new(AtomicBool::new(false)),
         )?;
 
         // Verify timeline was created (may be None if no lighting config)
@@ -1960,6 +2019,7 @@ mod test {
             ready_tx,
             std::time::Duration::ZERO,
             clock,
+            Arc::new(AtomicBool::new(false)),
         )?;
 
         // The tempo map should have been cleared (not inherited from the seeded state).
@@ -2015,6 +2075,7 @@ mod test {
             ready_tx,
             std::time::Duration::ZERO,
             clock,
+            Arc::new(AtomicBool::new(false)),
         )?;
 
         assert_lighting_state_cleared(&engine);
@@ -3454,6 +3515,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3485,6 +3547,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3517,6 +3580,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::from_secs(3),
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3555,6 +3619,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3601,6 +3666,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4269,6 +4335,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4311,6 +4378,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::from_secs(10),
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4359,6 +4427,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4434,6 +4503,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4495,6 +4565,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4607,6 +4678,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
             Ok(())

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -11,7 +11,12 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::{any::Any, error::Error, fmt, sync::Arc};
+use std::{
+    any::Any,
+    error::Error,
+    fmt,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use midly::live::LiveEvent;
 use tokio::sync::mpsc::Sender;
@@ -46,6 +51,7 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
         ready_tx: std::sync::mpsc::Sender<()>,
         start_time: std::time::Duration,
         clock: PlaybackClock,
+        loop_break: Arc<AtomicBool>,
     ) -> Result<(), Box<dyn Error>>;
 
     /// Emits an event.

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -182,6 +182,7 @@ impl super::Device for Device {
         ready_tx: std::sync::mpsc::Sender<()>,
         start_time: Duration,
         clock: PlaybackClock,
+        loop_break: Arc<AtomicBool>,
     ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (midir)");
         let _enter = span.enter();
@@ -318,6 +319,8 @@ impl super::Device for Device {
                         exclude_channels: &exclude_midi_channels,
                         beat_clock_barrier: beat_clock_internal_barrier,
                         clock: &clock,
+                        loop_playback: song.loop_playback(),
+                        loop_break: loop_break.clone(),
                     },
                 );
             })
@@ -668,6 +671,8 @@ struct PlaybackContext<'a> {
     exclude_channels: &'a HashSet<u8>,
     beat_clock_barrier: Option<Arc<Barrier>>,
     clock: &'a PlaybackClock,
+    loop_playback: bool,
+    loop_break: Arc<AtomicBool>,
 }
 
 /// Runs the MIDI playback thread body: signals readiness, waits for the clock
@@ -719,6 +724,22 @@ fn run_playback(sender: &mut dyn MidiSender, ctx: PlaybackContext<'_>) {
         ctx.exclude_channels,
         ctx.clock,
     );
+
+    // Loop if the song has loop_playback enabled.
+    while ctx.loop_playback
+        && !ctx.cancel_handle.is_cancelled()
+        && !ctx.loop_break.load(Ordering::Relaxed)
+    {
+        info!("MIDI loop: restarting from beginning");
+        play_precomputed(
+            ctx.precomputed,
+            Duration::ZERO,
+            sender,
+            ctx.cancel_handle,
+            ctx.exclude_channels,
+            ctx.clock,
+        );
+    }
 
     ctx.finished.store(true, Ordering::Relaxed);
     ctx.cancel_handle.notify();
@@ -1447,6 +1468,7 @@ mod test {
                 ready_tx,
                 Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
         }
@@ -1469,6 +1491,7 @@ mod test {
                 ready_tx,
                 Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
         }
@@ -1493,6 +1516,7 @@ mod test {
                 ready_tx,
                 Duration::ZERO,
                 clock,
+                Arc::new(AtomicBool::new(false)),
             );
             assert!(result.is_ok());
             assert!(
@@ -1820,6 +1844,8 @@ mod test {
                     exclude_channels: &exclude,
                     beat_clock_barrier: None,
                     clock: &clock,
+                    loop_playback: false,
+                    loop_break: Arc::new(AtomicBool::new(false)),
                 },
             );
 
@@ -1851,6 +1877,8 @@ mod test {
                     exclude_channels: &exclude,
                     beat_clock_barrier: None,
                     clock: &clock,
+                    loop_playback: false,
+                    loop_break: Arc::new(AtomicBool::new(false)),
                 },
             );
 
@@ -1889,6 +1917,8 @@ mod test {
                     exclude_channels: &exclude,
                     beat_clock_barrier: None,
                     clock: &clock,
+                    loop_playback: false,
+                    loop_break: Arc::new(AtomicBool::new(false)),
                 },
             );
 
@@ -1921,6 +1951,8 @@ mod test {
                     exclude_channels: &exclude,
                     beat_clock_barrier: None,
                     clock: &clock,
+                    loop_playback: false,
+                    loop_break: Arc::new(AtomicBool::new(false)),
                 },
             );
 
@@ -1970,6 +2002,8 @@ mod test {
                     exclude_channels: &exclude,
                     beat_clock_barrier: None,
                     clock: &clock,
+                    loop_playback: false,
+                    loop_break: Arc::new(AtomicBool::new(false)),
                 },
             );
 
@@ -2005,6 +2039,8 @@ mod test {
                         exclude_channels: &exclude,
                         beat_clock_barrier: None,
                         clock: &clock_clone,
+                        loop_playback: false,
+                        loop_break: Arc::new(AtomicBool::new(false)),
                     },
                 );
                 sender

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -149,6 +149,7 @@ impl super::Device for Device {
         ready_tx: std::sync::mpsc::Sender<()>,
         start_time: Duration,
         clock: PlaybackClock,
+        _loop_break: Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<(), Box<dyn Error>> {
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();

--- a/src/player.rs
+++ b/src/player.rs
@@ -133,6 +133,8 @@ struct PlaybackContext {
     play_tx: oneshot::Sender<Result<(), String>>,
     start_time: Duration,
     play_start_time: Arc<Mutex<Option<SystemTime>>>,
+    /// Shared flag to break out of the loop gracefully.
+    loop_break: Arc<AtomicBool>,
 }
 
 /// Groups hardware devices for constructing a Player without discovering real hardware.
@@ -204,6 +206,11 @@ pub struct Player {
     locked: Arc<AtomicBool>,
     /// Active controllers (gRPC, OSC, MIDI). Replaced on reload.
     controller: Arc<parking_lot::Mutex<Option<crate::controller::Controller>>>,
+    /// Signal to break out of a song loop gracefully (not a hard cancel).
+    /// Set by play()/next() when the current song is looping. The playback
+    /// loop checks this flag and exits cleanly, allowing the cleanup task
+    /// to advance the playlist and start the next song.
+    loop_break: Arc<AtomicBool>,
 }
 
 impl Player {
@@ -589,6 +596,7 @@ impl Player {
             state_tx: Arc::new(parking_lot::Mutex::new(None)),
             locked: Arc::new(AtomicBool::new(true)),
             controller: Arc::new(parking_lot::Mutex::new(None)),
+            loop_break: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -978,6 +986,18 @@ impl Player {
 
         let mut join = self.join.lock().await;
         if join.is_some() {
+            // If the current song is looping, break out immediately with crossfade.
+            // Fade out current audio, then cancel so subsystems exit. The cleanup
+            // task sees loop_broken and auto-plays the next song.
+            if self.is_current_song_looping() {
+                info!("Breaking out of song loop to advance playlist.");
+                self.fade_out_current_audio();
+                self.loop_break.store(true, Ordering::Relaxed);
+                if let Some(ref handles) = *join {
+                    handles.cancel.cancel();
+                }
+                return Ok(None);
+            }
             info!("Player is already playing a song.");
             return Ok(None);
         }
@@ -1044,6 +1064,7 @@ impl Player {
                 play_tx,
                 start_time,
                 play_start_time: play_start_time.clone(),
+                loop_break: self.loop_break.clone(),
             };
             tokio::task::spawn_blocking(move || {
                 Player::play_files(ctx);
@@ -1065,14 +1086,16 @@ impl Player {
                 };
 
                 let cancelled = cancel_handle_for_cleanup.is_cancelled();
+                let loop_broken = player.loop_break.swap(false, Ordering::Relaxed);
 
                 info!(
                     song = song.name(),
                     cancelled = cancelled,
+                    loop_broken = loop_broken,
                     "Song finished playing."
                 );
 
-                let action = decide_cleanup_action(result, cancelled);
+                let action = decide_cleanup_action(result, cancelled, loop_broken);
                 if action == CleanupAction::StopCancelled {
                     // stop() already cleared join and play_start_time.
                     // Touching them here would clobber state from a new play() that
@@ -1080,7 +1103,7 @@ impl Player {
                     return;
                 }
 
-                // Natural finish: advance playlist and clean up.
+                // Natural finish or loop break: advance playlist and clean up.
                 let mut join = player.join.lock().await;
                 if let Some(song) = playlist.next() {
                     player.emit_song_change(&song);
@@ -1093,6 +1116,21 @@ impl Player {
 
                 *join = None;
                 player.stop_run.store(false, Ordering::Relaxed);
+                let should_auto_play = action == CleanupAction::LoopBreakAndPlay;
+                drop(join);
+
+                // If loop was broken (play/next during loop), auto-play the next song.
+                // Use spawn_blocking + block_on to avoid the non-Send future issue
+                // with tokio::sync::Mutex guards inside play_from.
+                if should_auto_play {
+                    let player_for_play = player;
+                    tokio::task::spawn_blocking(move || {
+                        let rt = tokio::runtime::Handle::current();
+                        if let Err(e) = rt.block_on(player_for_play.play()) {
+                            error!(err = %e, "Failed to auto-play next song after loop break");
+                        }
+                    });
+                }
             });
         }
 
@@ -1111,6 +1149,7 @@ impl Player {
             play_tx,
             start_time,
             play_start_time,
+            loop_break,
         } = ctx;
 
         // Check if any subsystems are active.
@@ -1143,12 +1182,20 @@ impl Player {
             let audio_outcome = audio_outcome.clone();
             let ready_tx = ready_tx.clone();
             let clock = clock.clone();
+            let loop_break = loop_break.clone();
             expected_ready += 1;
 
             Some(thread::spawn(move || {
                 let song_name = song.name().to_string();
-                let result =
-                    device.play_from(song, &mappings, cancel_handle, ready_tx, clock, start_time);
+                let result = device.play_from(
+                    song,
+                    &mappings,
+                    cancel_handle,
+                    ready_tx,
+                    clock,
+                    start_time,
+                    loop_break,
+                );
                 if let Err(ref e) = result {
                     error!(
                         err = e.as_ref(),
@@ -1170,6 +1217,7 @@ impl Player {
             let cancel_handle = cancel_handle.clone();
             let clock = clock.clone();
             let ready_tx = ready_tx.clone();
+            let loop_break = loop_break.clone();
             expected_ready += 1;
 
             thread::spawn(move || {
@@ -1182,6 +1230,7 @@ impl Player {
                     ready_tx,
                     start_time,
                     clock,
+                    loop_break,
                 ) {
                     error!(
                         err = e.as_ref(),
@@ -1198,14 +1247,20 @@ impl Player {
             let cancel_handle = cancel_handle.clone();
             let ready_tx = ready_tx.clone();
             let clock = clock.clone();
+            let loop_break = loop_break.clone();
             expected_ready += 1;
 
             Some(thread::spawn(move || {
                 let song_name = song.name().to_string();
 
-                if let Err(e) =
-                    midi_device.play_from(song, cancel_handle, ready_tx, start_time, clock)
-                {
+                if let Err(e) = midi_device.play_from(
+                    song,
+                    cancel_handle,
+                    ready_tx,
+                    start_time,
+                    clock,
+                    loop_break,
+                ) {
                     error!(
                         err = e.as_ref(),
                         song = song_name,
@@ -1274,6 +1329,16 @@ impl Player {
     async fn navigate(&self, direction: PlaylistDirection) -> Option<Arc<Song>> {
         let join = self.join.lock().await;
         if join.is_some() {
+            // If the current song is looping, break out immediately with crossfade.
+            if self.is_current_song_looping() {
+                info!("Breaking out of song loop via {} navigation.", direction);
+                self.fade_out_current_audio();
+                self.loop_break.store(true, Ordering::Relaxed);
+                if let Some(ref handles) = *join {
+                    handles.cancel.cancel();
+                }
+                return self.get_playlist().current();
+            }
             let current = self.get_playlist().current();
             if let Some(ref song) = current {
                 info!(
@@ -1483,6 +1548,38 @@ impl Player {
         self.join.lock().await.is_some()
     }
 
+    /// Returns true if the current song has loop_playback enabled.
+    /// Does not require the join lock — just checks the playlist's current song.
+    pub fn is_current_song_looping(&self) -> bool {
+        self.get_playlist()
+            .current()
+            .map(|song| song.loop_playback())
+            .unwrap_or(false)
+    }
+
+    /// Sets fade-out envelopes on all current audio sources for a smooth
+    /// crossfade transition when breaking out of a loop.
+    fn fade_out_current_audio(&self) {
+        let hw = self.hardware.read();
+        if let Some(ref device) = hw.device {
+            if let Some(mixer) = device.mixer() {
+                let crossfade_samples = (0.1 * mixer.sample_rate() as f64) as u64;
+                let source_ids: Vec<u64> = {
+                    let sources = mixer.get_active_sources();
+                    let guard = sources.read();
+                    guard.iter().map(|s| s.lock().id).collect()
+                };
+                if !source_ids.is_empty() {
+                    let fade_out = Arc::new(crate::audio::crossfade::GainEnvelope::fade_out(
+                        crossfade_samples,
+                        crate::audio::crossfade::CrossfadeCurve::Linear,
+                    ));
+                    mixer.set_gain_envelope(&source_ids, fade_out);
+                }
+            }
+        }
+    }
+
     /// Returns true if the player is in locked mode (state-altering operations blocked).
     pub fn is_locked(&self) -> bool {
         self.locked.load(Ordering::Relaxed)
@@ -1674,10 +1771,22 @@ enum PlaybackResult {
 enum CleanupAction {
     AdvancePlaylist,
     StopCancelled,
+    /// Loop was broken via play/next — advance playlist and auto-play next song.
+    LoopBreakAndPlay,
 }
 
 /// Decides whether to advance the playlist or stop after playback finishes.
-fn decide_cleanup_action(result: PlaybackResult, cancelled: bool) -> CleanupAction {
+fn decide_cleanup_action(
+    result: PlaybackResult,
+    cancelled: bool,
+    loop_broken: bool,
+) -> CleanupAction {
+    // Loop break takes priority over cancel — we intentionally cancel
+    // playback to break out of a loop immediately, but the intent is
+    // to advance and play, not to stop.
+    if loop_broken {
+        return CleanupAction::LoopBreakAndPlay;
+    }
     if cancelled {
         return CleanupAction::StopCancelled;
     }
@@ -2637,7 +2746,7 @@ mod test {
     #[test]
     fn cleanup_success_not_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Success, false),
+            decide_cleanup_action(PlaybackResult::Success, false, false),
             CleanupAction::AdvancePlaylist
         );
     }
@@ -2645,7 +2754,7 @@ mod test {
     #[test]
     fn cleanup_success_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Success, true),
+            decide_cleanup_action(PlaybackResult::Success, true, false),
             CleanupAction::StopCancelled
         );
     }
@@ -2653,7 +2762,7 @@ mod test {
     #[test]
     fn cleanup_failed_not_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Failed("err".into()), false),
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), false, false),
             CleanupAction::AdvancePlaylist
         );
     }
@@ -2661,7 +2770,7 @@ mod test {
     #[test]
     fn cleanup_failed_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Failed("err".into()), true),
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, false),
             CleanupAction::StopCancelled
         );
     }
@@ -2669,8 +2778,26 @@ mod test {
     #[test]
     fn cleanup_sender_dropped_not_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::SenderDropped, false),
+            decide_cleanup_action(PlaybackResult::SenderDropped, false, false),
             CleanupAction::AdvancePlaylist
+        );
+    }
+
+    #[test]
+    fn cleanup_loop_broken() {
+        assert_eq!(
+            decide_cleanup_action(PlaybackResult::Success, false, true),
+            CleanupAction::LoopBreakAndPlay
+        );
+    }
+
+    #[test]
+    fn cleanup_loop_broken_takes_priority_over_cancel() {
+        // If both cancelled and loop_broken, loop_broken wins — we intentionally
+        // cancel to break out of the loop immediately, but the intent is to advance.
+        assert_eq!(
+            decide_cleanup_action(PlaybackResult::Success, true, true),
+            CleanupAction::LoopBreakAndPlay
         );
     }
 

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -129,6 +129,8 @@ pub struct Song {
     samples_config: config::SamplesConfig,
     /// Tempo map derived from click track analysis.
     beat_grid: Option<crate::audio::click_analysis::BeatGrid>,
+    /// Whether this song should loop when it finishes playing.
+    loop_playback: bool,
 }
 
 /// A simple sample for songs. Boils down to i32 or f32, which we can be reasonably assured that
@@ -236,6 +238,7 @@ impl Song {
             tracks,
             samples_config: config.samples_config(),
             beat_grid,
+            loop_playback: config.loop_playback(),
         })
     }
 
@@ -433,9 +436,14 @@ impl Song {
         &self.tracks
     }
 
-    /// Gets the click track tempo map, if available.
+    /// Gets the beat grid derived from click track analysis, if available.
     pub fn beat_grid(&self) -> Option<&crate::audio::click_analysis::BeatGrid> {
         self.beat_grid.as_ref()
+    }
+
+    /// Returns whether this song should loop when it finishes playing.
+    pub fn loop_playback(&self) -> bool {
+        self.loop_playback
     }
 
     /// Checks if this song requires transcoding for the given target format
@@ -621,6 +629,7 @@ impl Default for Song {
             tracks: Default::default(),
             samples_config: config::SamplesConfig::default(),
             beat_grid: None,
+            loop_playback: false,
         }
     }
 }

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -86,6 +86,7 @@ pub(super) async fn get_songs(State(state): State<WebUiState>) -> impl IntoRespo
                     "beats": g.beats,
                     "measure_starts": g.measure_starts,
                 })),
+                "loop_playback": song.loop_playback(),
             })
         })
         .collect();

--- a/src/webui/state.rs
+++ b/src/webui/state.rs
@@ -53,7 +53,7 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
         let is_playing = player.is_playing().await;
         let playlist = player.get_playlist();
 
-        let elapsed_ms = player
+        let raw_elapsed_ms = player
             .elapsed()
             .await
             .ok()
@@ -65,7 +65,7 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
         let playlist_position = playlist.position();
         let playlist_songs: Vec<String> = playlist.songs().clone();
 
-        let (song_name, song_duration_ms, tracks, beat_grid) =
+        let (song_name, song_duration_ms, tracks, beat_grid, looping) =
             if let Some(current_song) = playlist.current() {
                 let mappings = player.track_mappings();
                 let tracks: Vec<serde_json::Value> = current_song
@@ -95,13 +95,22 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
                     current_song.duration().as_millis() as u64,
                     tracks,
                     beat_grid,
+                    current_song.loop_playback(),
                 )
             } else {
-                (String::new(), 0, vec![], None)
+                (String::new(), 0, vec![], None, false)
             };
 
         let available_playlists = player.list_playlists();
         let persisted_playlist_name = player.persisted_playlist_name();
+
+        // For looping songs, wrap elapsed time to show position within the
+        // current loop iteration rather than total time since first play.
+        let elapsed_ms = if looping && song_duration_ms > 0 {
+            raw_elapsed_ms % song_duration_ms
+        } else {
+            raw_elapsed_ms
+        };
 
         let msg = json!({
             "type": "playback",
@@ -117,6 +126,7 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
             "persisted_playlist_name": persisted_playlist_name,
             "locked": player.is_locked(),
             "beat_grid": beat_grid,
+            "looping": looping,
         });
 
         let _ = tx.send(msg.to_string());

--- a/src/webui/svelte/e2e/mock-server/index.ts
+++ b/src/webui/svelte/e2e/mock-server/index.ts
@@ -45,9 +45,11 @@ app.get("/api/songs", (_req, res) => {
 app.get("/api/songs/:name", (req, res) => {
   const song = SONGS.songs.find((s) => s.name === req.params.name);
   if (!song) return res.status(404).json({ error: "Song not found" });
-  res
-    .type("text/yaml")
-    .send(`name: ${song.name}\ntracks:\n  - kick\n  - snare\n  - bass\n`);
+  let yaml = `name: ${song.name}\ntracks:\n  - kick\n  - snare\n  - bass\n`;
+  if (song.loop_playback) {
+    yaml += `loop_playback: true\n`;
+  }
+  res.type("text/yaml").send(yaml);
 });
 
 app.post("/api/songs/:name", (_req, res) => {

--- a/src/webui/svelte/e2e/mock-server/test-data.ts
+++ b/src/webui/svelte/e2e/mock-server/test-data.ts
@@ -27,6 +27,8 @@ export const SONGS = {
       base_dir: "Test Song Alpha",
       lighting_files: ["show.light"],
       midi_dmx_files: [],
+      beat_grid: null,
+      loop_playback: false,
     },
     {
       name: "Test Song Beta",
@@ -41,6 +43,8 @@ export const SONGS = {
       base_dir: "Test Song Beta",
       lighting_files: [],
       midi_dmx_files: [],
+      beat_grid: null,
+      loop_playback: true,
     },
   ],
   failures: [
@@ -176,6 +180,8 @@ export const PLAYBACK_STATE = {
   available_playlists: ["all_songs", "setlist"],
   persisted_playlist_name: "setlist",
   locked: false,
+  beat_grid: null,
+  looping: false,
 };
 
 export const METADATA_STATE = {

--- a/src/webui/svelte/e2e/tests/song-detail.spec.ts
+++ b/src/webui/svelte/e2e/tests/song-detail.spec.ts
@@ -106,6 +106,38 @@ test.describe("Song Detail", () => {
   });
 });
 
+test.describe("Song Detail - Loop Playback", () => {
+  test("does not show LOOP badge for non-looping song", async ({ page }) => {
+    await page.goto("/#/songs/Test%20Song%20Alpha");
+    await expect(page.locator(".badge.loop")).not.toBeVisible();
+  });
+
+  test("shows LOOP badge for looping song", async ({ page }) => {
+    await page.goto("/#/songs/Test%20Song%20Beta");
+    await expect(page.locator(".badge.loop")).toBeVisible();
+  });
+
+  test("loop checkbox is unchecked for non-looping song", async ({ page }) => {
+    await page.goto("/#/songs/Test%20Song%20Alpha");
+    const checkbox = page.locator("#loop-playback");
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).not.toBeChecked();
+  });
+
+  test("loop checkbox is checked for looping song", async ({ page }) => {
+    await page.goto("/#/songs/Test%20Song%20Beta");
+    const checkbox = page.locator("#loop-playback");
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).toBeChecked();
+  });
+
+  test("toggling loop checkbox marks config as dirty", async ({ page }) => {
+    await page.goto("/#/songs/Test%20Song%20Alpha");
+    await page.locator("#loop-playback").check();
+    await expect(page.locator(".unsaved")).toBeVisible();
+  });
+});
+
 test.describe("Song Detail - MIDI Event Editor", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/#/songs/Test%20Song%20Alpha");

--- a/src/webui/svelte/src/components/cards/PlaybackCard.svelte
+++ b/src/webui/svelte/src/components/cards/PlaybackCard.svelte
@@ -177,6 +177,9 @@
         {:else}
           <span class="stopped">{$t("playback.stopped")}</span>
         {/if}
+        {#if $playbackStore.looping}
+          <span class="loop-badge">LOOP</span>
+        {/if}
         {#if currentBeatInfo}
           <span class="beat-info"
             >m{currentBeatInfo.measure} b{currentBeatInfo.beat}</span
@@ -204,7 +207,9 @@
       <button
         class="btn"
         onclick={previous}
-        disabled={$playbackStore.is_playing || loading || !canPrev}
+        disabled={($playbackStore.is_playing && !$playbackStore.looping) ||
+          loading ||
+          !canPrev}
         title={$t("playback.prevTooltip")}>{$t("playback.prev")}</button
       >
       {#if $playbackStore.is_playing}
@@ -225,7 +230,9 @@
       <button
         class="btn"
         onclick={next}
-        disabled={$playbackStore.is_playing || loading || !canNext}
+        disabled={($playbackStore.is_playing && !$playbackStore.looping) ||
+          loading ||
+          !canNext}
         title={$t("playback.nextTooltip")}>{$t("playback.next")}</button
       >
     </div>
@@ -268,6 +275,15 @@
     margin-left: 8px;
     font-family: var(--mono);
     color: var(--text-dim);
+  }
+  .loop-badge {
+    margin-left: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: var(--accent);
+    color: var(--bg);
   }
   .progress-bar {
     height: 4px;

--- a/src/webui/svelte/src/components/songs/SongDetail.svelte
+++ b/src/webui/svelte/src/components/songs/SongDetail.svelte
@@ -115,6 +115,9 @@
   // MIDI event state
   let midiEvent = $state<MidiEvent | null>(null);
 
+  // Loop playback state
+  let loopPlayback = $state(false);
+
   // File browser state
   type BrowseTarget =
     | { kind: "track"; index: number }
@@ -187,6 +190,7 @@
           file_channel: t.file_channel as number | undefined,
         }));
         midiEvent = (parsed.midi_event as MidiEvent) ?? null;
+        loopPlayback = parsed.loop_playback === true;
         const s = parsed.samples;
         songSamples =
           s && typeof s === "object" ? (s as Record<string, any>) : {};
@@ -195,6 +199,7 @@
       parsedConfig = null;
       tracks = [];
       midiEvent = null;
+      loopPlayback = false;
       songSamples = {};
     }
   }
@@ -216,6 +221,11 @@
       updated.midi_event = midiEvent;
     } else {
       delete updated.midi_event;
+    }
+    if (loopPlayback) {
+      updated.loop_playback = true;
+    } else {
+      delete updated.loop_playback;
     }
     if (Object.keys(songSamples).length > 0) {
       updated.samples = songSamples;
@@ -517,6 +527,9 @@
         {#if song && song.midi_dmx_files.length > 0}
           <span class="badge midi-dmx">MIDI DMX</span>
         {/if}
+        {#if song?.loop_playback}
+          <span class="badge loop">LOOP</span>
+        {/if}
       </div>
     </div>
 
@@ -550,6 +563,22 @@
           >
         </div>
       {/if}
+
+      <div class="field">
+        <label for="loop-playback">
+          <input
+            id="loop-playback"
+            type="checkbox"
+            checked={loopPlayback}
+            onchange={(e) => {
+              loopPlayback = (e.currentTarget as HTMLInputElement).checked;
+              editedYaml = buildYaml();
+            }}
+          />
+          {$t("songs.detail.loopPlayback")}
+        </label>
+        <span class="field-hint">{$t("songs.detail.loopPlaybackHint")}</span>
+      </div>
     {/if}
 
     <!-- Tab bar with inline save -->
@@ -1015,6 +1044,10 @@
     background: var(--green-dim);
     color: var(--green);
   }
+  .badge.loop {
+    background: var(--accent);
+    color: var(--bg);
+  }
   .badge.failed {
     background: rgba(239, 68, 68, 0.15);
     color: var(--red);
@@ -1040,6 +1073,20 @@
     font-size: 14px;
     color: var(--text-muted);
     margin-bottom: 8px;
+  }
+  .field label:has(input[type="checkbox"]) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  .field-hint {
+    display: block;
+    font-size: 12px;
+    color: var(--text-dim);
+    margin-top: 2px;
+    margin-left: 24px;
   }
   .beat-grid-summary {
     display: flex;

--- a/src/webui/svelte/src/lib/api/songs.ts
+++ b/src/webui/svelte/src/lib/api/songs.ts
@@ -32,6 +32,8 @@ export interface SongSummary {
   midi_dmx_files: string[];
   /** Beat grid derived from click track analysis */
   beat_grid: { beats: number[]; measure_starts: number[] } | null;
+  /** Whether this song loops when it finishes playing */
+  loop_playback: boolean;
 }
 
 export interface WaveformTrack {

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -389,6 +389,8 @@
   "songs.detail.tabs.midi": "MIDI",
   "songs.detail.tabs.lighting": "Lighting",
   "songs.detail.tabs.config": "Config",
+  "songs.detail.loopPlayback": "Loop Playback",
+  "songs.detail.loopPlaybackHint": "Song will repeat from the beginning when it finishes, with audio crossfade at the loop boundary.",
   "songs.detail.failedToLoadSong": "Failed to load song",
   "songs.detail.failedToLoad": "This song failed to load and will not be playable until it's valid.",
   "songs.detail.noMidi": "No MIDI file configured for this song.",

--- a/src/webui/svelte/src/lib/ws/stores.ts
+++ b/src/webui/svelte/src/lib/ws/stores.ts
@@ -40,6 +40,7 @@ export interface PlaybackState {
   persisted_playlist_name: string;
   locked: boolean;
   beat_grid: BeatGrid | null;
+  looping: boolean;
 }
 
 export interface FixtureChannels {
@@ -84,6 +85,7 @@ export const playbackStore = writable<PlaybackState>({
   persisted_playlist_name: "",
   locked: true,
   beat_grid: null,
+  looping: false,
 });
 
 export const fixtureStore = writable<Record<string, FixtureChannels>>({});
@@ -123,6 +125,7 @@ on("playback", (msg) => {
     persisted_playlist_name: m.persisted_playlist_name ?? "",
     locked: m.locked ?? true,
     beat_grid: m.beat_grid ?? null,
+    looping: m.looping ?? false,
   });
 });
 


### PR DESCRIPTION
Songs can now loop perpetually. When songs loop, they will loop endlessly until the user hits "play" or "next." When looping, the end of the song will crossfade into the beginning of the song when looping.

Partially addresses the comments in https://github.com/mdwn/mtrack/issues/39