### PR TITLE
Refactor: deduplication, parser context struct, and hot-path performance fixes

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -12,11 +12,11 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use std::any::Any;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::{error::Error, fmt, sync::Arc, time::Duration};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::{error::Error, fmt, sync::Arc};
 
 use crate::config;
-use crate::playsync::CancelHandle;
+use crate::playsync::PlaybackSync;
 use crate::songs::Song;
 use std::collections::HashMap;
 
@@ -48,7 +48,6 @@ pub fn next_source_id() -> u64 {
 /// Type alias for the channel sender used to add sources to the mixer.
 pub type SourceSender = crossbeam_channel::Sender<mixer::ActiveSource>;
 
-#[allow(clippy::too_many_arguments)]
 pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Plays the given song through the audio interface, starting from a specific time.
     /// The `ready_tx` sender signals that setup is complete. The implementation should
@@ -58,14 +57,7 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
         &self,
         song: Arc<Song>,
         mappings: &HashMap<String, Vec<u16>>,
-        cancel_handle: CancelHandle,
-        ready_tx: std::sync::mpsc::Sender<()>,
-        clock: crate::clock::PlaybackClock,
-        start_time: Duration,
-        loop_break: Arc<AtomicBool>,
-        active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        section_loop_break: Arc<AtomicBool>,
-        loop_time_consumed: Arc<parking_lot::Mutex<Duration>>,
+        sync: PlaybackSync,
     ) -> Result<(), Box<dyn Error>>;
 
     /// Gets the mixer for adding triggered samples.
@@ -185,14 +177,7 @@ mod test {
                 &self,
                 _song: Arc<Song>,
                 _mappings: &HashMap<String, Vec<u16>>,
-                _cancel_handle: CancelHandle,
-                _ready_tx: std::sync::mpsc::Sender<()>,
-                _clock: crate::clock::PlaybackClock,
-                _start_time: Duration,
-                _loop_break: Arc<AtomicBool>,
-                _active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-                _section_loop_break: Arc<AtomicBool>,
-                _loop_time_consumed: Arc<parking_lot::Mutex<Duration>>,
+                _sync: PlaybackSync,
             ) -> Result<(), Box<dyn Error>> {
                 Ok(())
             }

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -1022,15 +1022,21 @@ impl AudioDevice for Device {
         &self,
         song: Arc<Song>,
         mappings: &HashMap<String, Vec<u16>>,
-        cancel_handle: CancelHandle,
-        ready_tx: std::sync::mpsc::Sender<()>,
-        clock: crate::clock::PlaybackClock,
-        start_time: Duration,
-        loop_break: Arc<AtomicBool>,
-        active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        section_loop_break: Arc<AtomicBool>,
-        loop_time_consumed: Arc<parking_lot::Mutex<Duration>>,
+        sync: crate::playsync::PlaybackSync,
     ) -> Result<(), Box<dyn Error>> {
+        let crate::playsync::PlaybackSync {
+            cancel_handle,
+            ready_tx,
+            clock,
+            start_time,
+            loop_control,
+        } = sync;
+        let crate::playsync::LoopControl {
+            loop_break,
+            active_section,
+            section_loop_break,
+            loop_time_consumed,
+        } = loop_control;
         let span = span!(Level::INFO, "play song (cpal)");
         let _enter = span.enter();
 

--- a/src/audio/cpal.rs
+++ b/src/audio/cpal.rs
@@ -986,6 +986,36 @@ impl Device {
     }
 }
 
+/// Constructs a `MixerActiveSource` and its finish flag.
+///
+/// Every call site in `play_from` follows the same pattern: allocate a source ID,
+/// create an `is_finished` flag, build the struct, and hand back the flag for
+/// monitoring. This helper captures that boilerplate.
+fn build_active_source(
+    source: Box<dyn crate::audio::sample_source::ChannelMappedSampleSource + Send + Sync>,
+    track_mappings: &HashMap<String, Vec<u16>>,
+    cancel_handle: &CancelHandle,
+    gain_envelope: Option<Arc<crate::audio::crossfade::GainEnvelope>>,
+) -> (MixerActiveSource, Arc<AtomicBool>) {
+    let id = crate::audio::next_source_id();
+    let cached_source_channel_count = source.source_channel_count();
+    let is_finished = Arc::new(AtomicBool::new(false));
+    let flag = is_finished.clone();
+    let active = MixerActiveSource {
+        id,
+        source,
+        track_mappings: track_mappings.clone(),
+        channel_mappings: Vec::new(),
+        cached_source_channel_count,
+        cancel_handle: cancel_handle.clone(),
+        is_finished,
+        start_at_sample: None,
+        cancel_at_sample: None,
+        gain_envelope,
+    };
+    (active, flag)
+}
+
 impl AudioDevice for Device {
     /// Play the given song through the audio device, starting from a specific time.
     fn play_from(
@@ -1022,13 +1052,7 @@ impl AudioDevice for Device {
 
         let _ = ready_tx.send(());
 
-        while clock.elapsed() == Duration::ZERO {
-            if cancel_handle.is_cancelled() {
-                return Ok(());
-            }
-            std::hint::spin_loop();
-        }
-
+        clock.wait_for_start_or_cancel(&cancel_handle);
         if cancel_handle.is_cancelled() {
             return Ok(());
         }
@@ -1076,38 +1100,29 @@ impl AudioDevice for Device {
         // Create sources and track their finish flags (no locks needed for monitoring)
         let mut source_finish_flags = Vec::new();
 
+        let song_crossfade_envelope = if has_existing_sources {
+            let cs = crate::audio::crossfade::default_crossfade_samples(
+                self.output_manager.mixer.sample_rate(),
+            );
+            // Linear is fine for ≤5ms crossfades — perceptual difference
+            // from EqualPower is inaudible at this duration, and Linear
+            // is cheaper (no trig).
+            Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+                cs,
+                crate::audio::crossfade::CrossfadeCurve::Linear,
+            )))
+        } else {
+            None
+        };
+
         for source in channel_mapped_sources.into_iter() {
-            let current_source_id = crate::audio::next_source_id();
-            let source_channel_count = source.source_channel_count();
-            let is_finished = Arc::new(AtomicBool::new(false));
-            source_finish_flags.push(is_finished.clone());
-
-            let active_source = MixerActiveSource {
-                id: current_source_id,
+            let (active_source, flag) = build_active_source(
                 source,
-                track_mappings: mappings.clone(),
-                channel_mappings: Vec::new(),
-                cached_source_channel_count: source_channel_count,
-                cancel_handle: cancel_handle.clone(),
-                is_finished,
-                start_at_sample: None,
-                cancel_at_sample: None,
-                gain_envelope: if has_existing_sources {
-                    let cs = crate::audio::crossfade::default_crossfade_samples(
-                        self.output_manager.mixer.sample_rate(),
-                    );
-                    // Linear is fine for ≤5ms crossfades — perceptual difference
-                    // from EqualPower is inaudible at this duration, and Linear
-                    // is cheaper (no trig).
-                    Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
-                        cs,
-                        crate::audio::crossfade::CrossfadeCurve::Linear,
-                    )))
-                } else {
-                    None
-                },
-            };
-
+                mappings,
+                &cancel_handle,
+                song_crossfade_envelope.clone(),
+            );
+            source_finish_flags.push(flag);
             self.output_manager.add_source(active_source)?;
         }
 
