### PR TITLE
Move status_events from top-level config to hardware profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names autocomplete from the song's defined sections.
 - **Global max sample voices setting**: The samples section in the config editor now
   includes a max sample voices field (default 32) controlling the global polyphony limit.
+- **Status events in hardware profile**: Status events (MIDI events emitted on player
+  state changes for off/idling/playing) are now configured per-profile in the new Status
+  Events tab. Each state supports a list of MIDI events. Legacy top-level `status_events`
+  is automatically normalized into the profile.
 
 ### Fixed
 

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -319,6 +319,11 @@ impl Player {
             if self.controller.is_some() || self.controllers.is_some() {
                 warn!("top-level 'controller'/'controllers' ignored when 'profiles' is present");
             }
+            if self.status_events.is_some() {
+                warn!(
+                    "top-level 'status_events' ignored when 'profiles' is present; move to profile"
+                );
+            }
             return;
         }
 
@@ -362,16 +367,20 @@ impl Player {
         // Collect controllers from legacy top-level fields.
         let controllers = self.collect_controllers();
 
+        let status_events = self.status_events.take();
+
         // Create a profile if any subsystem is configured.
         if audio_config.is_some()
             || midi.is_some()
             || dmx.is_some()
             || trigger.is_some()
             || !controllers.is_empty()
+            || status_events.is_some()
         {
             let mut profile = Profile::new(None, audio_config, midi, dmx);
             profile.set_trigger(trigger);
             profile.set_controllers(controllers);
+            profile.set_status_events(status_events);
             self.profiles = Some(vec![profile]);
         }
     }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -111,6 +111,10 @@ pub struct Profile {
     /// Notification audio configuration (global overrides).
     #[serde(default)]
     notifications: Option<NotificationConfig>,
+
+    /// Status events — MIDI events emitted on player state changes.
+    #[serde(default)]
+    status_events: Option<super::statusevents::StatusEvents>,
 }
 
 impl Profile {
@@ -130,6 +134,7 @@ impl Profile {
             trigger: None,
             controllers: Vec::new(),
             notifications: None,
+            status_events: None,
         }
     }
 
@@ -181,6 +186,19 @@ impl Profile {
     /// Returns the notification audio configuration, if present.
     pub fn notifications(&self) -> Option<&NotificationConfig> {
         self.notifications.as_ref()
+    }
+
+    /// Returns the status events configuration, if present.
+    pub fn status_events(&self) -> Option<&super::statusevents::StatusEvents> {
+        self.status_events.as_ref()
+    }
+
+    /// Sets the status events (used during legacy config normalization).
+    pub(super) fn set_status_events(
+        &mut self,
+        status_events: Option<super::statusevents::StatusEvents>,
+    ) {
+        self.status_events = status_events;
     }
 
     /// Validates the profile configuration for semantic issues.

--- a/src/player.rs
+++ b/src/player.rs
@@ -539,7 +539,12 @@ impl Player {
                 self.emit_song_change(&song);
             }
 
-            let status_events = match StatusEvents::new(config.status_events()) {
+            let status_events = match StatusEvents::new(
+                profile
+                    .status_events()
+                    .cloned()
+                    .or_else(|| config.status_events()),
+            ) {
                 Ok(se) => se,
                 Err(e) => {
                     warn!(error = %e, "Failed to create status events");

--- a/src/webui/svelte/e2e/tests/config-status-events.spec.ts
+++ b/src/webui/svelte/e2e/tests/config-status-events.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Profile Editor - Status Events", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/#/config");
+    await page.locator(".profile-row", { hasText: "test-host" }).click();
+    await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+    await page.locator(".tab", { hasText: "Status Events" }).click();
+    await expect(page.locator(".tab.active")).toContainText("Status Events");
+  });
+
+  test("shows enable button when not configured", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: /Enable Status Events/i }),
+    ).toBeVisible();
+  });
+
+  test("enabling shows three event groups", async ({ page }) => {
+    await page.getByRole("button", { name: /Enable Status Events/i }).click();
+    await expect(page.getByText("Off Events")).toBeVisible();
+    await expect(page.getByText("Idling Events")).toBeVisible();
+    await expect(page.getByText("Playing Events")).toBeVisible();
+  });
+
+  test("add button creates a MIDI event editor", async ({ page }) => {
+    await page.getByRole("button", { name: /Enable Status Events/i }).click();
+    const offGroup = page.locator(".event-group").first();
+    await offGroup.getByRole("button", { name: "Add" }).click();
+    await expect(offGroup.locator(".event-row")).toHaveCount(1);
+    await expect(
+      offGroup.locator('[id^="status-off_events-0-type"]'),
+    ).toBeVisible();
+  });
+
+  test("remove button deletes event from group", async ({ page }) => {
+    await page.getByRole("button", { name: /Enable Status Events/i }).click();
+    const offGroup = page.locator(".event-group").first();
+    await offGroup.getByRole("button", { name: "Add" }).click();
+    await expect(offGroup.locator(".event-row")).toHaveCount(1);
+    await offGroup.locator(".remove-btn").click();
+    await expect(offGroup.locator(".event-row")).toHaveCount(0);
+  });
+});

