### PR TITLE
Add MIDI-to-DMX editor and fix config URL deep-linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Events tab. Each state supports a list of MIDI events. Legacy top-level `status_events`
   is automatically normalized into the profile.
 
+- **MIDI-to-DMX editor in web UI**: The MIDI section now has a full editor for MIDI-to-DMX
+  passthrough mappings, replacing the previous read-only note. Each mapping configures a
+  MIDI channel routed to a DMX universe, with optional Note Mapper and CC Mapper
+  transformers that remap note/CC numbers before output.
+
 ### Fixed
 
 - **Missing OSC path overrides**: Added section_ack, stop_section_loop, and loop_section
   to the OSC controller advanced path overrides panel.
 - **Flaky save test**: Fixed race condition in song config save test by replacing a
   synchronous boolean flag with `waitForRequest`.
+- **Config editor URL rewrite on refresh**: Navigating to a deep-linked profile tab URL
+  (e.g. `#/config/profile-name/midi`) no longer rewrites to the bare profile URL on load,
+  so refreshing the page preserves the active tab.
 
 - **Song looping with crossfade**: Songs can now be configured to loop indefinitely by
   setting `loop_playback: true` in song.yaml. Audio crossfades seamlessly at loop boundaries

--- a/src/webui/svelte/e2e/tests/config-midi-to-dmx.spec.ts
+++ b/src/webui/svelte/e2e/tests/config-midi-to-dmx.spec.ts
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import { test, expect } from "@playwright/test";
+
+test.describe("MIDI to DMX Editor", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/#/config");
+    await page.locator(".profile-row", { hasText: "test-host" }).click();
+    await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+    await page.locator(".tab", { hasText: "MIDI" }).click();
+    await page.getByRole("button", { name: "Enable MIDI" }).click();
+  });
+
+  test("shows MIDI to DMX section with add button", async ({ page }) => {
+    await expect(page.getByText("MIDI to DMX")).toBeVisible();
+    const addBtn = page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" });
+    await expect(addBtn).toBeVisible();
+  });
+
+  test("adding mapping shows channel and universe fields", async ({ page }) => {
+    await page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await expect(page.locator(".mapping-card")).toHaveCount(1);
+    await expect(page.locator('[id^="mtd-ch-"]')).toBeVisible();
+    await expect(page.locator('[id^="mtd-univ-"]')).toBeVisible();
+  });
+
+  test("removing mapping removes card", async ({ page }) => {
+    await page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await expect(page.locator(".mapping-card")).toHaveCount(1);
+    await page
+      .locator(".mapping-card")
+      .getByRole("button", { name: "Remove" })
+      .click();
+    await expect(page.locator(".mapping-card")).toHaveCount(0);
+  });
+
+  test("adding transformer shows type selector", async ({ page }) => {
+    await page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await page
+      .locator(".transformers-area")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await expect(page.locator(".transformer-row")).toHaveCount(1);
+    await expect(page.locator(".transformer-type")).toBeVisible();
+  });
+
+  test("note mapper shows input note and output notes fields", async ({
+    page,
+  }) => {
+    await page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await page
+      .locator(".transformers-area")
+      .getByRole("button", { name: "Add" })
+      .click();
+    // Default is note_mapper
+    await expect(page.locator('[id$="-note"]')).toBeVisible();
+    await expect(page.locator('[id$="-notes"]')).toBeVisible();
+  });
+
+  test("switching to CC mapper shows controller fields", async ({ page }) => {
+    await page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await page
+      .locator(".transformers-area")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await page
+      .locator(".transformer-type")
+      .selectOption("control_change_mapper");
+    await expect(page.locator('[id$="-cc"]')).toBeVisible();
+    await expect(page.locator('[id$="-ccs"]')).toBeVisible();
+  });
+
+  test("removing transformer removes row", async ({ page }) => {
+    await page
+      .locator(".midi-to-dmx-section")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await page
+      .locator(".transformers-area")
+      .getByRole("button", { name: "Add" })
+      .click();
+    await expect(page.locator(".transformer-row")).toHaveCount(1);
+    await page.locator(".transformer-row .btn-danger").click();
+    await expect(page.locator(".transformer-row")).toHaveCount(0);
+  });
+});

--- a/src/webui/svelte/src/components/config/MidiSection.svelte
+++ b/src/webui/svelte/src/components/config/MidiSection.svelte
@@ -44,6 +44,84 @@
     }
     onchange();
   }
