### PR TITLE
Refactor: idiomatic Rust cleanup across config, lighting, audio, and player modules

### DIFF
--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -1122,7 +1122,7 @@ mod tests {
             Ok(got)
         }
 
-        fn channel_mappings(&self) -> &Vec<Vec<String>> {
+        fn channel_mappings(&self) -> &[Vec<String>] {
             self.inner.channel_mappings()
         }
 

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -105,7 +105,7 @@ impl BufferedSampleSource {
         let warmup_min_frames = device_buffer_frames.max(1);
         let refill_threshold_frames = capacity_frames / 2;
 
-        let channel_mappings = inner.channel_mappings().clone();
+        let channel_mappings = inner.channel_mappings().to_vec();
 
         let buffer_state = BufferState {
             data: vec![0.0; capacity_frames * channels],
@@ -382,7 +382,7 @@ impl ChannelMappedSampleSource for BufferedSampleSource {
         Ok(frames_read)
     }
 
-    fn channel_mappings(&self) -> &Vec<Vec<String>> {
+    fn channel_mappings(&self) -> &[Vec<String>] {
         &self.channel_mappings
     }
 

--- a/src/audio/sample_source/channel_mapped.rs
+++ b/src/audio/sample_source/channel_mapped.rs
@@ -45,7 +45,7 @@ impl ChannelMappedSampleSource for ChannelMappedSource {
         self.source.next_sample()
     }
 
-    fn channel_mappings(&self) -> &Vec<Vec<String>> {
+    fn channel_mappings(&self) -> &[Vec<String>] {
         &self.channel_mappings
     }
 

--- a/src/audio/sample_source/tests.rs
+++ b/src/audio/sample_source/tests.rs
@@ -3668,7 +3668,7 @@ mod sample_source_tests {
             Ok(Some(0.5))
         }
 
-        fn channel_mappings(&self) -> &Vec<Vec<String>> {
+        fn channel_mappings(&self) -> &[Vec<String>] {
             // Leak a static vec for testing convenience
             static EMPTY: std::sync::OnceLock<Vec<Vec<String>>> = std::sync::OnceLock::new();
             EMPTY.get_or_init(|| vec![vec!["M".to_string()]])

--- a/src/audio/sample_source/traits.rs
+++ b/src/audio/sample_source/traits.rs
@@ -133,7 +133,7 @@ pub trait ChannelMappedSampleSource: Send + Sync {
     /// Returns a Vec where each element corresponds to a source channel
     /// Each `Vec<String>` contains the labels that source channel maps to
     /// Empty Vec means that source channel is not mapped to any output
-    fn channel_mappings(&self) -> &Vec<Vec<String>>;
+    fn channel_mappings(&self) -> &[Vec<String>];
 
     /// Get the number of source channels in this sample source
     fn source_channel_count(&self) -> u16;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -288,11 +288,7 @@ pub async fn run(tui_mode: bool) -> Result<(), Box<dyn Error>> {
             let current_executable_path = env::current_exe()?;
             println!(
                 "{}",
-                render_systemd_service(
-                    current_executable_path
-                        .to_str()
-                        .expect("unable to convert current executable path to string")
-                )
+                render_systemd_service(&current_executable_path.to_string_lossy())
             )
         }
         Commands::CalibrateTriggers {

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,3 +67,17 @@ pub use self::track::Track;
 
 mod kind;
 pub use self::kind::{peek_kind, ConfigKind};
+
+use std::time::Duration;
+
+/// Parses an optional duration string (e.g. "500ms") into a `Duration`,
+/// returning `default` when `raw` is `None`.
+pub(crate) fn parse_playback_delay(
+    raw: &Option<String>,
+    default: Duration,
+) -> Result<Duration, Box<dyn std::error::Error>> {
+    match raw {
+        Some(s) => Ok(duration_string::DurationString::from_string(s.clone())?.into()),
+        None => Ok(default),
+    }
+}

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -103,10 +103,7 @@ impl Audio {
 
     /// Returns the playback delay from the configuration.
     pub fn playback_delay(&self) -> Result<Duration, Box<dyn Error>> {
-        match &self.playback_delay {
-            Some(playback_delay) => Ok(DurationString::from_string(playback_delay.clone())?.into()),
-            None => Ok(DEFAULT_AUDIO_PLAYBACK_DELAY),
-        }
+        super::parse_playback_delay(&self.playback_delay, DEFAULT_AUDIO_PLAYBACK_DELAY)
     }
 
     /// Returns the target sample rate (default: 44100)

--- a/src/config/dmx.rs
+++ b/src/config/dmx.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use std::time::Duration;
+use std::{error::Error, time::Duration};
 
 use duration_string::DurationString;
 use serde::{Deserialize, Serialize};
@@ -82,12 +82,8 @@ impl Dmx {
     }
 
     /// Gets the playback delay.
-    pub fn playback_delay(&self) -> Result<Duration, duration_string::Error> {
-        self.playback_delay
-            .as_ref()
-            .map_or(Ok(DEFAULT_DMX_PLAYBACK_DELAY), |duration| {
-                Ok(DurationString::from_string(duration.clone())?.into())
-            })
+    pub fn playback_delay(&self) -> Result<Duration, Box<dyn Error>> {
+        super::parse_playback_delay(&self.playback_delay, DEFAULT_DMX_PLAYBACK_DELAY)
     }
 
     /// Gets the OLA port to use.
@@ -97,8 +93,8 @@ impl Dmx {
     }
 
     /// Converts the configuration into universe configs.
-    pub fn universes(&self) -> Vec<Universe> {
-        self.universes.clone()
+    pub fn universes(&self) -> &[Universe] {
+        &self.universes
     }
 
     /// Gets the lighting configuration.

--- a/src/config/lighting.rs
+++ b/src/config/lighting.rs
@@ -53,7 +53,7 @@ impl LogicalGroup {
         &self.name
     }
 
-    pub fn constraints(&self) -> &Vec<GroupConstraint> {
+    pub fn constraints(&self) -> &[GroupConstraint] {
         &self.constraints
     }
 }
@@ -106,13 +106,17 @@ impl Lighting {
     }
 
     /// Gets the fixtures.
-    pub fn fixtures(&self) -> HashMap<String, String> {
-        self.fixtures.clone().unwrap_or_default()
+    pub fn fixtures(&self) -> &HashMap<String, String> {
+        static EMPTY: std::sync::LazyLock<HashMap<String, String>> =
+            std::sync::LazyLock::new(HashMap::new);
+        self.fixtures.as_ref().unwrap_or(&EMPTY)
     }
 
     /// Gets the logical groups.
-    pub fn groups(&self) -> HashMap<String, LogicalGroup> {
-        self.groups.clone().unwrap_or_default()
+    pub fn groups(&self) -> &HashMap<String, LogicalGroup> {
+        static EMPTY: std::sync::LazyLock<HashMap<String, LogicalGroup>> =
+            std::sync::LazyLock::new(HashMap::new);
+        self.groups.as_ref().unwrap_or(&EMPTY)
     }
 
     /// Gets the directories configuration.

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -56,10 +56,7 @@ impl Midi {
 
     /// Returns the playback delay from the configuration.
     pub fn playback_delay(&self) -> Result<Duration, Box<dyn Error>> {
-        match &self.playback_delay {
-            Some(playback_delay) => Ok(DurationString::from_string(playback_delay.clone())?.into()),
-            None => Ok(DEFAULT_MIDI_PLAYBACK_DELAY),
-        }
+        super::parse_playback_delay(&self.playback_delay, DEFAULT_MIDI_PLAYBACK_DELAY)
     }
 
     /// Returns whether beat clock output is enabled.
@@ -68,8 +65,8 @@ impl Midi {
     }
 
     /// Returns the MIDI to DMX configuration.
-    pub fn midi_to_dmx(&self) -> Vec<MidiToDmx> {
-        self.midi_to_dmx.clone().unwrap_or_default()
+    pub fn midi_to_dmx(&self) -> &[MidiToDmx] {
+        self.midi_to_dmx.as_deref().unwrap_or_default()
     }
 
     /// Validates the MIDI configuration for semantic issues.
@@ -116,13 +113,13 @@ impl MidiToDmx {
     }
 
     /// The DMX universe to map the MIDI channel to.
-    pub fn universe(&self) -> String {
-        self.universe.clone()
+    pub fn universe(&self) -> &str {
+        &self.universe
     }
 
     /// The transformers to apply to the input MIDI.
-    pub fn transformers(&self) -> Vec<MidiTransformer> {
-        self.transformers.clone().unwrap_or_default()
+    pub fn transformers(&self) -> &[MidiTransformer] {
+        self.transformers.as_deref().unwrap_or_default()
     }
 }
 

--- a/src/config/notification.rs
+++ b/src/config/notification.rs
@@ -82,58 +82,8 @@ impl NotificationConfig {
 
 /// Per-song notification audio overrides.
 ///
-/// Configured in the song YAML to override notifications for that specific song.
-///
-/// ```yaml
-/// notification_audio:
-///   loop_armed: custom_armed.wav
-///   sections:
-///     intro: intro_announce.wav
-///     bridge: bridge_announce.wav
-/// ```
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
-pub struct SongNotificationConfig {
-    /// Override audio for the "loop armed" notification.
-    #[serde(default)]
-    loop_armed: Option<String>,
-    /// Override audio for the "break requested" notification.
-    #[serde(default)]
-    break_requested: Option<String>,
-    /// Override audio for the "loop exited" notification.
-    #[serde(default)]
-    loop_exited: Option<String>,
-    /// Override audio for the generic "section entering" notification.
-    #[serde(default)]
-    section_entering: Option<String>,
-    /// Per-section-name audio overrides.
-    #[serde(default)]
-    sections: HashMap<String, String>,
-}
-
-impl SongNotificationConfig {
-    /// Returns a map of event key → file path for the configured overrides.
-    pub fn event_overrides(&self) -> HashMap<String, String> {
-        let mut overrides = HashMap::new();
-        if let Some(ref path) = self.loop_armed {
-            overrides.insert("loop_armed".to_string(), path.clone());
-        }
-        if let Some(ref path) = self.break_requested {
-            overrides.insert("break_requested".to_string(), path.clone());
-        }
-        if let Some(ref path) = self.loop_exited {
-            overrides.insert("loop_exited".to_string(), path.clone());
-        }
-        if let Some(ref path) = self.section_entering {
-            overrides.insert("section_entering".to_string(), path.clone());
-        }
-        overrides
-    }
-
-    /// Returns the per-section-name audio overrides.
-    pub fn section_overrides(&self) -> &HashMap<String, String> {
-        &self.sections
-    }
-}
+/// Identical to `NotificationConfig`; kept as a type alias for clarity at usage sites.
+pub type SongNotificationConfig = NotificationConfig;
 
 #[cfg(test)]
 mod tests {

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -163,6 +163,17 @@ impl Player {
         Ok(player)
     }
 
+    /// Deserializes a YAML string directly into a player configuration struct.
+    /// Does not load profiles_dir (no filesystem context). Runs normalize().
+    pub fn deserialize_from_str(yaml: &str) -> Result<Player, ConfigError> {
+        let mut player = Config::builder()
+            .add_source(config::File::from_str(yaml, config::FileFormat::Yaml))
+            .build()?
+            .try_deserialize::<Player>()?;
+        player.normalize();
+        Ok(player)
+    }
+
     /// Validates the player configuration for semantic issues that can be
     /// caught without runtime context. Call this before writing to disk.
     pub fn validate(&self) -> Result<(), Vec<String>> {
@@ -400,17 +411,18 @@ impl Player {
         vec![]
     }
 
+    /// Returns a reference to the first profile, if any.
+    fn first_profile(&self) -> Option<&Profile> {
+        self.profiles.as_ref().and_then(|ps| ps.first())
+    }
+
     /// Gets the controllers configuration from the first profile.
     /// Kept for backward compatibility in tests.
     #[cfg(test)]
     pub fn controllers(&self) -> Vec<Controller> {
-        if let Some(profiles) = &self.profiles {
-            if let Some(first) = profiles.first() {
-                return first.controllers().to_vec();
-            }
-        }
-
-        vec![]
+        self.first_profile()
+            .map(|p| p.controllers().to_vec())
+            .unwrap_or_default()
     }
 
     /// Returns profiles filtered by hostname and ordered by priority.
@@ -440,53 +452,32 @@ impl Player {
     /// Kept for backward compatibility in tests.
     #[cfg(test)]
     pub fn audio(&self) -> Option<Audio> {
-        if let Some(profiles) = &self.profiles {
-            if let Some(first) = profiles.first() {
-                return first.audio_config().map(|ac| ac.audio().clone());
-            }
-        }
-
-        None
+        self.first_profile()
+            .and_then(|p| p.audio_config())
+            .map(|ac| ac.audio().clone())
     }
 
     /// Gets the track mapping configuration from the first profile.
     /// Kept for backward compatibility. Returns a HashMap since callers
     /// (verify, CLI) don't need insertion-order preservation.
     pub fn track_mappings(&self) -> HashMap<String, Vec<u16>> {
-        if let Some(profiles) = &self.profiles {
-            if let Some(first) = profiles.first() {
-                if let Some(audio_config) = first.audio_config() {
-                    return audio_config.track_mappings_hash();
-                }
-            }
-        }
-
-        HashMap::new()
+        self.first_profile()
+            .and_then(|p| p.audio_config())
+            .map(|ac| ac.track_mappings_hash())
+            .unwrap_or_default()
     }
 
     /// Gets the MIDI configuration from the first profile.
     /// Kept for backward compatibility in tests.
     #[cfg(test)]
     pub fn midi(&self) -> Option<Midi> {
-        if let Some(profiles) = &self.profiles {
-            if let Some(first) = profiles.first() {
-                return first.midi().cloned();
-            }
-        }
-
-        None
+        self.first_profile().and_then(|p| p.midi().cloned())
     }
 
     /// Gets the DMX configuration from the first profile.
     /// Kept for backward compatibility.
     pub fn dmx(&self) -> Option<&Dmx> {
-        if let Some(profiles) = &self.profiles {
-            if let Some(first) = profiles.first() {
-                return first.dmx();
-            }
-        }
-
-        None
+        self.first_profile().and_then(|p| p.dmx())
     }
 
     /// Gets the status events configuration.
@@ -677,9 +668,7 @@ impl Player {
     /// Returns a reference to the DMX config's lighting section (through all profiles).
     /// Checks the first profile's DMX config for lighting.
     pub fn lighting_from_profiles(&self) -> Option<&Lighting> {
-        self.profiles
-            .as_ref()
-            .and_then(|ps| ps.first())
+        self.first_profile()
             .and_then(|p| p.dmx())
             .and_then(|d| d.lighting())
     }

--- a/src/config/playlist.rs
+++ b/src/config/playlist.rs
@@ -46,7 +46,7 @@ impl Playlist {
     }
 
     /// Get all songs in the playlist.
-    pub fn songs(&self) -> &Vec<String> {
+    pub fn songs(&self) -> &[String] {
         &self.songs
     }
 }

--- a/src/config/song.rs
+++ b/src/config/song.rs
@@ -225,17 +225,17 @@ impl Song {
     }
 
     /// Gets the light shows associated with the song.
-    pub fn light_shows(&self) -> Option<&Vec<LightShow>> {
-        self.light_shows.as_ref()
+    pub fn light_shows(&self) -> Option<&[LightShow]> {
+        self.light_shows.as_deref()
     }
 
     /// Gets the DSL lighting shows associated with the song.
-    pub fn lighting(&self) -> Option<&Vec<LightingShow>> {
-        self.lighting.as_ref()
+    pub fn lighting(&self) -> Option<&[LightingShow]> {
+        self.lighting.as_deref()
     }
 
     /// Gets the tracks associated with the song.
-    pub fn tracks(&self) -> &Vec<Track> {
+    pub fn tracks(&self) -> &[Track] {
         &self.tracks
     }
 
@@ -278,8 +278,8 @@ pub struct MidiPlayback {
 
 impl MidiPlayback {
     /// Gets the file associated with the MIDI playback.
-    pub fn file(&self) -> String {
-        self.file.clone()
+    pub fn file(&self) -> &str {
+        &self.file
     }
 
     /// Gets the MIDI channels to exclude.
@@ -319,13 +319,13 @@ impl LightShow {
     }
 
     /// Gets the universe name for the light show.
-    pub fn universe_name(&self) -> String {
-        self.universe_name.clone()
+    pub fn universe_name(&self) -> &str {
+        &self.universe_name
     }
 
     /// Gets the DMX (MIDI) file associated with the light show.
-    pub fn dmx_file(&self) -> String {
-        self.dmx_file.clone()
+    pub fn dmx_file(&self) -> &str {
+        &self.dmx_file
     }
 
     /// Gets the MIDI channels that should be associated with light show data.

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -174,11 +174,11 @@ impl Engine {
         let cancel_handle = CancelHandle::new();
         let universes: HashMap<u16, Universe> = config
             .universes()
-            .into_iter()
+            .iter()
             .map(|config| {
                 (
                     config.universe(),
-                    Universe::new(config, cancel_handle.clone(), sender.clone()),
+                    Universe::new(config.clone(), cancel_handle.clone(), sender.clone()),
                 )
             })
             .collect();
@@ -186,7 +186,7 @@ impl Engine {
         // Create mapping from universe names to IDs for MIDI DMX system
         let universe_name_to_id: HashMap<String, u16> = config
             .universes()
-            .into_iter()
+            .iter()
             .map(|config| (config.name().to_string(), config.universe()))
             .collect();
         let join_handles: Vec<JoinHandle<()>> = universes

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -12,17 +12,20 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-pub mod consistency_tests;
+#[cfg(test)]
+mod consistency_tests;
 pub mod effects;
 pub mod engine;
-pub mod layering_tests;
+#[cfg(test)]
+mod layering_tests;
 pub mod parser;
 pub mod system;
 pub mod tempo;
 pub mod timeline;
 pub mod types;
 pub mod validation;
-pub mod visual_consistency_tests;
+#[cfg(test)]
+mod visual_consistency_tests;
 
 // Re-export the main types for convenience
 // These are exported for external use of the lighting module

--- a/src/lighting/effects/color.rs
+++ b/src/lighting/effects/color.rs
@@ -22,12 +22,10 @@ pub struct Color {
 }
 
 impl Color {
-    #[cfg(test)]
     pub fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b, w: None }
     }
 
-    #[cfg(test)]
     pub fn from_hex(hex: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let hex = hex.trim_start_matches('#');
         if hex.len() != 6 {

--- a/src/lighting/effects/instance.rs
+++ b/src/lighting/effects/instance.rs
@@ -43,15 +43,11 @@ impl EffectInstance {
         hold_time: Option<Duration>,
         down_time: Option<Duration>,
     ) -> Self {
-        // Extract duration from effect_type
-        let duration = match &effect_type {
-            EffectType::Static { duration, .. }
-            | EffectType::Strobe { duration, .. }
-            | EffectType::Pulse { duration, .. }
-            | EffectType::ColorCycle { duration, .. }
-            | EffectType::Chase { duration, .. }
-            | EffectType::Rainbow { duration, .. } => Some(*duration),
-            EffectType::Dimmer { .. } => None, // Dimmer uses its own duration field directly
+        // Extract duration from effect_type (None for Dimmer, which uses its own timing model)
+        let duration = if matches!(&effect_type, EffectType::Dimmer { .. }) {
+            None
+        } else {
+            Some(effect_type.duration())
         };
 
         // Use the effect type's duration as hold_time if hold_time wasn't explicitly provided.

--- a/src/lighting/effects/types.rs
+++ b/src/lighting/effects/types.rs
@@ -79,8 +79,7 @@ pub enum EffectType {
 
 impl EffectType {
     /// Get the duration field from the effect type
-    #[cfg(test)]
-    pub fn get_duration(&self) -> Duration {
+    pub fn duration(&self) -> Duration {
         match self {
             EffectType::Static { duration, .. }
             | EffectType::Strobe { duration, .. }
@@ -172,7 +171,7 @@ mod tests {
             parameters: HashMap::new(),
             duration: Duration::from_secs(5),
         };
-        assert_eq!(effect.get_duration(), Duration::from_secs(5));
+        assert_eq!(effect.duration(), Duration::from_secs(5));
     }
 
     #[test]
@@ -181,7 +180,7 @@ mod tests {
             frequency: TempoAwareFrequency::Fixed(10.0),
             duration: Duration::from_millis(500),
         };
-        assert_eq!(effect.get_duration(), Duration::from_millis(500));
+        assert_eq!(effect.duration(), Duration::from_millis(500));
     }
 
     #[test]
@@ -192,7 +191,7 @@ mod tests {
             frequency: TempoAwareFrequency::Fixed(2.0),
             duration: Duration::from_secs(3),
         };
-        assert_eq!(effect.get_duration(), Duration::from_secs(3));
+        assert_eq!(effect.duration(), Duration::from_secs(3));
     }
 
     #[test]
@@ -203,7 +202,7 @@ mod tests {
             duration: Duration::from_secs(2),
             curve: DimmerCurve::Linear,
         };
-        assert_eq!(effect.get_duration(), Duration::from_secs(2));
+        assert_eq!(effect.duration(), Duration::from_secs(2));
     }
 
     #[test]
@@ -215,7 +214,7 @@ mod tests {
             transition: CycleTransition::Fade,
             duration: Duration::from_secs(10),
         };
-        assert_eq!(effect.get_duration(), Duration::from_secs(10));
+        assert_eq!(effect.duration(), Duration::from_secs(10));
     }
 
     #[test]
@@ -227,7 +226,7 @@ mod tests {
             transition: CycleTransition::Snap,
             duration: Duration::from_secs(5),
         };
-        assert_eq!(effect.get_duration(), Duration::from_secs(5));
+        assert_eq!(effect.duration(), Duration::from_secs(5));
     }
 
     #[test]
@@ -238,7 +237,7 @@ mod tests {
             brightness: 1.0,
             duration: Duration::from_secs(8),
         };
-        assert_eq!(effect.get_duration(), Duration::from_secs(8));
+        assert_eq!(effect.duration(), Duration::from_secs(8));
     }
 
     #[test]

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -269,15 +269,7 @@ pub(crate) fn parse_effect_definition(
     // Dimmer always has a duration (defaults to 1s). For all other types,
     // either the effect's duration field or hold_time must be set.
     if !matches!(&final_effect_type, EffectType::Dimmer { .. }) {
-        let effect_duration = match &final_effect_type {
-            EffectType::Static { duration, .. }
-            | EffectType::Strobe { duration, .. }
-            | EffectType::Pulse { duration, .. }
-            | EffectType::ColorCycle { duration, .. }
-            | EffectType::Chase { duration, .. }
-            | EffectType::Rainbow { duration, .. } => *duration,
-            EffectType::Dimmer { .. } => unreachable!(),
-        };
+        let effect_duration = final_effect_type.duration();
         if effect_duration.is_zero() && hold_time.is_none() {
             let effect_name = match &final_effect_type {
                 EffectType::Static { .. } => "static",

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -125,7 +125,7 @@ fn parse_fixture_type_definition(pair: Pair<Rule>) -> Result<FixtureType, Box<dy
         }
     }
 
-    let mut fixture_type = FixtureType::new(name, channels, special_cases);
+    let mut fixture_type = FixtureType::new(name, channels);
     fixture_type.max_strobe_frequency = max_strobe_frequency;
     fixture_type.min_strobe_frequency = min_strobe_frequency;
     fixture_type.strobe_dmx_offset = strobe_dmx_offset;

--- a/src/lighting/parser/tests/tempo_end_to_end_tests.rs
+++ b/src/lighting/parser/tests/tempo_end_to_end_tests.rs
@@ -126,7 +126,7 @@ show "Beat Duration Test" {
 
     // At 120 BPM: 4 beats = 2.0s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
     assert!(
         (duration.as_secs_f64() - 2.0).abs() < 0.001,
         "4 beats should be 2.0s at 120 BPM"
@@ -157,7 +157,7 @@ show "Measure Duration Test" {
 
     // At 120 BPM in 4/4: 2 measures = 4.0s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
     assert!(
         (duration.as_secs_f64() - 4.0).abs() < 0.001,
         "2 measures should be 4.0s at 120 BPM in 4/4"
@@ -276,7 +276,7 @@ show "Beat Duration Tempo Change Test" {
 
     // At 120 BPM: 4 beats = 2.0s
     let effect1 = &show.cues[0].effects[0];
-    let duration1 = effect1.effect_type.get_duration();
+    let duration1 = effect1.effect_type.duration();
     assert!(
         (duration1.as_secs_f64() - 2.0).abs() < 0.001,
         "4 beats at 120 BPM should be 2.0s"
@@ -286,7 +286,7 @@ show "Beat Duration Tempo Change Test" {
     // The tempo changes to 60 BPM at @4/1, so @5/1 should use 60 BPM
     let cue1_time = show.cues[1].time;
     let effect2 = &show.cues[1].effects[0];
-    let duration2 = effect2.effect_type.get_duration();
+    let duration2 = effect2.effect_type.duration();
     let actual_duration = duration2.as_secs_f64();
     println!("Beat duration with tempo change test: cue 0 at @2/1 (time={:?}), cue 1 at @5/1 (time={:?}), duration = {}s (expected 4.0s at 60 BPM)", show.cues[0].time, cue1_time, actual_duration);
     if let Some(tm) = &show.tempo_map {
@@ -788,7 +788,7 @@ show "Beat Duration During Transition" {
     // We need 2 beats starting at the beginning of the transition
     // Since BPM is increasing during the transition, 2 beats will take slightly less than 1.0s
     // The exact calculation integrates through the curve: approximately 0.899s
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
     // The duration should be less than 1.0s (which would be at constant 120 BPM)
     // and more than 0.667s (which would be at constant 180 BPM)
     assert!(
@@ -876,7 +876,7 @@ show "Duration Spanning Change" {
     // 8 beats: 4 beats at 120 BPM (measure 3) = 2.0s, then 4 beats at 60 BPM (measure 4) = 4.0s
     // Total = 6.0s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // Measure 3 has 4 beats at 120 BPM = 2.0s
     // Measure 4 starts when tempo changes to 60 BPM
@@ -920,7 +920,7 @@ show "Duration Spanning Gradual Transition" {
     // Then 2 beats at 180 BPM = 2 * 60 / 180 = ~0.667s
     // The transition: 4 beats at average BPM (150) = 1.6s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // Verify it integrates through the gradual transition
     // 2 beats at 120 BPM = 1.0s
@@ -973,7 +973,7 @@ show "Duration Mid Transition" {
     // BPM at that point: 120 + (180-120) * 0.375 = 142.5 BPM
     // We need to calculate duration for 2 beats starting from this point
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // The duration should integrate through the remaining transition
     // At 0.75s into transition: bpm = 142.5
@@ -1016,7 +1016,7 @@ show "Pulse Duration Spanning Change" {
     // 8 beats: 4 beats at 120 BPM (measure 3) = 2.0s, then 4 beats at 60 BPM (measure 4) = 4.0s
     // Total = 6.0s (same as static effect)
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // Measure 3 has 4 beats at 120 BPM = 2.0s
     // Measure 4 starts when tempo changes to 60 BPM
@@ -1057,7 +1057,7 @@ show "Strobe Duration Spanning Change" {
     // 8 beats: 4 beats at 120 BPM (measure 3) = 2.0s, then 4 beats at 60 BPM (measure 4) = 4.0s
     // Total = 6.0s (same as static effect)
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // Measure 3 has 4 beats at 120 BPM = 2.0s
     // Measure 4 starts when tempo changes to 60 BPM
@@ -1102,7 +1102,7 @@ show "Pulse Duration Spanning Gradual Transition" {
     // Then 4 beats during transition (120 -> 180 linearly)
     // Then 2 beats at 180 BPM = 2 * 60 / 180 = ~0.667s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // Verify it integrates through the gradual transition
     // 2 beats at 120 BPM = 1.0s
@@ -1155,7 +1155,7 @@ show "Strobe Duration Spanning Gradual Transition" {
     // Then 4 beats during transition (120 -> 180 linearly)
     // Then 2 beats at 180 BPM = 2 * 60 / 180 = ~0.667s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
 
     // Verify it integrates through the gradual transition
     // 2 beats at 120 BPM = 1.0s
@@ -1312,7 +1312,7 @@ show "Fractional Measure Duration" {
 
     // At 120 BPM in 4/4: 1.5 measures = 6 beats = 3.0s
     let effect = &show.cues[0].effects[0];
-    let duration = effect.effect_type.get_duration();
+    let duration = effect.effect_type.duration();
     assert!(
         (duration.as_secs_f64() - 3.0).abs() < 0.001,
         "1.5 measures should be 3.0s at 120 BPM in 4/4, got {}s",

--- a/src/lighting/parser/types.rs
+++ b/src/lighting/parser/types.rs
@@ -108,15 +108,7 @@ impl Effect {
         }
 
         // Extract the effect type's duration field
-        let effect_duration = match &self.effect_type {
-            EffectType::Static { duration, .. }
-            | EffectType::Strobe { duration, .. }
-            | EffectType::Pulse { duration, .. }
-            | EffectType::ColorCycle { duration, .. }
-            | EffectType::Chase { duration, .. }
-            | EffectType::Rainbow { duration, .. } => *duration,
-            EffectType::Dimmer { .. } => unreachable!(),
-        };
+        let effect_duration = self.effect_type.duration();
 
         // If hold_time is explicitly set, use up + hold + down.
         // Otherwise use up + effect_duration + down.

--- a/src/lighting/parser/utils.rs
+++ b/src/lighting/parser/utils.rs
@@ -182,18 +182,9 @@ pub(crate) fn parse_color_string(value: &str) -> Option<Color> {
         value
     };
 
-    if let Some(hex) = clean_value.strip_prefix('#') {
-        // Hex color
-        if hex.len() == 6 {
-            if let (Ok(r), Ok(g), Ok(b)) = (
-                u8::from_str_radix(&hex[0..2], 16),
-                u8::from_str_radix(&hex[2..4], 16),
-                u8::from_str_radix(&hex[4..6], 16),
-            ) {
-                return Some(Color { r, g, b, w: None });
-            }
-        }
-        None
+    if clean_value.starts_with('#') {
+        // Hex color — delegate to Color::from_hex
+        Color::from_hex(clean_value).ok()
     } else if clean_value.starts_with("rgb(") && clean_value.ends_with(')') {
         // RGB color
         let rgb = &clean_value[4..clean_value.len() - 1];

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -76,8 +76,8 @@ impl LightingSystem {
         }
 
         // Load inline fixtures and groups
-        self.inline_fixtures = config.fixtures();
-        self.logical_groups = config.groups();
+        self.inline_fixtures = config.fixtures().clone();
+        self.logical_groups = config.groups().clone();
 
         // Load directories if configured
         if let Some(dirs) = config.directories() {
@@ -1182,7 +1182,7 @@ mod tests {
         let mut channels = HashMap::new();
         channels.insert("dimmer".to_string(), 1);
         channels.insert("red".to_string(), 2);
-        let ft = super::super::types::FixtureType::new("Par".to_string(), channels, vec![]);
+        let ft = super::super::types::FixtureType::new("Par".to_string(), channels);
         system.fixture_types.insert("Par".to_string(), ft);
 
         // Create venue with a fixture

--- a/src/lighting/types.rs
+++ b/src/lighting/types.rs
@@ -38,11 +38,7 @@ pub struct FixtureType {
 
 impl FixtureType {
     /// Creates a new fixture type.
-    pub fn new(
-        name: String,
-        channels: HashMap<String, u16>,
-        _special_cases: Vec<String>,
-    ) -> FixtureType {
+    pub fn new(name: String, channels: HashMap<String, u16>) -> FixtureType {
         FixtureType {
             name,
             channels,
@@ -279,7 +275,7 @@ mod tests {
         channels.insert("red".to_string(), 1);
         channels.insert("green".to_string(), 2);
         channels.insert("blue".to_string(), 3);
-        let ft = FixtureType::new("RGB Par".to_string(), channels, vec![]);
+        let ft = FixtureType::new("RGB Par".to_string(), channels);
         assert_eq!(ft.name(), "RGB Par");
         assert_eq!(ft.channels().len(), 3);
         assert_eq!(ft.max_strobe_frequency(), None);
@@ -289,7 +285,7 @@ mod tests {
 
     #[test]
     fn fixture_type_strobe_fields() {
-        let mut ft = FixtureType::new("Strobe".to_string(), HashMap::new(), vec![]);
+        let mut ft = FixtureType::new("Strobe".to_string(), HashMap::new());
         ft.max_strobe_frequency = Some(25.0);
         ft.min_strobe_frequency = Some(1.0);
         ft.strobe_dmx_offset = Some(128);

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -571,7 +571,7 @@ fn build_transformers(config: &config::Midi) -> Result<TransformerConfig, Box<dy
 
     for midi_to_dmx in config.midi_to_dmx() {
         let midi_channel = midi_to_dmx.midi_channel()?.as_int();
-        midi_to_dmx_mappings.insert(midi_channel, midi_to_dmx.universe());
+        midi_to_dmx_mappings.insert(midi_channel, midi_to_dmx.universe().to_string());
 
         let mut transformers = Vec::new();
         for transformer in midi_to_dmx.transformers() {

--- a/src/player.rs
+++ b/src/player.rs
@@ -968,12 +968,13 @@ impl Player {
         let _enter = self.span.enter();
         info!("Reporting status");
 
-        let midi_device = self
-            .hardware
-            .read()
-            .midi_device
-            .clone()
-            .expect("MIDI device must be present for status reporting");
+        let midi_device = match self.hardware.read().midi_device.clone() {
+            Some(device) => device,
+            None => {
+                warn!("MIDI device not present for status reporting; skipping");
+                return;
+            }
+        };
         let join = self.join.clone();
 
         // This thread will run until the process is terminated.
@@ -1037,7 +1038,9 @@ impl Player {
             return Ok(None);
         }
 
-        let all_songs = self.get_all_songs_playlist();
+        let all_songs = self
+            .get_all_songs_playlist()
+            .ok_or_else(|| -> Box<dyn Error> { "all_songs playlist not available".into() })?;
         if all_songs.navigate_to(song_name).is_none() {
             return Err(format!("Song '{}' not found", song_name).into());
         }
@@ -1616,31 +1619,40 @@ impl Player {
     /// Returns the song registry from the all-songs playlist.
     pub fn songs(&self) -> Arc<Songs> {
         let playlists = self.playlists.read();
-        playlists
-            .get("all_songs")
-            .expect("all_songs must always be present")
-            .registry()
-            .clone()
+        match playlists.get("all_songs") {
+            Some(playlist) => playlist.registry().clone(),
+            None => {
+                error!("all_songs playlist missing from player state");
+                Arc::new(Songs::new(std::collections::HashMap::new()))
+            }
+        }
     }
 
     /// Gets the all-songs playlist (every song in the registry).
-    pub fn get_all_songs_playlist(&self) -> Arc<Playlist> {
+    pub fn get_all_songs_playlist(&self) -> Option<Arc<Playlist>> {
         let playlists = self.playlists.read();
-        playlists
-            .get("all_songs")
-            .expect("all_songs must always be present")
-            .clone()
+        let result = playlists.get("all_songs").cloned();
+        if result.is_none() {
+            error!("all_songs playlist missing from player state");
+        }
+        result
     }
 
     /// Gets the current playlist used by the player.
     pub fn get_playlist(&self) -> Arc<Playlist> {
         let name = self.active_playlist.read().clone();
         let playlists = self.playlists.read();
-        playlists
-            .get(&name)
-            .or_else(|| playlists.get("all_songs"))
-            .expect("all_songs must always be present")
-            .clone()
+        match playlists.get(&name).or_else(|| playlists.get("all_songs")) {
+            Some(playlist) => playlist.clone(),
+            None => {
+                // This should never happen because all_songs is always created
+                // during initialization, but handle it gracefully instead of panicking.
+                error!("No playlist available (not even all_songs) — returning empty fallback");
+                drop(playlists);
+                let empty_songs = Arc::new(Songs::new(std::collections::HashMap::new()));
+                playlist::from_songs(empty_songs).expect("empty playlist construction cannot fail")
+            }
+        }
     }
 
     /// Reinitializes all song-related state by rescanning songs from disk and
@@ -2709,7 +2721,9 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_all_songs_playlist() -> Result<(), Box<dyn Error>> {
         let player = make_test_player().await?;
-        let all = player.get_all_songs_playlist();
+        let all = player
+            .get_all_songs_playlist()
+            .expect("all_songs should be present in test");
         assert_eq!(all.name(), "all_songs");
         assert!(!all.songs().is_empty());
         Ok(())

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -71,7 +71,7 @@ impl Playlist {
 
         Ok(Arc::new(Playlist {
             name: name.to_string(),
-            songs: song_names.clone(),
+            songs: song_names.to_vec(),
             position: Arc::new(RwLock::new(0)),
             registry: Arc::clone(&registry),
             span: span!(Level::INFO, "playlist"),
@@ -108,10 +108,7 @@ impl Playlist {
             *position += 1;
         }
 
-        let current = &self
-            .registry
-            .get(&self.songs[*position])
-            .expect("unable to get song from the registry");
+        let current = self.registry.get(&self.songs[*position]).ok()?;
 
         info!(
             position = *position,
@@ -119,7 +116,7 @@ impl Playlist {
             "Moving to next playlist position."
         );
 
-        Some(current.clone())
+        Some(current)
     }
 
     /// Move to the previous element of the playlist. If we're at the beginning of the playlist, the position
@@ -135,18 +132,15 @@ impl Playlist {
             *position -= 1;
         }
 
-        let current = &self
-            .registry
-            .get(&self.songs[*position])
-            .expect("unable to find song in the registry");
+        let current = self.registry.get(&self.songs[*position]).ok()?;
 
         info!(
             position = *position,
             song = current.name(),
-            "Moving to next previous position."
+            "Moving to previous playlist position."
         );
 
-        Some(current.clone())
+        Some(current)
     }
 
     /// Sets the playlist position to the song matching the given name.
@@ -175,12 +169,7 @@ impl Playlist {
             return None;
         }
         let position = self.position.read();
-        Some(Arc::clone(
-            &self
-                .registry
-                .get(&self.songs[*position])
-                .expect("unable to find song in the registry"),
-        ))
+        self.registry.get(&self.songs[*position]).ok()
     }
 }
 

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -819,7 +819,7 @@ impl LightShow {
             return Err(format!("file {} does not exist", dmx_file.display()).into());
         }
         Ok(LightShow {
-            universe_name: config.universe_name(),
+            universe_name: config.universe_name().to_string(),
             dmx_file,
             midi_channels: config.midi_channels(),
         })

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -20,6 +20,7 @@ use ratatui::widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragra
 use ratatui::Frame;
 
 use super::app::App;
+use crate::util::duration_minutes_seconds;
 
 /// Renders the entire TUI layout.
 pub fn draw(frame: &mut Frame, app: &App) {
@@ -160,8 +161,8 @@ fn draw_now_playing(frame: &mut Frame, app: &App, area: Rect) {
             0.0
         };
 
-        let elapsed_str = format_duration(elapsed);
-        let total_str = format_duration(total);
+        let elapsed_str = duration_minutes_seconds(elapsed);
+        let total_str = duration_minutes_seconds(total);
         let label = format!("{} / {}", elapsed_str, total_str);
 
         let gauge = Gauge::default()
@@ -312,14 +313,6 @@ fn log_line_color(line: &str) -> Color {
     } else {
         Color::Gray
     }
-}
-
-/// Formats a Duration as "M:SS".
-fn format_duration(d: Duration) -> String {
-    let total_secs = d.as_secs();
-    let minutes = total_secs / 60;
-    let seconds = total_secs % 60;
-    format!("{}:{:02}", minutes, seconds)
 }
 
 #[cfg(test)]
@@ -560,45 +553,6 @@ mod tests {
             let backend = TestBackend::new(80, 24);
             let mut terminal = Terminal::new(backend).unwrap();
             terminal.draw(|frame| draw(frame, &app)).unwrap();
-        }
-    }
-
-    mod format_duration_tests {
-        use super::*;
-
-        #[test]
-        fn zero_duration() {
-            assert_eq!(format_duration(Duration::ZERO), "0:00");
-        }
-
-        #[test]
-        fn seconds_only() {
-            assert_eq!(format_duration(Duration::from_secs(45)), "0:45");
-        }
-
-        #[test]
-        fn one_minute() {
-            assert_eq!(format_duration(Duration::from_secs(60)), "1:00");
-        }
-
-        #[test]
-        fn minutes_and_seconds() {
-            assert_eq!(format_duration(Duration::from_secs(185)), "3:05");
-        }
-
-        #[test]
-        fn pads_single_digit_seconds() {
-            assert_eq!(format_duration(Duration::from_secs(61)), "1:01");
-        }
-
-        #[test]
-        fn large_duration() {
-            assert_eq!(format_duration(Duration::from_secs(3661)), "61:01");
-        }
-
-        #[test]
-        fn subsecond_truncated() {
-            assert_eq!(format_duration(Duration::from_millis(59_999)), "0:59");
         }
     }
 }

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -869,7 +869,10 @@ pub(super) fn resolve_song_dir(
     let root = VerifiedRoot::new(songs_path).map_err(|e| Box::new(e.into_response()))?;
 
     // Check the registry first — handles songs in nested subdirectories.
-    if let Some(song) = player.get_all_songs_playlist().get_song(name) {
+    if let Some(song) = player
+        .get_all_songs_playlist()
+        .and_then(|p| p.get_song(name))
+    {
         if let Ok(safe) = SafePath::resolve(song.base_path(), &root) {
             if safe.is_dir() {
                 return Ok(safe);

--- a/src/webui/config_io.rs
+++ b/src/webui/config_io.rs
@@ -39,16 +39,7 @@ pub fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
 
 /// Validates a player config YAML string by attempting to deserialize it.
 pub fn validate_player_config(yaml: &str) -> Result<(), Vec<String>> {
-    // Write to a temp file so config::Player::deserialize can read it
-    let tmp = tempfile::Builder::new()
-        .suffix(".yaml")
-        .tempfile()
-        .map_err(|e| vec![format!("Failed to create temp file: {}", e)])?;
-
-    std::fs::write(tmp.path(), yaml)
-        .map_err(|e| vec![format!("Failed to write temp file: {}", e)])?;
-
-    let player = config::Player::deserialize(tmp.path()).map_err(|e| vec![format!("{}", e)])?;
+    let player = config::Player::deserialize_from_str(yaml).map_err(|e| vec![format!("{}", e)])?;
     player.validate()?;
 
     Ok(())

--- a/src/webui/state.rs
+++ b/src/webui/state.rs
@@ -475,7 +475,10 @@ pub async fn waveform_prewarmer(player: Arc<Player>, cache: WaveformCache) {
         time::sleep(Duration::from_secs(1)).await;
     }
 
-    let all_songs = player.get_all_songs_playlist();
+    let all_songs = match player.get_all_songs_playlist() {
+        Some(playlist) => playlist,
+        None => return,
+    };
     let song_names: Vec<String> = all_songs.songs().clone();
     let total_songs = song_names.len();
 


### PR DESCRIPTION
- Fix cloning getters to return &str, &[T], and &HashMap refs instead of owned copies
- Replace expect() in production code with graceful error handling (playlist, player, cli)
- Extract EffectType::duration() method, eliminating 3 duplicated 7-arm match blocks
- Remove dead _special_cases parameter from FixtureType::new
- Unify NotificationConfig/SongNotificationConfig as type alias
- Extract first_profile() helper in config/player.rs (6 nested-if patterns collapsed)
- Extract parse_playback_delay() shared helper from 3 identical implementations
- Deduplicate format_duration (TUI now uses util::duration_minutes_seconds)
- Fix &Vec<T> return types to &[T] in traits and config getters
- Ungate Color::new/from_hex from #[cfg(test)]; deduplicate hex parsing in parser
- Fix test module visibility in lighting.rs (pub mod -> #[cfg(test)] mod)
- Add Player::deserialize_from_str(), eliminating temp-file hack in webui config_io