--- a/src/webui/svelte/src/components/config/ProfileEditor.svelte
+++ b/src/webui/svelte/src/components/config/ProfileEditor.svelte
@@ -27,6 +27,7 @@
   import LightingSection from "./LightingSection.svelte";
   import NotificationsSection from "./NotificationsSection.svelte";
   import type { NotifBrowseTarget } from "./NotificationsSection.svelte";
+  import StatusEventsSection from "./StatusEventsSection.svelte";
 
   interface Props {
     profile: any;
@@ -69,6 +70,7 @@
     { key: "trigger", labelKey: "profile.tabs.trigger" },
     { key: "controllers", labelKey: "profile.tabs.controllers" },
     { key: "notifications", labelKey: "profile.tabs.notifications" },
+    { key: "status_events", labelKey: "profile.tabs.statusEvents" },
   ] as const;
 
   type TabKey = (typeof tabs)[number]["key"];
@@ -94,6 +96,12 @@
       else if (section === "trigger") profile.trigger = { inputs: [] };
       else if (section === "controllers") profile.controllers = [];
       else if (section === "notifications") profile.notifications = {};
+      else if (section === "status_events")
+        profile.status_events = {
+          off_events: [],
+          idling_events: [],
+          playing_events: [],
+        };
     } else {
       if (section === "audio") delete profile.audio;
       else if (section === "midi") delete profile.midi;
@@ -101,6 +109,7 @@
       else if (section === "trigger") delete profile.trigger;
       else if (section === "controllers") delete profile.controllers;
       else if (section === "notifications") delete profile.notifications;
+      else if (section === "status_events") delete profile.status_events;
     }
     onchange();
   }
@@ -252,6 +261,13 @@
           onupload={onnotifupload}
           uploadMsg={notifUploadMsg}
           uploading={notifUploading}
+        />
+      </div>
+    {:else if activeTab === "status_events" && profile.status_events}
+      <div class="panel-body">
+        <StatusEventsSection
+          bind:statusEvents={profile.status_events}
+          {onchange}
         />
       </div>
     {/if}