+
+  // MIDI-to-DMX helpers
+  function getMappings(): any[] {
+    return midi.midi_to_dmx ?? [];
+  }
+
+  function addMapping() {
+    if (!midi.midi_to_dmx) midi.midi_to_dmx = [];
+    midi.midi_to_dmx = [...midi.midi_to_dmx, { midi_channel: 1, universe: "" }];
+    onchange();
+  }
+
+  function removeMapping(index: number) {
+    const list = [...getMappings()];
+    list.splice(index, 1);
+    midi.midi_to_dmx = list.length > 0 ? list : undefined;
+    onchange();
+  }
+
+  function updateMapping(index: number, key: string, value: any) {
+    midi.midi_to_dmx[index][key] = value;
+    onchange();
+  }
+
+  function addTransformer(mi: number) {
+    if (!midi.midi_to_dmx[mi].transformers)
+      midi.midi_to_dmx[mi].transformers = [];
+    midi.midi_to_dmx[mi].transformers = [
+      ...midi.midi_to_dmx[mi].transformers,
+      { type: "note_mapper", input_note: 0, convert_to_notes: [] },
+    ];
+    onchange();
+  }
+
+  function removeTransformer(mi: number, ti: number) {
+    const list = [...(midi.midi_to_dmx[mi].transformers ?? [])];
+    list.splice(ti, 1);
+    midi.midi_to_dmx[mi].transformers = list.length > 0 ? list : undefined;
+    onchange();
+  }
+
+  function setTransformerType(mi: number, ti: number, type: string) {
+    if (type === "note_mapper") {
+      midi.midi_to_dmx[mi].transformers[ti] = {
+        type: "note_mapper",
+        input_note: 0,
+        convert_to_notes: [],
+      };
+    } else {
+      midi.midi_to_dmx[mi].transformers[ti] = {
+        type: "control_change_mapper",
+        input_controller: 0,
+        convert_to_controllers: [],
+      };
+    }
+    onchange();
+  }
+
+  function updateTransformerField(
+    mi: number,
+    ti: number,
+    key: string,
+    value: any,
+  ) {
+    midi.midi_to_dmx[mi].transformers[ti][key] = value;
+    onchange();
+  }
+
+  function parseNumberList(str: string): number[] {
+    return str
+      .split(",")
+      .map((s) => parseInt(s.trim()))
+      .filter((n) => !isNaN(n));
+  }
+
+  function formatNumberList(nums: number[]): string {
+    return nums.join(", ");
+  }
 </script>
 
 <div class="section-fields">
@@ -102,11 +180,180 @@
     </label>
   </div>
 
