### PR TITLE
Typed error enums and EffectEngine decomposition

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -48,6 +48,31 @@ pub fn next_source_id() -> u64 {
 /// Type alias for the channel sender used to add sources to the mixer.
 pub type SourceSender = crossbeam_channel::Sender<mixer::ActiveSource>;
 
+/// Typed errors for the audio subsystem.
+#[derive(Debug, thiserror::Error)]
+pub enum AudioError {
+    #[error("Audio device not found: {0}")]
+    DeviceNotFound(String),
+
+    #[error("Audio format mismatch: {0}")]
+    FormatMismatch(String),
+
+    #[error("Audio playback error: {0}")]
+    Playback(String),
+
+    #[error("Audio stream error: {0}")]
+    Stream(String),
+
+    #[error(transparent)]
+    Other(Box<dyn Error + Send + Sync>),
+}
+
+impl From<Box<dyn Error + Send + Sync>> for AudioError {
+    fn from(e: Box<dyn Error + Send + Sync>) -> Self {
+        AudioError::Other(e)
+    }
+}
+
 pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Plays the given song through the audio interface, starting from a specific time.
     /// The `ready_tx` sender signals that setup is complete. The implementation should
@@ -58,7 +83,7 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
         song: Arc<Song>,
         mappings: &HashMap<String, Vec<u16>>,
         sync: PlaybackSync,
-    ) -> Result<(), Box<dyn Error>>;
+    ) -> Result<(), AudioError>;
 
     /// Gets the mixer for adding triggered samples.
     /// Returns None if the device doesn't support triggered samples.
@@ -84,15 +109,16 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     }
 
     #[cfg(test)]
-    fn to_mock(&self) -> Result<Arc<mock::Device>, Box<dyn Error>>;
+    fn to_mock(&self) -> Result<Arc<mock::Device>, AudioError>;
 }
 
 /// Finds a cpal input device by name, searching all available hosts.