@@ -1173,30 +1188,19 @@ impl AudioDevice for Device {
                             Ok(new_sources) => {
                                 // Replace finish flags with new source flags.
                                 source_finish_flags.clear();
+                                let fade_in_envelope =
+                                    Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+                                        crossfade_samples,
+                                        crate::audio::crossfade::CrossfadeCurve::Linear,
+                                    )));
                                 for source in new_sources {
-                                    let source_id = crate::audio::next_source_id();
-                                    let source_channel_count = source.source_channel_count();
-                                    let is_finished = Arc::new(AtomicBool::new(false));
-                                    source_finish_flags.push(is_finished.clone());
-
-                                    let active_source = MixerActiveSource {
-                                        id: source_id,
+                                    let (active_source, flag) = build_active_source(
                                         source,
-                                        track_mappings: mappings.clone(),
-                                        channel_mappings: Vec::new(),
-                                        cached_source_channel_count: source_channel_count,
-                                        cancel_handle: cancel_handle.clone(),
-                                        is_finished,
-                                        start_at_sample: None,
-                                        cancel_at_sample: None,
-                                        gain_envelope: Some(Arc::new(
-                                            crate::audio::crossfade::GainEnvelope::fade_in(
-                                                crossfade_samples,
-                                                crate::audio::crossfade::CrossfadeCurve::Linear,
-                                            ),
-                                        )),
-                                    };
-
+                                        mappings,
+                                        &cancel_handle,
+                                        fade_in_envelope.clone(),
+                                    );
+                                    source_finish_flags.push(flag);
                                     if let Err(e) = self.output_manager.add_source(active_source) {
                                         error!(err = %e, "Failed to add section loop source");
                                     }
@@ -1269,28 +1273,14 @@ impl AudioDevice for Device {
             };
 
             let mut new_finish_flags = Vec::new();
+            let fade_in_envelope = Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+                crossfade_samples,
+                crate::audio::crossfade::CrossfadeCurve::Linear,
+            )));
             for source in new_sources {
-                let source_id = crate::audio::next_source_id();
-                let source_channel_count = source.source_channel_count();
-                let is_finished = Arc::new(AtomicBool::new(false));
-                new_finish_flags.push(is_finished.clone());
-
-                let active_source = MixerActiveSource {
-                    id: source_id,
-                    source,
-                    track_mappings: mappings.clone(),
-                    channel_mappings: Vec::new(),
-                    cached_source_channel_count: source_channel_count,
-                    cancel_handle: cancel_handle.clone(),
-                    is_finished,
-                    start_at_sample: None,
-                    cancel_at_sample: None,
-                    gain_envelope: Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
-                        crossfade_samples,
-                        crate::audio::crossfade::CrossfadeCurve::Linear,
-                    ))),
-                };
-
+                let (active_source, flag) =
+                    build_active_source(source, mappings, &cancel_handle, fade_in_envelope.clone());
+                new_finish_flags.push(flag);
                 if let Err(e) = self.output_manager.add_source(active_source) {
                     error!(err = %e, "Failed to add loop source to mixer");
                     break;

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -87,15 +87,7 @@ impl crate::audio::Device for Device {
             thread::spawn(move || {
                 let _ = ready_tx.send(());
 
-                while clock.elapsed() == Duration::ZERO {
-                    if cancel_handle.is_cancelled() {
-                        finished.store(true, Ordering::Relaxed);
-                        cancel_handle.notify();
-                        return;
-                    }
-                    std::hint::spin_loop();
-                }
-
+                clock.wait_for_start_or_cancel(&cancel_handle);
                 if cancel_handle.is_cancelled() {
                     finished.store(true, Ordering::Relaxed);
                     cancel_handle.notify();

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -20,12 +20,11 @@ use std::{
         mpsc, Arc,
     },
     thread,
-    time::Duration,
 };
 
 use tracing::{info, span, Level};
 
-use crate::{playsync::CancelHandle, songs::Song};
+use crate::songs::Song;
 
 /// A mock device. Doesn't actually play anything.
 #[derive(Clone)]
@@ -56,15 +55,15 @@ impl crate::audio::Device for Device {
         &self,
         song: Arc<Song>,
         _: &HashMap<String, Vec<u16>>,
-        cancel_handle: CancelHandle,
-        ready_tx: std::sync::mpsc::Sender<()>,
-        clock: crate::clock::PlaybackClock,
-        start_time: Duration,
-        _loop_break: Arc<AtomicBool>,
-        _active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        _section_loop_break: Arc<AtomicBool>,
-        _loop_time_consumed: Arc<parking_lot::Mutex<Duration>>,
+        sync: crate::playsync::PlaybackSync,
     ) -> Result<(), Box<dyn Error>> {
+        let crate::playsync::PlaybackSync {
+            cancel_handle,
+            ready_tx,
+            clock,
+            start_time,
+            ..
+        } = sync;
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();
 
@@ -158,8 +157,9 @@ mod tests {
     fn play_from_zero_duration_completes() {
         use crate::audio::Device as DeviceTrait;
         use crate::clock::PlaybackClock;
-        use crate::playsync::CancelHandle;
+        use crate::playsync::{CancelHandle, PlaybackSync};
         use crate::songs::Song;
+        use std::time::Duration;
 
         let device = Device::get("mock-zero");
         // new_for_test creates a song with Duration::ZERO
@@ -179,14 +179,13 @@ mod tests {
             let _ = device_clone.play_from(
                 song,
                 &mappings,
-                cancel_clone,
-                ready_tx,
-                clock_clone,
-                Duration::from_millis(0),
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::Mutex::new(Duration::ZERO)),
+                PlaybackSync {
+                    cancel_handle: cancel_clone,
+                    ready_tx,
+                    clock: clock_clone,
+                    start_time: Duration::from_millis(0),
+                    loop_control: crate::playsync::LoopControl::new(),
+                },
             );
         });
 
@@ -205,8 +204,9 @@ mod tests {
     fn play_from_with_start_time_offset() {
         use crate::audio::Device as DeviceTrait;
         use crate::clock::PlaybackClock;
-        use crate::playsync::CancelHandle;
+        use crate::playsync::{CancelHandle, PlaybackSync};
         use crate::songs::Song;
+        use std::time::Duration;
 
         let device = Device::get("mock-offset");
         // new_for_test creates zero-duration song; start_time > duration => saturating_sub → 0
@@ -224,14 +224,13 @@ mod tests {
             let _ = device_clone.play_from(
                 song,
                 &mappings,
-                cancel_clone,
-                ready_tx,
-                clock_clone,
-                Duration::from_secs(1), // Start offset > duration → remaining = 0
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::Mutex::new(Duration::ZERO)),
+                PlaybackSync {
+                    cancel_handle: cancel_clone,
+                    ready_tx,
+                    clock: clock_clone,
+                    start_time: Duration::from_secs(1), // Start offset > duration → remaining = 0
+                    loop_control: crate::playsync::LoopControl::new(),
+                },
             );
         });
 
@@ -245,8 +244,9 @@ mod tests {
     fn play_from_cancel_before_barrier() {
         use crate::audio::Device as DeviceTrait;
         use crate::clock::PlaybackClock;
-        use crate::playsync::CancelHandle;
+        use crate::playsync::{CancelHandle, PlaybackSync};
         use crate::songs::Song;
+        use std::time::Duration;
 
         let device = Device::get("mock-precancel");
         let song = Arc::new(Song::new_for_test("song", &["t1"]));
@@ -266,14 +266,13 @@ mod tests {
             let _ = device_clone.play_from(
                 song,
                 &mappings,
-                cancel_clone,
-                ready_tx,
-                clock_clone,
-                Duration::from_millis(0),
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::Mutex::new(Duration::ZERO)),
+                PlaybackSync {
+                    cancel_handle: cancel_clone,
+                    ready_tx,
+                    clock: clock_clone,
+                    start_time: Duration::from_millis(0),
+                    loop_control: crate::playsync::LoopControl::new(),
+                },
             );
         });
 

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -87,6 +87,8 @@ pub struct BufferedSampleSource {
     warmup_min_frames: usize,
     channel_mappings: Vec<Vec<String>>,
     finished_flag: Arc<AtomicBool>,
+    /// Pre-allocated frame buffer reused by `next_sample` to avoid per-call allocation.
+    frame_buffer: Vec<f32>,
 }
 
 impl BufferedSampleSource {
@@ -134,6 +136,7 @@ impl BufferedSampleSource {
             warmup_min_frames,
             channel_mappings,
             finished_flag: finished_flag.clone(),
+            frame_buffer: vec![0.0f32; channels],
         };
 
         // Kick off initial warmup fill.
@@ -274,10 +277,13 @@ impl BufferedSampleSource {
 
 impl ChannelMappedSampleSource for BufferedSampleSource {
     fn next_sample(&mut self) -> Result<Option<f32>, SampleSourceError> {
-        let channels = self.channels as usize;
-        let mut frame = vec![0.0f32; channels];
-        match self.next_frame(&mut frame)? {
-            Some(count) if count > 0 => Ok(Some(frame[0])),
+        // Take the pre-allocated buffer out to satisfy the borrow checker
+        // (next_frame borrows &mut self, so we can't also borrow self.frame_buffer).
+        let mut frame = std::mem::take(&mut self.frame_buffer);
+        let result = self.next_frame(&mut frame);
+        self.frame_buffer = frame;
+        match result? {
+            Some(count) if count > 0 => Ok(Some(self.frame_buffer[0])),
             _ => Ok(None),
         }
     }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -12,8 +12,10 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
+
+use crate::playsync::CancelHandle;
 
 /// A playback clock that provides elapsed time since playback started.
 ///
@@ -26,10 +28,17 @@ use std::time::{Duration, Instant};
 /// releases) before `elapsed()` returns meaningful values.
 #[derive(Clone)]
 pub struct PlaybackClock {
-    inner: Arc<ClockInner>,
+    inner: Arc<ClockShared>,
 }
 
-enum ClockInner {
+struct ClockShared {
+    source: ClockSource,
+    /// Condvar+Mutex used to wake threads waiting for `start()`.
+    start_condvar: Condvar,
+    start_mutex: Mutex<bool>,
+}
+
+enum ClockSource {
     /// Derives time from the audio interface's sample counter.
     Audio {
         sample_counter: Arc<AtomicU64>,
@@ -49,10 +58,14 @@ impl PlaybackClock {
     pub fn from_sample_counter(sample_counter: Arc<AtomicU64>, sample_rate: u32) -> Self {
         debug_assert!(sample_rate > 0, "sample_rate must be > 0");
         PlaybackClock {
-            inner: Arc::new(ClockInner::Audio {
-                sample_counter,
-                sample_rate,
-                start_sample: AtomicU64::new(u64::MAX),
+            inner: Arc::new(ClockShared {
+                source: ClockSource::Audio {
+                    sample_counter,
+                    sample_rate,
+                    start_sample: AtomicU64::new(u64::MAX),
+                },
+                start_condvar: Condvar::new(),
+                start_mutex: Mutex::new(false),
             }),
         }
     }
@@ -60,8 +73,12 @@ impl PlaybackClock {
     /// Creates a clock backed by `Instant::now()`.
     pub fn wall() -> Self {
         PlaybackClock {
-            inner: Arc::new(ClockInner::Wall {
-                start_instant: parking_lot::Mutex::new(None),
+            inner: Arc::new(ClockShared {
+                source: ClockSource::Wall {
+                    start_instant: parking_lot::Mutex::new(None),
+                },
+                start_condvar: Condvar::new(),
+                start_mutex: Mutex::new(false),
             }),
         }
     }
@@ -70,8 +87,8 @@ impl PlaybackClock {
     /// Called by `play_files` once all subsystems have signaled readiness.
     /// Subsystems wait for `elapsed() > Duration::ZERO` as the "go" signal.
     pub fn start(&self) {
-        match self.inner.as_ref() {
-            ClockInner::Audio {
+        match &self.inner.source {
+            ClockSource::Audio {
                 sample_counter,
                 start_sample,
                 ..
@@ -79,18 +96,42 @@ impl PlaybackClock {
                 let current = sample_counter.load(Ordering::Relaxed);
                 start_sample.store(current, Ordering::Relaxed);
             }
-            ClockInner::Wall { start_instant } => {
+            ClockSource::Wall { start_instant } => {
                 let mut guard = start_instant.lock();
                 *guard = Some(Instant::now());
             }
+        }
+        // Wake any threads blocked in wait_for_start_or_cancel.
+        {
+            let mut started = self.inner.start_mutex.lock().unwrap();
+            *started = true;
+        }
+        self.inner.start_condvar.notify_all();
+    }
+
+    /// Blocks until the clock has been started (`elapsed() > ZERO`) or the
+    /// cancel handle is cancelled. Uses a condvar instead of spinning.
+    pub fn wait_for_start_or_cancel(&self, cancel: &CancelHandle) {
+        let mut started = self.inner.start_mutex.lock().unwrap();
+        while !*started {
+            if cancel.is_cancelled() {
+                return;
+            }
+            // Use a short timeout so we can re-check the cancel handle.
+            let (guard, _) = self
+                .inner
+                .start_condvar
+                .wait_timeout(started, Duration::from_millis(10))
+                .unwrap();
+            started = guard;
         }
     }
 
     /// Returns the elapsed time since `start()` was called.
     /// Returns `Duration::ZERO` if `start()` has not been called yet.
     pub fn elapsed(&self) -> Duration {
-        match self.inner.as_ref() {
-            ClockInner::Audio {
+        match &self.inner.source {
+            ClockSource::Audio {
                 sample_counter,
                 sample_rate,
                 start_sample,
@@ -103,7 +144,7 @@ impl PlaybackClock {
                 let delta = current.saturating_sub(start);
                 Duration::from_secs_f64(delta as f64 / *sample_rate as f64)
             }
-            ClockInner::Wall { start_instant } => {
+            ClockSource::Wall { start_instant } => {
                 let guard = start_instant.lock();
                 match *guard {
                     Some(instant) => instant.elapsed(),

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -401,7 +401,6 @@ impl Engine {
     }
 
     /// Plays the given song through the DMX interface.
-    #[allow(clippy::too_many_arguments)]
     pub fn play(
         dmx_engine: Arc<Engine>,
         song: Arc<Song>,
@@ -409,10 +408,14 @@ impl Engine {
         ready_tx: std::sync::mpsc::Sender<()>,
         start_time: Duration,
         clock: crate::clock::PlaybackClock,
-        loop_break: Arc<AtomicBool>,
-        active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        section_loop_break: Arc<AtomicBool>,
+        loop_control: crate::playsync::LoopControl,
     ) -> Result<(), Box<dyn Error>> {
+        let crate::playsync::LoopControl {
+            loop_break,
+            active_section,
+            section_loop_break,
+            ..
+        } = loop_control;
         let span = span!(Level::INFO, "play song (dmx)");
         let _enter = span.enter();
 
@@ -1405,7 +1408,7 @@ mod test {
         collections::HashSet,
         error::Error,
         net::{Ipv4Addr, SocketAddr, TcpListener},
-        sync::{atomic::AtomicBool, Arc},
+        sync::Arc,
         time::Duration,
     };
 
@@ -1892,9 +1895,7 @@ mod test {
             ready_tx,
             std::time::Duration::ZERO,
             clock,
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(parking_lot::RwLock::new(None)),
-            Arc::new(AtomicBool::new(false)),
+            crate::playsync::LoopControl::new(),
         )?;
 
         // Verify timeline was created (may be None if no lighting config)
@@ -2178,9 +2179,7 @@ mod test {
             ready_tx,
             std::time::Duration::ZERO,
             clock,
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(parking_lot::RwLock::new(None)),
-            Arc::new(AtomicBool::new(false)),
+            crate::playsync::LoopControl::new(),
         )?;
 
         // The tempo map should have been cleared (not inherited from the seeded state).
@@ -2236,9 +2235,7 @@ mod test {
             ready_tx,
             std::time::Duration::ZERO,
             clock,
-            Arc::new(AtomicBool::new(false)),
-            Arc::new(parking_lot::RwLock::new(None)),
-            Arc::new(AtomicBool::new(false)),
+            crate::playsync::LoopControl::new(),
         )?;
 
         assert_lighting_state_cleared(&engine);
@@ -3678,9 +3675,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3712,9 +3707,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3747,9 +3740,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::from_secs(3),
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3788,9 +3779,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok());
             Ok(())
@@ -3837,9 +3826,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4508,9 +4495,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4553,9 +4538,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::from_secs(10),
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4604,9 +4587,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4682,9 +4663,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4746,9 +4725,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok(), "play failed: {:?}", result.err());
             Ok(())
@@ -4861,9 +4838,7 @@ mod test {
                 ready_tx,
                 std::time::Duration::ZERO,
                 clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::LoopControl::new(),
             );
             assert!(result.is_ok());
             Ok(())

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -107,8 +107,8 @@ pub struct Engine {
     effects_loop_handle: Mutex<Option<JoinHandle<()>>>,
     /// Current song timeline (thread-safe access for effects loop)
     current_song_timeline: Arc<Mutex<Option<LightingTimeline>>>,
-    /// Current song time (thread-safe access for effects loop)
-    current_song_time: Arc<Mutex<Duration>>,
+    /// Current song time in nanoseconds (thread-safe access for effects loop)
+    current_song_time: Arc<AtomicU64>,
     /// Flag indicating the current song's timeline has finished (all cues processed)
     timeline_finished: Arc<AtomicBool>,
     /// Cancel handle for notifying when timeline finishes
@@ -213,7 +213,7 @@ impl Engine {
         let effect_engine = Arc::new(Mutex::new(ee));
         let current_song_timeline: Arc<Mutex<Option<LightingTimeline>>> =
             Arc::new(Mutex::new(None));
-        let current_song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let current_song_time = Arc::new(AtomicU64::new(0));
         let timeline_finished = Arc::new(AtomicBool::new(true));
         let timeline_cancel_handle: Arc<Mutex<Option<CancelHandle>>> = Arc::new(Mutex::new(None));
 
@@ -1122,18 +1122,14 @@ impl Engine {
     /// effect unchanged (groups are passed through as-is).
     fn resolve_effect_groups(
         &self,
-        mut effect: crate::lighting::EffectInstance,
+        effect: crate::lighting::EffectInstance,
     ) -> crate::lighting::EffectInstance {
         if let Some(lighting_system) = &self.lighting_system {
             let mut lighting_system = lighting_system.lock();
-            let mut resolved_fixtures = Vec::new();
-            for group_name in &effect.target_fixtures {
-                let fixtures = lighting_system.resolve_logical_group_graceful(group_name);
-                resolved_fixtures.extend(fixtures);
-            }
-            effect.target_fixtures = resolved_fixtures;
+            lighting_system.resolve_effect_groups(effect)
+        } else {
+            effect
         }
-        effect
     }
 
     /// Stops the lighting timeline
@@ -1151,14 +1147,13 @@ impl Engine {
 
     /// Updates the current song time
     pub fn update_song_time(&self, song_time: Duration) {
-        let mut current_time = self.current_song_time.lock();
-        *current_time = song_time;
+        self.current_song_time
+            .store(song_time.as_nanos() as u64, Ordering::Relaxed);
     }
 
     /// Gets the current song time
     pub fn get_song_time(&self) -> Duration {
-        let current_time = self.current_song_time.lock();
-        *current_time
+        Duration::from_nanos(self.current_song_time.load(Ordering::Relaxed))
     }
 
     /// Sets the broadcast channel so the file watcher can send reload notifications.

--- a/src/dmx/watcher.rs
+++ b/src/dmx/watcher.rs
@@ -16,6 +16,7 @@ use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use parking_lot::Mutex;
 use serde_json::json;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -43,7 +44,7 @@ pub fn start_watching(
     file_paths: Vec<PathBuf>,
     effect_engine: Arc<Mutex<EffectEngine>>,
     current_song_timeline: Arc<Mutex<Option<LightingTimeline>>>,
-    current_song_time: Arc<Mutex<Duration>>,
+    current_song_time: Arc<AtomicU64>,
     lighting_system: Option<Arc<Mutex<LightingSystem>>>,
     lighting_config: Option<crate::config::Lighting>,
     broadcast_tx: broadcast::Sender<String>,
@@ -136,7 +137,7 @@ fn reload_timeline(
     file_paths: &[PathBuf],
     effect_engine: &Arc<Mutex<EffectEngine>>,
     current_song_timeline: &Arc<Mutex<Option<LightingTimeline>>>,
-    current_song_time: &Arc<Mutex<Duration>>,
+    current_song_time: &Arc<AtomicU64>,
     lighting_system: Option<&Arc<Mutex<LightingSystem>>>,
     lighting_config: Option<&crate::config::Lighting>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -167,7 +168,7 @@ fn reload_timeline(
     let mut new_timeline = LightingTimeline::new(all_shows);
 
     // Get current song time
-    let song_time = { *current_song_time.lock() };
+    let song_time = Duration::from_nanos(current_song_time.load(Ordering::Relaxed));
 
     // Calculate the timeline update before acquiring the engine lock.
     let timeline_update = if song_time > Duration::ZERO {
@@ -245,18 +246,14 @@ fn reload_timeline(
 /// Resolves group names in an effect's target_fixtures to actual fixture names.
 fn resolve_effect_groups(
     lighting_system: Option<&Arc<Mutex<LightingSystem>>>,
-    mut effect: crate::lighting::EffectInstance,
+    effect: crate::lighting::EffectInstance,
 ) -> crate::lighting::EffectInstance {
     if let Some(ls) = lighting_system {
         let mut system = ls.lock();
-        let mut resolved_fixtures = Vec::new();
-        for group_name in &effect.target_fixtures {
-            let fixtures = system.resolve_logical_group_graceful(group_name);
-            resolved_fixtures.extend(fixtures);
-        }
-        effect.target_fixtures = resolved_fixtures;
+        system.resolve_effect_groups(effect)
+    } else {
+        effect
     }
-    effect
 }
 
 #[cfg(test)]
@@ -278,7 +275,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -309,7 +306,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::from_secs(3)));
+        let song_time = Arc::new(AtomicU64::new(Duration::from_secs(3).as_nanos() as u64));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -327,7 +324,7 @@ mod test {
     fn reload_timeline_with_missing_file() {
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[PathBuf::from("/nonexistent/show.light")],
@@ -348,7 +345,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -388,7 +385,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -428,7 +425,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -463,7 +460,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::from_secs(1)));
+        let song_time = Arc::new(AtomicU64::new(Duration::from_secs(1).as_nanos() as u64));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -486,7 +483,7 @@ mod test {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -521,7 +518,7 @@ mod test {
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
         // Set song_time > 0 to exercise the layer_commands/stop_sequences path
-        let song_time = Arc::new(Mutex::new(Duration::from_secs(3)));
+        let song_time = Arc::new(AtomicU64::new(Duration::from_secs(3).as_nanos() as u64));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -563,7 +560,7 @@ show "test" {
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
         // Set song_time past the stop sequence cue
-        let song_time = Arc::new(Mutex::new(Duration::from_secs(3)));
+        let song_time = Arc::new(AtomicU64::new(Duration::from_secs(3).as_nanos() as u64));
 
         let result = reload_timeline(
             &[dsl_path],
@@ -638,7 +635,7 @@ show "test" {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
 
         let result = reload_timeline(
             &[dsl_path1, dsl_path2],
@@ -666,7 +663,7 @@ show "test" {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
         let (tx, mut rx) = broadcast::channel(16);
 
         let _handle = start_watching(
@@ -736,7 +733,7 @@ show "test" {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
         let (tx, mut rx) = broadcast::channel(16);
 
         let _handle = start_watching(
@@ -791,7 +788,7 @@ show "test" {
 
         let effect_engine = Arc::new(Mutex::new(EffectEngine::new()));
         let timeline = Arc::new(Mutex::new(None));
-        let song_time = Arc::new(Mutex::new(Duration::ZERO));
+        let song_time = Arc::new(AtomicU64::new(0));
         let (tx, _rx) = broadcast::channel(16);
 
         let result = start_watching(

--- a/src/lighting/consistency_tests.rs
+++ b/src/lighting/consistency_tests.rs
@@ -190,9 +190,9 @@ mod tests {
 
         // For Multiply, both implementations should yield identical effective brightness
         // RGB-only fixture bakes multiplier into RGB; dedicated uses dimmer channel
-        let (r_rgb, g_rgb, b_rgb) = get_rgb(1, 1, &cmds_rgb_1s);
-        let (r_dim, g_dim, b_dim) = get_rgb(1, 2, &cmds_dim_1s); // base+1 because dimmer occupies ch1
-        let d_dim = get_dimmer(1, 1, &cmds_dim_1s) as f32 / 255.0;
+        let (r_rgb, g_rgb, b_rgb) = get_rgb(1, 1, cmds_rgb_1s);
+        let (r_dim, g_dim, b_dim) = get_rgb(1, 2, cmds_dim_1s); // base+1 because dimmer occupies ch1
+        let d_dim = get_dimmer(1, 1, cmds_dim_1s) as f32 / 255.0;
         let r_dim_eff = ((r_dim as f32) * d_dim).round() as u8;
         let g_dim_eff = ((g_dim as f32) * d_dim).round() as u8;
         let b_dim_eff = ((b_dim as f32) * d_dim).round() as u8;
@@ -245,9 +245,9 @@ mod tests {
         let cmds_dim_r_1s = eng_dim_r.update(Duration::from_secs(1), None).unwrap();
 
         // Visual equivalence: effective RGB should match between the two strategies
-        let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb_r_1s);
-        let (r2_raw, g2_raw, b2_raw) = get_rgb(1, 2, &cmds_dim_r_1s);
-        let d2 = get_dimmer(1, 1, &cmds_dim_r_1s) as f32 / 255.0;
+        let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb_r_1s);
+        let (r2_raw, g2_raw, b2_raw) = get_rgb(1, 2, cmds_dim_r_1s);
+        let d2 = get_dimmer(1, 1, cmds_dim_r_1s) as f32 / 255.0;
         let r2 = ((r2_raw as f32) * d2).round() as u8;
         let g2 = ((g2_raw as f32) * d2).round() as u8;
         let b2 = ((b2_raw as f32) * d2).round() as u8;
@@ -274,23 +274,23 @@ mod tests {
 
         // t=0
         let cmds_0 = eng.update(Duration::from_millis(0), None).unwrap();
-        let (_, _, b0) = get_rgb(1, 1, &cmds_0);
+        let (_, _, b0) = get_rgb(1, 1, cmds_0);
         assert_eq!(b0, 255);
 
         // t=1.0s -> ~50%
         let cmds_1 = eng.update(Duration::from_secs(1), None).unwrap();
-        let (_, _, b1) = get_rgb(1, 1, &cmds_1);
+        let (_, _, b1) = get_rgb(1, 1, cmds_1);
         assert!((120..=135).contains(&b1));
 
         // t=1.5s -> ~25%
         let cmds_15 = eng.update(Duration::from_millis(500), None).unwrap();
-        let (_, _, b15) = get_rgb(1, 1, &cmds_15);
+        let (_, _, b15) = get_rgb(1, 1, cmds_15);
         assert!((50..=75).contains(&b15));
 
         // effect ends at 2.0s; dimmer is removed, underlying static blue shows through
         let _cmds_2 = eng.update(Duration::from_millis(500), None).unwrap();
         let cmds_after = eng.update(Duration::from_millis(10), None).unwrap();
-        let (_, _, b_after) = get_rgb(1, 1, &cmds_after);
+        let (_, _, b_after) = get_rgb(1, 1, cmds_after);
         assert_eq!(b_after, 255, "After dimmer completes, blue returns to full");
     }
 
@@ -350,9 +350,9 @@ mod tests {
         for dt in [0u64, 500, 1000, 1500, 2000] {
             let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
             let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-            let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-            let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-            let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+            let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+            let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+            let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
             let r2e = ((r2 as f32) * d2).round() as u8;
             let g2e = ((g2 as f32) * d2).round() as u8;
             let b2e = ((b2 as f32) * d2).round() as u8;
@@ -420,9 +420,9 @@ mod tests {
         for dt in [0u64, 50, 100, 150, 200, 500] {
             let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
             let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-            let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-            let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-            let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+            let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+            let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+            let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
             let r2e = ((r2 as f32) * d2).round() as u8;
             let g2e = ((g2 as f32) * d2).round() as u8;
             let b2e = ((b2 as f32) * d2).round() as u8;
@@ -493,9 +493,9 @@ mod tests {
         for dt in [0u64, 250, 500, 750, 1000] {
             let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
             let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-            let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-            let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-            let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+            let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+            let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+            let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
             let r2e = ((r2 as f32) * d2).round() as u8;
             let g2e = ((g2 as f32) * d2).round() as u8;
             let b2e = ((b2 as f32) * d2).round() as u8;
@@ -569,9 +569,9 @@ mod tests {
         for dt in [0u64, 250, 500, 750, 1000] {
             let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
             let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-            let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-            let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-            let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+            let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+            let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+            let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
             let r2e = ((r2 as f32) * d2).round() as u8;
             let g2e = ((g2 as f32) * d2).round() as u8;
             let b2e = ((b2 as f32) * d2).round() as u8;
@@ -626,9 +626,9 @@ mod tests {
         for dt in [0u64, 250, 500, 750, 1000] {
             let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
             let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-            let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-            let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-            let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+            let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+            let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+            let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
             let r2e = ((r2 as f32) * d2).round() as u8;
             let g2e = ((g2 as f32) * d2).round() as u8;
             let b2e = ((b2 as f32) * d2).round() as u8;
@@ -705,9 +705,9 @@ mod tests {
                     for dt in sample_ms {
                         let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
                         let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-                        let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-                        let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-                        let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+                        let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+                        let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+                        let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
                         let r2e = ((r2 as f32) * d2).round() as u8;
                         let g2e = ((g2 as f32) * d2).round() as u8;
                         let b2e = ((b2 as f32) * d2).round() as u8;
@@ -777,9 +777,9 @@ mod tests {
             for dt in sample_ms {
                 let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
                 let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-                let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-                let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-                let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+                let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+                let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+                let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
                 let r2e = ((r2 as f32) * d2).round() as u8;
                 let g2e = ((g2 as f32) * d2).round() as u8;
                 let b2e = ((b2 as f32) * d2).round() as u8;
@@ -854,9 +854,9 @@ mod tests {
                     for dt in sample_ms {
                         let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
                         let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-                        let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-                        let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-                        let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+                        let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+                        let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+                        let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
                         let r2e = ((r2 as f32) * d2).round() as u8;
                         let g2e = ((g2 as f32) * d2).round() as u8;
                         let b2e = ((b2 as f32) * d2).round() as u8;
@@ -939,9 +939,9 @@ mod tests {
                     for dt in sample_ms {
                         let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
                         let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-                        let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-                        let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-                        let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+                        let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+                        let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+                        let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
                         let r2e = ((r2 as f32) * d2).round() as u8;
                         let g2e = ((g2 as f32) * d2).round() as u8;
                         let b2e = ((b2 as f32) * d2).round() as u8;
@@ -1002,9 +1002,9 @@ mod tests {
                     for dt in sample_ms {
                         let cmds_rgb = eng_rgb.update(Duration::from_millis(dt), None).unwrap();
                         let cmds_dim = eng_dim.update(Duration::from_millis(dt), None).unwrap();
-                        let (r1, g1, b1) = get_rgb(1, 1, &cmds_rgb);
-                        let (r2, g2, b2) = get_rgb(1, 2, &cmds_dim);
-                        let d2 = get_dimmer(1, 1, &cmds_dim) as f32 / 255.0;
+                        let (r1, g1, b1) = get_rgb(1, 1, cmds_rgb);
+                        let (r2, g2, b2) = get_rgb(1, 2, cmds_dim);
+                        let d2 = get_dimmer(1, 1, cmds_dim) as f32 / 255.0;
                         let r2e = ((r2 as f32) * d2).round() as u8;
                         let g2e = ((g2 as f32) * d2).round() as u8;
                         let b2e = ((b2 as f32) * d2).round() as u8;
@@ -1047,7 +1047,7 @@ mod tests {
             BlendMode::Multiply,
         );
         let cmds_100ms = eng.update(Duration::from_millis(100), None).unwrap();
-        let (_, _, b_100) = get_rgb(1, 1, &cmds_100ms);
+        let (_, _, b_100) = get_rgb(1, 1, cmds_100ms);
         assert!(b_100 > 240);
     }
 
@@ -1075,7 +1075,7 @@ mod tests {
         r_low.blend_mode = BlendMode::Replace;
         eng.start_effect(r_low).unwrap();
         let c0 = eng.update(Duration::from_millis(0), None).unwrap();
-        let (r0, g0, b0) = get_rgb(1, 1, &c0);
+        let (r0, g0, b0) = get_rgb(1, 1, c0);
 
         // High speed snapshot at non-integer multiple of the cycle (period=100ms at 10Hz); use 125ms
         let mut r_high = EffectInstance::new(
@@ -1095,7 +1095,7 @@ mod tests {
         r_high.blend_mode = BlendMode::Replace;
         eng.start_effect(r_high).unwrap();
         let c1 = eng.update(Duration::from_millis(125), None).unwrap();
-        let (r1, g1, b1) = get_rgb(1, 1, &c1);
+        let (r1, g1, b1) = get_rgb(1, 1, c1);
 
         assert_ne!((r0, g0, b0), (r1, g1, b1));
     }

--- a/src/lighting/effects.rs
+++ b/src/lighting/effects.rs
@@ -31,7 +31,7 @@ pub use fixture::{
 };
 pub use instance::EffectInstance;
 pub use state::{is_multiplier_channel, ChannelState, DmxCommand, FixtureState};
-pub use tempo_aware::{TempoAwareFrequency, TempoAwareSpeed};
+pub use tempo_aware::{TempoAwareFrequency, TempoAwareSpeed, TempoAwareValue};
 pub use types::{
     BlendMode, ChaseDirection, ChasePattern, CycleDirection, CycleTransition, DimmerCurve,
     EffectLayer, EffectType,

--- a/src/lighting/effects/tempo_aware.rs
+++ b/src/lighting/effects/tempo_aware.rs
@@ -55,87 +55,76 @@ fn beats_to_duration_secs(
     }
 }
 
-/// Tempo-aware speed specification that can adapt to tempo changes
+/// Tempo-aware value specification that can adapt to tempo changes.
+///
+/// Used for both speed (cycles per second) and frequency (Hz) parameters,
+/// since both resolve identically: the value either is a fixed rate or is
+/// derived from a musical duration (measures, beats, seconds) via 1/period.
 #[derive(Debug, Clone, PartialEq)]
-pub enum TempoAwareSpeed {
-    /// Fixed speed in cycles per second (not tempo-aware)
+pub enum TempoAwareValue {
+    /// Fixed rate (not tempo-aware)
     Fixed(f64),
-    /// Speed specified in measures (tempo-aware)
+    /// Rate specified in measures (tempo-aware)
     Measures(f64),
-    /// Speed specified in beats (tempo-aware)
+    /// Rate specified in beats (tempo-aware)
     Beats(f64),
-    /// Speed specified in seconds (fixed, not tempo-aware)
+    /// Rate specified in seconds (fixed, not tempo-aware)
     Seconds(f64),
 }
 
-impl TempoAwareSpeed {
-    /// Get the current speed in cycles per second, using tempo map if available
+impl TempoAwareValue {
+    /// Get the current rate (cycles per second / Hz), using tempo map if available
+    pub fn to_rate(
+        &self,
+        tempo_map: Option<&crate::lighting::tempo::TempoMap>,
+        at_time: Duration,
+    ) -> f64 {
+        match self {
+            TempoAwareValue::Fixed(rate) => *rate,
+            TempoAwareValue::Seconds(duration) => duration_to_rate(*duration),
+            TempoAwareValue::Measures(measures) => {
+                if *measures <= 0.0 {
+                    return 0.0;
+                }
+                let duration_secs = measures_to_duration_secs(*measures, tempo_map, at_time);
+                duration_to_rate(duration_secs)
+            }
+            TempoAwareValue::Beats(beats) => {
+                if *beats <= 0.0 {
+                    return 0.0;
+                }
+                let duration_secs = beats_to_duration_secs(*beats, tempo_map, at_time);
+                duration_to_rate(duration_secs)
+            }
+        }
+    }
+
+    /// Alias for `to_rate` — reads naturally when the value represents speed (cycles per second).
+    #[inline]
     pub fn to_cycles_per_second(
         &self,
         tempo_map: Option<&crate::lighting::tempo::TempoMap>,
         at_time: Duration,
     ) -> f64 {
-        match self {
-            TempoAwareSpeed::Fixed(speed) => *speed,
-            TempoAwareSpeed::Seconds(duration) => duration_to_rate(*duration),
-            TempoAwareSpeed::Measures(measures) => {
-                if *measures <= 0.0 {
-                    return 0.0; // Zero/negative measures means stopped
-                }
-                let duration_secs = measures_to_duration_secs(*measures, tempo_map, at_time);
-                duration_to_rate(duration_secs)
-            }
-            TempoAwareSpeed::Beats(beats) => {
-                if *beats <= 0.0 {
-                    return 0.0; // Zero/negative beats means stopped
-                }
-                let duration_secs = beats_to_duration_secs(*beats, tempo_map, at_time);
-                duration_to_rate(duration_secs)
-            }
-        }
+        self.to_rate(tempo_map, at_time)
     }
-}
 
-/// Tempo-aware frequency specification that can adapt to tempo changes
-#[derive(Debug, Clone, PartialEq)]
-pub enum TempoAwareFrequency {
-    /// Fixed frequency in Hz (not tempo-aware)
-    Fixed(f64),
-    /// Frequency specified in measures (tempo-aware)
-    Measures(f64),
-    /// Frequency specified in beats (tempo-aware)
-    Beats(f64),
-    /// Frequency specified in seconds (fixed, not tempo-aware)
-    Seconds(f64),
-}
-
-impl TempoAwareFrequency {
-    /// Get the current frequency in Hz, using tempo map if available
+    /// Alias for `to_rate` — reads naturally when the value represents frequency (Hz).
+    #[inline]
     pub fn to_hz(
         &self,
         tempo_map: Option<&crate::lighting::tempo::TempoMap>,
         at_time: Duration,
     ) -> f64 {
-        match self {
-            TempoAwareFrequency::Fixed(freq) => *freq,
-            TempoAwareFrequency::Seconds(duration) => duration_to_rate(*duration),
-            TempoAwareFrequency::Measures(measures) => {
-                if *measures <= 0.0 {
-                    return 0.0; // Zero/negative measures means stopped
-                }
-                let duration_secs = measures_to_duration_secs(*measures, tempo_map, at_time);
-                duration_to_rate(duration_secs)
-            }
-            TempoAwareFrequency::Beats(beats) => {
-                if *beats <= 0.0 {
-                    return 0.0; // Zero/negative beats means stopped
-                }
-                let duration_secs = beats_to_duration_secs(*beats, tempo_map, at_time);
-                duration_to_rate(duration_secs)
-            }
-        }
+        self.to_rate(tempo_map, at_time)
     }
 }
+
+/// Type alias for tempo-aware speed parameters (cycles per second).
+pub type TempoAwareSpeed = TempoAwareValue;
+
+/// Type alias for tempo-aware frequency parameters (Hz).
+pub type TempoAwareFrequency = TempoAwareValue;
 
 #[cfg(test)]
 mod tests {
@@ -163,163 +152,121 @@ mod tests {
         assert_eq!(duration_to_rate(-1.0), 0.0);
     }
 
-    // ── TempoAwareSpeed — Fixed ────────────────────────────────────
+    // ── TempoAwareValue — Fixed ────────────────────────────────────
 
     #[test]
-    fn speed_fixed() {
+    fn value_fixed() {
+        let val = TempoAwareValue::Fixed(2.5);
+        assert!((val.to_rate(None, Duration::ZERO) - 2.5).abs() < 1e-9);
+    }
+
+    // ── TempoAwareValue — Seconds ──────────────────────────────────
+
+    #[test]
+    fn value_seconds() {
+        let val = TempoAwareValue::Seconds(4.0);
+        assert!((val.to_rate(None, Duration::ZERO) - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn value_seconds_zero() {
+        let val = TempoAwareValue::Seconds(0.0);
+        assert_eq!(val.to_rate(None, Duration::ZERO), 0.0);
+    }
+
+    // ── TempoAwareValue — Beats (no tempo map -> fallback 120 BPM) ─
+
+    #[test]
+    fn value_beats_no_tempo_map() {
+        // 1 beat at 120 BPM = 0.5 seconds -> rate = 2.0
+        let val = TempoAwareValue::Beats(1.0);
+        let rate = val.to_rate(None, Duration::ZERO);
+        assert!((rate - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn value_beats_two_beats_no_tempo_map() {
+        // 2 beats at 120 BPM = 1.0 second -> rate = 1.0
+        let val = TempoAwareValue::Beats(2.0);
+        let rate = val.to_rate(None, Duration::ZERO);
+        assert!((rate - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn value_beats_zero() {
+        let val = TempoAwareValue::Beats(0.0);
+        assert_eq!(val.to_rate(None, Duration::ZERO), 0.0);
+    }
+
+    #[test]
+    fn value_beats_negative() {
+        let val = TempoAwareValue::Beats(-1.0);
+        assert_eq!(val.to_rate(None, Duration::ZERO), 0.0);
+    }
+
+    // ── TempoAwareValue — Measures (no tempo map -> fallback) ──────
+
+    #[test]
+    fn value_measures_no_tempo_map() {
+        // 1 measure = 4 beats at 120 BPM = 2.0 seconds -> rate = 0.5
+        let val = TempoAwareValue::Measures(1.0);
+        let rate = val.to_rate(None, Duration::ZERO);
+        assert!((rate - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn value_measures_zero() {
+        let val = TempoAwareValue::Measures(0.0);
+        assert_eq!(val.to_rate(None, Duration::ZERO), 0.0);
+    }
+
+    #[test]
+    fn value_measures_negative() {
+        let val = TempoAwareValue::Measures(-1.0);
+        assert_eq!(val.to_rate(None, Duration::ZERO), 0.0);
+    }
+
+    // ── Aliases work identically ───────────────────────────────────
+
+    #[test]
+    fn speed_alias_works() {
         let speed = TempoAwareSpeed::Fixed(2.5);
         assert!((speed.to_cycles_per_second(None, Duration::ZERO) - 2.5).abs() < 1e-9);
     }
 
-    // ── TempoAwareSpeed — Seconds ──────────────────────────────────
-
     #[test]
-    fn speed_seconds() {
-        let speed = TempoAwareSpeed::Seconds(4.0);
-        // 1 cycle per 4 seconds = 0.25 cps
-        assert!((speed.to_cycles_per_second(None, Duration::ZERO) - 0.25).abs() < 1e-9);
-    }
-
-    #[test]
-    fn speed_seconds_zero() {
-        let speed = TempoAwareSpeed::Seconds(0.0);
-        assert_eq!(speed.to_cycles_per_second(None, Duration::ZERO), 0.0);
-    }
-
-    // ── TempoAwareSpeed — Beats (no tempo map → fallback 120 BPM) ─
-
-    #[test]
-    fn speed_beats_no_tempo_map() {
-        // 1 beat at 120 BPM = 0.5 seconds → rate = 2.0 cps
-        let speed = TempoAwareSpeed::Beats(1.0);
-        let cps = speed.to_cycles_per_second(None, Duration::ZERO);
-        assert!((cps - 2.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn speed_beats_two_beats_no_tempo_map() {
-        // 2 beats at 120 BPM = 1.0 second → rate = 1.0 cps
-        let speed = TempoAwareSpeed::Beats(2.0);
-        let cps = speed.to_cycles_per_second(None, Duration::ZERO);
-        assert!((cps - 1.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn speed_beats_zero() {
-        let speed = TempoAwareSpeed::Beats(0.0);
-        assert_eq!(speed.to_cycles_per_second(None, Duration::ZERO), 0.0);
-    }
-
-    #[test]
-    fn speed_beats_negative() {
-        let speed = TempoAwareSpeed::Beats(-1.0);
-        assert_eq!(speed.to_cycles_per_second(None, Duration::ZERO), 0.0);
-    }
-
-    // ── TempoAwareSpeed — Measures (no tempo map → fallback) ──────
-
-    #[test]
-    fn speed_measures_no_tempo_map() {
-        // 1 measure = 4 beats at 120 BPM = 2.0 seconds → rate = 0.5 cps
-        let speed = TempoAwareSpeed::Measures(1.0);
-        let cps = speed.to_cycles_per_second(None, Duration::ZERO);
-        assert!((cps - 0.5).abs() < 1e-9);
-    }
-
-    #[test]
-    fn speed_measures_zero() {
-        let speed = TempoAwareSpeed::Measures(0.0);
-        assert_eq!(speed.to_cycles_per_second(None, Duration::ZERO), 0.0);
-    }
-
-    #[test]
-    fn speed_measures_negative() {
-        let speed = TempoAwareSpeed::Measures(-1.0);
-        assert_eq!(speed.to_cycles_per_second(None, Duration::ZERO), 0.0);
-    }
-
-    // ── TempoAwareFrequency — Fixed ────────────────────────────────
-
-    #[test]
-    fn freq_fixed() {
+    fn frequency_alias_works() {
         let freq = TempoAwareFrequency::Fixed(10.0);
         assert!((freq.to_hz(None, Duration::ZERO) - 10.0).abs() < 1e-9);
     }
 
-    // ── TempoAwareFrequency — Seconds ──────────────────────────────
+    // ── TempoAwareValue with TempoMap ──────────────────────────────
 
     #[test]
-    fn freq_seconds() {
-        let freq = TempoAwareFrequency::Seconds(0.5);
-        // 1 / 0.5 = 2.0 Hz
-        assert!((freq.to_hz(None, Duration::ZERO) - 2.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn freq_seconds_zero() {
-        let freq = TempoAwareFrequency::Seconds(0.0);
-        assert_eq!(freq.to_hz(None, Duration::ZERO), 0.0);
-    }
-
-    // ── TempoAwareFrequency — Beats (no tempo map) ─────────────────
-
-    #[test]
-    fn freq_beats_no_tempo_map() {
-        // 1 beat at 120 BPM = 0.5s → 2.0 Hz
-        let freq = TempoAwareFrequency::Beats(1.0);
-        let hz = freq.to_hz(None, Duration::ZERO);
-        assert!((hz - 2.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn freq_beats_zero() {
-        let freq = TempoAwareFrequency::Beats(0.0);
-        assert_eq!(freq.to_hz(None, Duration::ZERO), 0.0);
-    }
-
-    // ── TempoAwareFrequency — Measures (no tempo map) ──────────────
-
-    #[test]
-    fn freq_measures_no_tempo_map() {
-        // 1 measure = 4 beats at 120 BPM = 2.0s → 0.5 Hz
-        let freq = TempoAwareFrequency::Measures(1.0);
-        let hz = freq.to_hz(None, Duration::ZERO);
-        assert!((hz - 0.5).abs() < 1e-9);
-    }
-
-    #[test]
-    fn freq_measures_zero() {
-        let freq = TempoAwareFrequency::Measures(0.0);
-        assert_eq!(freq.to_hz(None, Duration::ZERO), 0.0);
-    }
-
-    // ── TempoAwareSpeed with TempoMap ──────────────────────────────
-
-    #[test]
-    fn speed_beats_with_tempo_map() {
+    fn value_beats_with_tempo_map() {
         use crate::lighting::tempo::{TempoMap, TimeSignature};
         let tm = TempoMap::new(Duration::ZERO, 90.0, TimeSignature::new(4, 4), vec![]);
-        // 1 beat at 90 BPM = 60/90 = 0.667s → rate ≈ 1.5 cps
-        let speed = TempoAwareSpeed::Beats(1.0);
-        let cps = speed.to_cycles_per_second(Some(&tm), Duration::ZERO);
-        assert!((cps - 1.5).abs() < 0.01);
+        // 1 beat at 90 BPM = 60/90 = 0.667s -> rate ~ 1.5
+        let val = TempoAwareValue::Beats(1.0);
+        let rate = val.to_rate(Some(&tm), Duration::ZERO);
+        assert!((rate - 1.5).abs() < 0.01);
     }
 
     #[test]
-    fn speed_measures_with_tempo_map() {
+    fn value_measures_with_tempo_map() {
         use crate::lighting::tempo::{TempoMap, TimeSignature};
         let tm = TempoMap::new(Duration::ZERO, 60.0, TimeSignature::new(4, 4), vec![]);
-        // 1 measure = 4 beats at 60 BPM = 4.0s → rate = 0.25 cps
-        let speed = TempoAwareSpeed::Measures(1.0);
-        let cps = speed.to_cycles_per_second(Some(&tm), Duration::ZERO);
-        assert!((cps - 0.25).abs() < 0.01);
+        // 1 measure = 4 beats at 60 BPM = 4.0s -> rate = 0.25
+        let val = TempoAwareValue::Measures(1.0);
+        let rate = val.to_rate(Some(&tm), Duration::ZERO);
+        assert!((rate - 0.25).abs() < 0.01);
     }
 
     #[test]
-    fn freq_beats_with_tempo_map() {
+    fn value_beats_with_tempo_map_via_hz() {
         use crate::lighting::tempo::{TempoMap, TimeSignature};
         let tm = TempoMap::new(Duration::ZERO, 60.0, TimeSignature::new(4, 4), vec![]);
-        // 1 beat at 60 BPM = 1.0s → 1.0 Hz
+        // 1 beat at 60 BPM = 1.0s -> 1.0 Hz
         let freq = TempoAwareFrequency::Beats(1.0);
         let hz = freq.to_hz(Some(&tm), Duration::ZERO);
         assert!((hz - 1.0).abs() < 0.01);

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -311,7 +311,7 @@ impl EffectEngine {
         &mut self,
         dt: Duration,
         song_time: Option<Duration>,
-    ) -> Result<Vec<DmxCommand>, EffectError> {
+    ) -> Result<&[DmxCommand], EffectError> {
         self.update_subphase.store(10, Ordering::Relaxed);
         self.current_time += dt;
         self.engine_elapsed += dt;
@@ -331,7 +331,7 @@ impl EffectEngine {
             // Unchanged since last frame — return cached commands.
             if store_gen == self.last_store_generation {
                 self.update_subphase.store(0, Ordering::Relaxed);
-                return Ok(self.cached_commands.clone());
+                return Ok(&self.cached_commands);
             }
 
             // Store changed — rebuild commands directly from store (no intermediate
@@ -369,10 +369,10 @@ impl EffectEngine {
                 }
             }
 
-            self.cached_commands.clone_from(&commands);
+            self.cached_commands = commands;
             self.last_store_generation = store_gen;
             self.update_subphase.store(0, Ordering::Relaxed);
-            return Ok(commands);
+            return Ok(&self.cached_commands);
         }
 
         // Cache-only fast path: effects existed previously but are now done,
@@ -386,7 +386,7 @@ impl EffectEngine {
                 .unwrap_or(0);
             if store_gen == self.last_store_generation {
                 self.update_subphase.store(0, Ordering::Relaxed);
-                return Ok(self.cached_commands.clone());
+                return Ok(&self.cached_commands);
             }
         }
 
@@ -637,7 +637,7 @@ impl EffectEngine {
 
         // Cache commands and store generation for fast-path short-circuit on
         // subsequent frames where nothing changes.
-        self.cached_commands = commands.clone();
+        self.cached_commands = commands;
         self.last_store_generation = self
             .midi_dmx_store
             .as_ref()
@@ -646,7 +646,7 @@ impl EffectEngine {
         self.cache_dirty = false;
 
         self.update_subphase.store(0, Ordering::Relaxed);
-        Ok(commands)
+        Ok(&self.cached_commands)
     }
 
     /// Stop all active effects

--- a/src/lighting/engine/tests/chase_tests.rs
+++ b/src/lighting/engine/tests/chase_tests.rs
@@ -67,7 +67,7 @@ fn test_chase_fixture_boundaries() {
     // At t=0ms: first fixture should be active (pattern_index = 0)
     let commands = engine.update(Duration::from_millis(0), None).unwrap();
     assert_eq!(
-        count_active(&commands),
+        count_active(commands),
         1,
         "At t=0ms exactly one fixture should be active"
     );
@@ -75,7 +75,7 @@ fn test_chase_fixture_boundaries() {
     // At t=350ms: second fixture should be active (past 333.33ms)
     let commands = engine.update(Duration::from_millis(350), None).unwrap();
     assert_eq!(
-        count_active(&commands),
+        count_active(commands),
         1,
         "At t=350ms exactly one fixture should be active"
     );
@@ -83,7 +83,7 @@ fn test_chase_fixture_boundaries() {
     // At t=700ms: third fixture should be active (past 666.66ms)
     let commands = engine.update(Duration::from_millis(350), None).unwrap();
     assert_eq!(
-        count_active(&commands),
+        count_active(commands),
         1,
         "At t=700ms exactly one fixture should be active"
     );
@@ -91,7 +91,7 @@ fn test_chase_fixture_boundaries() {
     // At t=1050ms: should wrap back (past 1000ms)
     let commands = engine.update(Duration::from_millis(350), None).unwrap();
     assert_eq!(
-        count_active(&commands),
+        count_active(commands),
         1,
         "At t=1050ms exactly one fixture should be active (wrapped)"
     );

--- a/src/lighting/engine/tests/chase_tests.rs
+++ b/src/lighting/engine/tests/chase_tests.rs
@@ -233,7 +233,7 @@ fn test_chase_effect() {
     assert!(commands.len() >= 3);
 
     // All commands should be for dimmer channels (but may be on different DMX addresses)
-    for cmd in &commands {
+    for cmd in commands {
         // The chase effect generates commands for different DMX addresses
         // but all should be for the dimmer channel (channel 1 relative to fixture address)
         assert!(cmd.channel >= 1 && cmd.channel <= 15); // Within reasonable DMX range

--- a/src/lighting/engine/tests/layer_commands_tests.rs
+++ b/src/lighting/engine/tests/layer_commands_tests.rs
@@ -115,9 +115,18 @@ fn test_freeze_unfreeze_layer() {
     assert!(engine.is_layer_frozen(EffectLayer::Background));
 
     // Update multiple times - the values should stay the same while frozen
-    let commands_frozen1 = engine.update(Duration::from_millis(100), None).unwrap();
-    let commands_frozen2 = engine.update(Duration::from_millis(100), None).unwrap();
-    let commands_frozen3 = engine.update(Duration::from_millis(500), None).unwrap();
+    let commands_frozen1 = engine
+        .update(Duration::from_millis(100), None)
+        .unwrap()
+        .to_vec();
+    let commands_frozen2 = engine
+        .update(Duration::from_millis(100), None)
+        .unwrap()
+        .to_vec();
+    let commands_frozen3 = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
 
     assert!(!commands_frozen1.is_empty());
     assert!(!commands_frozen2.is_empty());
@@ -148,8 +157,14 @@ fn test_freeze_unfreeze_layer() {
     assert!(!engine.is_layer_frozen(EffectLayer::Background));
 
     // After unfreezing, the effect should resume and values should change
-    let commands_after1 = engine.update(Duration::from_millis(100), None).unwrap();
-    let commands_after2 = engine.update(Duration::from_millis(200), None).unwrap();
+    let commands_after1 = engine
+        .update(Duration::from_millis(100), None)
+        .unwrap()
+        .to_vec();
+    let commands_after2 = engine
+        .update(Duration::from_millis(200), None)
+        .unwrap()
+        .to_vec();
 
     assert!(!commands_after1.is_empty());
     assert!(!commands_after2.is_empty());
@@ -468,8 +483,14 @@ fn test_speed_master_affects_effect_progression() {
 
     // With speed = 0, elapsed time stays at same effective position
     // So values should stay similar
-    let cmd2 = engine.update(Duration::from_millis(500), None).unwrap();
-    let cmd3 = engine.update(Duration::from_millis(500), None).unwrap();
+    let cmd2 = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
+    let cmd3 = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
 
     assert!(!cmd2.is_empty());
     assert!(!cmd3.is_empty());
@@ -526,8 +547,14 @@ fn test_speed_master_resume_from_zero() {
     engine.set_layer_speed_master(EffectLayer::Background, 1.0);
 
     // The effect should now progress from where it was frozen
-    let resume_cmd1 = engine.update(Duration::from_millis(100), None).unwrap();
-    let resume_cmd2 = engine.update(Duration::from_millis(100), None).unwrap();
+    let resume_cmd1 = engine
+        .update(Duration::from_millis(100), None)
+        .unwrap()
+        .to_vec();
+    let resume_cmd2 = engine
+        .update(Duration::from_millis(100), None)
+        .unwrap()
+        .to_vec();
 
     // After resuming, values should change (effect is running again)
     // We can't predict exact values due to sinusoidal pulse, but they should differ

--- a/src/lighting/engine/tests/seeking_tests.rs
+++ b/src/lighting/engine/tests/seeking_tests.rs
@@ -162,7 +162,7 @@ fn test_start_effect_with_elapsed_color_cycle() {
     let mut red = 0;
     let mut green = 0;
     let mut blue = 0;
-    for cmd in &commands {
+    for cmd in commands {
         if cmd.channel == 2 {
             red = cmd.value;
         } else if cmd.channel == 3 {
@@ -251,7 +251,7 @@ fn test_start_effect_with_elapsed_rainbow() {
     let mut red = 0;
     let mut green = 0;
     let mut blue = 0;
-    for cmd in &commands {
+    for cmd in commands {
         if cmd.channel == 2 {
             red = cmd.value;
         } else if cmd.channel == 3 {
@@ -322,7 +322,10 @@ fn test_start_effect_with_elapsed_zero_elapsed() {
     );
 
     engine.start_effect(effect1).unwrap();
-    let commands1 = engine.update(Duration::from_millis(16), None).unwrap();
+    let commands1 = engine
+        .update(Duration::from_millis(16), None)
+        .unwrap()
+        .to_vec();
 
     // Reset and try with zero elapsed
     engine.stop_all_effects();

--- a/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
+++ b/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
@@ -520,15 +520,24 @@ fn test_freeze_unfreeze_multiple_effects_same_layer() {
 
     // Let effects run
     let _commands1 = engine.update(Duration::from_millis(200), None).unwrap();
-    let commands_before = engine.update(Duration::from_millis(10), None).unwrap();
+    let commands_before = engine
+        .update(Duration::from_millis(10), None)
+        .unwrap()
+        .to_vec();
 
     // Freeze the layer
     engine.freeze_layer(EffectLayer::Background);
     assert!(engine.is_layer_frozen(EffectLayer::Background));
 
     // Update multiple times - values should stay frozen
-    let commands_frozen1 = engine.update(Duration::from_millis(500), None).unwrap();
-    let commands_frozen2 = engine.update(Duration::from_millis(500), None).unwrap();
+    let commands_frozen1 = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
+    let commands_frozen2 = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
 
     // Frozen commands should match (or be very close due to rounding)
     // Sort by channel for comparison

--- a/src/lighting/engine/tests/utility_and_edge_cases_tests.rs
+++ b/src/lighting/engine/tests/utility_and_edge_cases_tests.rs
@@ -653,9 +653,18 @@ fn test_update_multiple_times_sequential() {
     engine.start_effect(effect).unwrap();
 
     // Multiple sequential updates should work
-    let commands1 = engine.update(Duration::from_millis(16), None).unwrap();
-    let commands2 = engine.update(Duration::from_millis(16), None).unwrap();
-    let commands3 = engine.update(Duration::from_millis(16), None).unwrap();
+    let commands1 = engine
+        .update(Duration::from_millis(16), None)
+        .unwrap()
+        .to_vec();
+    let commands2 = engine
+        .update(Duration::from_millis(16), None)
+        .unwrap()
+        .to_vec();
+    let commands3 = engine
+        .update(Duration::from_millis(16), None)
+        .unwrap()
+        .to_vec();
 
     // All should produce commands
     assert!(!commands1.is_empty());

--- a/src/lighting/layering_tests/chase_tests.rs
+++ b/src/lighting/layering_tests/chase_tests.rs
@@ -700,7 +700,7 @@ fn test_random_chase_pattern_visibility() {
 
         // Track which fixtures have non-zero values (active)
         // For PixelBrick, red channel is at address, green at address+1, blue at address+2
-        for cmd in &cmds {
+        for cmd in cmds {
             if cmd.value > 0 {
                 // Find which fixture this command belongs to
                 for i in 1..=8 {

--- a/src/lighting/layering_tests/dimmer_tests.rs
+++ b/src/lighting/layering_tests/dimmer_tests.rs
@@ -451,7 +451,7 @@ fn test_dimmer_precedence_and_selective_dimming() {
     let commands = engine.update(Duration::from_millis(0), None).unwrap();
 
     println!("Commands: {:?}", commands);
-    for cmd in &commands {
+    for cmd in commands {
         let channel_name = match cmd.channel {
             1 => "Red",
             2 => "Green",
@@ -497,7 +497,7 @@ fn test_dimmer_precedence_and_selective_dimming() {
             .unwrap();
         previous_time = time_ms;
         println!("\n  At {} ({}ms):", description, time_ms);
-        for cmd in &commands {
+        for cmd in commands {
             let channel_name = match cmd.channel {
                 1 => "Red",
                 2 => "Green",
@@ -598,7 +598,7 @@ fn test_dimmer_debug() {
     let commands = engine.update(Duration::from_millis(16), None).unwrap();
 
     println!("Commands at start:");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -607,7 +607,7 @@ fn test_dimmer_debug() {
     let commands = engine.update(Duration::from_millis(16), None).unwrap();
 
     println!("Commands at middle (should be dimmed blue):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -692,7 +692,7 @@ fn test_static_with_dimmer_parameter() {
     // Check what the static effect produces
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("Static effect with dimmer parameter:");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -715,7 +715,7 @@ fn test_static_with_dimmer_parameter() {
     // Check what happens with the dimmer effect
     let commands = engine.update(Duration::from_secs(500), None).unwrap(); // 50% through dimmer
     println!("\nWith dimmer effect (50% through):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -793,7 +793,7 @@ fn test_dimmer_replace_vs_multiply() {
     let commands = engine.update(Duration::from_millis(16), None).unwrap();
 
     println!("Commands with Replace blend mode:");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -839,7 +839,7 @@ fn test_dimmer_replace_vs_multiply() {
     let commands = engine2.update(Duration::from_millis(16), None).unwrap();
 
     println!("Commands with Multiply blend mode:");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -920,7 +920,7 @@ fn test_astera_pixelblock_dimmer() {
     let commands = engine.update(Duration::from_millis(16), None).unwrap();
 
     println!("Commands with Astera PixelBlock fixture:");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -962,7 +962,7 @@ fn test_astera_pixelblock_dimmer() {
     let commands = engine2.update(Duration::from_millis(16), None).unwrap();
 
     println!("Commands with Replace blend mode:");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -1282,7 +1282,7 @@ fn test_multiple_dimmer_fade_to_black() {
     let final_commands = engine.update(Duration::from_millis(2000), None).unwrap();
     // Dimmers persist at 0.0, so dimmer channels should be 0
     // (or no commands if fixtures have no RGB to emit)
-    for cmd in &final_commands {
+    for cmd in final_commands {
         assert_eq!(cmd.value, 0, "Dimmer should persist at 0 after completion");
     }
 

--- a/src/lighting/layering_tests/integration_tests.rs
+++ b/src/lighting/layering_tests/integration_tests.rs
@@ -90,7 +90,7 @@ fn test_layering_demo() {
         if (time * 5.0) as i32 % 2 == 0 {
             println!("Time: {:.1}s", time);
 
-            for cmd in &commands {
+            for cmd in commands {
                 let channel_name = match cmd.channel {
                     1 => "Red",
                     2 => "Green",
@@ -174,7 +174,7 @@ fn test_multiple_effects_simultaneous() {
     // Check at 0s
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("=== At 0s (Static blue on 4 fixtures) ===");
-    for cmd in &commands {
+    for cmd in commands {
         let fixture_num = ((cmd.channel - 1) / 4) + 1;
         let channel_in_fixture = ((cmd.channel - 1) % 4) + 1;
         let channel_name = match channel_in_fixture {
@@ -214,7 +214,7 @@ fn test_multiple_effects_simultaneous() {
     // Check at 2s (dimmer start)
     let commands = engine.update(Duration::from_secs(2), None).unwrap();
     println!("\n=== At 2s (Dimmer starts on 4 fixtures) ===");
-    for cmd in &commands {
+    for cmd in commands {
         let fixture_num = ((cmd.channel - 1) / 4) + 1;
         let channel_in_fixture = ((cmd.channel - 1) % 4) + 1;
         let channel_name = match channel_in_fixture {
@@ -232,7 +232,10 @@ fn test_multiple_effects_simultaneous() {
 
     // Check at 4.5s (50% through dimmer)
     engine.update(Duration::from_secs(2), None).unwrap();
-    let commands = engine.update(Duration::from_secs(0), None).unwrap();
+    let commands = engine
+        .update(Duration::from_secs(0), None)
+        .unwrap()
+        .to_vec();
     println!("\n=== At 4.5s (50% through dimmer on 4 fixtures) ===");
 
     // Advance to 25s to trigger debug logging
@@ -240,7 +243,7 @@ fn test_multiple_effects_simultaneous() {
     let commands_25s = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\n=== At 25s (Debug logging should appear) ===");
     println!("Commands at 25s: {} commands", commands_25s.len());
-    for cmd in &commands_25s {
+    for cmd in commands_25s {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
     for cmd in &commands {
@@ -365,7 +368,7 @@ fn test_astera_pixelblock_real_behavior() {
     // Check at 0s
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\n=== At 0s (Static blue) ===");
-    for cmd in &commands {
+    for cmd in commands {
         let channel_name = match cmd.channel {
             1 => "Red",
             2 => "Green",
@@ -397,7 +400,7 @@ fn test_astera_pixelblock_real_behavior() {
     // Check at 2s (dimmer start)
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\n=== At 2s (Dimmer starts) ===");
-    for cmd in &commands {
+    for cmd in commands {
         let channel_name = match cmd.channel {
             1 => "Red",
             2 => "Green",
@@ -412,7 +415,7 @@ fn test_astera_pixelblock_real_behavior() {
     engine.update(Duration::from_secs(2), None).unwrap();
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\n=== At 4.5s (50% through dimmer) ===");
-    for cmd in &commands {
+    for cmd in commands {
         let channel_name = match cmd.channel {
             1 => "Red",
             2 => "Green",
@@ -524,7 +527,7 @@ fn test_permanent_vs_temporary_effects() {
     let commands = engine.update(Duration::from_secs(1), None).unwrap();
 
     println!("Testing permanent effect behavior:");
-    for cmd in &commands {
+    for cmd in commands {
         let channel_name = match cmd.channel {
             1 => "Dimmer",
             2 => "Red",
@@ -637,7 +640,7 @@ fn test_grandma_style_fade_out() {
     // Test during fade-out
     let commands_1s = engine.update(Duration::from_secs(1), None).unwrap();
     println!("\nAt 1s (50% through fade-out):");
-    for cmd in &commands_1s {
+    for cmd in commands_1s {
         let channel_name = match cmd.channel {
             1 => "Dimmer",
             2 => "Red",
@@ -656,7 +659,7 @@ fn test_grandma_style_fade_out() {
     // Test at end of fade-out
     let commands_2s = engine.update(Duration::from_secs(1), None).unwrap();
     println!("\nAt 2s (end of fade-out):");
-    for cmd in &commands_2s {
+    for cmd in commands_2s {
         let channel_name = match cmd.channel {
             1 => "Dimmer",
             2 => "Red",
@@ -675,7 +678,7 @@ fn test_grandma_style_fade_out() {
     // Test after fade-out (should stay at 0 - grandMA behavior)
     let commands_3s = engine.update(Duration::from_secs(1), None).unwrap();
     println!("\nAt 3s (after fade-out - should stay at 0):");
-    for cmd in &commands_3s {
+    for cmd in commands_3s {
         let channel_name = match cmd.channel {
             1 => "Dimmer",
             2 => "Red",
@@ -793,7 +796,7 @@ fn test_real_layering_show_file() {
     // At 0 seconds - should have static blue
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("At 0s (static blue):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -801,7 +804,7 @@ fn test_real_layering_show_file() {
     engine.update(Duration::from_secs(2), None).unwrap();
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\nAt 2s (static blue + dimmer start):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -809,7 +812,7 @@ fn test_real_layering_show_file() {
     engine.update(Duration::from_secs(2), None).unwrap();
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\nAt 4.5s (50% through dimmer):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -918,7 +921,7 @@ fn test_layering_show_effect_execution() {
     // At 0 seconds - should have static blue
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("At 0s (static blue):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -926,7 +929,7 @@ fn test_layering_show_effect_execution() {
     engine.update(Duration::from_secs(2), None).unwrap();
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\nAt 2s (static blue + dimmer start):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -934,7 +937,7 @@ fn test_layering_show_effect_execution() {
     engine.update(Duration::from_secs(2), None).unwrap();
     let commands = engine.update(Duration::from_secs(0), None).unwrap();
     println!("\nAt 4.5s (50% through dimmer):");
-    for cmd in &commands {
+    for cmd in commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
     }
 
@@ -1007,7 +1010,7 @@ fn test_custom_rgb_dimming() {
     let commands = engine.update(Duration::from_millis(0), None).unwrap();
 
     println!("Commands: {:?}", commands);
-    for cmd in &commands {
+    for cmd in commands {
         let channel_name = match cmd.channel {
             1 => "Red",
             2 => "Green",
@@ -1048,7 +1051,7 @@ fn test_custom_rgb_dimming() {
             .unwrap();
         println!("\n  At {} ({}ms):", description, time_ms);
         last_time = time_ms;
-        for cmd in &commands {
+        for cmd in commands {
             let channel_name = match cmd.channel {
                 1 => "Red",
                 2 => "Green",
@@ -1538,7 +1541,7 @@ fn test_full_layering_show_sequence_with_replace() {
     // Check state before fade-out
     println!("\nAt 25s (before fade-out):");
     let commands = engine.update(Duration::from_secs(25), None).unwrap();
-    for cmd in &commands {
+    for cmd in commands {
         let fixture = if cmd.channel <= 4 {
             "front_wash"
         } else {
@@ -1612,7 +1615,7 @@ fn test_full_layering_show_sequence_with_replace() {
         let commands = engine.update(Duration::from_millis(time_ms), None).unwrap();
         println!("\nAt {} ({}ms):", description, time_ms);
 
-        for cmd in &commands {
+        for cmd in commands {
             let fixture = if cmd.channel <= 4 {
                 "front_wash"
             } else {

--- a/src/lighting/layering_tests/static_effect_tests.rs
+++ b/src/lighting/layering_tests/static_effect_tests.rs
@@ -83,7 +83,10 @@ fn test_static_replace_blend_mode() {
     engine.start_effect(static_effect).unwrap();
 
     // Check what the static effect produces
-    let commands = engine.update(Duration::from_secs(0), None).unwrap();
+    let commands = engine
+        .update(Duration::from_secs(0), None)
+        .unwrap()
+        .to_vec();
     println!("Static effect with replace blend mode:");
     for cmd in &commands {
         println!("  Channel {}: {}", cmd.channel, cmd.value);
@@ -153,9 +156,12 @@ fn test_static_effect_timing() {
     // Let it run for a bit
     engine.update(Duration::from_secs(1), None).unwrap();
 
-    let commands_1s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_1s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("Indefinite static at 1s:");
-    for cmd in &commands_1s {
+    for cmd in commands_1s {
         let channel_name = match cmd.channel {
             1 => "Red",
             2 => "Green",
@@ -194,7 +200,10 @@ fn test_static_effect_timing() {
     engine.start_effect(timed_static.clone()).unwrap();
 
     // Test at various times
-    let commands_1s_timed = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_1s_timed = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nTimed static at 1s (should be green):");
     for cmd in &commands_1s_timed {
         let channel_name = match cmd.channel {
@@ -211,7 +220,10 @@ fn test_static_effect_timing() {
         );
     }
 
-    let commands_4s = engine.update(Duration::from_secs(3), None).unwrap();
+    let commands_4s = engine
+        .update(Duration::from_secs(3), None)
+        .unwrap()
+        .to_vec();
     println!("\nTimed static at 4s (should be no commands - timed static ended, indefinite static was stopped):");
     println!("Active effects count: {}", engine.active_effects_count());
     for cmd in &commands_4s {
@@ -303,7 +315,10 @@ fn test_static_effect_with_up_time() {
     engine.start_effect(static_effect).unwrap();
 
     // Test at various times during fade-in
-    let commands_0s = engine.update(Duration::from_secs(0), None).unwrap();
+    let commands_0s = engine
+        .update(Duration::from_secs(0), None)
+        .unwrap()
+        .to_vec();
     println!("Static with up_time at 0s (should be off):");
     for cmd in &commands_0s {
         let channel_name = match cmd.channel {
@@ -321,7 +336,10 @@ fn test_static_effect_with_up_time() {
         );
     }
 
-    let commands_1s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_1s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with up_time at 1s (should be 50%):");
     for cmd in &commands_1s {
         let channel_name = match cmd.channel {
@@ -339,7 +357,10 @@ fn test_static_effect_with_up_time() {
         );
     }
 
-    let commands_2s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_2s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with up_time at 2s (should be 100%):");
     for cmd in &commands_2s {
         let channel_name = match cmd.channel {
@@ -357,7 +378,10 @@ fn test_static_effect_with_up_time() {
         );
     }
 
-    let commands_3s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_3s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with up_time at 3s (should still be 100%):");
     for cmd in &commands_3s {
         let channel_name = match cmd.channel {
@@ -453,7 +477,10 @@ fn test_static_effect_with_down_time() {
     engine.start_effect(static_effect.clone()).unwrap();
 
     // Test at various times during the effect
-    let commands_0s = engine.update(Duration::from_secs(0), None).unwrap();
+    let commands_0s = engine
+        .update(Duration::from_secs(0), None)
+        .unwrap()
+        .to_vec();
     println!("Static with down_time at 0s (should be off):");
     for cmd in &commands_0s {
         let channel_name = match cmd.channel {
@@ -471,7 +498,10 @@ fn test_static_effect_with_down_time() {
         );
     }
 
-    let commands_0_5s = engine.update(Duration::from_millis(500), None).unwrap();
+    let commands_0_5s = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 0.5s (should be 50% fade in):");
     for cmd in &commands_0_5s {
         let channel_name = match cmd.channel {
@@ -489,7 +519,10 @@ fn test_static_effect_with_down_time() {
         );
     }
 
-    let commands_1s = engine.update(Duration::from_millis(500), None).unwrap();
+    let commands_1s = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 1s (should be 100% - fade in complete):");
     for cmd in &commands_1s {
         let channel_name = match cmd.channel {
@@ -507,7 +540,10 @@ fn test_static_effect_with_down_time() {
         );
     }
 
-    let commands_2s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_2s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 2s (should be 100% - hold phase):");
     for cmd in &commands_2s {
         let channel_name = match cmd.channel {
@@ -525,7 +561,10 @@ fn test_static_effect_with_down_time() {
         );
     }
 
-    let commands_3s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_3s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 3s (should be 100% - end of hold phase):");
     for cmd in &commands_3s {
         let channel_name = match cmd.channel {
@@ -544,7 +583,10 @@ fn test_static_effect_with_down_time() {
     }
 
     // Test at 3.5s (middle of fade-out phase)
-    let commands_3_5s = engine.update(Duration::from_millis(500), None).unwrap();
+    let commands_3_5s = engine
+        .update(Duration::from_millis(500), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 3.5s (should be 75% - fade out phase):");
     for cmd in &commands_3_5s {
         let channel_name = match cmd.channel {
@@ -562,7 +604,10 @@ fn test_static_effect_with_down_time() {
         );
     }
 
-    let commands_4s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_4s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 4s (should be 50% - middle of fade out):");
     for cmd in &commands_4s {
         let channel_name = match cmd.channel {
@@ -580,7 +625,10 @@ fn test_static_effect_with_down_time() {
         );
     }
 
-    let commands_5s = engine.update(Duration::from_secs(1), None).unwrap();
+    let commands_5s = engine
+        .update(Duration::from_secs(1), None)
+        .unwrap()
+        .to_vec();
     println!("\nStatic with down_time at 5s (should be 0% - effect ended):");
     for cmd in &commands_5s {
         let channel_name = match cmd.channel {
@@ -723,10 +771,13 @@ fn test_static_effect_fade_out() {
         (1500, "75%"),
         (2000, "End"),
     ] {
-        let commands = engine.update(Duration::from_millis(time_ms), None).unwrap();
+        let commands = engine
+            .update(Duration::from_millis(time_ms), None)
+            .unwrap()
+            .to_vec();
         println!("\nAt {} ({}ms):", description, time_ms);
 
-        for cmd in &commands {
+        for cmd in commands {
             let channel_name = match cmd.channel {
                 1 => "Dimmer",
                 2 => "Red",
@@ -744,7 +795,10 @@ fn test_static_effect_fade_out() {
     }
 
     // Verify the behavior
-    let final_commands = engine.update(Duration::from_millis(2000), None).unwrap();
+    let final_commands = engine
+        .update(Duration::from_millis(2000), None)
+        .unwrap()
+        .to_vec();
     assert!(final_commands.is_empty(), "Effect should have ended at 2s");
 
     println!("✅ Static effect fade-out test completed");

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -22,7 +22,7 @@ use super::super::effects::{
 };
 use super::super::tempo::TempoMap;
 use super::grammar::Rule;
-use super::types::Effect;
+use super::types::{Effect, ParseContext};
 use super::utils::{
     parse_color_string, parse_duration_string, parse_frequency_string, parse_percentage_to_f64,
     parse_speed_string,
@@ -61,13 +61,14 @@ fn clean_string_value(value: &str) -> String {
 
 pub(crate) fn parse_effect_definition(
     pair: Pair<Rule>,
-    tempo_map: &Option<TempoMap>,
-    cue_time: Duration,
-    offset_secs: f64,
-    unshifted_score_time: Option<Duration>,
-    score_measure: Option<u32>,
-    measure_offset: u32,
+    ctx: &ParseContext,
 ) -> Result<Effect, Box<dyn Error>> {
+    let tempo_map = &ctx.tempo_map;
+    let cue_time = ctx.cue_time;
+    let offset_secs = ctx.offset_secs;
+    let unshifted_score_time = ctx.unshifted_score_time;
+    let score_measure = ctx.score_measure;
+    let measure_offset = ctx.measure_offset;
     let mut groups = Vec::new();
     let mut effect_type = EffectType::Static {
         parameters: HashMap::new(),
@@ -256,14 +257,8 @@ pub(crate) fn parse_effect_definition(
     }
 
     // Apply parameters to the effect type
-    let final_effect_type = apply_parameters_to_effect_type(
-        effect_type,
-        &parameters,
-        &color_parameters,
-        tempo_map,
-        cue_time,
-        offset_secs,
-    )?;
+    let final_effect_type =
+        apply_parameters_to_effect_type(effect_type, &parameters, &color_parameters, ctx)?;
 
     // Validate that every effect has an explicit duration.
     // Dimmer always has a duration (defaults to 1s). For all other types,
@@ -306,10 +301,11 @@ pub(crate) fn apply_parameters_to_effect_type(
     mut effect_type: EffectType,
     parameters: &HashMap<String, String>,
     color_parameters: &[String],
-    tempo_map: &Option<TempoMap>,
-    cue_time: Duration,
-    offset_secs: f64,
+    ctx: &ParseContext,
 ) -> Result<EffectType, Box<dyn Error>> {
+    let tempo_map = &ctx.tempo_map;
+    let cue_time = ctx.cue_time;
+    let offset_secs = ctx.offset_secs;
     match &mut effect_type {
         EffectType::Static {
             parameters: static_params,
@@ -603,6 +599,18 @@ pub(crate) fn apply_parameters_to_effect_type(
 mod tests {
     use super::*;
 
+    /// Default ParseContext used by unit tests that don't need tempo/offset.
+    fn default_ctx() -> ParseContext {
+        ParseContext {
+            tempo_map: None,
+            cue_time: Duration::ZERO,
+            offset_secs: 0.0,
+            unshifted_score_time: None,
+            score_measure: None,
+            measure_offset: 0,
+        }
+    }
+
     // ── color_to_normalized_params ─────────────────────────────────
 
     #[test]
@@ -700,8 +708,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("dimmer".to_string(), "50%".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["dimmer"] - 0.5).abs() < 1e-9);
         } else {
@@ -717,8 +724,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("color".to_string(), "#FF8000".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["red"] - 1.0).abs() < 1e-9);
             assert!((parameters["green"] - 128.0 / 255.0).abs() < 1e-2);
@@ -738,8 +744,7 @@ mod tests {
         params.insert("red".to_string(), "100%".to_string());
         params.insert("green".to_string(), "50%".to_string());
         params.insert("blue".to_string(), "0%".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["red"] - 1.0).abs() < 1e-9);
             assert!((parameters["green"] - 0.5).abs() < 1e-9);
@@ -757,8 +762,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("duration".to_string(), "2s".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Static { duration, .. } = result {
             assert_eq!(duration, Duration::from_secs(2));
         } else {
@@ -778,15 +782,8 @@ mod tests {
             duration: Duration::ZERO,
         };
         let colors = vec!["red".to_string(), "#0000FF".to_string()];
-        let result = apply_parameters_to_effect_type(
-            et,
-            &HashMap::new(),
-            &colors,
-            &None,
-            Duration::ZERO,
-            0.0,
-        )
-        .unwrap();
+        let result =
+            apply_parameters_to_effect_type(et, &HashMap::new(), &colors, &default_ctx()).unwrap();
         if let EffectType::ColorCycle { colors, .. } = result {
             assert_eq!(colors.len(), 2);
             assert_eq!(colors[0].r, 255);
@@ -807,8 +804,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "backward".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::ColorCycle { direction, .. } = result {
             assert_eq!(direction, CycleDirection::Backward);
         } else {
@@ -827,8 +823,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("transition".to_string(), "crossfade".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::ColorCycle { transition, .. } = result {
             assert_eq!(transition, CycleTransition::Fade);
         } else {
@@ -846,8 +841,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("frequency".to_string(), "15.0".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Strobe { frequency, .. } = result {
             assert_eq!(frequency, TempoAwareFrequency::Fixed(15.0));
         } else {
@@ -863,8 +857,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("rate".to_string(), "20.0".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Strobe { frequency, .. } = result {
             assert_eq!(frequency, TempoAwareFrequency::Fixed(20.0));
         } else {
@@ -886,8 +879,7 @@ mod tests {
         params.insert("base_level".to_string(), "20%".to_string());
         params.insert("intensity".to_string(), "80%".to_string());
         params.insert("frequency".to_string(), "4.0".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Pulse {
             base_level,
             pulse_amplitude,
@@ -918,8 +910,7 @@ mod tests {
         params.insert("pattern".to_string(), "snake".to_string());
         params.insert("direction".to_string(), "clockwise".to_string());
         params.insert("transition".to_string(), "fade".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Chase {
             pattern,
             direction,
@@ -950,8 +941,7 @@ mod tests {
         params.insert("end".to_string(), "75%".to_string());
         params.insert("duration".to_string(), "3s".to_string());
         params.insert("curve".to_string(), "exponential".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Dimmer {
             start_level,
             end_level,
@@ -978,7 +968,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("curve".to_string(), "invalid_curve".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -996,8 +986,7 @@ mod tests {
         params.insert("saturation".to_string(), "80%".to_string());
         params.insert("brightness".to_string(), "60%".to_string());
         params.insert("speed".to_string(), "2.0".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Rainbow {
             speed,
             saturation,
@@ -1026,7 +1015,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "sideways".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1041,7 +1030,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "diagonal".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1056,7 +1045,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("transition".to_string(), "dissolve".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1072,8 +1061,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("curve".to_string(), "logarithmic".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Dimmer { curve, .. } = result {
             assert!(matches!(curve, DimmerCurve::Logarithmic));
         } else {
@@ -1094,8 +1082,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "pingpong".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::ColorCycle { direction, .. } = result {
             assert_eq!(direction, CycleDirection::PingPong);
         } else {
@@ -1116,8 +1103,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "right_to_left".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Chase { direction, .. } = result {
             assert!(matches!(direction, ChaseDirection::RightToLeft));
         } else {
@@ -1138,8 +1124,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("pattern".to_string(), "random".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Chase { pattern, .. } = result {
             assert!(matches!(pattern, ChasePattern::Random));
         } else {
@@ -1160,7 +1145,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("pattern".to_string(), "invalid_pattern".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1177,8 +1162,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("transition".to_string(), "crossfade".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Chase { transition, .. } = result {
             assert_eq!(transition, CycleTransition::Fade);
         } else {
@@ -1197,7 +1181,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("transition".to_string(), "wipe".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1212,8 +1196,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("custom_param".to_string(), "0.75".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["custom_param"] - 0.75).abs() < 1e-9);
         } else {
@@ -1234,8 +1217,7 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("start_level".to_string(), "30%".to_string());
         params.insert("end_level".to_string(), "90%".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Dimmer {
             start_level,
             end_level,
@@ -1261,8 +1243,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("duration".to_string(), "5s".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Pulse { duration, .. } = result {
             assert_eq!(duration, Duration::from_secs(5));
         } else {
@@ -1280,8 +1261,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("duration".to_string(), "3s".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Strobe { duration, .. } = result {
             assert_eq!(duration, Duration::from_secs(3));
         } else {
@@ -1302,8 +1282,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "2.5".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::ColorCycle { speed, .. } = result {
             assert_eq!(speed, TempoAwareSpeed::Fixed(2.5));
         } else {
@@ -1324,8 +1303,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "3.0".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Chase { speed, .. } = result {
             assert_eq!(speed, TempoAwareSpeed::Fixed(3.0));
         } else {
@@ -1346,7 +1324,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "not_a_number".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1361,7 +1339,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "invalid".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1375,7 +1353,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "bad".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1389,7 +1367,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("frequency".to_string(), "not_valid".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1403,7 +1381,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("frequency".to_string(), "xyz".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0);
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx());
         assert!(result.is_err());
     }
 
@@ -1419,8 +1397,7 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("pulse_amplitude".to_string(), "70%".to_string());
-        let result =
-            apply_parameters_to_effect_type(et, &params, &[], &None, Duration::ZERO, 0.0).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Pulse {
             pulse_amplitude, ..
         } = result

--- a/src/lighting/parser/show.rs
+++ b/src/lighting/parser/show.rs
@@ -22,7 +22,7 @@ use super::effect_parse::parse_effect_definition;
 use super::error::{analyze_parsing_failure, get_error_context};
 use super::grammar::{LightingParser, Rule};
 use super::tempo_parse::parse_tempo_definition;
-use super::types::{Cue, LayerCommand, LayerCommandType, LightShow, Sequence};
+use super::types::{Cue, LayerCommand, LayerCommandType, LightShow, ParseContext, Sequence};
 use super::types::{SequenceLoop, UnexpandedSequenceCue};
 use super::utils::{parse_measure_time, parse_time_string};
 use pest::iterators::Pair;
@@ -584,15 +584,15 @@ fn parse_sequence_cue_structure(
         None
     };
     for effect_pair in effect_pairs {
-        let effect = parse_effect_definition(
-            effect_pair,
-            tempo_map,
-            abs_time,
-            applied_offset_secs,
-            unshifted_for_effects,
+        let effect_ctx = ParseContext {
+            tempo_map: tempo_map.clone(),
+            cue_time: abs_time,
+            offset_secs: applied_offset_secs,
+            unshifted_score_time: unshifted_for_effects,
             score_measure,
-            cumulative_measure_offset,
-        )?;
+            measure_offset: cumulative_measure_offset,
+        };
+        let effect = parse_effect_definition(effect_pair, &effect_ctx)?;
         effects.push(effect);
     }
 
@@ -1308,20 +1308,20 @@ fn parse_cue_definition(
         let mut expanded_cues = Vec::new();
 
         // Parse effects and layer commands for the base cue
+        let seq_effect_ctx = ParseContext {
+            tempo_map: tempo_map.clone(),
+            cue_time: abs_time,
+            offset_secs: applied_offset_secs,
+            unshifted_score_time: if unshifted_score_time_seq != Duration::ZERO {
+                Some(unshifted_score_time_seq)
+            } else {
+                None
+            },
+            score_measure: score_measure_seq,
+            measure_offset: cumulative_measure_offset_seq,
+        };
         for effect_pair in effect_pairs {
-            let effect = parse_effect_definition(
-                effect_pair,
-                tempo_map,
-                abs_time,
-                applied_offset_secs,
-                if unshifted_score_time_seq != Duration::ZERO {
-                    Some(unshifted_score_time_seq)
-                } else {
-                    None
-                },
-                score_measure_seq,
-                cumulative_measure_offset_seq,
-            )?;
+            let effect = parse_effect_definition(effect_pair, &seq_effect_ctx)?;
             effects.push(effect);
         }
 
@@ -1492,20 +1492,20 @@ fn parse_cue_definition(
 
     // No sequence references - return a single cue
     // Second pass: parse effects now that we know the cue time
+    let seq_effect_ctx = ParseContext {
+        tempo_map: tempo_map.clone(),
+        cue_time: abs_time,
+        offset_secs: applied_offset_secs,
+        unshifted_score_time: if unshifted_score_time_seq != Duration::ZERO {
+            Some(unshifted_score_time_seq)
+        } else {
+            None
+        },
+        score_measure: score_measure_seq,
+        measure_offset: cumulative_measure_offset_seq,
+    };
     for effect_pair in effect_pairs {
-        let effect = parse_effect_definition(
-            effect_pair,
-            tempo_map,
-            abs_time,
-            applied_offset_secs,
-            if unshifted_score_time_seq != Duration::ZERO {
-                Some(unshifted_score_time_seq)
-            } else {
-                None
-            },
-            score_measure_seq,
-            cumulative_measure_offset_seq,
-        )?;
+        let effect = parse_effect_definition(effect_pair, &seq_effect_ctx)?;
         effects.push(effect);
     }
 

--- a/src/lighting/parser/types.rs
+++ b/src/lighting/parser/types.rs
@@ -15,6 +15,20 @@
 use std::time::Duration;
 
 use super::super::effects::{BlendMode, EffectLayer, EffectType};
+use super::super::tempo::TempoMap;
+
+/// Bundles the per-cue context that flows through the parsing pipeline,
+/// replacing the 5-7 individual parameters previously threaded through
+/// `parse_effect_definition` and friends.
+#[derive(Clone)]
+pub(crate) struct ParseContext {
+    pub tempo_map: Option<TempoMap>,
+    pub cue_time: Duration,
+    pub offset_secs: f64,
+    pub unshifted_score_time: Option<Duration>,
+    pub score_measure: Option<u32>,
+    pub measure_offset: u32,
+}
 
 // Light show DSL data structures
 #[derive(Debug, Clone)]

--- a/src/lighting/parser/utils.rs
+++ b/src/lighting/parser/utils.rs
@@ -15,7 +15,7 @@
 use std::error::Error;
 use std::time::Duration;
 
-use super::super::effects::{Color, TempoAwareFrequency, TempoAwareSpeed};
+use super::super::effects::{Color, TempoAwareFrequency, TempoAwareSpeed, TempoAwareValue};
 use super::super::tempo::TempoMap;
 use super::grammar::Rule;
 use pest::iterators::Pair;
@@ -32,102 +32,71 @@ pub(crate) fn parse_percentage_to_f64(value: &str) -> Result<f64, Box<dyn Error>
     }
 }
 
-/// Parses a frequency value to TempoAwareFrequency
+/// Parses a tempo-aware value string into a `TempoAwareValue`.
 /// Supports:
-/// - Numeric values (e.g., "4.0") -> Fixed Hz
-/// - Time-based values (e.g., "1measure", "2beats", "0.5s") -> TempoAwareFrequency
+/// - Numeric values (e.g., "4.0") -> Fixed
+/// - Time-based values (e.g., "1measure", "2beats", "0.5s", "500ms") -> Measures/Beats/Seconds
 ///
+/// `kind_label` is used in error messages (e.g. "frequency" or "speed").
 /// For beats/measures, requires tempo_map to be available.
+pub(crate) fn parse_tempo_aware_string(
+    value: &str,
+    tempo_map: &Option<TempoMap>,
+    kind_label: &str,
+) -> Result<TempoAwareValue, Box<dyn Error>> {
+    let value = value.trim();
+
+    // Try parsing as a simple number first — fixed rate
+    if let Ok(val) = value.parse::<f64>() {
+        return Ok(TempoAwareValue::Fixed(val));
+    }
+
+    // Try parsing as a time-based value
+    if value.ends_with("ms") {
+        let num_str = value.trim_end_matches("ms");
+        let num = num_str.parse::<f64>()?;
+        let duration_secs = num / 1000.0;
+        Ok(TempoAwareValue::Seconds(duration_secs))
+    } else if value.ends_with("measures") {
+        let num_str = value.trim_end_matches("measures");
+        let num = num_str.parse::<f64>()?;
+        if tempo_map.is_some() {
+            Ok(TempoAwareValue::Measures(num))
+        } else {
+            Err(format!("Measure-based {kind_label} values require a tempo section").into())
+        }
+    } else if value.ends_with("beats") {
+        let num_str = value.trim_end_matches("beats");
+        let num = num_str.parse::<f64>()?;
+        if tempo_map.is_some() {
+            Ok(TempoAwareValue::Beats(num))
+        } else {
+            Err(format!("Beat-based {kind_label} values require a tempo section").into())
+        }
+    } else if value.ends_with('s') {
+        let num_str = value.trim_end_matches('s');
+        let num = num_str.parse::<f64>()?;
+        Ok(TempoAwareValue::Seconds(num))
+    } else {
+        // Fallback: try parsing as a number
+        Ok(TempoAwareValue::Fixed(value.parse::<f64>()?))
+    }
+}
+
+/// Parses a frequency value to TempoAwareFrequency (type alias for TempoAwareValue).
 pub(crate) fn parse_frequency_string(
     value: &str,
     tempo_map: &Option<TempoMap>,
 ) -> Result<TempoAwareFrequency, Box<dyn Error>> {
-    let value = value.trim();
-
-    // Try parsing as a simple number first (Hz) - fixed frequency
-    if let Ok(val) = value.parse::<f64>() {
-        return Ok(TempoAwareFrequency::Fixed(val));
-    }
-
-    // Try parsing as a time-based value
-    if value.ends_with("ms") {
-        let num_str = value.trim_end_matches("ms");
-        let num = num_str.parse::<f64>()?;
-        let duration_secs = num / 1000.0;
-        Ok(TempoAwareFrequency::Seconds(duration_secs))
-    } else if value.ends_with("measures") {
-        let num_str = value.trim_end_matches("measures");
-        let num = num_str.parse::<f64>()?;
-        if tempo_map.is_some() {
-            Ok(TempoAwareFrequency::Measures(num))
-        } else {
-            Err("Measure-based frequencies require a tempo section".into())
-        }
-    } else if value.ends_with("beats") {
-        let num_str = value.trim_end_matches("beats");
-        let num = num_str.parse::<f64>()?;
-        if tempo_map.is_some() {
-            Ok(TempoAwareFrequency::Beats(num))
-        } else {
-            Err("Beat-based frequencies require a tempo section".into())
-        }
-    } else if value.ends_with('s') {
-        let num_str = value.trim_end_matches('s');
-        let num = num_str.parse::<f64>()?;
-        Ok(TempoAwareFrequency::Seconds(num))
-    } else {
-        // Fallback: try parsing as a number
-        Ok(TempoAwareFrequency::Fixed(value.parse::<f64>()?))
-    }
+    parse_tempo_aware_string(value, tempo_map, "frequency")
 }
 
-/// Parses a speed value to TempoAwareSpeed
-/// Supports:
-/// - Numeric values (e.g., "1.5") -> Fixed cycles per second
-/// - Time-based values (e.g., "1measure", "2beats", "0.5s") -> TempoAwareSpeed
-///
-/// For beats/measures, requires tempo_map to be available.
+/// Parses a speed value to TempoAwareSpeed (type alias for TempoAwareValue).
 pub(crate) fn parse_speed_string(
     value: &str,
     tempo_map: &Option<TempoMap>,
 ) -> Result<TempoAwareSpeed, Box<dyn Error>> {
-    let value = value.trim();
-
-    // Try parsing as a simple number first (cycles per second) - fixed speed
-    if let Ok(val) = value.parse::<f64>() {
-        return Ok(TempoAwareSpeed::Fixed(val));
-    }
-
-    // Try parsing as a time-based value
-    if value.ends_with("ms") {
-        let num_str = value.trim_end_matches("ms");
-        let num = num_str.parse::<f64>()?;
-        let duration_secs = num / 1000.0;
-        Ok(TempoAwareSpeed::Seconds(duration_secs))
-    } else if value.ends_with("measures") {
-        let num_str = value.trim_end_matches("measures");
-        let num = num_str.parse::<f64>()?;
-        if tempo_map.is_some() {
-            Ok(TempoAwareSpeed::Measures(num))
-        } else {
-            Err("Measure-based speeds require a tempo section".into())
-        }
-    } else if value.ends_with("beats") {
-        let num_str = value.trim_end_matches("beats");
-        let num = num_str.parse::<f64>()?;
-        if tempo_map.is_some() {
-            Ok(TempoAwareSpeed::Beats(num))
-        } else {
-            Err("Beat-based speeds require a tempo section".into())
-        }
-    } else if value.ends_with('s') {
-        let num_str = value.trim_end_matches('s');
-        let num = num_str.parse::<f64>()?;
-        Ok(TempoAwareSpeed::Seconds(num))
-    } else {
-        // Fallback: try parsing as a number
-        Ok(TempoAwareSpeed::Fixed(value.parse::<f64>()?))
-    }
+    parse_tempo_aware_string(value, tempo_map, "speed")
 }
 
 /// Parses a duration string (e.g., "2s", "500ms", "4beats", "2measures") to Duration

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -405,6 +405,22 @@ impl LightingSystem {
 
         Ok(selected)
     }
+
+    /// Resolves group names in an effect's target_fixtures to actual fixture names.
+    /// Each name in `target_fixtures` is looked up as a logical group; if it resolves,
+    /// the individual fixture names replace the group name.
+    pub fn resolve_effect_groups(
+        &mut self,
+        mut effect: super::EffectInstance,
+    ) -> super::EffectInstance {
+        let mut resolved_fixtures = Vec::new();
+        for group_name in &effect.target_fixtures {
+            let fixtures = self.resolve_logical_group_graceful(group_name);
+            resolved_fixtures.extend(fixtures);
+        }
+        effect.target_fixtures = resolved_fixtures;
+        effect
+    }
 }
 
 #[cfg(test)]

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -11,19 +11,12 @@
 // You should have received a copy of the GNU General Public License along with
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
-use std::{
-    any::Any,
-    error::Error,
-    fmt,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{any::Any, error::Error, fmt, sync::Arc};
 
 use midly::live::LiveEvent;
 use tokio::sync::mpsc::Sender;
 
-use crate::{
-    clock::PlaybackClock, config, dmx::engine::Engine, playsync::CancelHandle, songs::Song,
-};
+use crate::{config, dmx::engine::Engine, playsync::PlaybackSync, songs::Song};
 
 pub(crate) mod beat_clock;
 pub(crate) mod midir;
@@ -44,18 +37,7 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Plays the given song through the MIDI interface, starting from a specific time.
     /// The `ready_tx` sender signals that setup is complete. The implementation should
     /// then wait for `clock.elapsed() > Duration::ZERO` as the "go" signal.
-    #[allow(clippy::too_many_arguments)]
-    fn play_from(
-        &self,
-        song: Arc<Song>,
-        cancel_handle: CancelHandle,
-        ready_tx: std::sync::mpsc::Sender<()>,
-        start_time: std::time::Duration,
-        clock: PlaybackClock,
-        loop_break: Arc<AtomicBool>,
-        active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        section_loop_break: Arc<AtomicBool>,
-    ) -> Result<(), Box<dyn Error>>;
+    fn play_from(&self, song: Arc<Song>, sync: PlaybackSync) -> Result<(), Box<dyn Error>>;
 
     /// Emits an event.
     fn emit(&self, midi_event: Option<LiveEvent<'static>>) -> Result<(), Box<dyn Error>>;

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -178,14 +178,21 @@ impl super::Device for Device {
     fn play_from(
         &self,
         song: Arc<Song>,
-        cancel_handle: CancelHandle,
-        ready_tx: std::sync::mpsc::Sender<()>,
-        start_time: Duration,
-        clock: PlaybackClock,
-        loop_break: Arc<AtomicBool>,
-        active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        section_loop_break: Arc<AtomicBool>,
+        sync: crate::playsync::PlaybackSync,
     ) -> Result<(), Box<dyn Error>> {
+        let crate::playsync::PlaybackSync {
+            cancel_handle,
+            ready_tx,
+            clock,
+            start_time,
+            loop_control,
+        } = sync;
+        let crate::playsync::LoopControl {
+            loop_break,
+            active_section,
+            section_loop_break,
+            ..
+        } = loop_control;
         let span = span!(Level::INFO, "play song (midir)");
         let _enter = span.enter();
 
@@ -1562,13 +1569,13 @@ mod test {
             let result = <Device as crate::midi::Device>::play_from(
                 &device,
                 song,
-                cancel,
-                ready_tx,
-                Duration::ZERO,
-                clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::PlaybackSync {
+                    cancel_handle: cancel,
+                    ready_tx,
+                    clock,
+                    start_time: Duration::ZERO,
+                    loop_control: crate::playsync::LoopControl::new(),
+                },
             );
             assert!(result.is_ok());
         }
@@ -1587,23 +1594,19 @@ mod test {
             let result = <Device as crate::midi::Device>::play_from(
                 &device,
                 song,
-                cancel,
-                ready_tx,
-                Duration::ZERO,
-                clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::PlaybackSync {
+                    cancel_handle: cancel,
+                    ready_tx,
+                    clock,
+                    start_time: Duration::ZERO,
+                    loop_control: crate::playsync::LoopControl::new(),
+                },
             );
             assert!(result.is_ok());
         }
 
         #[test]
         fn play_from_without_midi_playback_sends_ready() {
-            // When a MIDI device exists but the song has no MIDI sheet,
-            // play_from must still send the ready signal so the playback
-            // clock starts. Without this, all subsystems (audio, DMX)
-            // spin forever waiting for the clock.
             let device = Device::new_default("test".to_string());
             let (_tmp_dir, song) = make_song();
             assert!(song.midi_playback().is_none());
@@ -1614,13 +1617,13 @@ mod test {
             let result = <Device as crate::midi::Device>::play_from(
                 &device,
                 song,
-                cancel,
-                ready_tx,
-                Duration::ZERO,
-                clock,
-                Arc::new(AtomicBool::new(false)),
-                Arc::new(parking_lot::RwLock::new(None)),
-                Arc::new(AtomicBool::new(false)),
+                crate::playsync::PlaybackSync {
+                    cancel_handle: cancel,
+                    ready_tx,
+                    clock,
+                    start_time: Duration::ZERO,
+                    loop_control: crate::playsync::LoopControl::new(),
+                },
             );
             assert!(result.is_ok());
             assert!(

--- a/src/midi/mock.rs
+++ b/src/midi/mock.rs
@@ -26,7 +26,7 @@ use midly::live::LiveEvent;
 use tokio::{sync::mpsc::Sender, task::JoinHandle};
 use tracing::{info, span, Level};
 
-use crate::{clock::PlaybackClock, playsync::CancelHandle, songs::Song};
+use crate::songs::Song;
 
 /// A mock device. Doesn't actually play anything.
 #[derive(Clone)]
@@ -145,14 +145,15 @@ impl super::Device for Device {
     fn play_from(
         &self,
         song: Arc<Song>,
-        cancel_handle: CancelHandle,
-        ready_tx: std::sync::mpsc::Sender<()>,
-        start_time: Duration,
-        clock: PlaybackClock,
-        _loop_break: Arc<std::sync::atomic::AtomicBool>,
-        _active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
-        _section_loop_break: Arc<std::sync::atomic::AtomicBool>,
+        sync: crate::playsync::PlaybackSync,
     ) -> Result<(), Box<dyn Error>> {
+        let crate::playsync::PlaybackSync {
+            cancel_handle,
+            ready_tx,
+            clock,
+            start_time,
+            ..
+        } = sync;
         let span = span!(Level::INFO, "play song (mock)");
         let _enter = span.enter();
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -133,14 +133,8 @@ struct PlaybackContext {
     play_tx: oneshot::Sender<Result<(), String>>,
     start_time: Duration,
     play_start_time: Arc<Mutex<Option<SystemTime>>>,
-    /// Shared flag to break out of the loop gracefully.
-    loop_break: Arc<AtomicBool>,
-    /// Active section loop bounds (shared with player).
-    active_section: Arc<parking_lot::RwLock<Option<SectionBounds>>>,
-    /// Shared flag to break out of a section loop.
-    section_loop_break: Arc<AtomicBool>,
-    /// Accumulated time consumed by section loop iterations.
-    loop_time_consumed: Arc<parking_lot::Mutex<Duration>>,
+    /// Loop control state shared with audio/MIDI/DMX subsystems.
+    loop_control: crate::playsync::LoopControl,
 }
 
 /// Groups hardware devices for constructing a Player without discovering real hardware.
@@ -1165,10 +1159,12 @@ impl Player {
                 play_tx,
                 start_time,
                 play_start_time: play_start_time.clone(),
-                loop_break: self.loop_break.clone(),
-                active_section: self.active_section.clone(),
-                section_loop_break: self.section_loop_break.clone(),
-                loop_time_consumed: self.loop_time_consumed.clone(),
+                loop_control: crate::playsync::LoopControl {
+                    loop_break: self.loop_break.clone(),
+                    active_section: self.active_section.clone(),
+                    section_loop_break: self.section_loop_break.clone(),
+                    loop_time_consumed: self.loop_time_consumed.clone(),
+                },
             };
             tokio::task::spawn_blocking(move || {
                 Player::play_files(ctx);
@@ -1273,10 +1269,7 @@ impl Player {
             play_tx,
             start_time,
             play_start_time,
-            loop_break,
-            active_section,
-            section_loop_break,
-            loop_time_consumed,
+            loop_control,
         } = ctx;
 
         // Check if any subsystems are active.
@@ -1309,10 +1302,7 @@ impl Player {
             let audio_outcome = audio_outcome.clone();
             let ready_tx = ready_tx.clone();
             let clock = clock.clone();
-            let loop_break = loop_break.clone();
-            let active_section = active_section.clone();
-            let section_loop_break = section_loop_break.clone();
-            let loop_time_consumed = loop_time_consumed.clone();
+            let loop_control = loop_control.clone();
             expected_ready += 1;
 
             Some(thread::spawn(move || {
@@ -1320,14 +1310,13 @@ impl Player {
                 let result = device.play_from(
                     song,
                     &mappings,
-                    cancel_handle,
-                    ready_tx,
-                    clock,
-                    start_time,
-                    loop_break,
-                    active_section,
-                    section_loop_break,
-                    loop_time_consumed,
+                    crate::playsync::PlaybackSync {
+                        cancel_handle,
+                        ready_tx,
+                        clock,
+                        start_time,
+                        loop_control,
+                    },
                 );
                 if let Err(ref e) = result {
                     error!(
@@ -1350,9 +1339,7 @@ impl Player {
             let cancel_handle = cancel_handle.clone();
             let clock = clock.clone();
             let ready_tx = ready_tx.clone();
-            let loop_break = loop_break.clone();
-            let active_section = active_section.clone();
-            let section_loop_break = section_loop_break.clone();
+            let loop_control = loop_control.clone();
             expected_ready += 1;
 
             thread::spawn(move || {
@@ -1365,9 +1352,7 @@ impl Player {
                     ready_tx,
                     start_time,
                     clock,
-                    loop_break,
-                    active_section,
-                    section_loop_break,
+                    loop_control,
                 ) {
                     error!(
                         err = e.as_ref(),
@@ -1384,9 +1369,7 @@ impl Player {
             let cancel_handle = cancel_handle.clone();
             let ready_tx = ready_tx.clone();
             let clock = clock.clone();
-            let loop_break = loop_break.clone();
-            let active_section = active_section.clone();
-            let section_loop_break = section_loop_break.clone();
+            let loop_control = loop_control.clone();
             expected_ready += 1;
 
             Some(thread::spawn(move || {
@@ -1394,13 +1377,13 @@ impl Player {
 
                 if let Err(e) = midi_device.play_from(
                     song,
-                    cancel_handle,
-                    ready_tx,
-                    start_time,
-                    clock,
-                    loop_break,
-                    active_section,
-                    section_loop_break,
+                    crate::playsync::PlaybackSync {
+                        cancel_handle,
+                        ready_tx,
+                        clock,
+                        start_time,
+                        loop_control,
+                    },
                 ) {
                     error!(
                         err = e.as_ref(),

--- a/src/playsync.rs
+++ b/src/playsync.rs
@@ -13,6 +13,50 @@
 //
 use parking_lot::{Condvar, Mutex};
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
+use std::time::Duration;
+
+/// Bundles the playback synchronization state passed to `play_from` / `play`.
+/// Includes the cancel handle, clock, ready signal, start time, and loop control.
+#[derive(Clone)]
+pub struct PlaybackSync {
+    pub cancel_handle: CancelHandle,
+    pub ready_tx: std::sync::mpsc::Sender<()>,
+    pub clock: crate::clock::PlaybackClock,
+    pub start_time: Duration,
+    pub loop_control: LoopControl,
+}
+
+/// Bundles the shared loop-control state threaded through audio, MIDI, and DMX
+/// `play_from` / `play` methods.
+#[derive(Clone)]
+pub struct LoopControl {
+    /// Shared flag to break out of the whole-song loop gracefully.
+    pub loop_break: Arc<AtomicBool>,
+    /// Active section loop bounds (shared with player).
+    pub active_section: Arc<parking_lot::RwLock<Option<crate::player::SectionBounds>>>,
+    /// Shared flag to break out of a section loop.
+    pub section_loop_break: Arc<AtomicBool>,
+    /// Accumulated time consumed by section loop iterations.
+    pub loop_time_consumed: Arc<parking_lot::Mutex<Duration>>,
+}
+
+impl LoopControl {
+    /// Creates a new `LoopControl` with all flags in their default (inactive) state.
+    pub fn new() -> Self {
+        Self {
+            loop_break: Arc::new(AtomicBool::new(false)),
+            active_section: Arc::new(parking_lot::RwLock::new(None)),
+            section_loop_break: Arc::new(AtomicBool::new(false)),
+            loop_time_consumed: Arc::new(parking_lot::Mutex::new(Duration::ZERO)),
+        }
+    }
+}
+
+impl Default for LoopControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Represents the current cancel state.
 #[derive(PartialEq)]

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -15,6 +15,7 @@
 pub(crate) mod browse;
 pub(crate) mod config_api;
 pub(crate) mod devices;
+pub(crate) mod helpers;
 pub(crate) mod lighting_api;
 pub(crate) mod playlists;
 pub(crate) mod profiles;

--- a/src/webui/api/config_api.rs
+++ b/src/webui/api/config_api.rs
@@ -29,35 +29,36 @@ use crate::config;
 /// GET /api/config — returns the raw YAML content of the player config file.
 pub(super) async fn get_config_raw(State(state): State<WebUiState>) -> impl IntoResponse {
     // codeql[rust/path-injection] config_path is set at startup, not from user input.
-    match std::fs::read_to_string(&state.config_path) {
+    let path = state.config_path.clone();
+    match super::helpers::spawn_blocking_io("read config", move || std::fs::read_to_string(&path))
+        .await
+    {
         Ok(content) => (
             StatusCode::OK,
             [("content-type", "text/yaml; charset=utf-8")],
             content,
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to read config: {}", e)})),
-        )
-            .into_response(),
+        Err(e) => e,
     }
 }
 
 /// GET /api/config/parsed — returns the player config as JSON.
 pub(super) async fn get_config_parsed(State(state): State<WebUiState>) -> impl IntoResponse {
-    match config::Player::deserialize(&state.config_path) {
-        Ok(player_config) => match serde_json::to_value(&player_config) {
-            Ok(json_val) => (StatusCode::OK, Json(json_val)).into_response(),
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to serialize config: {}", e)})),
-            )
-                .into_response(),
-        },
+    let path = state.config_path.clone();
+    let player_config = match super::helpers::spawn_blocking_io("parse config", move || {
+        config::Player::deserialize(&path).map_err(|e| e.to_string())
+    })
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    match serde_json::to_value(&player_config) {
+        Ok(json_val) => (StatusCode::OK, Json(json_val)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to parse config: {}", e)})),
+            Json(json!({"error": format!("Failed to serialize config: {}", e)})),
         )
             .into_response(),
     }
@@ -69,9 +70,14 @@ pub(super) async fn put_config(State(state): State<WebUiState>, body: String) ->
         return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
     }
 
-    match config_io::atomic_write(&state.config_path, &body) {
+    let path = state.config_path.clone();
+    match super::helpers::spawn_blocking_io("write config", move || {
+        config_io::atomic_write(&path, &body)
+    })
+    .await
+    {
         Ok(()) => (StatusCode::OK, Json(json!({"status": "saved"}))).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response(),
+        Err(e) => e,
     }
 }
 
@@ -175,57 +181,115 @@ pub(super) async fn get_config_store(State(state): State<WebUiState>) -> impl In
     }
 }
 
+/// Trait for config section types that support validation.
+trait Validatable {
+    fn validate(&self) -> Result<(), Vec<String>>;
+}
+impl Validatable for config::Audio {
+    fn validate(&self) -> Result<(), Vec<String>> {
+        self.validate()
+    }
+}
+impl Validatable for config::Midi {
+    fn validate(&self) -> Result<(), Vec<String>> {
+        self.validate()
+    }
+}
+impl Validatable for config::Dmx {
+    fn validate(&self) -> Result<(), Vec<String>> {
+        self.validate()
+    }
+}
+
+/// Extracts the expected_checksum from a JSON body, or returns a 400 error.
+#[allow(clippy::result_large_err)]
+fn extract_checksum(body: &serde_json::Value) -> Result<String, axum::response::Response> {
+    body.get("expected_checksum")
+        .and_then(|v| v.as_str())
+        .map(|c| c.to_string())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "missing expected_checksum"})),
+            )
+                .into_response()
+        })
+}
+
+/// Deserializes an optional config section from a JSON body field.
+/// Returns `None` if the field is absent or null; returns a 400 error on
+/// deserialization failure.
+#[allow(clippy::result_large_err)]
+fn deserialize_optional_section<T: serde::de::DeserializeOwned>(
+    body: &serde_json::Value,
+    field: &str,
+) -> Result<Option<T>, axum::response::Response> {
+    match body.get(field) {
+        Some(v) if !v.is_null() => serde_json::from_value(v.clone()).map(Some).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("invalid {}: {}", field, e)})),
+            )
+                .into_response()
+        }),
+        _ => Ok(None),
+    }
+}
+
+/// Shared preamble for optional, validatable config section updates.
+///
+/// Handles: reject_if_playing, checksum extraction, deserialization, validation,
+/// config store lookup. Returns the deserialized value, checksum, and store on
+/// success.
+#[allow(clippy::result_large_err)]
+async fn prepare_optional_update<T>(
+    state: &WebUiState,
+    body: &serde_json::Value,
+    field: &str,
+) -> Result<(Option<T>, String, std::sync::Arc<config::ConfigStore>), axum::response::Response>
+where
+    T: serde::de::DeserializeOwned + Validatable,
+{
+    if let Some(resp) = reject_if_playing(state).await {
+        return Err(resp);
+    }
+    let checksum = extract_checksum(body)?;
+    let value: Option<T> = deserialize_optional_section(body, field)?;
+    if let Some(ref v) = value {
+        if let Err(errors) = v.validate() {
+            return Err((StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response());
+        }
+    }
+    let store = require_config_store(state)?;
+    Ok((value, checksum, store))
+}
+
+/// Completes a config section update: calls the store updater, reloads hardware,
+/// and returns the response.
+async fn finish_config_update(
+    state: &WebUiState,
+    result: Result<config::store::ConfigSnapshot, config::ConfigError>,
+) -> axum::response::Response {
+    match result {
+        Ok(snapshot) => {
+            reload_hardware_after_mutation(state).await;
+            config_snapshot_response(snapshot, StatusCode::OK)
+        }
+        Err(e) => config_store_error_response(e),
+    }
+}
+
 /// PUT /api/config/audio — update audio config section.
 pub(super) async fn put_config_audio(
     State(state): State<WebUiState>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    if let Some(resp) = reject_if_playing(&state).await {
-        return resp;
-    }
-
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
-    };
-
-    let audio: Option<config::Audio> = match body.get("audio") {
-        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
-            Ok(a) => Some(a),
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("invalid audio: {}", e)})),
-                )
-                    .into_response()
-            }
-        },
-        _ => None,
-    };
-
-    if let Some(ref audio) = audio {
-        if let Err(errors) = audio.validate() {
-            return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
-        }
-    }
-
-    let store = match require_config_store(&state) {
-        Ok(s) => s,
-        Err(e) => return e,
-    };
-    match store.update_audio(audio, &checksum).await {
-        Ok(snapshot) => {
-            reload_hardware_after_mutation(&state).await;
-            config_snapshot_response(snapshot, StatusCode::OK)
-        }
-        Err(e) => config_store_error_response(e),
-    }
+    let (audio, checksum, store) =
+        match prepare_optional_update::<config::Audio>(&state, &body, "audio").await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+    finish_config_update(&state, store.update_audio(audio, &checksum).await).await
 }
 
 /// PUT /api/config/midi — update MIDI config section.
@@ -233,52 +297,12 @@ pub(super) async fn put_config_midi(
     State(state): State<WebUiState>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    if let Some(resp) = reject_if_playing(&state).await {
-        return resp;
-    }
-
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
-    };
-
-    let midi: Option<config::Midi> = match body.get("midi") {
-        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
-            Ok(m) => Some(m),
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("invalid midi: {}", e)})),
-                )
-                    .into_response()
-            }
-        },
-        _ => None,
-    };
-
-    if let Some(ref midi) = midi {
-        if let Err(errors) = midi.validate() {
-            return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
-        }
-    }
-
-    let store = match require_config_store(&state) {
-        Ok(s) => s,
-        Err(e) => return e,
-    };
-    match store.update_midi(midi, &checksum).await {
-        Ok(snapshot) => {
-            reload_hardware_after_mutation(&state).await;
-            config_snapshot_response(snapshot, StatusCode::OK)
-        }
-        Err(e) => config_store_error_response(e),
-    }
+    let (midi, checksum, store) =
+        match prepare_optional_update::<config::Midi>(&state, &body, "midi").await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+    finish_config_update(&state, store.update_midi(midi, &checksum).await).await
 }
 
 /// PUT /api/config/dmx — update DMX config section.
@@ -286,52 +310,12 @@ pub(super) async fn put_config_dmx(
     State(state): State<WebUiState>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    if let Some(resp) = reject_if_playing(&state).await {
-        return resp;
-    }
-
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
-    };
-
-    let dmx: Option<config::Dmx> = match body.get("dmx") {
-        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
-            Ok(d) => Some(d),
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("invalid dmx: {}", e)})),
-                )
-                    .into_response()
-            }
-        },
-        _ => None,
-    };
-
-    if let Some(ref dmx) = dmx {
-        if let Err(errors) = dmx.validate() {
-            return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
-        }
-    }
-
-    let store = match require_config_store(&state) {
-        Ok(s) => s,
-        Err(e) => return e,
-    };
-    match store.update_dmx(dmx, &checksum).await {
-        Ok(snapshot) => {
-            reload_hardware_after_mutation(&state).await;
-            config_snapshot_response(snapshot, StatusCode::OK)
-        }
-        Err(e) => config_store_error_response(e),
-    }
+    let (dmx, checksum, store) =
+        match prepare_optional_update::<config::Dmx>(&state, &body, "dmx").await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+    finish_config_update(&state, store.update_dmx(dmx, &checksum).await).await
 }
 
 /// PUT /api/config/controllers — update controllers config.
@@ -342,16 +326,9 @@ pub(super) async fn put_config_controllers(
     if let Some(resp) = reject_if_playing(&state).await {
         return resp;
     }
-
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
+    let checksum = match extract_checksum(&body) {
+        Ok(c) => c,
+        Err(e) => return e,
     };
 
     let controllers: Vec<config::Controller> = match body.get("controllers") {
@@ -396,15 +373,9 @@ pub(super) async fn put_config_samples(
         return resp;
     }
 
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
+    let checksum = match extract_checksum(&body) {
+        Ok(c) => c,
+        Err(e) => return e,
     };
 
     let samples: std::collections::HashMap<String, config::SampleDefinition> =
@@ -458,15 +429,9 @@ pub(super) async fn post_config_profile(
         return resp;
     }
 
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
+    let checksum = match extract_checksum(&body) {
+        Ok(c) => c,
+        Err(e) => return e,
     };
 
     let profile: config::Profile = match body.get("profile") {
@@ -516,15 +481,9 @@ pub(super) async fn put_config_profile(
         return resp;
     }
 
-    let checksum = match body.get("expected_checksum").and_then(|v| v.as_str()) {
-        Some(c) => c.to_string(),
-        None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "missing expected_checksum"})),
-            )
-                .into_response()
-        }
+    let checksum = match extract_checksum(&body) {
+        Ok(c) => c,
+        Err(e) => return e,
     };
 
     let profile: config::Profile = match body.get("profile") {

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use axum::{http::StatusCode, response::IntoResponse, Json};
+use serde_json::json;
+use std::path::PathBuf;
+
+use super::super::safe_path::VerifiedRoot;
+
+/// Validates a resource name for use in file paths.
+///
+/// Rejects names that would be unsafe as filenames (empty, path traversal, etc.)
+/// and optionally rejects a reserved name.
+#[allow(clippy::result_large_err)]
+pub(crate) fn validate_resource_name(
+    name: &str,
+    label: &str,
+    reserved: Option<&str>,
+) -> Result<(), axum::response::Response> {
+    use super::super::safe_path::SafePath;
+    let is_reserved = reserved.is_some_and(|r| name == r);
+    if is_reserved || SafePath::validate_name(name).is_err() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("Invalid {} name", label)})),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Returns a configured directory path, or an error response if it is `None`.
+#[allow(clippy::result_large_err)]
+pub(crate) fn require_configured_dir(
+    dir: &Option<PathBuf>,
+    label: &str,
+    status: StatusCode,
+) -> Result<PathBuf, axum::response::Response> {
+    dir.clone().ok_or_else(|| {
+        (
+            status,
+            Json(json!({"error": format!("No {} directory configured", label)})),
+        )
+            .into_response()
+    })
+}
+
+/// Resolves a resource file path within a directory, verifying that the result
+/// does not escape via symlinks or other tricks.
+///
+/// For existing files, canonicalizes and verifies containment. For new files,
+/// returns the joined path directly (the name has already been validated).
+#[allow(clippy::result_large_err)]
+pub(crate) fn resolve_resource_path(
+    dir: &std::path::Path,
+    name: &str,
+    ext: &str,
+) -> Result<PathBuf, axum::response::Response> {
+    let root = VerifiedRoot::new(dir).map_err(|e| e.into_response())?;
+    let file_path = root.as_path().join(format!("{}.{}", name, ext));
+    if file_path.exists() {
+        let safe = super::super::safe_path::SafePath::resolve(&file_path, &root)
+            .map_err(|e| e.into_response())?;
+        Ok(safe.as_path().to_path_buf())
+    } else {
+        Ok(file_path)
+    }
+}
+
+/// Wraps a blocking filesystem operation in `tokio::task::spawn_blocking`,
+/// mapping errors to HTTP responses.
+///
+/// Both the join error (task panic) and the inner result error are handled.
+pub(crate) async fn spawn_blocking_io<F, T, E>(
+    label: &str,
+    f: F,
+) -> Result<T, axum::response::Response>
+where
+    F: FnOnce() -> Result<T, E> + Send + 'static,
+    T: Send + 'static,
+    E: std::fmt::Display + Send + 'static,
+{
+    let label = label.to_string();
+    match tokio::task::spawn_blocking(f).await {
+        Ok(Ok(val)) => Ok(val),
+        Ok(Err(e)) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to {}: {}", label, e)})),
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("{} task failed: {}", label, e)})),
+        )
+            .into_response()),
+    }
+}

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -27,14 +27,18 @@ use crate::lighting;
 
 /// GET /api/lighting — lists available .light files from the songs directory.
 pub(super) async fn get_lighting_files(State(state): State<WebUiState>) -> impl IntoResponse {
-    let mut light_files: Vec<serde_json::Value> = Vec::new();
-    if let Err(e) = find_light_files(&state.songs_path, &state.songs_path, &mut light_files) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to scan for lighting files: {}", e)})),
-        )
-            .into_response();
-    }
+    let songs_path = state.songs_path.clone();
+    let mut light_files =
+        match super::helpers::spawn_blocking_io("scan for lighting files", move || {
+            let mut files = Vec::new();
+            find_light_files(&songs_path, &songs_path, &mut files)?;
+            Ok::<_, std::io::Error>(files)
+        })
+        .await
+        {
+            Ok(f) => f,
+            Err(e) => return e,
+        };
     light_files.sort_by(|a, b| {
         a.get("path")
             .and_then(|v| v.as_str())
@@ -105,18 +109,19 @@ pub(super) async fn get_lighting_file(
         }
     };
 
-    match std::fs::read_to_string(safe.as_path()) {
+    let path = safe.as_path().to_path_buf();
+    match super::helpers::spawn_blocking_io("read lighting file", move || {
+        std::fs::read_to_string(&path)
+    })
+    .await
+    {
         Ok(content) => (
             StatusCode::OK,
             [("content-type", "text/plain; charset=utf-8")],
             content,
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to read lighting file: {}", e)})),
-        )
-            .into_response(),
+        Err(e) => e,
     }
 }
 
@@ -158,9 +163,15 @@ pub(super) async fn put_lighting_file(
         return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
     }
 
-    match config_io::atomic_write(&verified_path, &body) {
+    let vp = verified_path;
+    let body_owned = body;
+    match super::helpers::spawn_blocking_io("write lighting file", move || {
+        config_io::atomic_write(&vp, &body_owned)
+    })
+    .await
+    {
         Ok(()) => (StatusCode::OK, Json(json!({"status": "saved"}))).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response(),
+        Err(e) => e,
     }
 }
 
@@ -195,13 +206,14 @@ pub(super) async fn delete_lighting_file(
     }
 
     // codeql[rust/path-injection] safe is verified via SafePath::resolve against songs_path root.
-    match std::fs::remove_file(safe.as_path()) {
+    let path = safe.as_path().to_path_buf();
+    match super::helpers::spawn_blocking_io("delete lighting file", move || {
+        std::fs::remove_file(&path)
+    })
+    .await
+    {
         Ok(()) => (StatusCode::OK, Json(json!({"status": "deleted"}))).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to delete file: {}", e)})),
-        )
-            .into_response(),
+        Err(e) => e,
     }
 }
 
@@ -296,8 +308,8 @@ pub(super) async fn get_fixture_types(
             (StatusCode::OK, Json(json!({"fixture_types": {}}))).into_response(),
         );
     }
-    let mut all = std::collections::HashMap::new();
-    if let Err(e) =
+    let all = super::helpers::spawn_blocking_io("load fixture types", move || {
+        let mut all = std::collections::HashMap::new();
         load_light_files_from_dir(&dir, |content| match lighting::parser::parse_fixture_types(
             content,
         ) {
@@ -307,13 +319,10 @@ pub(super) async fn get_fixture_types(
             }
             Err(e) => Err(e),
         })
-    {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to load fixture types: {}", e)})),
-        )
-            .into_response());
-    }
+        .map_err(|e| e.to_string())?;
+        Ok::<_, String>(all)
+    })
+    .await?;
     Ok((StatusCode::OK, Json(json!({"fixture_types": all}))).into_response())
 }
 
@@ -337,13 +346,11 @@ pub(super) async fn get_fixture_type(
         )
             .into_response());
     }
-    let content = std::fs::read_to_string(&file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to read file: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let fp = file_path.clone();
+    let content = super::helpers::spawn_blocking_io("read fixture type", move || {
+        std::fs::read_to_string(&fp)
+    })
+    .await?;
     let types = lighting::parser::parse_fixture_types(&content).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -418,17 +425,15 @@ pub(super) async fn put_fixture_type(
             .into_response()
     })?;
 
-    // Ensure directory exists
-    ensure_lighting_dir(&dir)?;
-
     let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
-    config_io::atomic_write(&file_path, &dsl).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to write file: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let dir_owned = dir;
+    let fp = file_path;
+    let dsl_owned = dsl;
+    super::helpers::spawn_blocking_io("write fixture type", move || {
+        ensure_lighting_dir_sync(&dir_owned)?;
+        config_io::atomic_write(&fp, &dsl_owned)
+    })
+    .await?;
 
     Ok::<_, axum::response::Response>(
         (
@@ -459,13 +464,9 @@ pub(super) async fn delete_fixture_type(
         )
             .into_response());
     }
-    std::fs::remove_file(&file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to delete file: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let fp = file_path;
+    super::helpers::spawn_blocking_io("delete fixture type", move || std::fs::remove_file(&fp))
+        .await?;
     Ok::<_, axum::response::Response>(
         (
             StatusCode::OK,
@@ -487,8 +488,8 @@ pub(super) async fn get_venues(
             (StatusCode::OK, Json(json!({"venues": {}}))).into_response(),
         );
     }
-    let mut all = std::collections::HashMap::new();
-    if let Err(e) =
+    let all = super::helpers::spawn_blocking_io("load venues", move || {
+        let mut all = std::collections::HashMap::new();
         load_light_files_from_dir(&dir, |content| {
             match lighting::parser::parse_venues(content) {
                 Ok(venues) => {
@@ -498,13 +499,10 @@ pub(super) async fn get_venues(
                 Err(e) => Err(e),
             }
         })
-    {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to load venues: {}", e)})),
-        )
-            .into_response());
-    }
+        .map_err(|e| e.to_string())?;
+        Ok::<_, String>(all)
+    })
+    .await?;
     Ok((StatusCode::OK, Json(json!({"venues": all}))).into_response())
 }
 
@@ -524,13 +522,10 @@ pub(super) async fn get_venue(
         )
             .into_response());
     }
-    let content = std::fs::read_to_string(&file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to read file: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let fp = file_path.clone();
+    let content =
+        super::helpers::spawn_blocking_io("read venue file", move || std::fs::read_to_string(&fp))
+            .await?;
     let venues = lighting::parser::parse_venues(&content).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -593,16 +588,15 @@ pub(super) async fn put_venue(
             .into_response()
     })?;
 
-    ensure_lighting_dir(&dir)?;
-
     let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
-    config_io::atomic_write(&file_path, &dsl).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to write file: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let dir_owned = dir;
+    let fp = file_path;
+    let dsl_owned = dsl;
+    super::helpers::spawn_blocking_io("write venue", move || {
+        ensure_lighting_dir_sync(&dir_owned)?;
+        config_io::atomic_write(&fp, &dsl_owned)
+    })
+    .await?;
 
     Ok::<_, axum::response::Response>(
         (
@@ -629,13 +623,8 @@ pub(super) async fn delete_venue(
         )
             .into_response());
     }
-    std::fs::remove_file(&file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to delete file: {}", e)})),
-        )
-            .into_response()
-    })?;
+    let fp = file_path;
+    super::helpers::spawn_blocking_io("delete venue", move || std::fs::remove_file(&fp)).await?;
     Ok::<_, axum::response::Response>(
         (
             StatusCode::OK,
@@ -665,17 +654,10 @@ fn load_light_files_from_dir(
     Ok(())
 }
 
-/// Ensures a lighting directory exists, creating it if necessary.
-#[allow(clippy::result_large_err)]
-fn ensure_lighting_dir(dir: &std::path::Path) -> Result<(), axum::response::Response> {
+/// Ensures a lighting directory exists (sync version for use inside spawn_blocking).
+fn ensure_lighting_dir_sync(dir: &std::path::Path) -> Result<(), String> {
     if !dir.exists() {
-        std::fs::create_dir_all(dir).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to create directory: {}", e)})),
-            )
-                .into_response()
-        })?;
+        std::fs::create_dir_all(dir).map_err(|e| format!("Failed to create directory: {}", e))?;
     }
     Ok(())
 }
@@ -1647,14 +1629,14 @@ show "test" {
         let dir = tempfile::tempdir().unwrap();
         let sub = dir.path().join("new_subdir");
         assert!(!sub.exists());
-        ensure_lighting_dir(&sub).unwrap();
+        ensure_lighting_dir_sync(&sub).unwrap();
         assert!(sub.is_dir());
     }
 
     #[test]
     fn ensure_lighting_dir_existing_is_ok() {
         let dir = tempfile::tempdir().unwrap();
-        ensure_lighting_dir(dir.path()).unwrap();
+        ensure_lighting_dir_sync(dir.path()).unwrap();
         assert!(dir.path().is_dir());
     }
 

--- a/src/webui/api/playlists.rs
+++ b/src/webui/api/playlists.rs
@@ -20,10 +20,9 @@ use axum::{
 };
 use serde_json::json;
 
-use std::path::PathBuf;
-
 use super::super::config_io;
 use super::super::server::WebUiState;
+use super::helpers::{require_configured_dir, resolve_resource_path, validate_resource_name};
 use crate::config;
 
 // ---------------------------------------------------------------------------
@@ -33,52 +32,7 @@ use crate::config;
 /// Validates a playlist name for use in file paths.
 #[allow(clippy::result_large_err)]
 fn validate_playlist_name(name: &str) -> Result<(), axum::response::Response> {
-    use super::super::safe_path::SafePath;
-    if name == "all_songs" || SafePath::validate_name(name).is_err() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid playlist name"})),
-        )
-            .into_response());
-    }
-    Ok(())
-}
-
-/// Returns the playlists directory, or an error response if not configured.
-#[allow(clippy::result_large_err)]
-fn require_playlists_dir(state: &WebUiState) -> Result<PathBuf, axum::response::Response> {
-    state.playlists_dir.clone().ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "No playlists directory configured"})),
-        )
-            .into_response()
-    })
-}
-
-/// Resolves a playlist file path within the playlists directory, verifying
-/// that the result does not escape the directory via symlinks or other tricks.
-/// Uses SafePath for containment verification.
-#[allow(clippy::result_large_err)]
-fn resolve_playlist_path(
-    playlists_dir: &std::path::Path,
-    name: &str,
-    ext: &str,
-) -> Result<PathBuf, axum::response::Response> {
-    use super::super::safe_path::VerifiedRoot;
-
-    let root = VerifiedRoot::new(playlists_dir).map_err(|e| e.into_response())?;
-    // Name is pre-validated by validate_playlist_name (no "..", "/", "\", null).
-    // Joining a validated filename to a canonical root is safe.
-    let file_path = root.as_path().join(format!("{}.{}", name, ext));
-    if file_path.exists() {
-        // Verify existing file hasn't escaped via symlink.
-        let safe = super::super::safe_path::SafePath::resolve(&file_path, &root)
-            .map_err(|e| e.into_response())?;
-        Ok(safe.as_path().to_path_buf())
-    } else {
-        Ok(file_path)
-    }
+    validate_resource_name(name, "playlist", Some("all_songs"))
 }
 
 /// GET /api/playlists — list all playlists with name, song count, and active status.
@@ -146,7 +100,8 @@ pub(super) async fn put_playlist_by_name(
     Json(body): Json<PlaylistBody>,
 ) -> impl IntoResponse {
     validate_playlist_name(&name)?;
-    let playlists_dir = require_playlists_dir(&state)?;
+    let playlists_dir =
+        require_configured_dir(&state.playlists_dir, "playlists", StatusCode::NOT_FOUND)?;
 
     // Write the playlist YAML file.
     let playlist_config = config::Playlist::new(&body.songs);
@@ -161,21 +116,19 @@ pub(super) async fn put_playlist_by_name(
         }
     };
 
-    // Ensure the playlists directory exists.
-    if let Err(e) = std::fs::create_dir_all(&playlists_dir) {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to create playlists directory: {}", e)})),
-        )
-            .into_response());
-    }
-
     // codeql[rust/path-injection] name is validated by validate_playlist_name; path is
-    // verified via canonicalize + starts_with containment in resolve_playlist_path.
-    let file_path = resolve_playlist_path(&playlists_dir, &name, "yaml")?;
-    if let Err(e) = config_io::atomic_write(&file_path, &yaml) {
-        return Err((StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response());
-    }
+    // verified via canonicalize + starts_with containment in resolve_resource_path.
+    let file_path = resolve_resource_path(&playlists_dir, &name, "yaml")?;
+
+    // Ensure directory exists and write atomically, off the async runtime.
+    let dir = playlists_dir.clone();
+    let fp = file_path.clone();
+    let yaml_owned = yaml;
+    super::helpers::spawn_blocking_io("write playlist", move || {
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        config_io::atomic_write(&fp, &yaml_owned)
+    })
+    .await?;
 
     // Reload songs to pick up the new playlist.
     state.player.reload_songs(
@@ -199,38 +152,28 @@ pub(super) async fn delete_playlist_by_name(
     Path(name): Path<String>,
 ) -> impl IntoResponse {
     validate_playlist_name(&name)?;
-    let playlists_dir = require_playlists_dir(&state)?;
+    let playlists_dir =
+        require_configured_dir(&state.playlists_dir, "playlists", StatusCode::NOT_FOUND)?;
 
     // codeql[rust/path-injection] name is validated by validate_playlist_name; path is
-    // verified via canonicalize + starts_with containment in resolve_playlist_path.
-    let file_path = resolve_playlist_path(&playlists_dir, &name, "yaml")?;
-    if !file_path.is_file() {
-        // Also check .yml extension.
-        let yml_path = resolve_playlist_path(&playlists_dir, &name, "yml")?;
-        if yml_path.is_file() {
-            std::fs::remove_file(&yml_path).map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("Failed to delete file: {}", e)})),
-                )
-                    .into_response()
-            })?;
-        } else {
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Playlist '{}' not found", name)})),
-            )
-                .into_response());
-        }
+    // verified via canonicalize + starts_with containment in resolve_resource_path.
+    let file_path = resolve_resource_path(&playlists_dir, &name, "yaml")?;
+    let yml_path = resolve_resource_path(&playlists_dir, &name, "yml")?;
+
+    // Determine which file to delete, then remove it off the async runtime.
+    let target = if file_path.is_file() {
+        file_path
+    } else if yml_path.is_file() {
+        yml_path
     } else {
-        std::fs::remove_file(&file_path).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to delete file: {}", e)})),
-            )
-                .into_response()
-        })?;
-    }
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("Playlist '{}' not found", name)})),
+        )
+            .into_response());
+    };
+    super::helpers::spawn_blocking_io("delete playlist", move || std::fs::remove_file(&target))
+        .await?;
 
     // Reload songs to remove the playlist.
     state.player.reload_songs(

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -20,125 +20,79 @@ use axum::{
 };
 use serde_json::json;
 
-use std::path::PathBuf;
-
 use super::super::config_io;
 use super::super::server::WebUiState;
 use super::config_api::{reject_if_playing, reload_hardware_after_mutation};
+use super::helpers::{
+    require_configured_dir, resolve_resource_path, spawn_blocking_io, validate_resource_name,
+};
 use crate::config::Profile;
 use config::Config;
 
 /// Validates a profile filename for use in file paths.
 #[allow(clippy::result_large_err)]
 fn validate_profile_filename(name: &str) -> Result<(), axum::response::Response> {
-    use super::super::safe_path::SafePath;
-    if SafePath::validate_name(name).is_err() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid profile filename"})),
-        )
-            .into_response());
-    }
-    Ok(())
-}
-
-/// Returns the profiles directory, or an error response if not configured.
-#[allow(clippy::result_large_err)]
-fn require_profiles_dir(state: &WebUiState) -> Result<PathBuf, axum::response::Response> {
-    state.profiles_dir.clone().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "No profiles directory configured"})),
-        )
-            .into_response()
-    })
-}
-
-/// Resolves a profile file path within the profiles directory, verifying
-/// that the result does not escape the directory via symlinks or other tricks.
-/// Uses SafePath for containment verification.
-#[allow(clippy::result_large_err)]
-fn resolve_profile_path(
-    profiles_dir: &std::path::Path,
-    name: &str,
-    ext: &str,
-) -> Result<PathBuf, axum::response::Response> {
-    use super::super::safe_path::VerifiedRoot;
-
-    let root = VerifiedRoot::new(profiles_dir).map_err(|e| e.into_response())?;
-    // Name is pre-validated by validate_profile_filename (no "..", "/", "\", null).
-    let file_path = root.as_path().join(format!("{}.{}", name, ext));
-    if file_path.exists() {
-        let safe = super::super::safe_path::SafePath::resolve(&file_path, &root)
-            .map_err(|e| e.into_response())?;
-        Ok(safe.as_path().to_path_buf())
-    } else {
-        Ok(file_path)
-    }
+    validate_resource_name(name, "profile", None)
 }
 
 /// GET /api/profiles — list profile files from profiles_dir.
 pub(super) async fn get_profiles(State(state): State<WebUiState>) -> impl IntoResponse {
-    let profiles_dir = require_profiles_dir(&state)?;
+    let profiles_dir = require_configured_dir(
+        &state.profiles_dir,
+        "profiles",
+        StatusCode::SERVICE_UNAVAILABLE,
+    )?;
 
     // codeql[rust/path-injection] profiles_dir comes from server config, not user input.
-    let entries = match std::fs::read_dir(&profiles_dir) {
-        Ok(e) => e,
-        Err(e) => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to read profiles dir: {}", e)})),
-            )
-                .into_response());
+    let result = spawn_blocking_io("read profiles dir", move || {
+        let entries = std::fs::read_dir(&profiles_dir)?;
+        let mut items: Vec<(String, serde_json::Value)> = Vec::new();
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if ext != "yaml" && ext != "yml" {
+                continue;
+            }
+            let filename = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+
+            // Parse the profile; skip unparseable files.
+            let profile = match Config::builder()
+                .add_source(config::File::from(path.as_path()))
+                .build()
+                .and_then(|c| c.try_deserialize::<Profile>())
+            {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            items.push((
+                filename.clone(),
+                json!({
+                    "filename": filename,
+                    "hostname": profile.hostname(),
+                    "has_audio": profile.audio_config().is_some(),
+                    "has_midi": profile.midi().is_some(),
+                    "has_dmx": profile.dmx().is_some(),
+                    "has_trigger": profile.trigger().is_some(),
+                    "has_controllers": !profile.controllers().is_empty(),
+                }),
+            ));
         }
-    };
-
-    let mut items: Vec<(String, serde_json::Value)> = Vec::new();
-    for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if ext != "yaml" && ext != "yml" {
-            continue;
-        }
-        let filename = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_string();
-
-        // Parse the profile; skip unparseable files.
-        let profile = match Config::builder()
-            .add_source(config::File::from(path.as_path()))
-            .build()
-            .and_then(|c| c.try_deserialize::<Profile>())
-        {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        items.push((
-            filename.clone(),
-            json!({
-                "filename": filename,
-                "hostname": profile.hostname(),
-                "has_audio": profile.audio_config().is_some(),
-                "has_midi": profile.midi().is_some(),
-                "has_dmx": profile.dmx().is_some(),
-                "has_trigger": profile.trigger().is_some(),
-                "has_controllers": !profile.controllers().is_empty(),
-            }),
-        ));
-    }
-
-    items.sort_by(|a, b| a.0.cmp(&b.0));
-    let result: Vec<serde_json::Value> = items.into_iter().map(|(_, v)| v).collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok::<_, std::io::Error>(items.into_iter().map(|(_, v)| v).collect::<Vec<_>>())
+    })
+    .await?;
     Ok::<_, axum::response::Response>((StatusCode::OK, Json(json!(result))).into_response())
 }
 
@@ -148,15 +102,19 @@ pub(super) async fn get_profile(
     Path(filename): Path<String>,
 ) -> impl IntoResponse {
     validate_profile_filename(&filename)?;
-    let profiles_dir = require_profiles_dir(&state)?;
+    let profiles_dir = require_configured_dir(
+        &state.profiles_dir,
+        "profiles",
+        StatusCode::SERVICE_UNAVAILABLE,
+    )?;
 
     // Try .yaml then .yml.
     let file_path = {
-        let yaml_path = resolve_profile_path(&profiles_dir, &filename, "yaml")?;
+        let yaml_path = resolve_resource_path(&profiles_dir, &filename, "yaml")?;
         if yaml_path.is_file() {
             yaml_path
         } else {
-            let yml_path = resolve_profile_path(&profiles_dir, &filename, "yml")?;
+            let yml_path = resolve_resource_path(&profiles_dir, &filename, "yml")?;
             if yml_path.is_file() {
                 yml_path
             } else {
@@ -169,26 +127,19 @@ pub(super) async fn get_profile(
         }
     };
 
-    // codeql[rust/path-injection] file_path is validated via resolve_profile_path.
-    let raw = std::fs::read_to_string(&file_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to read profile: {}", e)})),
-        )
-            .into_response()
-    })?;
-
-    let profile: Profile = Config::builder()
-        .add_source(config::File::from(file_path.as_path()))
-        .build()
-        .and_then(|c| c.try_deserialize())
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to parse profile: {}", e)})),
-            )
-                .into_response()
-        })?;
+    // codeql[rust/path-injection] file_path is validated via resolve_resource_path.
+    let fp = file_path.clone();
+    let (raw, profile) = spawn_blocking_io("read profile", move || {
+        let raw =
+            std::fs::read_to_string(&fp).map_err(|e| format!("Failed to read profile: {}", e))?;
+        let profile: Profile = Config::builder()
+            .add_source(config::File::from(fp.as_path()))
+            .build()
+            .and_then(|c| c.try_deserialize())
+            .map_err(|e| format!("Failed to parse profile: {}", e))?;
+        Ok::<_, String>((raw, profile))
+    })
+    .await?;
 
     let profile_json = serde_json::to_value(&profile).map_err(|e| {
         (
@@ -217,7 +168,11 @@ pub(super) async fn put_profile(
     if let Some(resp) = reject_if_playing(&state).await {
         return Err(resp);
     }
-    let profiles_dir = require_profiles_dir(&state)?;
+    let profiles_dir = require_configured_dir(
+        &state.profiles_dir,
+        "profiles",
+        StatusCode::SERVICE_UNAVAILABLE,
+    )?;
 
     // Validate that the body deserializes as a Profile.
     let profile: Profile = serde_json::from_value(body).map_err(|e| {
@@ -236,20 +191,18 @@ pub(super) async fn put_profile(
             .into_response()
     })?;
 
-    // codeql[rust/path-injection] profiles_dir comes from server config, not user input.
-    if let Err(e) = std::fs::create_dir_all(&profiles_dir) {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to create profiles directory: {}", e)})),
-        )
-            .into_response());
-    }
+    // codeql[rust/path-injection] filename is validated; path is verified via resolve_resource_path.
+    let file_path = resolve_resource_path(&profiles_dir, &filename, "yaml")?;
 
-    // codeql[rust/path-injection] filename is validated; path is verified via resolve_profile_path.
-    let file_path = resolve_profile_path(&profiles_dir, &filename, "yaml")?;
-    if let Err(e) = config_io::atomic_write(&file_path, &yaml) {
-        return Err((StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response());
-    }
+    // Write directory and file off the async runtime.
+    let dir = profiles_dir;
+    let fp = file_path;
+    let yaml_owned = yaml;
+    spawn_blocking_io("write profile", move || {
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        config_io::atomic_write(&fp, &yaml_owned)
+    })
+    .await?;
 
     reload_hardware_after_mutation(&state).await;
 
@@ -271,37 +224,28 @@ pub(super) async fn delete_profile_file(
     if let Some(resp) = reject_if_playing(&state).await {
         return Err(resp);
     }
-    let profiles_dir = require_profiles_dir(&state)?;
+    let profiles_dir = require_configured_dir(
+        &state.profiles_dir,
+        "profiles",
+        StatusCode::SERVICE_UNAVAILABLE,
+    )?;
 
-    // codeql[rust/path-injection] filename is validated; path is verified via resolve_profile_path.
-    let file_path = resolve_profile_path(&profiles_dir, &filename, "yaml")?;
-    if !file_path.is_file() {
-        // Also check .yml extension.
-        let yml_path = resolve_profile_path(&profiles_dir, &filename, "yml")?;
-        if yml_path.is_file() {
-            std::fs::remove_file(&yml_path).map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("Failed to delete file: {}", e)})),
-                )
-                    .into_response()
-            })?;
-        } else {
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Profile '{}' not found", filename)})),
-            )
-                .into_response());
-        }
+    // codeql[rust/path-injection] filename is validated; path is verified via resolve_resource_path.
+    let file_path = resolve_resource_path(&profiles_dir, &filename, "yaml")?;
+    let yml_path = resolve_resource_path(&profiles_dir, &filename, "yml")?;
+
+    let target = if file_path.is_file() {
+        file_path
+    } else if yml_path.is_file() {
+        yml_path
     } else {
-        std::fs::remove_file(&file_path).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to delete file: {}", e)})),
-            )
-                .into_response()
-        })?;
-    }
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("Profile '{}' not found", filename)})),
+        )
+            .into_response());
+    };
+    spawn_blocking_io("delete profile", move || std::fs::remove_file(&target)).await?;
 
     reload_hardware_after_mutation(&state).await;
 

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -122,40 +122,54 @@ pub(super) async fn get_songs(State(state): State<WebUiState>) -> impl IntoRespo
 }
 
 /// GET /api/songs/:name — returns a single song's config YAML.
+/// Helper to find a song's YAML config path (tries .yaml then .yml).
+fn find_yaml_path(base: &std::path::Path) -> Option<std::path::PathBuf> {
+    let yaml = base.join("song.yaml");
+    if yaml.exists() {
+        return Some(yaml);
+    }
+    let yml = base.join("song.yml");
+    if yml.exists() {
+        return Some(yml);
+    }
+    None
+}
+
+/// Reads a YAML file in a blocking task, returning a text/yaml response.
+async fn read_yaml_response(path: std::path::PathBuf) -> axum::response::Response {
+    match super::helpers::spawn_blocking_io("read song config", move || {
+        std::fs::read_to_string(&path)
+    })
+    .await
+    {
+        Ok(content) => (
+            StatusCode::OK,
+            [("content-type", "text/yaml; charset=utf-8")],
+            content,
+        )
+            .into_response(),
+        Err(e) => e,
+    }
+}
+
 pub(super) async fn get_song(
     State(state): State<WebUiState>,
     Path(name): Path<String>,
-) -> impl IntoResponse {
-    let all_songs = state.player.songs();
-    match all_songs.get(&name) {
-        Ok(song) => {
-            // Try to read the song's config YAML from its base_path
-            let config_path = song.base_path().join("song.yaml");
-            let alt_config_path = song.base_path().join("song.yml");
-            let yaml_path = if config_path.exists() {
-                Some(config_path)
-            } else if alt_config_path.exists() {
-                Some(alt_config_path)
-            } else {
-                None
-            };
+) -> axum::response::Response {
+    // Gather all data we need from the song registry synchronously, then drop
+    // the Arc<Songs> before any .await so the future remains Send.
+    enum GetSongResult {
+        YamlPath(std::path::PathBuf),
+        Summary(axum::response::Response),
+        NotFound(axum::response::Response),
+    }
 
-            match yaml_path {
-                Some(path) => match std::fs::read_to_string(&path) {
-                    Ok(content) => (
-                        StatusCode::OK,
-                        [("content-type", "text/yaml; charset=utf-8")],
-                        content,
-                    )
-                        .into_response(),
-                    Err(e) => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": format!("Failed to read song config: {}", e)})),
-                    )
-                        .into_response(),
-                },
-                None => {
-                    // Return a JSON summary if no config file found
+    let result = {
+        let all_songs = state.player.songs();
+        match all_songs.get(&name) {
+            Ok(song) => match find_yaml_path(song.base_path()) {
+                Some(path) => GetSongResult::YamlPath(path),
+                None => GetSongResult::Summary(
                     (
                         StatusCode::OK,
                         Json(json!({
@@ -168,51 +182,37 @@ pub(super) async fn get_song(
                             "config_file": false,
                         })),
                     )
-                        .into_response()
+                        .into_response(),
+                ),
+            },
+            Err(_) => {
+                if let Some(failure) = all_songs.failures().iter().find(|f| f.name() == name) {
+                    match find_yaml_path(failure.base_path()) {
+                        Some(path) => GetSongResult::YamlPath(path),
+                        None => GetSongResult::NotFound(
+                            (
+                                StatusCode::NOT_FOUND,
+                                Json(json!({"error": format!("No config file found for failed song: {}", name)})),
+                            )
+                                .into_response(),
+                        ),
+                    }
+                } else {
+                    GetSongResult::NotFound(
+                        (
+                            StatusCode::NOT_FOUND,
+                            Json(json!({"error": format!("Song not found: {}", name)})),
+                        )
+                            .into_response(),
+                    )
                 }
             }
         }
-        Err(_) => {
-            // Check if this is a failed song — serve its raw config for editing.
-            if let Some(failure) = all_songs.failures().iter().find(|f| f.name() == name) {
-                let config_path = failure.base_path().join("song.yaml");
-                let alt_config_path = failure.base_path().join("song.yml");
-                let yaml_path = if config_path.exists() {
-                    Some(config_path)
-                } else if alt_config_path.exists() {
-                    Some(alt_config_path)
-                } else {
-                    None
-                };
+    };
 
-                return match yaml_path {
-                    Some(path) => match std::fs::read_to_string(&path) {
-                        Ok(content) => (
-                            StatusCode::OK,
-                            [("content-type", "text/yaml; charset=utf-8")],
-                            content,
-                        )
-                            .into_response(),
-                        Err(e) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(json!({"error": format!("Failed to read song config: {}", e)})),
-                        )
-                            .into_response(),
-                    },
-                    None => (
-                        StatusCode::NOT_FOUND,
-                        Json(json!({"error": format!("No config file found for failed song: {}", name)})),
-                    )
-                        .into_response(),
-                };
-            }
-
-            (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("Song not found: {}", name)})),
-            )
-                .into_response()
-        }
+    match result {
+        GetSongResult::YamlPath(path) => read_yaml_response(path).await,
+        GetSongResult::Summary(resp) | GetSongResult::NotFound(resp) => resp,
     }
 }
 
@@ -291,12 +291,12 @@ pub(super) async fn import_file_to_song(
     // codeql[rust/path-injection] dest_path is under song_dir (verified by resolve_or_create_song_dir),
     // filename is validated by validate_track_filename (no .. or / allowed).
     let dest_path = song_dir.join_filename(filename);
-    if let Err(e) = std::fs::copy(&source, &dest_path) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to copy file: {}", e)})),
-        )
-            .into_response();
+    let src = source.as_path().to_path_buf();
+    let dst = dest_path.clone();
+    if let Err(e) =
+        super::helpers::spawn_blocking_io("copy file", move || std::fs::copy(&src, &dst)).await
+    {
+        return e;
     }
 
     if let Err(e) = ensure_song_config(&song_dir) {
@@ -362,20 +362,20 @@ pub(super) async fn delete_song(
             .into_response();
     }
 
-    if let Err(e) = std::fs::remove_file(&config_path) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to delete song.yaml: {}", e)})),
-        )
-            .into_response();
+    let cp = config_path.clone();
+    let song_name = name.clone();
+    let pl_dir = state.playlists_dir.clone();
+    let legacy_pl = state.legacy_playlist_path.clone();
+    if let Err(e) = super::helpers::spawn_blocking_io("delete song", move || {
+        std::fs::remove_file(&cp)?;
+        // Remove the song from any playlist files on disk so they stay valid.
+        remove_song_from_playlists(&song_name, pl_dir.as_deref(), legacy_pl.as_deref());
+        Ok::<_, std::io::Error>(())
+    })
+    .await
+    {
+        return e;
     }
-
-    // Remove the song from any playlist files on disk so they stay valid.
-    remove_song_from_playlists(
-        &name,
-        state.playlists_dir.as_deref(),
-        state.legacy_playlist_path.as_deref(),
-    );
 
     // Refresh the player's song state.
     state.player.reload_songs(
@@ -559,52 +559,49 @@ pub(super) async fn get_song_files(
         }
     };
 
-    let song_dir = song.base_path();
+    let song_dir = song.base_path().to_path_buf();
 
-    let mut files: Vec<serde_json::Value> = Vec::new();
-    match std::fs::read_dir(song_dir) {
-        Ok(entries) => {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if !path.is_file() {
-                    continue;
-                }
-                let filename = match path.file_name().and_then(|n| n.to_str()) {
-                    Some(n) => n.to_string(),
-                    None => continue,
-                };
-                // Skip song config files
-                if filename == "song.yaml" || filename == "song.yml" {
-                    continue;
-                }
-                let ext = path
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-                let file_type = if songs::is_supported_audio_extension(&ext) {
-                    "audio"
-                } else if ext == "mid" {
-                    "midi"
-                } else if ext == "light" {
-                    "lighting"
-                } else {
-                    "other"
-                };
-                files.push(json!({
-                    "name": filename,
-                    "type": file_type,
-                }));
+    let mut files = match super::helpers::spawn_blocking_io("read song dir", move || {
+        let mut files: Vec<serde_json::Value> = Vec::new();
+        for entry in std::fs::read_dir(&song_dir)?.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
             }
+            let filename = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            // Skip song config files
+            if filename == "song.yaml" || filename == "song.yml" {
+                continue;
+            }
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+            let file_type = if songs::is_supported_audio_extension(&ext) {
+                "audio"
+            } else if ext == "mid" {
+                "midi"
+            } else if ext == "light" {
+                "lighting"
+            } else {
+                "other"
+            };
+            files.push(json!({
+                "name": filename,
+                "type": file_type,
+            }));
         }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to read directory: {}", e)})),
-            )
-                .into_response();
-        }
-    }
+        Ok::<_, std::io::Error>(files)
+    })
+    .await
+    {
+        Ok(f) => f,
+        Err(e) => return e,
+    };
 
     files.sort_by(|a, b| {
         a.get("name")
@@ -652,21 +649,26 @@ pub(super) async fn post_song(
             .into_response();
     }
 
-    match config_io::atomic_write(&config_path, &body) {
-        Ok(()) => {
-            state.player.reload_songs(
-                &state.songs_path,
-                state.playlists_dir.as_deref(),
-                state.legacy_playlist_path.as_deref(),
-            );
-            (
-                StatusCode::CREATED,
-                Json(json!({"status": "created", "song": name})),
-            )
-                .into_response()
-        }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response(),
+    let cp = config_path;
+    let body_owned = body;
+    if let Err(e) = super::helpers::spawn_blocking_io("write song config", move || {
+        config_io::atomic_write(&cp, &body_owned)
+    })
+    .await
+    {
+        return e;
     }
+
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
+    (
+        StatusCode::CREATED,
+        Json(json!({"status": "created", "song": name})),
+    )
+        .into_response()
 }
 
 /// PUT /api/songs/:name — validates and atomically writes a song config.
@@ -690,17 +692,22 @@ pub(super) async fn put_song(
         return e;
     }
 
-    match config_io::atomic_write(&config_path, &body) {
-        Ok(()) => {
-            state.player.reload_songs(
-                &state.songs_path,
-                state.playlists_dir.as_deref(),
-                state.legacy_playlist_path.as_deref(),
-            );
-            (StatusCode::OK, Json(json!({"status": "saved"}))).into_response()
-        }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e}))).into_response(),
+    let cp = config_path;
+    let body_owned = body;
+    if let Err(e) = super::helpers::spawn_blocking_io("write song config", move || {
+        config_io::atomic_write(&cp, &body_owned)
+    })
+    .await
+    {
+        return e;
     }
+
+    state.player.reload_songs(
+        &state.songs_path,
+        state.playlists_dir.as_deref(),
+        state.legacy_playlist_path.as_deref(),
+    );
+    (StatusCode::OK, Json(json!({"status": "saved"}))).into_response()
 }
 
 /// PUT /api/songs/:name/tracks/:filename — uploads a single track file.
@@ -718,13 +725,9 @@ pub(super) async fn upload_track_single(
 
     let file_path = song_dir.join_filename(&filename);
     let replaced = file_path.exists();
-    if let Err(e) = std::fs::write(&file_path, &body) {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("Failed to write file: {}", e)})),
-        )
-            .into_response());
-    }
+    let fp = file_path.clone();
+    let data = body.to_vec();
+    super::helpers::spawn_blocking_io("write track", move || std::fs::write(&fp, &data)).await?;
 
     ensure_song_config(&song_dir).map_err(|e| *e)?;
     state.player.reload_songs(
@@ -733,7 +736,7 @@ pub(super) async fn upload_track_single(
         state.legacy_playlist_path.as_deref(),
     );
 
-    Ok((
+    Ok::<_, axum::response::Response>((
         StatusCode::OK,
         Json(json!({
             "status": if replaced { "replaced" } else { "uploaded" },
@@ -782,13 +785,12 @@ pub(super) async fn upload_tracks_multipart(
         })?;
 
         let file_path = song_dir.join_filename(&filename);
-        std::fs::write(&file_path, &data).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("Failed to write file {}: {}", filename, e)})),
-            )
-                .into_response()
-        })?;
+        let fp = file_path.clone();
+        let data_vec = data.to_vec();
+        super::helpers::spawn_blocking_io("write track file", move || {
+            std::fs::write(&fp, &data_vec)
+        })
+        .await?;
 
         uploaded.push(filename);
     }


### PR DESCRIPTION
- Extract resolve_effect_groups to LightingSystem method (dedup dmx/engine + watcher)
- Introduce ParseContext struct, collapsing 6-7 parser function params into one
- Extract build_active_source helper in cpal.rs (3 identical construction sites)
- Fix BufferedSampleSource::next_sample per-call Vec allocation with reusable buffer
- EffectEngine::update() returns &[DmxCommand] instead of cloning Vec every frame
- Replace spin-wait with condvar-based PlaybackClock::wait_for_start_or_cancel()
- Replace Mutex<Duration> with AtomicU64 for DMX engine current_song_time