### PR TITLE
Add in light show tempo guessing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tint. The sequences lane shows sequence references as blocks spanning their full expanded
   duration (all loop iterations), and dragging the right edge adjusts the loop count, snapping
   to whole iterations.
+- **Tempo map detection from MIDI**: When a song has a MIDI file, the lighting
+  tempo editor can extract an authoritative tempo map directly from MIDI
+  `SetTempo` and `TimeSignature` meta events. Consecutive monotonic BPM changes
+  (ritardandos/accelerandos) are automatically collapsed into single transitions.
+  Falls back to beat grid estimation when no MIDI file is available. The beat
+  grid's start offset (first audible beat) is used in both cases.
+- **Tempo map estimation from beat grid**: Songs with a click track but no MIDI
+  file can estimate a tempo map from the detected beat grid. Finds stable tempo
+  sections, detects time signature changes from measure boundary spacing, and
+  identifies discrete tempo changes. Results are snapped to measure boundaries.
+  Displayed with an "estimated from beat grid" badge to indicate it's a guess.
+- **Beat grid refinement**: Beat positions within stable tempo sections are
+  snapped to an ideal grid after onset detection, removing ±5-15ms jitter from
+  the onset detector. This improves tempo calculation accuracy at section
+  boundaries.
+- **Tempo editor in visual timeline**: The tempo map editor is now accessible
+  by clicking the tempo lane in the visual timeline. Includes controls for BPM,
+  time signature, start offset, and tempo changes. A "Detect from MIDI" or
+  "Guess from beat grid" button populates the tempo map automatically.
+- **Snap subdivisions**: The snap resolution in both the main timeline and the
+  sequence editor now includes 1/2, 1/4, 1/8, and 1/16 beat subdivisions in
+  addition to beat and measure snapping.
 
 ### Changed
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -26,9 +26,11 @@ pub mod context;
 pub mod cpal;
 pub mod crossfade;
 pub mod format;
+pub mod midi_tempo;
 pub mod mixer;
 pub mod mock;
 pub mod sample_source;
+pub mod tempo_guess;
 
 // Re-export the format types for backward compatibility
 pub use context::PlaybackContext;

