### PR TITLE
Faster local builds, GHA uses Makefile.

### DIFF
--- a/.github/workflows/mtrack.yaml
+++ b/.github/workflows/mtrack.yaml
@@ -32,7 +32,7 @@ jobs:
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: node-modules-${{ runner.os }}-
     - name: Build frontend
-      run: cd src/webui/svelte && npm ci && npx @bufbuild/buf generate && npm run build
+      run: make build-ui
     - name: Build mtrack
       run: cargo build --all-targets --all-features
     - name: Check if Cargo.lock is up to date
@@ -67,9 +67,9 @@ jobs:
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: node-modules-${{ runner.os }}-
     - name: Build frontend
-      run: cd src/webui/svelte && npm ci && npx @bufbuild/buf generate && npm run build
+      run: make build-ui
     - name: Run clippy
-      run: cargo clippy --all --all-targets --all-features
+      run: make lint-rust
 
   # Make sure the code is properly formatted.
   rustfmt-check:
@@ -81,7 +81,7 @@ jobs:
       with:
         components: rustfmt
     - name: Run rustfmt
-      run: cargo fmt --all -- --check
+      run: make fmt-rust-check
 
   # Make sure the tests pass.
   test:
@@ -104,7 +104,7 @@ jobs:
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: node-modules-${{ runner.os }}-
     - name: Build frontend
-      run: cd src/webui/svelte && npm ci && npx @bufbuild/buf generate && npm run build
+      run: make build-ui
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-tarpaulin
@@ -131,13 +131,11 @@ jobs:
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: node-modules-${{ runner.os }}-
     - name: Install and generate
-      run: cd src/webui/svelte && npm ci && npx @bufbuild/buf generate
+      run: make install-ui gen-proto
     - name: Lint
-      run: cd src/webui/svelte && npm run lint
+      run: make lint-ui
     - name: Format check
       run: cd src/webui/svelte && npm run format:check
-    - name: Type check
-      run: cd src/webui/svelte && npm run check
 
   # Run Playwright E2E tests against mock backend.
   playwright:
@@ -154,13 +152,13 @@ jobs:
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: node-modules-${{ runner.os }}-
     - name: Install and generate
-      run: cd src/webui/svelte && npm ci && npx @bufbuild/buf generate
+      run: make install-ui gen-proto
     - name: Install Playwright browsers
       run: cd src/webui/svelte && npx playwright install chromium
     - name: Install Playwright system deps
       run: cd src/webui/svelte && npx playwright install-deps chromium
     - name: Run Playwright tests
-      run: cd src/webui/svelte && npx playwright test --project=mock
+      run: make test-ui
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: node-modules-${{ runner.os }}-
     - name: Build frontend
-      run: cd src/webui/svelte && npm ci && npx @bufbuild/buf generate && npm run build
+      run: make build-ui
     - name: Run publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SVELTE_DIR := $(ROOT_DIR)/src/webui/svelte
 DOCS_DIR := $(ROOT_DIR)/docs
 
-.PHONY: all setup setup-dev build gen-proto build-ui build-rust test test-ui test-systemd lint lint-ui lint-rust fmt fmt-ui fmt-rust check clean dev-ui docs docs-serve docs-clean
+.PHONY: all setup setup-dev build gen-proto install-ui build-ui build-rust test test-ui test-systemd lint lint-ui lint-rust fmt fmt-ui fmt-rust check fmt-ui-check fmt-rust-check clean dev-ui docs docs-serve docs-clean
 
 all: build
 
@@ -30,13 +30,27 @@ setup-dev:
 ## Build everything
 build: build-ui build-rust
 
+## Compute a hash of all frontend inputs (source, proto, lockfile).
+FRONTEND_HASH := $(shell find $(SVELTE_DIR)/src $(ROOT_DIR)/src/proto -type f 2>/dev/null | sort | xargs cat 2>/dev/null | git hash-object --stdin)
+FRONTEND_STAMP := $(SVELTE_DIR)/dist/.build-stamp
+
+## Install frontend dependencies
+install-ui:
+	cd $(SVELTE_DIR) && npm ci
+
 ## Generate protobuf TypeScript bindings
 gen-proto:
-	cd $(SVELTE_DIR) && buf generate
+	cd $(SVELTE_DIR) && npx @bufbuild/buf generate
 
-## Build the Svelte frontend (generates protobuf bindings first)
-build-ui: gen-proto
-	cd $(SVELTE_DIR) && npm ci && npm run build
+## Build the Svelte frontend (skips if sources unchanged)
+build-ui:
+	@if [ -f "$(FRONTEND_STAMP)" ] && [ "$$(cat "$(FRONTEND_STAMP)")" = "$(FRONTEND_HASH)" ]; then \
+		echo "Frontend up to date, skipping build."; \
+	else \
+		$(MAKE) install-ui gen-proto && \
+		cd $(SVELTE_DIR) && npm run build && \
+		echo "$(FRONTEND_HASH)" > "$(FRONTEND_STAMP)"; \
+	fi
 
 ## Build the Rust binary
 build-rust:
@@ -73,7 +87,7 @@ lint-ui:
 
 ## Lint the Rust code
 lint-rust:
-	cargo clippy --manifest-path $(ROOT_DIR)/Cargo.toml
+	cargo clippy --manifest-path $(ROOT_DIR)/Cargo.toml --all --all-targets --all-features
 
 ## Format everything
 fmt: fmt-ui fmt-rust
@@ -87,8 +101,14 @@ fmt-rust:
 	cargo fmt --manifest-path $(ROOT_DIR)/Cargo.toml
 
 ## Check formatting without writing
-check:
+check: fmt-ui-check fmt-rust-check
+
+## Check frontend formatting
+fmt-ui-check:
 	cd $(SVELTE_DIR) && npm run format:check
+
+## Check Rust formatting
+fmt-rust-check:
 	cargo fmt --manifest-path $(ROOT_DIR)/Cargo.toml --check
 
 ## Start the Vite dev server


### PR DESCRIPTION
Local builds won't rebuild the UI if there haven't been changes. This makes repeated builds faster. Also, the GHA workflows will use the Makefile instead of duplicating calls, which will hopefully prevent drift in the future.