--- a/src/webui/svelte/src/components/config/StatusEventsSection.svelte
+++ b/src/webui/svelte/src/components/config/StatusEventsSection.svelte
@@ -1,0 +1,157 @@
+<!-- *     * Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+     *
+     * This program is free software: you can redistribute it and/or modify it under
+     * the terms of the GNU General Public License as published by the Free Software
+     * Foundation, version 3.
+     *
+     * This program is distributed in the hope that it will be useful, but WITHOUT
+     * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+     * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+     *
+     * You should have received a copy of the GNU General Public License along with
+     * this program. If not, see <https://www.gnu.org/licenses/>.
+     *
+     * -->
+<script lang="ts">
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  import { t } from "svelte-i18n";
+  import Tooltip from "./Tooltip.svelte";
+  import MidiEventEditor from "./MidiEventEditor.svelte";
+  import type { MidiEvent } from "./MidiEventEditor.svelte";
+
+  interface Props {
+    statusEvents: Record<string, any>;
+    onchange: () => void;
+  }
+
+  let { statusEvents = $bindable(), onchange }: Props = $props();
+
+  const eventGroups: [string, string, string][] = [
+    ["off_events", "statusEvents.offEvents", "tooltips.statusEvents.offEvents"],
+    [
+      "idling_events",
+      "statusEvents.idlingEvents",
+      "tooltips.statusEvents.idlingEvents",
+    ],
+    [
+      "playing_events",
+      "statusEvents.playingEvents",
+      "tooltips.statusEvents.playingEvents",
+    ],
+  ];
+
+  function defaultEvent(): MidiEvent {
+    return { type: "note_on", channel: 1, key: 60, velocity: 127 };
+  }
+
+  function getEvents(key: string): MidiEvent[] {
+    return (statusEvents[key] as MidiEvent[]) ?? [];
+  }
+
+  function addEvent(key: string) {
+    if (!statusEvents[key]) {
+      statusEvents[key] = [];
+    }
+    statusEvents[key] = [...statusEvents[key], defaultEvent()];
+    onchange();
+  }
+
+  function removeEvent(key: string, index: number) {
+    const list = [...getEvents(key)];
+    list.splice(index, 1);
+    statusEvents[key] = list;
+    onchange();
+  }
+
+  function onEventChange() {
+    onchange();
+  }
+</script>
+
+<div class="section-fields">
+  <p class="muted hint-text">{$t("statusEvents.hint")}</p>
+
+  {#each eventGroups as [key, labelKey, tooltipKey] (key)}
+    <div class="event-group">
+      <div class="group-header">
+        <span class="group-label"
+          >{$t(labelKey)} <Tooltip text={$t(tooltipKey)} /></span
+        >
+        <button class="btn btn-sm" onclick={() => addEvent(key)}
+          >{$t("common.add")}</button
+        >
+      </div>
+      {#if getEvents(key).length === 0}
+        <p class="muted empty-text">{$t("statusEvents.noEvents")}</p>
+      {/if}
+      <!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
+      {#each getEvents(key) as _evt, i (i)}
+        <div class="event-row">
+          <MidiEventEditor
+            bind:event={statusEvents[key][i]}
+            onchange={onEventChange}
+            idPrefix="status-{key}-{i}"
+          />
+          <button
+            class="btn btn-danger btn-sm remove-btn"
+            onclick={() => removeEvent(key, i)}>&times;</button
+          >
+        </div>
+      {/each}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .section-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .hint-text {
+    font-size: 13px;
+    color: var(--text-dim);
+    margin: 0;
+  }
+  .event-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .group-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .group-label {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+  }
+  .empty-text {
+    font-size: 13px;
+    color: var(--text-dim);
+    margin: 0;
+    font-style: italic;
+  }
+  .event-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+  }
+  .event-row :global(.midi-event-row) {
+    flex: 1;
+  }
+  .remove-btn {
+    flex: 0 0 auto;
+    padding: 4px 8px;
+    font-size: 16px;
+    line-height: 1;
+  }
+</style>

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -138,6 +138,7 @@
   "profile.tabs.trigger": "Triggers",
   "profile.tabs.controllers": "Controllers",
   "profile.tabs.notifications": "Notifications",
+  "profile.tabs.statusEvents": "Status Events",
 
   "audio.device": "Device",
   "audio.devicePlaceholder": "Type or select a device",
@@ -668,6 +669,21 @@
   "midiEvent.programChange": "Program Change",
   "midiEvent.channelAftertouch": "Channel Aftertouch",
   "midiEvent.pitchBend": "Pitch Bend",
+
+  "statusEvents.title": "Status Events",
+  "statusEvents.hint": "MIDI events emitted when the player state changes. Used to drive external indicators like LEDs on a MIDI controller.",
+  "statusEvents.description": "Configure MIDI events that are sent when the player transitions between off, idling, and playing states.",
+  "statusEvents.enable": "Enable Status Events",
+  "statusEvents.save": "Save Status Events",
+  "statusEvents.remove": "Remove Status Events",
+  "statusEvents.offEvents": "Off Events",
+  "statusEvents.idlingEvents": "Idling Events",
+  "statusEvents.playingEvents": "Playing Events",
+  "statusEvents.noEvents": "No events configured.",
+
+  "tooltips.statusEvents.offEvents": "MIDI events sent to clear the status indicator. Typically turns off LEDs or resets controller state.",
+  "tooltips.statusEvents.idlingEvents": "MIDI events sent when the player is idle and waiting for input. Can drive a steady LED or status display.",
+  "tooltips.statusEvents.playingEvents": "MIDI events sent when the player is actively playing a song. Can drive a different LED color or blinking state.",
 
   "tooltips.profile.hostname": "System hostname this profile applies to. When mtrack starts, it matches the machine's hostname to select the correct profile. Leave empty for a default profile that matches any host.",
 


### PR DESCRIPTION
- Add status_events field to Profile struct with getter/setter
- Add Status Events tab to profile editor (reuses StatusEventsSection)
- Normalize legacy top-level status_events into profile on config load
- Runtime reads from profile first, falls back to legacy top-level field
- Remove dedicated status events API endpoint and config store method
- Remove status events section from ConfigEditor (now in profile)