--- a/src/audio/click_analysis.rs
+++ b/src/audio/click_analysis.rs
@@ -375,15 +375,125 @@ pub fn analyze_click_track(
         .map(|(i, _)| i)
         .collect();
 
-    Some(BeatGrid {
+    let mut grid = BeatGrid {
         beats,
         measure_starts,
-    })
+    };
+
+    // Refine beat positions to remove onset detection jitter
+    refine_beat_grid(&mut grid);
+
+    Some(grid)
 }
 
 /// Convenience wrapper that uses `ZcrClassifier` as the default accent classifier.
 pub fn analyze_click_track_default(file: &Path, file_channel: u16) -> Option<BeatGrid> {
     analyze_click_track(file, file_channel, &ZcrClassifier)
+}
+
+/// Refine beat positions by snapping beats in stable tempo sections to an
+/// ideal grid. This removes onset detection jitter (typically ±5-10ms) which
+/// can cause BPM miscalculations at section boundaries.
+///
+/// Only beats within stable sections (where consecutive intervals are within
+/// `band_bpm` of each other) are adjusted. Beats in ramps/transitions are
+/// left at their detected positions.
+pub fn refine_beat_grid(grid: &mut BeatGrid) {
+    if grid.beats.len() < 2 {
+        return;
+    }
+
+    // Configuration
+    let band_bpm = 4.0; // max BPM deviation within a stable section
+    let min_stable = 8; // minimum beats to form a stable section
+    let max_snap_secs = 0.015; // don't move a beat more than 15ms
+
+    // Compute instantaneous BPM at each beat
+    let mut bpms: Vec<f64> = grid
+        .beats
+        .windows(2)
+        .map(|w| {
+            let interval = w[1] - w[0];
+            if interval > 0.0 {
+                60.0 / interval
+            } else {
+                0.0
+            }
+        })
+        .collect();
+    if let Some(&last) = bpms.last() {
+        bpms.push(last);
+    }
+
+    // Find stable sections using fixed-mean approach
+    let mut sections: Vec<(usize, usize, f64)> = Vec::new(); // (start, end_exclusive, mean_bpm)
+    let mut pos = 0;
+    while pos < bpms.len() {
+        let seed_end = (pos + min_stable).min(bpms.len());
+        if seed_end > bpms.len() || seed_end - pos < min_stable {
+            break;
+        }
+        let seed_bpms = &bpms[pos..seed_end];
+        let seed_mean = seed_bpms.iter().sum::<f64>() / seed_bpms.len() as f64;
+        let max_dev = seed_bpms
+            .iter()
+            .map(|b| (b - seed_mean).abs())
+            .fold(0.0f64, f64::max);
+        if max_dev > band_bpm {
+            pos += 1;
+            continue;
+        }
+
+        // Extend using fixed mean
+        let mut end = seed_end;
+        while end < bpms.len() {
+            if (bpms[end] - seed_mean).abs() > band_bpm {
+                break;
+            }
+            end += 1;
+        }
+
+        if end - pos >= min_stable {
+            // Recompute mean from the full section for precision
+            let mean = bpms[pos..end].iter().sum::<f64>() / (end - pos) as f64;
+            sections.push((pos, end, mean));
+            pos = end;
+        } else {
+            pos += 1;
+        }
+    }
+
+    // Snap beats within each stable section to the ideal grid.
+    // Anchor from a few beats into the section (not the very first beat,
+    // which may be at the boundary and jittery). Snap both forward and
+    // backward from the anchor.
+    for &(start, end, mean_bpm) in &sections {
+        let ideal_interval = 60.0 / mean_bpm;
+        let section_len = end - start;
+
+        // Anchor a few beats in (or at the midpoint for short sections)
+        let anchor_offset = min_stable.min(section_len / 2).max(1);
+        let anchor_idx = start + anchor_offset;
+        let anchor_time = grid.beats[anchor_idx];
+
+        // Snap forward from anchor
+        for i in (anchor_idx + 1)..end.min(grid.beats.len()) {
+            let beats_from_anchor = (i - anchor_idx) as f64;
+            let ideal_time = anchor_time + beats_from_anchor * ideal_interval;
+            if (ideal_time - grid.beats[i]).abs() <= max_snap_secs {
+                grid.beats[i] = ideal_time;
+            }
+        }
+
+        // Snap backward from anchor (including the first beat)
+        for i in (start..anchor_idx).rev() {
+            let beats_from_anchor = (anchor_idx - i) as f64;
+            let ideal_time = anchor_time - beats_from_anchor * ideal_interval;
+            if (ideal_time - grid.beats[i]).abs() <= max_snap_secs {
+                grid.beats[i] = ideal_time;
+            }
+        }
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/src/audio/midi_tempo.rs
+++ b/src/audio/midi_tempo.rs
@@ -1,0 +1,435 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Extract a tempo map from a MIDI file.
+//!
+//! MIDI files contain explicit `SetTempo` and `TimeSignature` meta events
+//! that provide an authoritative tempo map. Combined with the beat grid's
+//! start offset (when the first beat actually sounds in the audio), this
+//! produces an accurate tempo section for lighting show authoring.
+
+use std::path::Path;
+
+use midly::{Format, MetaMessage, Smf, TrackEventKind};
+
+use super::tempo_guess::{GuessedTempo, GuessedTempoChange};
+
+/// A tempo event at a tick position.
+struct TempoEvent {
+    tick: u64,
+    micros_per_beat: u32,
+}
+
+/// A time signature event at a tick position.
+struct TimeSigEvent {
+    tick: u64,
+    numerator: u8,
+    denominator_power: u8, // actual denominator = 2^power
+}
+
+/// Extract a tempo map from a MIDI file, using the beat grid's start offset.
+///
+/// Returns `None` if the MIDI file can't be parsed or has no tempo information.
+pub fn extract_tempo_from_midi(
+    midi_path: &Path,
+    start_offset_seconds: f64,
+) -> Option<GuessedTempo> {
+    let data = std::fs::read(midi_path).ok()?;
+    let smf = Smf::parse(&data).ok()?;
+
+    let tpb = match smf.header.timing {
+        midly::Timing::Metrical(tpb) => tpb.as_int() as u64,
+        midly::Timing::Timecode(_, _) => return None, // SMPTE not supported
+    };
+
+    // Extract tempo and time signature events from the appropriate track(s)
+    let (tempo_events, time_sig_events) = extract_events(&smf);
+
+    if tempo_events.is_empty() {
+        return None;
+    }
+
+    // Build the tempo map: convert tick positions to measure/beat
+    let base_micros_per_beat = tempo_events[0].micros_per_beat;
+    let base_bpm = (60_000_000.0 / base_micros_per_beat as f64).round() as u32;
+
+    let base_time_sig = if let Some(ts) = time_sig_events.first() {
+        if ts.tick == 0 {
+            [ts.numerator as u32, 1u32 << ts.denominator_power as u32]
+        } else {
+            [4, 4]
+        }
+    } else {
+        [4, 4]
+    };
+
+    let mut changes = Vec::new();
+    let mut current_bpm = base_bpm;
+    let mut current_ts = base_time_sig;
+
+    // Walk through all events in tick order, tracking measure/beat position
+    let mut all_events: Vec<(u64, EventKind)> = Vec::new();
+    for te in &tempo_events {
+        if te.tick > 0 {
+            all_events.push((te.tick, EventKind::Tempo(te.micros_per_beat)));
+        }
+    }
+    for ts in &time_sig_events {
+        if ts.tick > 0 {
+            all_events.push((
+                ts.tick,
+                EventKind::TimeSig(ts.numerator, ts.denominator_power),
+            ));
+        }
+    }
+    all_events.sort_by_key(|(tick, _)| *tick);
+
+    // Convert ticks to measure/beat position
+    let mut tick_cursor: u64 = 0;
+    let mut measure: u32 = 1;
+    let mut beat_in_measure: f64 = 0.0;
+    let mut beats_per_measure = base_time_sig[0];
+    let ticks_per_beat = tpb;
+
+    for (tick, event) in &all_events {
+        // Advance measure/beat from cursor to this tick
+        let delta_ticks = tick - tick_cursor;
+        let delta_beats = delta_ticks as f64 / ticks_per_beat as f64;
+        beat_in_measure += delta_beats;
+
+        // Roll over complete measures
+        while beat_in_measure >= beats_per_measure as f64 {
+            beat_in_measure -= beats_per_measure as f64;
+            measure += 1;
+        }
+
+        tick_cursor = *tick;
+
+        let beat_number = beat_in_measure.floor() as u32 + 1;
+
+        match event {
+            EventKind::Tempo(micros_per_beat) => {
+                let bpm = (60_000_000.0 / *micros_per_beat as f64).round() as u32;
+                if bpm != current_bpm {
+                    changes.push(GuessedTempoChange {
+                        measure,
+                        beat: beat_number,
+                        bpm,
+                        time_signature: [beats_per_measure, current_ts[1]],
+                        transition_beats: None,
+                    });
+                    current_bpm = bpm;
+                }
+            }
+            EventKind::TimeSig(numerator, denom_power) => {
+                let new_ts = [*numerator as u32, 1u32 << *denom_power as u32];
+                if new_ts != current_ts {
+                    // Emit a change with the current BPM and new time sig
+                    changes.push(GuessedTempoChange {
+                        measure,
+                        beat: beat_number,
+                        bpm: current_bpm,
+                        time_signature: new_ts,
+                        transition_beats: None,
+                    });
+                    beats_per_measure = new_ts[0];
+                    current_ts = new_ts;
+                }
+            }
+        }
+    }
+
+    // Deduplicate: if a tempo and time sig change land at the same measure/beat,
+    // merge them into one change
+    dedup_changes(&mut changes);
+
+    // Collapse consecutive monotonic BPM changes into transitions (rit/accel).
+    // With MIDI data this is exact — no estimation needed.
+    collapse_ramps(&mut changes);
+
+    Some(GuessedTempo {
+        start_seconds: start_offset_seconds,
+        bpm: base_bpm,
+        time_signature: base_time_sig,
+        changes,
+    })
+}
+
+enum EventKind {
+    Tempo(u32),
+    TimeSig(u8, u8),
+}
+
+/// Extract tempo and time signature events from all relevant tracks.
+fn extract_events(smf: &Smf) -> (Vec<TempoEvent>, Vec<TimeSigEvent>) {
+    let mut tempo_events = Vec::new();
+    let mut time_sig_events = Vec::new();
+
+    // For Format 0 and 1, meta events are in the first track (or the only track)
+    // For Format 2, we'd need to handle each track separately (rare)
+    let tracks_to_scan: Vec<&[midly::TrackEvent]> = match smf.header.format {
+        Format::SingleTrack => smf.tracks.iter().map(|t| t.as_slice()).collect(),
+        Format::Parallel => {
+            // Scan all tracks for meta events (some DAWs put them on track 0,
+            // others distribute them)
+            smf.tracks.iter().map(|t| t.as_slice()).collect()
+        }
+        Format::Sequential => smf.tracks.iter().map(|t| t.as_slice()).collect(),
+    };
+
+    for track in tracks_to_scan {
+        let mut tick: u64 = 0;
+        for event in track {
+            tick += event.delta.as_int() as u64;
+            match event.kind {
+                TrackEventKind::Meta(MetaMessage::Tempo(tempo)) => {
+                    // Avoid duplicate tempo events at the same tick
+                    if !tempo_events.iter().any(|e: &TempoEvent| e.tick == tick) {
+                        tempo_events.push(TempoEvent {
+                            tick,
+                            micros_per_beat: tempo.as_int(),
+                        });
+                    }
+                }
+                TrackEventKind::Meta(MetaMessage::TimeSignature(
+                    numerator,
+                    denominator,
+                    _clocks_per_click,
+                    _thirty_seconds_per_quarter,
+                )) => {
+                    if !time_sig_events
+                        .iter()
+                        .any(|e: &TimeSigEvent| e.tick == tick)
+                    {
+                        time_sig_events.push(TimeSigEvent {
+                            tick,
+                            numerator,
+                            denominator_power: denominator,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    tempo_events.sort_by_key(|e| e.tick);
+    time_sig_events.sort_by_key(|e| e.tick);
+
+    (tempo_events, time_sig_events)
+}
+
+/// Collapse consecutive monotonic BPM changes into single transitions.
+/// For example, 92→82→72→62 at consecutive beats becomes a single change
+/// with transition_beats spanning the full run.
+fn collapse_ramps(changes: &mut Vec<GuessedTempoChange>) {
+    if changes.len() < 2 {
+        return;
+    }
+
+    const MAX_GAP_MEASURES: u32 = 4;
+
+    let mut i = 0;
+    while i + 1 < changes.len() {
+        // Determine direction
+        let bpm_i = changes[i].bpm as i32;
+        let bpm_next = changes[i + 1].bpm as i32;
+        let going_down = bpm_next < bpm_i;
+        let going_up = bpm_next > bpm_i;
+
+        if !going_down && !going_up {
+            i += 1;
+            continue;
+        }
+
+        // Must have same time signature and be close together
+        if changes[i].time_signature != changes[i + 1].time_signature {
+            i += 1;
+            continue;
+        }
+
+        let first_gap = changes[i + 1].measure.saturating_sub(changes[i].measure);
+        if first_gap > MAX_GAP_MEASURES {
+            i += 1;
+            continue;
+        }
+
+        // Extend the run as long as BPM keeps moving in the same direction,
+        // same time signature, and changes are close together.
+        let mut run_end = i + 1;
+        while run_end + 1 < changes.len() {
+            let prev_bpm = changes[run_end].bpm as i32;
+            let next_bpm = changes[run_end + 1].bpm as i32;
+            let same_dir = if going_down {
+                next_bpm < prev_bpm
+            } else {
+                next_bpm > prev_bpm
+            };
+            let same_ts = changes[run_end + 1].time_signature == changes[i].time_signature;
+            let measure_gap = changes[run_end + 1]
+                .measure
+                .saturating_sub(changes[run_end].measure);
+            let close = measure_gap <= MAX_GAP_MEASURES;
+            if same_dir && same_ts && close {
+                run_end += 1;
+            } else {
+                break;
+            }
+        }
+
+        let run_len = run_end - i + 1;
+        if run_len < 2 {
+            i += 1;
+            continue;
+        }
+
+        // Compute total beat span from first change to last change.
+        // Use the time signature to convert measure/beat deltas to beats.
+        let first = &changes[i];
+        let last = &changes[run_end];
+        let bpm_ts = first.time_signature[0]; // beats per measure
+
+        let first_beat_abs = (first.measure - 1) * bpm_ts + (first.beat - 1);
+        let last_beat_abs = (last.measure - 1) * bpm_ts + (last.beat - 1);
+        let transition_beats = last_beat_abs.saturating_sub(first_beat_abs);
+
+        // Collapse: keep the first change, set BPM to the last value,
+        // set transition_beats
+        let final_bpm = changes[run_end].bpm;
+        changes[i].bpm = final_bpm;
+        changes[i].transition_beats = if transition_beats > 0 {
+            Some(transition_beats)
+        } else {
+            None
+        };
+
+        // Remove the collapsed changes
+        changes.drain((i + 1)..=run_end);
+        i += 1;
+    }
+}
+
+/// Merge changes at the same measure/beat into a single change.
+fn dedup_changes(changes: &mut Vec<GuessedTempoChange>) {
+    let mut i = 0;
+    while i + 1 < changes.len() {
+        if changes[i].measure == changes[i + 1].measure && changes[i].beat == changes[i + 1].beat {
+            // Keep the later one's BPM and time sig (it's the most recent)
+            changes[i].bpm = changes[i + 1].bpm;
+            changes[i].time_signature = changes[i + 1].time_signature;
+            changes.remove(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saxon_shore_midi() {
+        let midi_path = std::path::Path::new(&std::env::var("HOME").unwrap_or_default())
+            .join("src/backing-tracks/Isenmor/Saxon Shore/Saxon Shore.mid");
+        if !midi_path.exists() {
+            eprintln!("Skipping: MIDI not found");
+            return;
+        }
+
+        let result = extract_tempo_from_midi(&midi_path, 0.0).unwrap();
+
+        eprintln!("Base: {} BPM, {:?}", result.bpm, result.time_signature);
+        for c in &result.changes {
+            eprintln!(
+                "  m{}/{}  {} BPM  ts={}/{}",
+                c.measure, c.beat, c.bpm, c.time_signature[0], c.time_signature[1]
+            );
+        }
+
+        assert_eq!(result.bpm, 150, "Base should be 150");
+    }
+
+    #[test]
+    fn sigurds_song_midi() {
+        let midi_path = std::path::Path::new(&std::env::var("HOME").unwrap_or_default())
+            .join("src/backing-tracks/Isenmor/Sigurd's Song/Sigurd's Song.mid");
+        if !midi_path.exists() {
+            // Try alternate name
+            let alt = std::path::Path::new(&std::env::var("HOME").unwrap_or_default())
+                .join("src/backing-tracks/Isenmor/Sigurd's Song/Midi.mid");
+            if !alt.exists() {
+                eprintln!("Skipping: MIDI not found");
+                return;
+            }
+            let result = extract_tempo_from_midi(&alt, 0.0).unwrap();
+            eprintln!("Base: {} BPM, {:?}", result.bpm, result.time_signature);
+            for c in &result.changes {
+                eprintln!(
+                    "  m{}/{}  {} BPM  ts={}/{}",
+                    c.measure, c.beat, c.bpm, c.time_signature[0], c.time_signature[1]
+                );
+            }
+            assert_eq!(result.bpm, 120, "Base should be 120");
+            return;
+        }
+
+        let result = extract_tempo_from_midi(&midi_path, 0.0).unwrap();
+        eprintln!("Base: {} BPM, {:?}", result.bpm, result.time_signature);
+        for c in &result.changes {
+            eprintln!(
+                "  m{}/{}  {} BPM  ts={}/{}",
+                c.measure, c.beat, c.bpm, c.time_signature[0], c.time_signature[1]
+            );
+        }
+        assert_eq!(result.bpm, 120, "Base should be 120");
+    }
+
+    #[test]
+    fn operation_orcinianus_copia_midi() {
+        let midi_path = std::path::Path::new(&std::env::var("HOME").unwrap_or_default()).join(
+            "src/backing-tracks/Recently Vacated Graves/Operation Orcinianus Copia/automation.mid",
+        );
+        if !midi_path.exists() {
+            eprintln!("Skipping: MIDI not found");
+            return;
+        }
+
+        let result = extract_tempo_from_midi(&midi_path, 0.0).unwrap();
+
+        eprintln!("Base: {} BPM, {:?}", result.bpm, result.time_signature);
+        for c in &result.changes {
+            eprintln!(
+                "  m{}/{}  {} BPM  ts={}/{}  transition={:?}",
+                c.measure,
+                c.beat,
+                c.bpm,
+                c.time_signature[0],
+                c.time_signature[1],
+                c.transition_beats
+            );
+        }
+
+        // Should detect the rit at measure 25 as a transition, not discrete steps
+        let rit = result
+            .changes
+            .iter()
+            .find(|c| c.measure >= 24 && c.measure <= 26 && c.transition_beats.is_some());
+        assert!(
+            rit.is_some(),
+            "Expected a rit transition near measure 25, got: {:?}",
+            result.changes
+        );
+    }
+}

--- a/src/audio/tempo_guess.rs
+++ b/src/audio/tempo_guess.rs
@@ -1,0 +1,598 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Estimate a tempo map from a beat grid detected by click track analysis.
+//!
+//! Two-pass approach:
+//!   1. **Find stable sections** — runs of beats with BPM within a tight band
+//!   2. **Classify gaps** — gaps between stable sections are snap transitions
+//!
+//! Detected boundaries are snapped to the nearest measure boundary.
+//! Time signature changes are detected separately from measure spacing.
+
+use serde::Serialize;
+
+use super::click_analysis::BeatGrid;
+
+/// A guessed tempo map derived from beat grid analysis.
+#[derive(Debug, Clone, Serialize)]
+pub struct GuessedTempo {
+    pub start_seconds: f64,
+    pub bpm: u32,
+    pub time_signature: [u32; 2],
+    pub changes: Vec<GuessedTempoChange>,
+}
+
+/// A single tempo or time-signature change.
+#[derive(Debug, Clone, Serialize)]
+pub struct GuessedTempoChange {
+    pub measure: u32,
+    pub beat: u32,
+    pub bpm: u32,
+    pub time_signature: [u32; 2],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transition_beats: Option<u32>,
+}
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+/// Maximum BPM deviation from the seed mean for a beat to be "stable."
+const STABLE_BAND: f64 = 4.0;
+
+/// Minimum number of consecutive in-band beats to form a stable section.
+const MIN_STABLE_BEATS: usize = 8;
+
+/// How many beats a boundary can be nudged to snap to a measure start.
+const SNAP_TOLERANCE: usize = 3;
+
+/// Maximum gap between adjacent sections to merge (jitter repair).
+const MAX_MERGE_GAP: usize = 8;
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+pub fn guess_tempo(grid: &BeatGrid) -> Option<GuessedTempo> {
+    if grid.beats.len() < 2 {
+        return None;
+    }
+
+    let bpms = compute_instantaneous_bpms(grid);
+    let measure_lengths = compute_measure_lengths(grid);
+
+    // Pass 1: Find stable sections
+    let mut stables = find_stable_sections(&bpms);
+
+    // Merge adjacent fragments at similar BPM (jitter repair)
+    merge_nearby_sections(&mut stables, &bpms);
+
+    // Force splits at time signature changes
+    let ts_changes = find_time_sig_change_beats(&measure_lengths);
+    split_at_time_sig_changes(&mut stables, &ts_changes, &bpms);
+
+    if stables.is_empty() {
+        return None;
+    }
+
+    // Snap section starts to measure boundaries
+    for sec in stables.iter_mut() {
+        sec.start = snap_to_measure(sec.start, &grid.measure_starts, SNAP_TOLERANCE);
+    }
+
+    // Pass 2: Build tempo changes from gaps between stable sections
+    let base_bpm = round_bpm(stables[0].bpm);
+    let base_ts = beats_per_measure_at(stables[0].start, &measure_lengths);
+    let changes = build_changes(&stables, &measure_lengths, base_bpm, base_ts);
+
+    Some(GuessedTempo {
+        start_seconds: grid.beats[0],
+        bpm: base_bpm,
+        time_signature: [base_ts, 4],
+        changes,
+    })
+}
+
+// ── Pass 1: Find stable sections ────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct StableSection {
+    start: usize,
+    end: usize,
+    bpm: f64,
+}
+
+fn find_stable_sections(bpms: &[f64]) -> Vec<StableSection> {
+    let mut sections = Vec::new();
+    let mut pos = 0;
+
+    while pos < bpms.len() {
+        let section_end = extend_stable(bpms, pos);
+        if section_end - pos >= MIN_STABLE_BEATS {
+            let mean = mean_of(&bpms[pos..section_end]);
+            sections.push(StableSection {
+                start: pos,
+                end: section_end,
+                bpm: mean,
+            });
+            pos = section_end;
+        } else {
+            pos += 1;
+        }
+    }
+
+    sections
+}
+
+/// Extend a stable section from `pos` using a fixed seed mean.
+fn extend_stable(bpms: &[f64], pos: usize) -> usize {
+    if pos >= bpms.len() {
+        return pos;
+    }
+
+    let seed_end = (pos + MIN_STABLE_BEATS).min(bpms.len());
+    if seed_end - pos < MIN_STABLE_BEATS {
+        return pos;
+    }
+
+    let seed_bpms = &bpms[pos..seed_end];
+    let seed_mean = seed_bpms.iter().sum::<f64>() / seed_bpms.len() as f64;
+    let max_dev = seed_bpms
+        .iter()
+        .map(|b| (b - seed_mean).abs())
+        .fold(0.0f64, f64::max);
+    if max_dev > STABLE_BAND {
+        return pos;
+    }
+
+    let mut end = seed_end;
+    while end < bpms.len() {
+        if (bpms[end] - seed_mean).abs() > STABLE_BAND {
+            break;
+        }
+        end += 1;
+    }
+
+    end
+}
+
+/// Merge adjacent stable sections at similar BPM separated by small gaps.
+fn merge_nearby_sections(stables: &mut Vec<StableSection>, bpms: &[f64]) {
+    let mut i = 0;
+    while i + 1 < stables.len() {
+        let gap = stables[i + 1].start.saturating_sub(stables[i].end);
+        let bpm_diff = (stables[i].bpm - stables[i + 1].bpm).abs();
+
+        let gap_is_transitional = if gap > 0 && stables[i].end < bpms.len() {
+            let gap_end = stables[i + 1].start.min(bpms.len());
+            let gap_bpms = &bpms[stables[i].end..gap_end];
+            !gap_bpms.is_empty()
+                && gap_bpms
+                    .iter()
+                    .any(|b| (b - stables[i].bpm).abs() > STABLE_BAND * 2.0)
+        } else {
+            false
+        };
+
+        if gap <= MAX_MERGE_GAP && bpm_diff <= STABLE_BAND && !gap_is_transitional {
+            stables[i].end = stables[i + 1].end;
+            stables[i].bpm = mean_of(&bpms[stables[i].start..stables[i].end]);
+            stables.remove(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Split stable sections at time signature change boundaries.
+fn split_at_time_sig_changes(
+    sections: &mut Vec<StableSection>,
+    ts_change_beats: &[usize],
+    bpms: &[f64],
+) {
+    for &beat in ts_change_beats {
+        let mut i = 0;
+        while i < sections.len() {
+            let sec = &sections[i];
+            if beat > sec.start && beat < sec.end {
+                let first = StableSection {
+                    start: sec.start,
+                    end: beat,
+                    bpm: mean_of(&bpms[sec.start..beat]),
+                };
+                let second = StableSection {
+                    start: beat,
+                    end: sec.end,
+                    bpm: mean_of(&bpms[beat..sec.end]),
+                };
+                sections.splice(i..=i, [first, second]);
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+// ── Boundary snapping ───────────────────────────────────────────────────────
+
+/// Snap a beat index to the nearest measure start within tolerance,
+/// preferring the forward (at or after) direction.
+fn snap_to_measure(beat: usize, measure_starts: &[usize], tolerance: usize) -> usize {
+    let mut best = beat;
+    let mut best_dist = tolerance + 1;
+    let mut best_forward = false;
+
+    for &ms in measure_starts {
+        let dist = (ms as isize - beat as isize).unsigned_abs();
+        if dist > tolerance {
+            if ms > beat {
+                break;
+            }
+            continue;
+        }
+        let is_forward = ms >= beat;
+        if dist < best_dist || (dist == best_dist && is_forward && !best_forward) {
+            best = ms;
+            best_dist = dist;
+            best_forward = is_forward;
+        }
+    }
+
+    if best < beat {
+        for &ms in measure_starts {
+            if ms >= beat {
+                let forward_dist = ms - beat;
+                if forward_dist <= tolerance {
+                    return ms;
+                }
+                break;
+            }
+        }
+    }
+
+    best
+}
+
+// ── Pass 2: Build tempo changes ─────────────────────────────────────────────
+
+fn build_changes(
+    stables: &[StableSection],
+    measure_lengths: &[(usize, u32)],
+    base_bpm: u32,
+    base_ts: u32,
+) -> Vec<GuessedTempoChange> {
+    let mut changes = Vec::new();
+    let mut current_bpm = base_bpm;
+    let mut current_ts = base_ts;
+
+    for sec in stables.iter().skip(1) {
+        let bpm = round_bpm(sec.bpm);
+        let ts = beats_per_measure_at(sec.start, measure_lengths);
+
+        if bpm != current_bpm || ts != current_ts {
+            let (measure, beat) = beat_to_measure_beat(sec.start, measure_lengths);
+            changes.push(GuessedTempoChange {
+                measure,
+                beat,
+                bpm,
+                time_signature: [ts, 4],
+                transition_beats: None,
+            });
+            current_bpm = bpm;
+            current_ts = ts;
+        }
+    }
+
+    changes
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn compute_instantaneous_bpms(grid: &BeatGrid) -> Vec<f64> {
+    let mut bpms = Vec::with_capacity(grid.beats.len());
+    for i in 0..grid.beats.len() - 1 {
+        let interval = grid.beats[i + 1] - grid.beats[i];
+        bpms.push(if interval > 0.0 { 60.0 / interval } else { 0.0 });
+    }
+    if let Some(&last) = bpms.last() {
+        bpms.push(last);
+    }
+    bpms
+}
+
+fn compute_measure_lengths(grid: &BeatGrid) -> Vec<(usize, u32)> {
+    let mut result = Vec::new();
+    if grid.measure_starts.len() >= 2 {
+        for i in 0..grid.measure_starts.len() {
+            let len = if i + 1 < grid.measure_starts.len() {
+                (grid.measure_starts[i + 1] - grid.measure_starts[i]) as u32
+            } else if i > 0 {
+                (grid.measure_starts[i] - grid.measure_starts[i - 1]) as u32
+            } else {
+                4
+            };
+            result.push((grid.measure_starts[i], len.max(1)));
+        }
+    }
+    result
+}
+
+fn beats_per_measure_at(beat_idx: usize, measure_lengths: &[(usize, u32)]) -> u32 {
+    let mut result = 4u32;
+    for &(start, len) in measure_lengths {
+        if start <= beat_idx {
+            result = len;
+        }
+    }
+    result
+}
+
+fn find_time_sig_change_beats(measure_lengths: &[(usize, u32)]) -> Vec<usize> {
+    let mut changes = Vec::new();
+    if measure_lengths.len() < 2 {
+        return changes;
+    }
+    let mut prev = measure_lengths[0].1;
+    for &(start, len) in measure_lengths.iter().skip(1) {
+        if len != prev {
+            changes.push(start);
+            prev = len;
+        }
+    }
+    changes
+}
+
+fn beat_to_measure_beat(beat_idx: usize, measure_lengths: &[(usize, u32)]) -> (u32, u32) {
+    let mut measure: u32 = 1;
+    let mut current_beat: usize = 0;
+    let mut current_bpm = 4u32;
+
+    for &(start, len) in measure_lengths {
+        if start > beat_idx {
+            break;
+        }
+        if start > current_beat {
+            let beats_in_section = start - current_beat;
+            measure += (beats_in_section / current_bpm as usize) as u32;
+            current_beat = start;
+        }
+        current_bpm = len;
+    }
+
+    let remaining = beat_idx - current_beat;
+    measure += (remaining / current_bpm as usize) as u32;
+    let beat = (remaining % current_bpm as usize) as u32 + 1;
+
+    (measure, beat)
+}
+
+fn mean_of(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+fn round_bpm(bpm: f64) -> u32 {
+    bpm.round().max(1.0) as u32
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_grid(bpm: f64, beats: usize, beats_per_measure: usize) -> BeatGrid {
+        let interval = 60.0 / bpm;
+        let beat_times: Vec<f64> = (0..beats).map(|i| i as f64 * interval).collect();
+        let measure_starts: Vec<usize> = (0..beats).step_by(beats_per_measure).collect();
+        BeatGrid {
+            beats: beat_times,
+            measure_starts,
+        }
+    }
+
+    fn make_grid_with_offset(
+        bpm: f64,
+        beats: usize,
+        beats_per_measure: usize,
+        offset: f64,
+    ) -> BeatGrid {
+        let interval = 60.0 / bpm;
+        let beat_times: Vec<f64> = (0..beats).map(|i| offset + i as f64 * interval).collect();
+        let measure_starts: Vec<usize> = (0..beats).step_by(beats_per_measure).collect();
+        BeatGrid {
+            beats: beat_times,
+            measure_starts,
+        }
+    }
+
+    #[test]
+    fn too_few_beats_returns_none() {
+        assert!(guess_tempo(&BeatGrid {
+            beats: vec![0.0],
+            measure_starts: vec![0]
+        })
+        .is_none());
+    }
+
+    #[test]
+    fn constant_tempo() {
+        let result = guess_tempo(&make_grid(120.0, 64, 4)).unwrap();
+        assert_eq!(result.bpm, 120);
+        assert_eq!(result.time_signature, [4, 4]);
+        assert!(result.changes.is_empty(), "Got: {:?}", result.changes);
+    }
+
+    #[test]
+    fn start_offset_captured() {
+        let result = guess_tempo(&make_grid_with_offset(120.0, 64, 4, 1.5)).unwrap();
+        assert!((result.start_seconds - 1.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn detects_time_signature_change() {
+        let mut beats = Vec::new();
+        let mut measure_starts = Vec::new();
+        let mut t = 0.0;
+        let interval = 60.0 / 120.0;
+        for i in 0..32 {
+            if i % 4 == 0 {
+                measure_starts.push(beats.len());
+            }
+            beats.push(t);
+            t += interval;
+        }
+        for i in 0..24 {
+            if i % 3 == 0 {
+                measure_starts.push(beats.len());
+            }
+            beats.push(t);
+            t += interval;
+        }
+        let result = guess_tempo(&BeatGrid {
+            beats,
+            measure_starts,
+        })
+        .unwrap();
+        assert_eq!(result.time_signature, [4, 4]);
+        let ts = result.changes.iter().find(|c| c.time_signature != [4, 4]);
+        assert!(
+            ts.is_some(),
+            "Expected time sig change, got: {:?}",
+            result.changes
+        );
+        assert_eq!(ts.unwrap().time_signature, [3, 4]);
+    }
+
+    #[test]
+    fn detects_snap_tempo_change() {
+        let mut beats = Vec::new();
+        let mut t = 0.0;
+        for _ in 0..32 {
+            beats.push(t);
+            t += 60.0 / 120.0;
+        }
+        for _ in 0..32 {
+            beats.push(t);
+            t += 60.0 / 160.0;
+        }
+        let measure_starts: Vec<usize> = (0..64).step_by(4).collect();
+        let result = guess_tempo(&BeatGrid {
+            beats,
+            measure_starts,
+        })
+        .unwrap();
+        assert_eq!(result.bpm, 120);
+        let c = result.changes.iter().find(|c| c.bpm >= 158);
+        assert!(c.is_some(), "Expected ~160, got: {:?}", result.changes);
+        assert!(c.unwrap().transition_beats.is_none(), "Should be snap");
+        assert_eq!(c.unwrap().beat, 1, "Should snap to beat 1");
+    }
+
+    #[test]
+    fn jitter_not_detected() {
+        let mut beats = Vec::new();
+        let mut t = 0.0;
+        for i in 0..64 {
+            beats.push(t);
+            let jitter = if i % 2 == 0 { 0.98 } else { 1.02 };
+            t += (60.0 / 120.0) * jitter;
+        }
+        let measure_starts: Vec<usize> = (0..64).step_by(4).collect();
+        let result = guess_tempo(&BeatGrid {
+            beats,
+            measure_starts,
+        })
+        .unwrap();
+        assert!(
+            (result.bpm as i32 - 120).unsigned_abs() <= 2,
+            "Base BPM {} should be ~120",
+            result.bpm
+        );
+        assert!(result.changes.is_empty(), "Got: {:?}", result.changes);
+    }
+
+    #[test]
+    fn saxon_shore_click_track() {
+        let click_path = std::path::Path::new(&std::env::var("HOME").unwrap_or_default())
+            .join("src/backing-tracks/Isenmor/Saxon Shore/Click.flac");
+        if !click_path.exists() {
+            eprintln!("Skipping: not found");
+            return;
+        }
+
+        let grid =
+            crate::audio::click_analysis::analyze_click_track_default(&click_path, 0).unwrap();
+        let result = guess_tempo(&grid).unwrap();
+
+        eprintln!("Base: {} BPM, {:?}", result.bpm, result.time_signature);
+        for c in &result.changes {
+            eprintln!(
+                "  m{}/{}  {} BPM  ts={}/{}  transition={:?}",
+                c.measure,
+                c.beat,
+                c.bpm,
+                c.time_signature[0],
+                c.time_signature[1],
+                c.transition_beats
+            );
+        }
+
+        assert_eq!(result.bpm, 150, "Base should be 150");
+        let c160 = result.changes.iter().find(|c| c.bpm >= 158);
+        assert!(c160.is_some(), "Expected ~160, got: {:?}", result.changes);
+        assert!(
+            c160.unwrap().transition_beats.is_none(),
+            "150->160 should be snap, got {:?}",
+            c160.unwrap().transition_beats
+        );
+    }
+
+    #[test]
+    fn sigurds_song_click_track() {
+        let click_path = std::path::Path::new(&std::env::var("HOME").unwrap_or_default())
+            .join("src/backing-tracks/Isenmor/Sigurd's Song/Click.flac");
+        if !click_path.exists() {
+            eprintln!("Skipping: not found");
+            return;
+        }
+
+        let grid =
+            crate::audio::click_analysis::analyze_click_track_default(&click_path, 0).unwrap();
+        let result = guess_tempo(&grid).unwrap();
+
+        eprintln!("Base: {} BPM, {:?}", result.bpm, result.time_signature);
+        for c in &result.changes {
+            eprintln!(
+                "  m{}/{}  {} BPM  ts={}/{}  transition={:?}",
+                c.measure,
+                c.beat,
+                c.bpm,
+                c.time_signature[0],
+                c.time_signature[1],
+                c.transition_beats
+            );
+        }
+
+        assert_eq!(result.bpm, 120, "Base should be 120");
+        let ts_change = result.changes.iter().find(|c| c.time_signature != [4, 4]);
+        assert!(
+            ts_change.is_some(),
+            "Expected time sig change, got: {:?}",
+            result.changes
+        );
+        let c155 = result.changes.iter().find(|c| c.bpm >= 153);
+        assert!(c155.is_some(), "Expected ~155, got: {:?}", result.changes);
+    }
+}

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -732,6 +732,11 @@ impl MidiPlayback {
     }
 
     /// Returns a MIDI sheet for the song.
+    /// Gets the path to the MIDI file.
+    pub fn file_path(&self) -> &Path {
+        &self.file
+    }
+
     pub fn midi_sheet(&self) -> Result<MidiSheet, Box<dyn Error>> {
         parse_midi(&self.file)
     }

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -100,6 +100,10 @@ pub fn router() -> Router<WebUiState> {
                 .delete(songs_api::delete_song),
         )
         .route("/songs/{name}/waveform", get(songs_api::get_song_waveform))
+        .route(
+            "/songs/{name}/tempo-guess",
+            get(songs_api::get_song_tempo_guess),
+        )
         .route("/songs/{name}/files", get(songs_api::get_song_files))
         .route("/songs/{name}/import", post(songs_api::import_file_to_song))
         .route("/browse", get(browse::browse_directory))

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -469,6 +469,80 @@ pub(super) async fn get_song_waveform(
     }
 }
 
+/// GET /api/songs/:name/tempo-guess — estimate a tempo map.
+///
+/// Tries MIDI file first (authoritative tempo events), then falls back to
+/// beat grid analysis (estimated from click track). The beat grid's start
+/// offset is used in both cases.
+/// Returns 404 if neither source is available.
+pub(super) async fn get_song_tempo_guess(
+    State(state): State<WebUiState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let all_songs = state.player.songs();
+    let song = match all_songs.get(&name) {
+        Ok(s) => s,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("Song not found: {}", name)})),
+            )
+                .into_response();
+        }
+    };
+
+    // Get the start offset from the beat grid (when the first beat sounds)
+    let start_offset = song
+        .beat_grid()
+        .and_then(|bg| bg.beats.first().copied())
+        .unwrap_or(0.0);
+
+    // Try MIDI file first — it has authoritative tempo/time-sig events
+    if let Some(midi_playback) = song.midi_playback() {
+        if let Some(guessed) = crate::audio::midi_tempo::extract_tempo_from_midi(
+            midi_playback.file_path(),
+            start_offset,
+        ) {
+            return (
+                StatusCode::OK,
+                Json(json!({
+                    "source": "midi",
+                    "tempo": guessed,
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // Fall back to beat grid analysis
+    let beat_grid = match song.beat_grid() {
+        Some(bg) => bg,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "Song has no MIDI file or beat grid"})),
+            )
+                .into_response();
+        }
+    };
+
+    match crate::audio::tempo_guess::guess_tempo(beat_grid) {
+        Some(guessed) => (
+            StatusCode::OK,
+            Json(json!({
+                "source": "beat_grid",
+                "tempo": guessed,
+            })),
+        )
+            .into_response(),
+        None => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": "Beat grid has too few beats to estimate tempo"})),
+        )
+            .into_response(),
+    }
+}
+
 /// GET /api/songs/:name/files — lists files in a song's directory.
 ///
 /// Returns audio, MIDI, and lighting files with type classification.

--- a/src/webui/svelte/src/components/lighting/TempoEditor.svelte
+++ b/src/webui/svelte/src/components/lighting/TempoEditor.svelte
@@ -15,15 +15,62 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
   import type { TempoSection, TempoChange } from "../../lib/lighting/types";
+  import { fetchTempoGuess, type GuessedTempo } from "../../lib/api/songs";
   import TimestampInput from "./TimestampInput.svelte";
 
   interface Props {
     tempo: TempoSection | undefined;
     onchange: (tempo: TempoSection | undefined) => void;
     onclose?: () => void;
+    songName?: string;
+    hasBeatGrid?: boolean;
+    hasMidi?: boolean;
   }
 
-  let { tempo, onchange, onclose }: Props = $props();
+  let {
+    tempo,
+    onchange,
+    onclose,
+    songName,
+    hasBeatGrid = false,
+    hasMidi = false,
+  }: Props = $props();
+
+  let guessSource = $state<"midi" | "beat_grid" | null>(null);
+  let guessing = $state(false);
+
+  function convertGuessToTempo(guessed: GuessedTempo): TempoSection {
+    return {
+      start: { value: guessed.start_seconds, unit: "s" },
+      bpm: guessed.bpm,
+      time_signature: guessed.time_signature,
+      changes: guessed.changes.map((c) => {
+        const change: TempoChange = {
+          timestamp: { type: "measure_beat", measure: c.measure, beat: c.beat },
+          bpm: c.bpm,
+          time_signature: c.time_signature,
+        };
+        if (c.transition_beats) {
+          change.transition = `${c.transition_beats}`;
+        }
+        return change;
+      }),
+    };
+  }
+
+  async function guessTempoMap() {
+    if (!songName) return;
+    guessing = true;
+    try {
+      const result = await fetchTempoGuess(songName);
+      if (result) {
+        guessSource = result.source;
+        onchange(convertGuessToTempo(result.tempo));
+      }
+    } finally {
+      guessing = false;
+    }
+  }
 
   let expanded = $state(true);
 
@@ -115,6 +162,25 @@
         {$t("tempo.bpm")}, {tempo.time_signature[0]}/{tempo
           .time_signature[1]}</span
       >
+      {#if guessSource}
+        <span class="estimated-badge">
+          {guessSource === "midi" ? "from MIDI" : "estimated from beat grid"}
+        </span>
+      {/if}
+      {#if (hasBeatGrid || hasMidi) && songName}
+        <button
+          class="btn btn-sm btn-accent"
+          onclick={guessTempoMap}
+          disabled={guessing}
+          >{guessing
+            ? "Loading..."
+            : guessSource
+              ? "Re-detect"
+              : hasMidi
+                ? "Detect from MIDI"
+                : "Guess from beat grid"}</button
+        >
+      {/if}
       <button class="btn btn-sm btn-danger" onclick={disableTempo}
         >{$t("common.remove")}</button
       >
@@ -127,6 +193,11 @@
       <button class="btn btn-sm btn-primary" onclick={enableTempo}
         >{$t("tempo.addTempo")}</button
       >
+      {#if (hasBeatGrid || hasMidi) && songName}
+        <button class="btn btn-sm btn-accent" onclick={guessTempoMap}
+          >{hasMidi ? "Detect from MIDI" : "Guess from beat grid"}</button
+        >
+      {/if}
       {#if onclose}
         <button class="btn btn-sm" onclick={onclose}
           >{$t("common.close")}</button
@@ -346,6 +417,22 @@
     color: var(--text-muted);
     font-size: 13px;
     flex: 1;
+  }
+  .estimated-badge {
+    font-size: 11px;
+    color: var(--yellow, #eab308);
+    background: rgba(234, 179, 8, 0.12);
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-style: italic;
+  }
+  .btn-accent {
+    background: rgba(94, 202, 234, 0.15);
+    color: var(--accent, #5ecaea);
+    border: 1px solid rgba(94, 202, 234, 0.3);
+  }
+  .btn-accent:hover {
+    background: rgba(94, 202, 234, 0.25);
   }
   .tempo-body {
     padding: 8px 12px 12px;

--- a/src/webui/svelte/src/components/lighting/timeline/TimelineEditor.svelte
+++ b/src/webui/svelte/src/components/lighting/timeline/TimelineEditor.svelte
@@ -46,6 +46,9 @@
     sequenceNames: string[];
     songDurationMs: number;
     waveformTracks: WaveformTrack[];
+    songName?: string;
+    hasBeatGrid?: boolean;
+    hasMidi?: boolean;
     isPlaying?: boolean;
     playheadMs?: number | null;
     onchange: (lightFile: LightFile) => void;
@@ -59,6 +62,9 @@
     sequenceNames,
     songDurationMs,
     waveformTracks,
+    songName,
+    hasBeatGrid = false,
+    hasMidi = false,
     isPlaying = false,
     playheadMs = null,
     onchange,
@@ -606,6 +612,9 @@
     <div class="tempo-editor-panel">
       <TempoEditor
         tempo={lightFile.tempo}
+        {songName}
+        {hasBeatGrid}
+        {hasMidi}
         onchange={(tempo) => {
           onchange({ ...lightFile, tempo });
           if (!tempo) showTempoEditor = false;

--- a/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
@@ -510,6 +510,9 @@
       {sequenceNames}
       songDurationMs={song.duration_ms}
       {waveformTracks}
+      songName={song.name}
+      hasBeatGrid={!!song.beat_grid}
+      hasMidi={song.has_midi}
       {isPlaying}
       {playheadMs}
       onchange={onTimelineChange}

--- a/src/webui/svelte/src/lib/api/songs.ts
+++ b/src/webui/svelte/src/lib/api/songs.ts
@@ -119,6 +119,33 @@ export async function deleteSong(name: string): Promise<Response> {
   return fetch(`/api/songs/${encodeURIComponent(name)}`, { method: "DELETE" });
 }
 
+export interface GuessedTempo {
+  start_seconds: number;
+  bpm: number;
+  time_signature: [number, number];
+  changes: {
+    measure: number;
+    beat: number;
+    bpm: number;
+    time_signature: [number, number];
+    transition_beats?: number;
+  }[];
+}
+
+export interface TempoGuessResult {
+  source: "midi" | "beat_grid";
+  tempo: GuessedTempo;
+}
+
+export async function fetchTempoGuess(
+  name: string,
+): Promise<TempoGuessResult | null> {
+  const res = await get(`/songs/${encodeURIComponent(name)}/tempo-guess`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to fetch tempo guess: ${res.status}`);
+  return res.json();
+}
+
 export async function fetchWaveform(name: string): Promise<WaveformData> {
   const res = await get(`/songs/${encodeURIComponent(name)}/waveform`);
   if (!res.ok) throw new Error(`Failed to fetch waveform: ${res.status}`);


### PR DESCRIPTION
Lighting shows can now get a reasonable guess of tempo based on the beat grid and any supplied MIDI files. MIDI is preferred here, as it's expected to be more accurate. Ritardando/ramping tempo sections are only possible to detect automatically with MIDI.