-  {#if midi.midi_to_dmx}
-    <div class="note">
-      {$t("midi.midiToDmxNote")}
+  <div class="midi-to-dmx-section">
+    <div class="field-header">
+      <span class="field-label"
+        >{$t("midi.midiToDmx")}
+        <Tooltip text={$t("tooltips.midi.midiToDmx")} /></span
+      >
+      <button class="btn" onclick={addMapping}>{$t("common.add")}</button>
     </div>
-  {/if}
+    <p class="hint-text">{$t("midi.midiToDmxHint")}</p>
+
+    {#each getMappings() as mapping, mi (mi)}
+      <div class="mapping-card">
+        <div class="mapping-header">
+          <span class="mapping-label">{$t("midi.mapping")} {mi + 1}</span>
+          <button
+            class="btn btn-danger btn-sm"
+            onclick={() => removeMapping(mi)}>{$t("common.remove")}</button
+          >
+        </div>
+
+        <div class="mapping-fields">
+          <div class="field field-narrow">
+            <label for="mtd-ch-{mi}">{$t("midi.midiChannel")}</label>
+            <input
+              id="mtd-ch-{mi}"
+              class="input"
+              type="number"
+              min="1"
+              max="16"
+              value={mapping.midi_channel ?? 1}
+              onchange={(e) =>
+                updateMapping(
+                  mi,
+                  "midi_channel",
+                  parseInt((e.target as HTMLInputElement).value) || 1,
+                )}
+            />
+          </div>
+          <div class="field">
+            <label for="mtd-univ-{mi}">{$t("midi.universe")}</label>
+            <input
+              id="mtd-univ-{mi}"
+              class="input"
+              type="text"
+              placeholder={$t("midi.universePlaceholder")}
+              value={mapping.universe ?? ""}
+              onchange={(e) =>
+                updateMapping(
+                  mi,
+                  "universe",
+                  (e.target as HTMLInputElement).value.trim(),
+                )}
+            />
+          </div>
+        </div>
+
+        <div class="transformers-area">
+          <div class="field-header">
+            <span class="transformer-label">{$t("midi.transformers")}</span>
+            <button class="btn btn-sm" onclick={() => addTransformer(mi)}
+              >{$t("common.add")}</button
+            >
+          </div>
+          {#each mapping.transformers ?? [] as transformer, ti (ti)}
+            <div class="transformer-row">
+              <select
+                class="input transformer-type"
+                value={transformer.type}
+                onchange={(e) =>
+                  setTransformerType(
+                    mi,
+                    ti,
+                    (e.target as HTMLSelectElement).value,
+                  )}
+              >
+                <option value="note_mapper">{$t("midi.noteMapper")}</option>
+                <option value="control_change_mapper"
+                  >{$t("midi.ccMapper")}</option
+                >
+              </select>
+
+              {#if transformer.type === "note_mapper"}
+                <div class="field field-narrow">
+                  <label for="mtd-{mi}-t{ti}-note">{$t("midi.inputNote")}</label
+                  >
+                  <input
+                    id="mtd-{mi}-t{ti}-note"
+                    class="input"
+                    type="number"
+                    min="0"
+                    max="127"
+                    value={transformer.input_note ?? 0}
+                    onchange={(e) =>
+                      updateTransformerField(
+                        mi,
+                        ti,
+                        "input_note",
+                        parseInt((e.target as HTMLInputElement).value) || 0,
+                      )}
+                  />
+                </div>
+                <div class="field">
+                  <label for="mtd-{mi}-t{ti}-notes"
+                    >{$t("midi.convertToNotes")}</label
+                  >
+                  <input
+                    id="mtd-{mi}-t{ti}-notes"
+                    class="input"
+                    type="text"
+                    placeholder="61, 62"
+                    value={formatNumberList(transformer.convert_to_notes ?? [])}
+                    onchange={(e) =>
+                      updateTransformerField(
+                        mi,
+                        ti,
+                        "convert_to_notes",
+                        parseNumberList((e.target as HTMLInputElement).value),
+                      )}
+                  />
+                </div>
+              {:else}
+                <div class="field field-narrow">
+                  <label for="mtd-{mi}-t{ti}-cc"
+                    >{$t("midi.inputController")}</label
+                  >
+                  <input
+                    id="mtd-{mi}-t{ti}-cc"
+                    class="input"
+                    type="number"
+                    min="0"
+                    max="127"
+                    value={transformer.input_controller ?? 0}
+                    onchange={(e) =>
+                      updateTransformerField(
+                        mi,
+                        ti,
+                        "input_controller",
+                        parseInt((e.target as HTMLInputElement).value) || 0,
+                      )}
+                  />
+                </div>
+                <div class="field">
+                  <label for="mtd-{mi}-t{ti}-ccs"
+                    >{$t("midi.convertToControllers")}</label
+                  >
+                  <input
+                    id="mtd-{mi}-t{ti}-ccs"
+                    class="input"
+                    type="text"
+                    placeholder="8, 9"
+                    value={formatNumberList(
+                      transformer.convert_to_controllers ?? [],
+                    )}
+                    onchange={(e) =>
+                      updateTransformerField(
+                        mi,
+                        ti,
+                        "convert_to_controllers",
+                        parseNumberList((e.target as HTMLInputElement).value),
+                      )}
+                  />
+                </div>
+              {/if}
+
+              <button
+                class="btn btn-danger btn-sm"
+                onclick={() => removeTransformer(mi, ti)}>&times;</button
+              >
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
 </div>
 
 <style>
@@ -142,9 +389,81 @@
   .field-row .input {
     flex: 1;
   }
-  .note {
+  .midi-to-dmx-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+  .field-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .field-label {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+  }
+  .hint-text {
     font-size: 13px;
     color: var(--text-dim);
-    font-style: italic;
+    margin: 0;
+  }
+  .mapping-card {
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mapping-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .mapping-label {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+  }
+  .mapping-fields {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+  }
+  .field-narrow {
+    width: 80px;
+    flex-shrink: 0;
+  }
+  .transformers-area {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--border);
+  }
+  .transformer-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-dim);
+  }
+  .transformer-row {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+  }
+  .transformer-type {
+    width: 160px;
+    flex-shrink: 0;
   }
 </style>

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -160,7 +160,19 @@
   "midi.playbackDelay": "Playback Delay",
   "midi.playbackDelayPlaceholder": "e.g. 500ms",
   "midi.enableBeatClock": "Enable Beat Clock",
-  "midi.midiToDmxNote": "MIDI-to-DMX mappings configured. Edit in raw YAML for advanced configuration.",
+  "midi.midiToDmx": "MIDI to DMX",
+  "midi.midiToDmxHint": "Route MIDI channels to DMX universes with optional note/CC transformations.",
+  "midi.mapping": "Mapping",
+  "midi.midiChannel": "Channel",
+  "midi.universe": "Universe",
+  "midi.universePlaceholder": "universe name",
+  "midi.transformers": "Transformers",
+  "midi.noteMapper": "Note Mapper",
+  "midi.ccMapper": "CC Mapper",
+  "midi.inputNote": "Input Note",
+  "midi.convertToNotes": "Output Notes",
+  "midi.inputController": "Input CC",
+  "midi.convertToControllers": "Output CCs",
 
   "dmx.olaPort": "OLA Port",
   "dmx.dimSpeedModifier": "Dim Speed Modifier",
@@ -696,6 +708,7 @@
 
   "tooltips.midi.playbackDelay": "Delay before MIDI playback starts, e.g. '500ms'. Used to synchronize MIDI output with audio and lighting.",
   "tooltips.midi.beatClock": "Sends MIDI Beat Clock messages to the output device during playback. External gear can sync its tempo to this clock.",
+  "tooltips.midi.midiToDmx": "Maps MIDI channels from the song's MIDI file to DMX universes. Notes and CCs on the mapped channel are converted to DMX values. Transformers can remap note/CC numbers before output.",
 
   "tooltips.dmx.olaPort": "Port number for the Open Lighting Architecture (OLA) server. OLA must be running to send DMX data. Default is 9010.",
   "tooltips.dmx.dimSpeedModifier": "Multiplier that scales the speed of all dimming transitions. Values above 1.0 speed up fades; below 1.0 slows them down.",

--- a/src/webui/svelte/src/pages/ConfigEditor.svelte
+++ b/src/webui/svelte/src/pages/ConfigEditor.svelte
@@ -203,7 +203,7 @@
 
   // --- File-based profile operations ---
 
-  async function selectFileProfile(filename: string) {
+  async function selectFileProfile(filename: string, section?: string) {
     saving = false;
     saveMsg = "";
     saveOk = false;
@@ -215,7 +215,7 @@
       selectedIndex = 0;
       profiles = [data.profile as any];
 
-      updateConfigUrl(filename.replace(/\.\w+$/, ""));
+      updateConfigUrl(filename.replace(/\.\w+$/, ""), section);
     } catch (e: any) {
       error = e.message;
     }
@@ -297,7 +297,7 @@
 
   // --- Inline profile operations ---
 
-  function selectProfile(index: number) {
+  function selectProfile(index: number, section?: string) {
     selectedIndex = index;
     isNew = false;
 
@@ -305,7 +305,7 @@
     saveMsg = "";
     saveOk = false;
     const name = profiles[index]?.hostname || `Profile #${index}`;
-    updateConfigUrl(name);
+    updateConfigUrl(name, section);
   }
 
   function addNewProfile() {
@@ -535,7 +535,7 @@
         (f) => f.filename.replace(/\.\w+$/, "") === routeProfile,
       );
       if (match && selectedFilename !== match.filename) {
-        selectFileProfile(match.filename);
+        selectFileProfile(match.filename, routeSection);
       }
     } else {
       // Inline: match by hostname or index
@@ -544,7 +544,7 @@
           (p.hostname || `Profile #${profiles.indexOf(p)}`) === routeProfile,
       );
       if (idx >= 0) {
-        selectProfile(idx);
+        selectProfile(idx, routeSection);
       }
     }
   });


### PR DESCRIPTION
- Replace read-only MIDI-to-DMX note with full editor supporting channel-to-universe mappings and Note/CC Mapper transformers
- Fix config editor URL rewrite that dropped the tab section on page refresh, breaking deep-linked profile tab URLs
- Add Playwright tests for MIDI-to-DMX editor