-pub(crate) fn find_input_device(name: &str) -> Result<::cpal::Device, Box<dyn Error>> {
+pub(crate) fn find_input_device(name: &str) -> Result<::cpal::Device, AudioError> {
     use ::cpal::traits::{DeviceTrait, HostTrait};
 
     for host_id in ::cpal::available_hosts() {
-        let host = ::cpal::host_from_id(host_id)?;
+        let host =
+            ::cpal::host_from_id(host_id).map_err(|e| AudioError::Playback(e.to_string()))?;
         let devices = match host.input_devices() {
             Ok(d) => d,
             Err(e) => {
@@ -116,24 +142,28 @@ pub(crate) fn find_input_device(name: &str) -> Result<::cpal::Device, Box<dyn Er
         }
     }
 
-    Err(format!("No input device found with name '{}'", name).into())
+    Err(AudioError::DeviceNotFound(name.to_string()))
 }
 
 /// Lists audio devices as simple info structs for the web UI.
-pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, Box<dyn Error>> {
-    cpal::list_device_info()
+pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, AudioError> {
+    cpal::list_device_info().map_err(|e| AudioError::Playback(e.to_string()))
 }
 
 /// Lists devices known to cpal.
-pub fn list_devices() -> Result<Vec<Box<dyn Device>>, Box<dyn Error>> {
-    cpal::Device::list()
+pub fn list_devices() -> Result<Vec<Box<dyn Device>>, AudioError> {
+    cpal::Device::list().map_err(|e| AudioError::Playback(e.to_string()))
 }
 
 /// Gets a device with the given name.
-pub fn get_device(config: Option<config::Audio>) -> Result<Arc<dyn Device>, Box<dyn Error>> {
+pub fn get_device(config: Option<config::Audio>) -> Result<Arc<dyn Device>, AudioError> {
     let config = match config {
         Some(config) => config,
-        None => return Err("there must be an audio device specified".into()),
+        None => {
+            return Err(AudioError::DeviceNotFound(
+                "there must be an audio device specified".to_string(),
+            ))
+        }
     };
 
     let device = config.device();
@@ -141,7 +171,9 @@ pub fn get_device(config: Option<config::Audio>) -> Result<Arc<dyn Device>, Box<
         return Ok(Arc::new(mock::Device::get(device)));
     };
 
-    Ok(Arc::new(cpal::Device::get(config)?))
+    Ok(Arc::new(
+        cpal::Device::get(config).map_err(|e| AudioError::Playback(e.to_string()))?,
+    ))
 }
 
 #[cfg(test)]
@@ -152,7 +184,10 @@ mod test {
     fn get_device_none_returns_error() {
         let result = get_device(None);
         match result {
-            Err(e) => assert!(e.to_string().contains("audio device specified")),
+            Err(AudioError::DeviceNotFound(msg)) => {
+                assert!(msg.contains("audio device specified"))
+            }
+            Err(e) => panic!("expected DeviceNotFound, got: {}", e),
             Ok(_) => panic!("expected error for None config"),
         }
     }
@@ -178,11 +213,11 @@ mod test {
                 _song: Arc<Song>,
                 _mappings: &HashMap<String, Vec<u16>>,
                 _sync: PlaybackSync,
-            ) -> Result<(), Box<dyn Error>> {
+            ) -> Result<(), AudioError> {
                 Ok(())
             }
-            fn to_mock(&self) -> Result<Arc<mock::Device>, Box<dyn Error>> {
-                Err("not a mock".into())
+            fn to_mock(&self) -> Result<Arc<mock::Device>, AudioError> {
+                Err(AudioError::Other("not a mock".into()))
             }
         }
         let d = Dummy;
@@ -252,5 +287,18 @@ mod test {
                 "IDs should be monotonically increasing"
             );
         }
+    }
+
+    #[test]
+    fn audio_error_device_not_found() {
+        let e = AudioError::DeviceNotFound("test-device".to_string());
+        assert!(e.to_string().contains("test-device"));
+    }
+
+    #[test]
+    fn audio_error_from_boxed() {
+        let boxed: Box<dyn Error + Send + Sync> = "something failed".into();
+        let e: AudioError = boxed.into();
+        assert!(e.to_string().contains("something failed"));
     }
 }

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -437,7 +437,7 @@ impl AudioDevice for Device {
         song: Arc<Song>,
         mappings: &HashMap<String, Vec<u16>>,
         sync: crate::playsync::PlaybackSync,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), crate::audio::AudioError> {
         let crate::playsync::PlaybackSync {
             cancel_handle,
             mut ready_tx,
@@ -468,7 +468,8 @@ impl AudioDevice for Device {
             "Playing song."
         );
 
-        validate_channel_count(mappings, self.max_channels, song.name(), &self.name)?;
+        validate_channel_count(mappings, self.max_channels, song.name(), &self.name)
+            .map_err(|e| crate::audio::AudioError::Playback(e.to_string()))?;
 
         ready_tx.send();
 
@@ -502,12 +503,15 @@ impl AudioDevice for Device {
         );
 
         // Create channel mapped sources for each track in the song, starting from start_time.
-        let channel_mapped_sources =
-            song.create_channel_mapped_sources_from(&playback_context, start_time, mappings)?;
+        let channel_mapped_sources = song
+            .create_channel_mapped_sources_from(&playback_context, start_time, mappings)
+            .map_err(|e| crate::audio::AudioError::Playback(e.to_string()))?;
 
         // Add all sources to the output manager
         if channel_mapped_sources.is_empty() {
-            return Err("No sources found in song".into());
+            return Err(crate::audio::AudioError::Playback(
+                "No sources found in song".to_string(),
+            ));
         }
 
         // If there are already sources in the mixer (fading out from a previous
@@ -543,7 +547,9 @@ impl AudioDevice for Device {
                 song_crossfade_envelope.clone(),
             );
             source_finish_flags.push(flag);
-            self.output_manager.add_source(active_source)?;
+            self.output_manager
+                .add_source(active_source)
+                .map_err(|e| crate::audio::AudioError::Playback(e.to_string()))?;
         }
 
         // Monitor loop: polls for source completion, cancellation, and section boundaries.
@@ -755,8 +761,8 @@ impl AudioDevice for Device {
     }
 
     #[cfg(test)]
-    fn to_mock(&self) -> Result<Arc<super::super::mock::Device>, Box<dyn Error>> {
-        Err("not a mock".into())
+    fn to_mock(&self) -> Result<Arc<super::super::mock::Device>, crate::audio::AudioError> {
+        Err(crate::audio::AudioError::Other("not a mock".into()))
     }
 }
 

--- a/src/audio/mock.rs
+++ b/src/audio/mock.rs
@@ -13,7 +13,6 @@
 //
 use std::{
     collections::HashMap,
-    error::Error,
     fmt,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -56,7 +55,7 @@ impl crate::audio::Device for Device {
         song: Arc<Song>,
         _: &HashMap<String, Vec<u16>>,
         sync: crate::playsync::PlaybackSync,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), crate::audio::AudioError> {
         let crate::playsync::PlaybackSync {
             cancel_handle,
             ready_tx,
@@ -108,18 +107,22 @@ impl crate::audio::Device for Device {
         // This ensures tests can check is_playing immediately after stop() without races
         self.is_playing.store(false, Ordering::Relaxed);
 
-        sleep_tx.send(())?;
+        sleep_tx
+            .send(())
+            .map_err(|e| crate::audio::AudioError::Playback(e.to_string()))?;
         let join_result = join_handle.join();
 
         if join_result.is_err() {
-            return Err("Error while joining thread!".into());
+            return Err(crate::audio::AudioError::Playback(
+                "Error while joining thread!".to_string(),
+            ));
         }
 
         Ok(())
     }
 
     #[cfg(test)]
-    fn to_mock(&self) -> Result<Arc<Device>, Box<dyn Error>> {
+    fn to_mock(&self) -> Result<Arc<Device>, crate::audio::AudioError> {
         Ok(Arc::new(self.clone()))
     }
 }

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -46,6 +46,15 @@ pub enum ConfigError {
 
     #[error("Invalid profile index {index} (have {len} profiles)")]
     InvalidProfileIndex { index: usize, len: usize },
+
+    #[error("Validation error: {0}")]
+    Validation(String),
+
+    #[error("Missing field: {0}")]
+    MissingField(String),
+
+    #[error(transparent)]
+    Other(Box<dyn std::error::Error + Send + Sync>),
 }
 
 #[cfg(test)]

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -27,7 +27,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::error::ConfigError;
-use std::error::Error;
 use tracing::{error, info, warn};
 
 fn default_active_playlist() -> String {
@@ -535,7 +534,7 @@ impl Player {
 
     /// Gets the samples configuration, merging inline definitions with any external file.
     /// The player_path is used to resolve relative paths.
-    pub fn samples_config(&self, player_path: &Path) -> Result<SamplesConfig, Box<dyn Error>> {
+    pub fn samples_config(&self, player_path: &Path) -> Result<SamplesConfig, ConfigError> {
         let mut config = SamplesConfig::new(
             self.samples.clone(),
             Vec::new(),

--- a/src/dmx.rs
+++ b/src/dmx.rs
@@ -30,6 +30,28 @@ use std::time::Duration;
 use std::{error::Error, path::Path, sync::Arc};
 use tracing::info;
 
+/// Typed errors for the DMX subsystem.
+#[derive(Debug, thiserror::Error)]
+pub enum DmxError {
+    #[error("DMX engine initialization error: {0}")]
+    Init(String),
+
+    #[error("DMX playback error: {0}")]
+    Playback(String),
+
+    #[error("DMX validation error: {0}")]
+    Validation(String),
+
+    #[error(transparent)]
+    Other(Box<dyn Error + Send + Sync>),
+}
+
+impl From<Box<dyn Error + Send + Sync>> for DmxError {
+    fn from(e: Box<dyn Error + Send + Sync>) -> Self {
+        DmxError::Other(e)
+    }
+}
+
 /// Creates a DMX engine, connecting to the OLA daemon for output.
 /// Falls back to a no-op OLA client if the OLA daemon is unavailable, so the
 /// lighting/effects engine can still run without physical hardware (web UI, etc.).

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -31,50 +31,137 @@ use tracing::debug;
 
 use crate::dmx::midi_dmx_store::MidiDmxStore;
 
+/// Registry of known fixtures and their DMX mappings.
+pub(crate) struct FixtureRegistry {
+    fixtures: HashMap<String, FixtureInfo>,
+    /// Reverse map from (universe_id, dmx_channel) to (fixture_name, channel_name).
+    /// Only built during tests for validation; not needed in production.
+    #[cfg(test)]
+    dmx_to_fixture_map: HashMap<(u16, u16), (String, String)>,
+}
+
+impl FixtureRegistry {
+    fn new() -> Self {
+        Self {
+            fixtures: HashMap::new(),
+            #[cfg(test)]
+            dmx_to_fixture_map: HashMap::new(),
+        }
+    }
+
+    fn register(&mut self, fixture: FixtureInfo) {
+        #[cfg(test)]
+        {
+            for (channel_name, &offset) in &fixture.channels {
+                let dmx_channel = fixture.address + offset - 1;
+                self.dmx_to_fixture_map.insert(
+                    (fixture.universe, dmx_channel),
+                    (fixture.name.clone(), channel_name.clone()),
+                );
+            }
+        }
+        self.fixtures.insert(fixture.name.clone(), fixture);
+    }
+
+    fn get(&self, name: &str) -> Option<&FixtureInfo> {
+        self.fixtures.get(name)
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.fixtures.contains_key(name)
+    }
+
+    fn as_map(&self) -> &HashMap<String, FixtureInfo> {
+        &self.fixtures
+    }
+
+    #[cfg(test)]
+    fn lookup_dmx_channel(&self, universe: u16, dmx_channel: u16) -> Option<&(String, String)> {
+        self.dmx_to_fixture_map.get(&(universe, dmx_channel))
+    }
+}
+
+/// Layer control state: intensity masters, speed masters, and frozen layers.
+struct LayerState {
+    /// Layer intensity masters (0.0 to 1.0) — multiplies effect output per layer.
+    intensity_masters: HashMap<EffectLayer, f64>,
+    /// Layer speed masters (0.0+) — multiplies effect speed per layer (1.0 = normal).
+    speed_masters: HashMap<EffectLayer, f64>,
+    /// Frozen layers — maps layer to the Instant when it was frozen.
+    frozen: HashMap<EffectLayer, Instant>,
+}
+
+impl LayerState {
+    fn new() -> Self {
+        Self {
+            intensity_masters: HashMap::new(),
+            speed_masters: HashMap::new(),
+            frozen: HashMap::new(),
+        }
+    }
+
+    fn intensity_master(&self, layer: &EffectLayer) -> f64 {
+        *self.intensity_masters.get(layer).unwrap_or(&1.0)
+    }
+
+    fn speed_master(&self, layer: &EffectLayer) -> f64 {
+        *self.speed_masters.get(layer).unwrap_or(&1.0)
+    }
+}
+
+/// Caches the last computed DmxCommands so unchanged frames skip recomputation.
+struct EffectCache {
+    commands: Vec<DmxCommand>,
+    /// Last-seen MIDI DMX store generation.
+    last_store_generation: u32,
+    /// True when engine state changed outside update() (e.g. clear_layer).
+    dirty: bool,
+}
+
+impl EffectCache {
+    fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+            last_store_generation: 0,
+            dirty: false,
+        }
+    }
+
+    fn invalidate(&mut self) {
+        self.dirty = true;
+    }
+
+    fn get_cached(&self) -> &[DmxCommand] {
+        &self.commands
+    }
+
+    fn update(&mut self, commands: Vec<DmxCommand>, generation: u32) {
+        self.commands = commands;
+        self.last_store_generation = generation;
+        self.dirty = false;
+    }
+}
+
 /// The main effects engine that manages and processes lighting effects
 pub struct EffectEngine {
     active_effects: HashMap<String, EffectInstance>,
-    fixture_registry: HashMap<String, FixtureInfo>,
+    fixtures: FixtureRegistry,
     current_time: Instant,
     /// Elapsed simulated time since engine start
     engine_elapsed: Duration,
     /// Optional tempo map for tempo-aware effects (measure/beat-based timing)
     tempo_map: Option<TempoMap>,
-    /// Layer intensity masters (0.0 to 1.0) - multiplies effect output per layer
-    layer_intensity_masters: HashMap<EffectLayer, f64>,
-    /// Layer speed masters (0.0+) - multiplies effect speed per layer (1.0 = normal)
-    layer_speed_masters: HashMap<EffectLayer, f64>,
-    /// Frozen layers - maps layer to the Instant when it was frozen
-    /// Effects on frozen layers use this time instead of current_time for elapsed calculation
-    frozen_layers: HashMap<EffectLayer, Instant>,
-    /// Effects being released - tracks (release_fade_time, release_start_time) per effect
+    layer_state: LayerState,
+    /// Effects being released — tracks (release_fade_time, release_start_time) per effect
     releasing_effects: HashMap<String, (Duration, Instant)>,
     /// Last computed merged fixture states (for preview/debugging)
-    /// This stores the merged states from the last update() call
     last_merged_states: HashMap<String, FixtureState>,
     /// Last known song time (score-time) for tempo-aware speed lookups.
-    /// Updated each frame from update(). Used as the time reference for
-    /// tempo map BPM lookups instead of engine_elapsed, which drifts from
-    /// song position if the engine starts before the song.
     last_song_time: Option<Duration>,
-    /// Reverse map from (universe_id, dmx_channel) to (fixture_name, channel_name).
-    /// Only built during tests for validation; not needed in production.
-    #[cfg(test)]
-    dmx_to_fixture_map: HashMap<(u16, u16), (String, String)>,
     /// Reference to the MIDI DMX store for reading interpolated values each frame.
     midi_dmx_store: Option<Arc<parking_lot::RwLock<MidiDmxStore>>>,
-    /// Cached DmxCommands from the last update() — returned when nothing has changed.
-    cached_commands: Vec<DmxCommand>,
-    /// Last-seen MIDI DMX store generation (used to detect when recomputation can be skipped).
-    last_store_generation: u32,
-    /// Set when engine state is mutated outside of update() (e.g. clear_layer,
-    /// stop_all_effects). Forces the next update() to do a full recomputation
-    /// instead of returning cached commands.
-    cache_dirty: bool,
-    /// Sub-phase indicator for update() progress. Shared via Arc so external
-    /// code (heartbeat checker) can read it without holding the effect_engine lock.
-    /// 0=idle, 10=fast_path, 20=state_setup, 30=midi_dmx_inject, 40=effect_sort,
-    /// 50=effect_process, 60=completed_effects, 70=persist_state, 80=dmx_generate.
+    cache: EffectCache,
+    /// Sub-phase indicator for update() progress.
     update_subphase: Arc<AtomicU64>,
 }
 
@@ -88,22 +175,16 @@ impl EffectEngine {
     pub fn new() -> Self {
         Self {
             active_effects: HashMap::new(),
-            fixture_registry: HashMap::new(),
+            fixtures: FixtureRegistry::new(),
             current_time: Instant::now(),
             engine_elapsed: Duration::ZERO,
             tempo_map: None,
-            layer_intensity_masters: HashMap::new(),
-            layer_speed_masters: HashMap::new(),
-            frozen_layers: HashMap::new(),
+            layer_state: LayerState::new(),
             releasing_effects: HashMap::new(),
             last_merged_states: HashMap::new(),
             last_song_time: None,
-            #[cfg(test)]
-            dmx_to_fixture_map: HashMap::new(),
             midi_dmx_store: None,
-            cached_commands: Vec::new(),
-            last_store_generation: 0,
-            cache_dirty: false,
+            cache: EffectCache::new(),
             update_subphase: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -111,6 +192,14 @@ impl EffectEngine {
     /// Returns the shared update sub-phase Arc for external monitoring.
     pub fn update_subphase(&self) -> Arc<AtomicU64> {
         self.update_subphase.clone()
+    }
+
+    /// Returns the current MIDI DMX store generation, or 0 if no store is set.
+    fn store_generation(&self) -> u32 {
+        self.midi_dmx_store
+            .as_ref()
+            .map(|s| s.read().generation())
+            .unwrap_or(0)
     }
 
     /// Set the tempo map for tempo-aware effects
@@ -215,23 +304,13 @@ impl EffectEngine {
             );
         }
 
-        // Build reverse map entries for test validation
-        #[cfg(test)]
-        for (channel_name, &offset) in &fixture.channels {
-            let dmx_channel = fixture.address + offset - 1;
-            self.dmx_to_fixture_map.insert(
-                (fixture.universe, dmx_channel),
-                (fixture.name.clone(), channel_name.clone()),
-            );
-        }
-
-        self.fixture_registry.insert(fixture.name.clone(), fixture);
+        self.fixtures.register(fixture);
     }
 
-    /// Look up which fixture and channel a DMX address belongs to.
+    /// Look up which fixture and channel a DMX address belongs to (test only).
     #[cfg(test)]
     pub fn lookup_dmx_channel(&self, universe: u16, dmx_channel: u16) -> Option<&(String, String)> {
-        self.dmx_to_fixture_map.get(&(universe, dmx_channel))
+        self.fixtures.lookup_dmx_channel(universe, dmx_channel)
     }
 
     /// Set the MIDI DMX store reference for reading interpolated MIDI values.
@@ -242,7 +321,7 @@ impl EffectEngine {
     /// Start an effect
     pub fn start_effect(&mut self, mut effect: EffectInstance) -> Result<(), EffectError> {
         // Validate effect
-        validation::validate_effect(&self.fixture_registry, &effect)?;
+        validation::validate_effect(self.fixtures.as_map(), &effect)?;
 
         // Log effect parameters
         let (effect_kind, effect_params) = Self::format_effect_for_logging(&effect);
@@ -263,7 +342,7 @@ impl EffectEngine {
         // Set the start time to the current engine time
         effect.start_time = Some(self.current_time);
         self.active_effects.insert(effect.id.clone(), effect);
-        self.cache_dirty = true;
+        self.cache.invalidate();
         Ok(())
     }
 
@@ -275,7 +354,7 @@ impl EffectEngine {
         elapsed_time: Duration,
     ) -> Result<(), EffectError> {
         // Validate effect
-        validation::validate_effect(&self.fixture_registry, &effect)?;
+        validation::validate_effect(self.fixtures.as_map(), &effect)?;
 
         // Log effect parameters
         let (effect_kind, effect_params) = Self::format_effect_for_logging(&effect);
@@ -301,7 +380,7 @@ impl EffectEngine {
                 .unwrap_or(self.current_time),
         );
         self.active_effects.insert(effect.id.clone(), effect);
-        self.cache_dirty = true;
+        self.cache.invalidate();
         Ok(())
     }
 
@@ -320,7 +399,7 @@ impl EffectEngine {
         // Fast path for MIDI-DMX-only frames: when no DSL effects are running,
         // generate DmxCommands directly from the store. This skips all HashMap
         // cloning, fixture state rebuilding, and the full pipeline.
-        if !self.cache_dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
+        if !self.cache.dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
         {
             let store_gen = self
                 .midi_dmx_store
@@ -329,9 +408,9 @@ impl EffectEngine {
                 .unwrap_or(0);
 
             // Unchanged since last frame — return cached commands.
-            if store_gen == self.last_store_generation {
+            if store_gen == self.cache.last_store_generation {
                 self.update_subphase.store(0, Ordering::Relaxed);
-                return Ok(&self.cached_commands);
+                return Ok(self.cache.get_cached());
             }
 
             // Store changed — rebuild commands directly from store (no intermediate
@@ -343,7 +422,7 @@ impl EffectEngine {
                 let store = store.read();
                 for (slot_idx, normalized_value) in store.iter_active() {
                     let (fixture_name, channel_name) = store.fixture_info(slot_idx);
-                    if let Some(fixture_info) = self.fixture_registry.get(fixture_name) {
+                    if let Some(fixture_info) = self.fixtures.get(fixture_name) {
                         if let Some(&offset) = fixture_info.channels.get(channel_name) {
                             let dmx_channel = fixture_info.address + offset - 1;
                             let dmx_value = (normalized_value * 255.0) as u8;
@@ -369,24 +448,23 @@ impl EffectEngine {
                 }
             }
 
-            self.cached_commands = commands;
-            self.last_store_generation = store_gen;
+            self.cache.update(commands, store_gen);
             self.update_subphase.store(0, Ordering::Relaxed);
-            return Ok(&self.cached_commands);
+            return Ok(self.cache.get_cached());
         }
 
         // Cache-only fast path: effects existed previously but are now done,
         // permanent state exists, and nothing has changed.
-        if !self.cache_dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
+        if !self.cache.dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
         {
             let store_gen = self
                 .midi_dmx_store
                 .as_ref()
                 .map(|s| s.read().generation())
                 .unwrap_or(0);
-            if store_gen == self.last_store_generation {
+            if store_gen == self.cache.last_store_generation {
                 self.update_subphase.store(0, Ordering::Relaxed);
-                return Ok(&self.cached_commands);
+                return Ok(self.cache.get_cached());
             }
         }
 
@@ -406,7 +484,7 @@ impl EffectEngine {
             let store = store.read();
             for (slot_idx, normalized_value) in store.iter_active() {
                 let (fixture_name, channel_name) = store.fixture_info(slot_idx);
-                if self.fixture_registry.contains_key(fixture_name) {
+                if self.fixtures.contains(fixture_name) {
                     let state = current_fixture_states
                         .entry(fixture_name.clone())
                         .or_insert_with(FixtureState::new);
@@ -488,7 +566,7 @@ impl EffectEngine {
             // Get layer masters
             let layer_intensity = self.get_layer_intensity_master(layer);
             let layer_speed = self.get_layer_speed_master(layer);
-            let frozen_at = self.frozen_layers.get(&layer).cloned();
+            let frozen_at = self.layer_state.frozen.get(&layer).cloned();
 
             for effect_id in effect_ids {
                 // Get reference to effect to avoid unnecessary clone
@@ -552,7 +630,7 @@ impl EffectEngine {
 
                 // Process the effect and get fixture states
                 if let Some(mut effect_states) = processing::process_effect(
-                    &self.fixture_registry,
+                    self.fixtures.as_map(),
                     effect,
                     elapsed,
                     absolute_time,
@@ -587,7 +665,7 @@ impl EffectEngine {
 
                     // Blend the effect states into the current fixture states
                     for (fixture_name, effect_state) in effect_states {
-                        if self.fixture_registry.contains_key(&fixture_name) {
+                        if self.fixtures.contains(&fixture_name) {
                             current_fixture_states
                                 .entry(fixture_name.clone())
                                 .or_insert_with(FixtureState::new)
@@ -630,23 +708,18 @@ impl EffectEngine {
         // Convert fixture states to DMX commands.
         let mut commands = Vec::new();
         for (fixture_name, fixture_state) in current_fixture_states {
-            if let Some(fixture_info) = self.fixture_registry.get(&fixture_name) {
+            if let Some(fixture_info) = self.fixtures.get(&fixture_name) {
                 commands.extend(fixture_state.to_dmx_commands(fixture_info));
             }
         }
 
         // Cache commands and store generation for fast-path short-circuit on
         // subsequent frames where nothing changes.
-        self.cached_commands = commands;
-        self.last_store_generation = self
-            .midi_dmx_store
-            .as_ref()
-            .map(|s| s.read().generation())
-            .unwrap_or(0);
-        self.cache_dirty = false;
+        let gen = self.store_generation();
+        self.cache.update(commands, gen);
 
         self.update_subphase.store(0, Ordering::Relaxed);
-        Ok(&self.cached_commands)
+        Ok(self.cache.get_cached())
     }
 
     /// Stop all active effects
@@ -660,7 +733,7 @@ impl EffectEngine {
         if let Some(ref store) = self.midi_dmx_store {
             store.read().clear();
         }
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Stop all effects from a specific sequence
@@ -681,7 +754,7 @@ impl EffectEngine {
             self.active_effects.remove(&effect_id);
             self.releasing_effects.remove(&effect_id);
         }
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     // ===== Layer Control Methods (grandMA-inspired) =====
@@ -692,11 +765,11 @@ impl EffectEngine {
         layers::clear_layer(
             &mut self.active_effects,
             &mut self.releasing_effects,
-            &mut self.frozen_layers,
+            &mut self.layer_state.frozen,
             layer,
         );
         self.last_merged_states.clear();
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Clear all layers - immediately stops all effects on all layers
@@ -705,10 +778,10 @@ impl EffectEngine {
         layers::clear_all_layers(
             &mut self.active_effects,
             &mut self.releasing_effects,
-            &mut self.frozen_layers,
+            &mut self.layer_state.frozen,
         );
         self.last_merged_states.clear();
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Release a layer - gracefully fades out all effects on the specified layer
@@ -723,41 +796,41 @@ impl EffectEngine {
         layers::release_layer_with_time(
             &mut self.active_effects,
             &mut self.releasing_effects,
-            &mut self.frozen_layers,
+            &mut self.layer_state.frozen,
             layer,
             fade_time,
             self.current_time,
         );
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Freeze a layer - pauses all effects on the layer at their current state
     /// Effects maintain their current output values but don't advance in time
     pub fn freeze_layer(&mut self, layer: EffectLayer) {
         layers::freeze_layer(
-            &mut self.frozen_layers,
+            &mut self.layer_state.frozen,
             &mut self.active_effects,
             layer,
             self.current_time,
         );
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Unfreeze a layer - resumes effects on the layer from where they left off
     pub fn unfreeze_layer(&mut self, layer: EffectLayer) {
         layers::unfreeze_layer(
-            &mut self.frozen_layers,
+            &mut self.layer_state.frozen,
             &mut self.active_effects,
             layer,
             self.current_time,
         );
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Check if a layer is frozen
     #[cfg(test)]
     pub fn is_layer_frozen(&self, layer: EffectLayer) -> bool {
-        self.frozen_layers.contains_key(&layer)
+        self.layer_state.frozen.contains_key(&layer)
     }
 
     // ===== Layer Master Methods =====
@@ -765,13 +838,17 @@ impl EffectEngine {
     /// Set the intensity master for a layer (0.0 to 1.0)
     /// This multiplies with all effect outputs on the layer
     pub fn set_layer_intensity_master(&mut self, layer: EffectLayer, intensity: f64) {
-        layers::set_layer_intensity_master(&mut self.layer_intensity_masters, layer, intensity);
-        self.cache_dirty = true;
+        layers::set_layer_intensity_master(
+            &mut self.layer_state.intensity_masters,
+            layer,
+            intensity,
+        );
+        self.cache.invalidate();
     }
 
     /// Get the intensity master for a layer (defaults to 1.0)
     pub fn get_layer_intensity_master(&self, layer: EffectLayer) -> f64 {
-        *self.layer_intensity_masters.get(&layer).unwrap_or(&1.0)
+        self.layer_state.intensity_master(&layer)
     }
 
     /// Set the speed master for a layer (0.0+ where 1.0 = normal speed)
@@ -779,19 +856,19 @@ impl EffectEngine {
     /// 0.5 = half speed, 2.0 = double speed, 0.0 = frozen at current state
     pub fn set_layer_speed_master(&mut self, layer: EffectLayer, speed: f64) {
         layers::set_layer_speed_master(
-            &mut self.layer_speed_masters,
-            &mut self.frozen_layers,
+            &mut self.layer_state.speed_masters,
+            &mut self.layer_state.frozen,
             &mut self.active_effects,
             layer,
             speed,
             self.current_time,
         );
-        self.cache_dirty = true;
+        self.cache.invalidate();
     }
 
     /// Get the speed master for a layer (defaults to 1.0)
     pub fn get_layer_speed_master(&self, layer: EffectLayer) -> f64 {
-        *self.layer_speed_masters.get(&layer).unwrap_or(&1.0)
+        self.layer_state.speed_master(&layer)
     }
 
     /// Dispatch a single layer command to the appropriate engine method.
@@ -866,7 +943,7 @@ impl EffectEngine {
     /// Get the fixture registry (for simulator to determine fixture capabilities).
     #[allow(dead_code)]
     pub fn get_fixture_registry(&self) -> &HashMap<String, FixtureInfo> {
-        &self.fixture_registry
+        self.fixtures.as_map()
     }
 
     /// Get a formatted string listing all active effects

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -25,6 +25,28 @@ pub mod morningstar;
 pub(crate) mod playback;
 mod transform;
 
+/// Typed errors for the MIDI subsystem.
+#[derive(Debug, thiserror::Error)]
+pub enum MidiError {
+    #[error("MIDI device not found: {0}")]
+    DeviceNotFound(String),
+
+    #[error("MIDI port error: {0}")]
+    Port(String),
+
+    #[error("MIDI playback error: {0}")]
+    Playback(String),
+
+    #[error(transparent)]
+    Other(Box<dyn Error + Send + Sync>),
+}
+
+impl From<Box<dyn Error + Send + Sync>> for MidiError {
+    fn from(e: Box<dyn Error + Send + Sync>) -> Self {
+        MidiError::Other(e)
+    }
+}
+
 /// A MIDI device that can play MIDI files and listen for inputs.
 pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Watches MIDI input for events and sends them to the given sender. If a DMX engine

--- a/src/player/playback.rs
+++ b/src/player/playback.rs
@@ -110,7 +110,7 @@ impl Player {
             if let Err(e) = dmx_engine.validate_song_lighting(&song) {
                 error!(
                     song = song.name(),
-                    err = e.as_ref(),
+                    err = %e,
                     "Lighting show validation failed, preventing song playback"
                 );
                 return Err(e);
@@ -304,7 +304,7 @@ impl Player {
                 );
                 if let Err(ref e) = result {
                     error!(
-                        err = e.as_ref(),
+                        err = %e,
                         song = song_name,
                         "Error while playing song"
                     );
@@ -341,7 +341,7 @@ impl Player {
                     },
                 ) {
                     error!(
-                        err = e.as_ref(),
+                        err = %e,
                         song = song_name,
                         "Error while playing DMX"
                     );


### PR DESCRIPTION
- Introduce typed error enums (ConfigError, AudioError, MidiError, DmxError) replacing Box<dyn Error> in module APIs with structured variants
- Decompose EffectEngine into sub-structs (FixtureRegistry, LayerState, EffectCache), reducing direct field count from 17 to 11
- Add store_generation() helper to deduplicate MIDI DMX store reads
- All error Other variants use Box<dyn Error + Send + Sync> for axum handler compat