### PR TITLE
Split dmx/engine.rs into submodules

### DIFF
--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -29,24 +29,24 @@ use std::{
 use super::midi_dmx_store::MidiDmxStore;
 use super::ola_client::OlaClient;
 use ola::DmxBuffer;
-use tracing::{debug, error, info, span, warn, Level};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     config,
-    lighting::{
-        system::LightingSystem, timeline::LightingTimeline, validation::validate_light_shows,
-        EffectEngine,
-    },
+    lighting::{system::LightingSystem, timeline::LightingTimeline, EffectEngine},
     midi::playback::PrecomputedMidi,
     playsync::CancelHandle,
-    songs::{MidiSheet, Song},
 };
 
 use super::universe::Universe;
 
+mod midi_playback;
+mod playback;
+mod timeline;
+
 /// The result of classifying a MIDI message for DMX purposes.
 #[derive(Debug, PartialEq)]
-enum MidiDmxAction {
+pub(super) enum MidiDmxAction {
     /// NoteOn/NoteOff: key+1 → DMX channel, velocity*2 → value, uses dimming.
     KeyVelocity { channel: u16, value: u8 },
     /// Controller: controller+1 → DMX channel, value*2 → value, no dimming.
@@ -63,7 +63,7 @@ enum MidiDmxAction {
 /// - NoteOn/NoteOff: channel = key + 1 (0-based MIDI → 1-based DMX), value = velocity * 2
 /// - Controller: channel = controller + 1, value = value * 2
 /// - ProgramChange: dimming duration = program * dimming_speed_modifier seconds
-fn classify_midi_dmx_action(
+pub(super) fn classify_midi_dmx_action(
     midi_message: midly::MidiMessage,
     dimming_speed_modifier: f64,
 ) -> MidiDmxAction {
@@ -88,59 +88,36 @@ fn classify_midi_dmx_action(
 /// The DMX engine. This is meant to control the current state of the
 /// universe(s) that should be sent to our DMX interface(s).
 pub struct Engine {
-    dimming_speed_modifier: f64,
-    /// How long to wait before starting MIDI DMX DMX playback.
-    playback_delay: Duration,
-    universes: HashMap<u16, Universe>,
-    /// Mapping from universe names to IDs for MIDI DMX system
-    universe_name_to_id: HashMap<String, u16>,
-    cancel_handle: CancelHandle,
-    client_handle: Option<JoinHandle<()>>,
-    join_handles: Vec<JoinHandle<()>>,
-    /// Effects engine for processing lighting effects
-    effect_engine: Arc<Mutex<EffectEngine>>,
-    /// Lighting system for fixture and group management
-    lighting_system: Option<Arc<Mutex<LightingSystem>>>,
-    /// Lighting configuration for validation
-    lighting_config: Option<config::Lighting>,
-    /// Handle for the persistent effects loop thread
-    effects_loop_handle: Mutex<Option<JoinHandle<()>>>,
-    /// Current song timeline (thread-safe access for effects loop)
-    current_song_timeline: Arc<Mutex<Option<LightingTimeline>>>,
-    /// Current song time in nanoseconds (thread-safe access for effects loop)
-    current_song_time: Arc<AtomicU64>,
-    /// Flag indicating the current song's timeline has finished (all cues processed)
-    timeline_finished: Arc<AtomicBool>,
-    /// Cancel handle for notifying when timeline finishes
-    timeline_cancel_handle: Arc<Mutex<Option<CancelHandle>>>,
-    /// Broadcast sender for the web UI, used to start the file watcher per-song
-    broadcast_tx: Mutex<Option<tokio::sync::broadcast::Sender<String>>>,
-    /// Handle to the current file watcher (dropped/replaced per-song)
-    watcher_handle: Mutex<Option<super::watcher::WatcherHandle>>,
-    /// Lockless store for MIDI DMX DMX values with built-in interpolation.
-    /// RwLock protects structural changes (register_slot); hot-path reads
-    /// (write/tick/iter_active) take a cheap read lock while atomics handle data.
-    midi_dmx_store: Arc<parking_lot::RwLock<MidiDmxStore>>,
-    /// Active MIDI DMX playbacks dispatched from the effects loop.
-    midi_dmx_playbacks: Mutex<Vec<MidiDmxPlayback>>,
-    /// Heartbeat counter incremented by the effects loop each frame.
-    /// Used by barrier threads to detect if the effects loop has died.
-    effects_loop_heartbeat: Arc<AtomicU64>,
-    /// Phase indicator for the effects loop (0=idle, 1=tick, 2=midi_advance,
-    /// 3=update_effects, 4=update_song_lighting, 5=timeline_check).
-    /// Used for diagnostics when the heartbeat goes stale.
-    effects_loop_phase: Arc<AtomicU64>,
-    /// Sub-phase indicator from EffectEngine::update() for finer-grained diagnostics.
-    /// Shared Arc with the EffectEngine instance.
-    update_subphase: Arc<AtomicU64>,
+    pub(super) dimming_speed_modifier: f64,
+    pub(super) playback_delay: Duration,
+    pub(super) universes: HashMap<u16, Universe>,
+    pub(super) universe_name_to_id: HashMap<String, u16>,
+    pub(super) cancel_handle: CancelHandle,
+    pub(super) client_handle: Option<JoinHandle<()>>,
+    pub(super) join_handles: Vec<JoinHandle<()>>,
+    pub(super) effect_engine: Arc<Mutex<EffectEngine>>,
+    pub(super) lighting_system: Option<Arc<Mutex<LightingSystem>>>,
+    pub(super) lighting_config: Option<config::Lighting>,
+    pub(super) effects_loop_handle: Mutex<Option<JoinHandle<()>>>,
+    pub(super) current_song_timeline: Arc<Mutex<Option<LightingTimeline>>>,
+    pub(super) current_song_time: Arc<AtomicU64>,
+    pub(super) timeline_finished: Arc<AtomicBool>,
+    pub(super) timeline_cancel_handle: Arc<Mutex<Option<CancelHandle>>>,
+    pub(super) broadcast_tx: Mutex<Option<tokio::sync::broadcast::Sender<String>>>,
+    pub(super) watcher_handle: Mutex<Option<super::watcher::WatcherHandle>>,
+    pub(super) midi_dmx_store: Arc<parking_lot::RwLock<MidiDmxStore>>,
+    pub(super) midi_dmx_playbacks: Mutex<Vec<MidiDmxPlayback>>,
+    pub(super) effects_loop_heartbeat: Arc<AtomicU64>,
+    pub(super) effects_loop_phase: Arc<AtomicU64>,
+    pub(super) update_subphase: Arc<AtomicU64>,
 }
 
 /// A MIDI DMX light show being played back from the effects loop.
-struct MidiDmxPlayback {
-    precomputed: PrecomputedMidi,
-    cursor: usize,
-    universe_id: u16,
-    midi_channels: HashSet<u8>,
+pub(super) struct MidiDmxPlayback {
+    pub(super) precomputed: PrecomputedMidi,
+    pub(super) cursor: usize,
+    pub(super) universe_id: u16,
+    pub(super) midi_channels: HashSet<u8>,
 }
 
 /// DmxMessage is a message that can be passed around between senders and receivers.
@@ -375,487 +352,6 @@ impl Engine {
         self.universes.get(&universe_id)
     }
 
-    /// Validates a song's lighting shows against the engine's lighting config.
-    /// Returns an error if any lighting show references invalid groups or fixtures.
-    pub fn validate_song_lighting(&self, song: &Song) -> Result<(), Box<dyn Error>> {
-        let dsl_lighting_shows = song.dsl_lighting_shows();
-
-        if dsl_lighting_shows.is_empty() {
-            return Ok(());
-        }
-
-        // Validate group/fixture references against lighting config
-        if let Some(ref lighting_config) = self.lighting_config {
-            for dsl_show in dsl_lighting_shows {
-                validate_light_shows(dsl_show.shows(), Some(lighting_config)).map_err(|e| {
-                    format!(
-                        "Light show validation failed for {}: {}",
-                        dsl_show.file_path().display(),
-                        e
-                    )
-                })?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Plays the given song through the DMX interface.
-    pub fn play(
-        dmx_engine: Arc<Engine>,
-        song: Arc<Song>,
-        sync: crate::playsync::PlaybackSync,
-    ) -> Result<(), Box<dyn Error>> {
-        let crate::playsync::PlaybackSync {
-            cancel_handle,
-            mut ready_tx,
-            clock,
-            start_time,
-            loop_control,
-        } = sync;
-        let crate::playsync::LoopControl {
-            loop_break,
-            active_section,
-            section_loop_break,
-            ..
-        } = loop_control;
-        let span = span!(Level::INFO, "play song (dmx)");
-        let _enter = span.enter();
-
-        // Check if there are any lighting systems to play
-        let light_shows = song.light_shows();
-        let dsl_lighting_shows = song.dsl_lighting_shows();
-        let has_lighting = !dsl_lighting_shows.is_empty();
-
-        if light_shows.is_empty() && !has_lighting {
-            ready_tx.send();
-            return Ok(());
-        }
-
-        info!(
-            song = song.name(),
-            duration = song.duration_string(),
-            "Playing song DMX."
-        );
-
-        // Register fixtures with the effects engine if lighting system is available
-        if let Err(_e) = dmx_engine.register_venue_fixtures_safe() {
-            // Failed to register venue fixtures, continue without them
-        }
-
-        // Setup song lighting if available - work directly with DSL shows
-        if has_lighting {
-            info!(
-                "Setup lighting timeline with {} DSL light shows",
-                dsl_lighting_shows.len()
-            );
-
-            // Collect cached shows from DSL lighting shows
-            let all_shows: Vec<_> = dsl_lighting_shows
-                .iter()
-                .flat_map(|dsl_show| dsl_show.shows().values().cloned())
-                .collect();
-
-            if !all_shows.is_empty() {
-                let timeline = LightingTimeline::new(all_shows);
-                // Set or clear the tempo map — a song without a tempo block must not
-                // inherit one from the previous song.
-                {
-                    let mut effect_engine = dmx_engine.effect_engine.lock();
-                    effect_engine.set_tempo_map(timeline.tempo_map().cloned());
-                }
-                {
-                    let mut current_timeline = dmx_engine.current_song_timeline.lock();
-                    *current_timeline = Some(timeline);
-                }
-            }
-        } else {
-            // Clear lighting state from previous song so MIDI DMX songs
-            // don't inherit a stale tempo map or timeline.
-            {
-                let mut effect_engine = dmx_engine.effect_engine.lock();
-                effect_engine.set_tempo_map(None);
-            }
-            {
-                let mut current_timeline = dmx_engine.current_song_timeline.lock();
-                *current_timeline = None;
-            }
-        }
-
-        // Reset song time to start time for new song BEFORE starting timeline
-        // This ensures the effects loop uses the correct time when updating
-        dmx_engine.update_song_time(start_time);
-
-        // Start the lighting timeline at the specified time
-        dmx_engine.start_lighting_timeline_at(start_time);
-
-        // Start file watcher for hot-reload if broadcast channel is available
-        {
-            let broadcast_tx = dmx_engine.broadcast_tx.lock();
-            if let Some(tx) = broadcast_tx.as_ref() {
-                let file_paths: Vec<std::path::PathBuf> = dsl_lighting_shows
-                    .iter()
-                    .map(|s| s.file_path().to_path_buf())
-                    .collect();
-                if !file_paths.is_empty() {
-                    match super::watcher::start_watching(
-                        file_paths,
-                        dmx_engine.effect_engine.clone(),
-                        dmx_engine.current_song_timeline.clone(),
-                        dmx_engine.current_song_time.clone(),
-                        dmx_engine.lighting_system.clone(),
-                        dmx_engine.lighting_config.clone(),
-                        tx.clone(),
-                    ) {
-                        Ok(handle) => {
-                            *dmx_engine.watcher_handle.lock() = Some(handle);
-                        }
-                        Err(e) => {
-                            warn!("Failed to start light show file watcher: {}", e);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Note: Effects loop is now persistent and started in Engine::new()
-
-        let universe_ids: HashSet<u16> = dmx_engine.universes.keys().cloned().collect();
-
-        let mut dmx_midi_sheets: HashMap<String, (MidiSheet, Vec<u8>)> = HashMap::new();
-        for light_show in song.light_shows().iter() {
-            let universe_name = light_show.universe_name();
-            if let Some(&universe_id) = dmx_engine.universe_name_to_id.get(&universe_name) {
-                if !universe_ids.contains(&universe_id) {
-                    continue;
-                }
-
-                dmx_midi_sheets.insert(
-                    universe_name.clone(),
-                    (light_show.dmx_midi_sheet()?, light_show.midi_channels()),
-                );
-            }
-        }
-
-        if dmx_midi_sheets.is_empty() && !has_lighting {
-            info!(song = song.name(), "Song has no matching light shows.");
-            ready_tx.send();
-            return Ok(());
-        }
-
-        // Build MIDI DMX playbacks and store them for effects-loop dispatch.
-        // Drain the map to take ownership of MidiSheets (avoids cloning event vecs).
-        // This must happen BEFORE resetting timeline_finished to avoid a race where
-        // the effects loop sees empty playbacks + no timeline and sets finished=true.
-        {
-            let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
-            playbacks.clear();
-            for (universe_name, (midi_sheet, channels)) in dmx_midi_sheets.drain() {
-                let midi_channels = HashSet::from_iter(channels);
-                let universe_id = match dmx_engine.universe_name_to_id.get(&universe_name) {
-                    Some(&id) => id,
-                    None => continue,
-                };
-                let events = midi_sheet.precomputed.into_events();
-                // Seek cursor past start_time
-                let cursor = events.partition_point(|e| e.time < start_time);
-                playbacks.push(MidiDmxPlayback {
-                    precomputed: PrecomputedMidi::from_events(events),
-                    cursor,
-                    universe_id,
-                    midi_channels,
-                });
-            }
-        }
-
-        // Reset timeline finished flag for new song AFTER populating playbacks.
-        // This must be set to false before starting the song time tracker, since the
-        // tracker exits when timeline_finished is true.
-        dmx_engine.timeline_finished.store(false, Ordering::Relaxed);
-
-        // Start song time tracking (per-song, tracks elapsed time).
-        // Must start AFTER timeline_finished is reset, otherwise the tracker
-        // sees true from the previous song and exits immediately.
-        // Flag set by the section loop thread when it takes over song time writes.
-        // Until set, the song time tracker writes normally.
-        let section_owns_time = Arc::new(AtomicBool::new(false));
-
-        let song_time_tracker = Self::start_song_time_tracker_with_section(
-            dmx_engine.clone(),
-            cancel_handle.clone(),
-            start_time,
-            clock.clone(),
-            Some(section_owns_time.clone()),
-        );
-
-        // Store the cancel handle so the effects loop can notify when everything finishes
-        {
-            let mut handle = dmx_engine.timeline_cancel_handle.lock();
-            *handle = Some(cancel_handle.clone());
-        }
-
-        // Signal readiness — all setup is complete.
-        ready_tx.send();
-
-        // Wait for the clock to start (the "go" signal from play_files).
-        while clock.elapsed() == Duration::ZERO {
-            if cancel_handle.is_cancelled() {
-                dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
-                if let Err(e) = song_time_tracker.join() {
-                    error!("Error waiting for song time tracker to stop: {:?}", e);
-                }
-                return Ok(());
-            }
-            std::hint::spin_loop();
-        }
-
-        // Wait for the timeline to finish, using a heartbeat-aware loop that
-        // can recover if the effects loop dies.
-        let timeline_watcher = {
-            let cancel_handle = cancel_handle.clone();
-            let timeline_finished = dmx_engine.timeline_finished.clone();
-            let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
-            let phase = dmx_engine.effects_loop_phase.clone();
-            let subphase = dmx_engine.update_subphase.clone();
-            thread::spawn(move || {
-                Self::wait_for_timeline_with_heartbeat(
-                    &cancel_handle,
-                    timeline_finished,
-                    &heartbeat,
-                    &phase,
-                    &subphase,
-                );
-            })
-        };
-
-        // Section loop: continuously update song time to wrap within section bounds.
-        // Runs alongside the timeline watcher and song time tracker. When active,
-        // it overrides the song time tracker's writes with the wrapped time.
-        let section_loop_thread = {
-            let cancel_handle = cancel_handle.clone();
-            let active_section = active_section.clone();
-            let section_loop_break = section_loop_break.clone();
-            let section_owns_time = section_owns_time.clone();
-            let dmx_engine = dmx_engine.clone();
-            let clock = clock.clone();
-            let timeline_finished = dmx_engine.timeline_finished.clone();
-            thread::spawn(move || {
-                let mut section_monitor = crate::section_loop::SectionLoopMonitor::new();
-                let mut iteration_start: Option<Duration> = None;
-                // After loop break: (resume_time, clock_at_break). The thread
-                // keeps writing song time advancing from the resume point.
-                let mut continue_from: Option<(Duration, Duration)> = None;
-
-                loop {
-                    if cancel_handle.is_cancelled() || timeline_finished.load(Ordering::Relaxed) {
-                        break;
-                    }
-
-                    // Post-break: advance song time from resume point.
-                    if let Some((resume_time, break_clock)) = continue_from {
-                        let since_break = clock.elapsed().saturating_sub(break_clock);
-                        dmx_engine.update_song_time(resume_time + since_break);
-                        thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-
-                    // Check for loop break first (before reading active_section,
-                    // which may already be cleared by stop_section_loop).
-                    if section_loop_break.load(Ordering::Relaxed) {
-                        if let Some(section) = section_monitor.cached_section().cloned() {
-                            let elapsed = clock.elapsed();
-                            let current_pos = if let Some(iter_start) = iteration_start {
-                                let time_since = elapsed.saturating_sub(iter_start);
-                                let sd = section.end_time.saturating_sub(section.start_time);
-                                section.start_time + time_since.min(sd)
-                            } else {
-                                section.end_time
-                            };
-                            info!(
-                                position = ?current_pos,
-                                "DMX section loop: breaking, continuing from current position"
-                            );
-                            dmx_engine.update_song_time(current_pos);
-                            dmx_engine.start_lighting_timeline_at(current_pos);
-                            {
-                                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
-                                for playback in playbacks.iter_mut() {
-                                    let events = playback.precomputed.events();
-                                    playback.cursor =
-                                        events.partition_point(|e| e.time < current_pos);
-                                }
-                            }
-                            continue_from = Some((current_pos, elapsed));
-                        } else {
-                            // No cached section — just hand back to tracker.
-                            section_owns_time.store(false, Ordering::Relaxed);
-                        }
-                        thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-
-                    let elapsed = clock.elapsed();
-                    match section_monitor.poll(&active_section, elapsed) {
-                        crate::section_loop::LoopPoll::Waiting(ref section) => {
-                            let section_duration =
-                                section.end_time.saturating_sub(section.start_time);
-                            if section_duration.is_zero() {
-                                break;
-                            }
-                            if let Some(iter_start) = iteration_start {
-                                let time_since = elapsed.saturating_sub(iter_start);
-                                let position = time_since.min(section_duration);
-                                dmx_engine.update_song_time(section.start_time + position);
-                            }
-                        }
-                        crate::section_loop::LoopPoll::Triggered(ref section) => {
-                            info!(
-                                section = section.name,
-                                "DMX section loop: resetting for next iteration"
-                            );
-                            dmx_engine.start_lighting_timeline_at(section.start_time);
-                            {
-                                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
-                                for playback in playbacks.iter_mut() {
-                                    let events = playback.precomputed.events();
-                                    playback.cursor =
-                                        events.partition_point(|e| e.time < section.start_time);
-                                }
-                            }
-                            dmx_engine.update_song_time(section.start_time);
-                            section_owns_time.store(true, Ordering::Relaxed);
-                            iteration_start = Some(elapsed);
-                        }
-                        crate::section_loop::LoopPoll::SectionCleared => {
-                            iteration_start = None;
-                            section_owns_time.store(false, Ordering::Relaxed);
-                        }
-                        crate::section_loop::LoopPoll::NoSection => {
-                            iteration_start = None;
-                            section_owns_time.store(false, Ordering::Relaxed);
-                        }
-                    }
-
-                    thread::sleep(Duration::from_millis(10));
-                }
-            })
-        };
-
-        if let Err(e) = timeline_watcher.join() {
-            error!("Error while joining timeline watcher thread: {:?}", e);
-        }
-
-        // Song playback finished - signal the song time tracker to stop.
-        dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
-
-        if let Err(e) = song_time_tracker.join() {
-            error!("Error waiting for song time tracker to stop: {:?}", e);
-        }
-
-        // Loop if the song has loop_playback enabled.
-        while song.loop_playback()
-            && !cancel_handle.is_cancelled()
-            && !loop_break.load(Ordering::Relaxed)
-        {
-            info!(
-                song = song.name(),
-                "DMX loop: restarting timeline from beginning"
-            );
-
-            // Reset state for new loop iteration.
-            dmx_engine.update_song_time(Duration::ZERO);
-            dmx_engine.start_lighting_timeline_at(Duration::ZERO);
-
-            // Reset MIDI DMX playback cursors to the beginning.
-            {
-                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
-                for playback in playbacks.iter_mut() {
-                    playback.cursor = 0;
-                }
-            }
-
-            dmx_engine.timeline_finished.store(false, Ordering::Relaxed);
-
-            // Start a new song time tracker for this loop iteration.
-            let loop_time_tracker = Self::start_song_time_tracker_from(
-                dmx_engine.clone(),
-                cancel_handle.clone(),
-                Duration::ZERO,
-                clock.clone(),
-            );
-
-            // Wait for timeline to finish again.
-            let loop_watcher = {
-                let cancel_handle = cancel_handle.clone();
-                let timeline_finished = dmx_engine.timeline_finished.clone();
-                let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
-                let phase = dmx_engine.effects_loop_phase.clone();
-                let subphase = dmx_engine.update_subphase.clone();
-                thread::spawn(move || {
-                    Self::wait_for_timeline_with_heartbeat(
-                        &cancel_handle,
-                        timeline_finished,
-                        &heartbeat,
-                        &phase,
-                        &subphase,
-                    );
-                })
-            };
-
-            if let Err(e) = loop_watcher.join() {
-                error!("Error while joining loop timeline watcher: {:?}", e);
-            }
-
-            dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
-
-            if let Err(e) = loop_time_tracker.join() {
-                error!("Error waiting for loop time tracker to stop: {:?}", e);
-            }
-        }
-
-        // Stop section loop thread.
-        section_loop_break.store(true, Ordering::Relaxed);
-        if let Err(e) = section_loop_thread.join() {
-            error!("Error joining section loop thread: {:?}", e);
-        }
-
-        // Final cleanup.
-        dmx_engine.stop_lighting_timeline();
-        dmx_engine.midi_dmx_playbacks.lock().clear();
-
-        info!("DMX playback stopped.");
-
-        Ok(())
-    }
-
-    /// Advances all MIDI DMX playback cursors to the current song time,
-    /// dispatching events via handle_midi_event_by_id.
-    fn advance_midi_dmx_playbacks(&self) {
-        let song_time = match self.get_song_time().checked_sub(self.playback_delay) {
-            Some(t) => t,
-            None => return, // Still within the playback delay period
-        };
-        let mut playbacks = self.midi_dmx_playbacks.lock();
-        for playback in playbacks.iter_mut() {
-            let events = playback.precomputed.events();
-            while playback.cursor < events.len() && events[playback.cursor].time <= song_time {
-                let event = &events[playback.cursor];
-                if playback.midi_channels.is_empty()
-                    || playback.midi_channels.contains(&event.channel)
-                {
-                    self.handle_midi_event_by_id(playback.universe_id, event.message);
-                }
-                playback.cursor += 1;
-            }
-        }
-    }
-
-    /// Returns true if all MIDI DMX playbacks have finished.
-    fn midi_dmx_playbacks_finished(&self) -> bool {
-        let playbacks = self.midi_dmx_playbacks.lock();
-        playbacks.iter().all(|p| p.cursor >= p.precomputed.len())
-    }
-
     /// Handles an incoming MIDI event (by universe name).
     pub fn handle_midi_event(&self, universe_name: String, midi_message: midly::MidiMessage) {
         if let Some(&universe_id) = self.universe_name_to_id.get(&universe_name) {
@@ -1006,150 +502,6 @@ impl Engine {
         Ok(())
     }
 
-    /// Updates the lighting timeline with the current song time
-    pub fn update_song_lighting(
-        &self,
-        song_time: std::time::Duration,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let timeline_update = {
-            let mut current_timeline = self.current_song_timeline.lock();
-            if let Some(timeline) = current_timeline.as_mut() {
-                timeline.update(song_time)
-            } else {
-                crate::lighting::timeline::TimelineUpdate::default()
-            }
-        };
-
-        self.apply_timeline_update(timeline_update)
-    }
-
-    /// Starts the lighting timeline at a specific time
-    pub fn start_lighting_timeline_at(&self, start_time: Duration) {
-        // Clear effects from previous song before starting new timeline
-        {
-            let mut effect_engine = self.effect_engine.lock();
-            effect_engine.stop_all_effects();
-        }
-        // Clear effect deduplication caches so the new song's first frame is applied
-        for universe in self.universes.values() {
-            universe.clear_effect_cache();
-        }
-
-        let timeline_update = {
-            let mut current_timeline = self.current_song_timeline.lock();
-            if let Some(timeline) = current_timeline.as_mut() {
-                if start_time == Duration::ZERO {
-                    timeline.start();
-                    crate::lighting::timeline::TimelineUpdate::default()
-                } else {
-                    // Process historical cues to ensure deterministic state
-                    timeline.start_at(start_time)
-                }
-            } else {
-                crate::lighting::timeline::TimelineUpdate::default()
-            }
-        };
-
-        // Apply the historical timeline update to ensure deterministic state
-        // This must happen before the effects loop can process new cues to avoid conflicts
-        if start_time > Duration::ZERO {
-            if let Err(e) = self.apply_timeline_update(timeline_update) {
-                error!("Failed to apply historical timeline state: {}", e);
-            }
-        }
-    }
-
-    /// Applies a timeline update (effects and layer commands)
-    fn apply_timeline_update(
-        &self,
-        timeline_update: crate::lighting::timeline::TimelineUpdate,
-    ) -> Result<(), Box<dyn Error>> {
-        // Process layer commands first (they affect subsequent effects)
-        if !timeline_update.layer_commands.is_empty() {
-            let mut effects_engine = self.effect_engine.lock();
-            for cmd in &timeline_update.layer_commands {
-                effects_engine.apply_layer_command(cmd);
-            }
-        }
-
-        // Process stop sequence commands
-        if !timeline_update.stop_sequences.is_empty() {
-            let mut effects_engine = self.effect_engine.lock();
-            for sequence_name in &timeline_update.stop_sequences {
-                effects_engine.stop_sequence(sequence_name);
-            }
-        }
-
-        // Start effects with pre-calculated elapsed time (from seeking)
-        // Sort by cue_time to ensure chronological order — later effects properly
-        // conflict with and stop earlier ones
-        let mut effects_sorted: Vec<_> = timeline_update.effects_with_elapsed.values().collect();
-        effects_sorted.sort_by_key(|(effect, _)| effect.cue_time.unwrap_or(Duration::ZERO));
-
-        for (effect, elapsed_time) in effects_sorted {
-            let resolved = self.resolve_effect_groups(effect.clone());
-            let mut effect_engine = self.effect_engine.lock();
-            if let Err(e) = effect_engine.start_effect_with_elapsed(resolved, *elapsed_time) {
-                error!("Failed to start lighting effect with elapsed time: {}", e);
-            }
-        }
-
-        // Handle regular effects (from normal timeline updates).
-        // Sort so sequence effects start before song effects. When a sequence's
-        // last cue (timing anchor) fires at the same time as the next show cue,
-        // starting sequence effects first ensures show-level effects win any
-        // Replace-blend conflicts via the conflict resolution in start_effect().
-        let mut effects = timeline_update.effects;
-        effects.sort_by_key(|e| if e.id.starts_with("seq_") { 0 } else { 1 });
-        for effect in effects {
-            let resolved = self.resolve_effect_groups(effect);
-            if let Err(e) = self.start_effect(resolved) {
-                error!("Failed to start lighting effect: {}", e);
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Resolves group names in an effect's target_fixtures to actual fixture names
-    /// using the lighting system. If no lighting system is available, returns the
-    /// effect unchanged (groups are passed through as-is).
-    fn resolve_effect_groups(
-        &self,
-        effect: crate::lighting::EffectInstance,
-    ) -> crate::lighting::EffectInstance {
-        if let Some(lighting_system) = &self.lighting_system {
-            let mut lighting_system = lighting_system.lock();
-            lighting_system.resolve_effect_groups(effect)
-        } else {
-            effect
-        }
-    }
-
-    /// Stops the lighting timeline
-    pub fn stop_lighting_timeline(&self) {
-        let mut current_timeline = self.current_song_timeline.lock();
-        if let Some(timeline) = current_timeline.as_mut() {
-            timeline.stop();
-        }
-
-        // Note: We do NOT stop effects here - they should continue running
-        // until they naturally complete or until the next song starts.
-        // Effects are only cleared when a new song starts (in start_lighting_timeline_at)
-        // or when explicitly stopping playback.
-    }
-
-    /// Updates the current song time
-    pub fn update_song_time(&self, song_time: Duration) {
-        self.current_song_time
-            .store(song_time.as_nanos() as u64, Ordering::Relaxed);
-    }
-
-    /// Gets the current song time
-    pub fn get_song_time(&self) -> Duration {
-        Duration::from_nanos(self.current_song_time.load(Ordering::Relaxed))
-    }
-
     /// Sets the broadcast channel so the file watcher can send reload notifications.
     pub fn set_broadcast_tx(&self, tx: tokio::sync::broadcast::Sender<String>) {
         *self.broadcast_tx.lock() = Some(tx);
@@ -1177,138 +529,6 @@ impl Engine {
     pub fn format_active_effects(&self) -> String {
         let effect_engine = self.effect_engine.lock();
         effect_engine.format_active_effects()
-    }
-
-    /// Gets all cues from the current timeline with their times and indices
-    pub fn get_timeline_cues(&self) -> Vec<(Duration, usize)> {
-        let timeline = self.current_song_timeline.lock();
-        if let Some(timeline) = timeline.as_ref() {
-            timeline.cues()
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Waits for the lighting timeline to finish, with a heartbeat check to detect
-    /// a dead effects loop. If the heartbeat stops advancing for 10 seconds, the
-    /// effects loop is assumed dead and the wait is abandoned so `Engine::play()`
-    /// can clean up instead of blocking forever.
-    fn wait_for_timeline_with_heartbeat(
-        cancel_handle: &CancelHandle,
-        timeline_finished: Arc<AtomicBool>,
-        heartbeat: &AtomicU64,
-        phase: &AtomicU64,
-        update_subphase: &AtomicU64,
-    ) {
-        // Check every 5 seconds; declare dead after 2 consecutive stale checks (10s).
-        const CHECK_INTERVAL: Duration = Duration::from_secs(5);
-        const MAX_STALE_CHECKS: u32 = 2;
-
-        let mut last_heartbeat = heartbeat.load(Ordering::Relaxed);
-        let mut stale_count: u32 = 0;
-
-        loop {
-            if cancel_handle.wait_with_timeout(timeline_finished.clone(), CHECK_INTERVAL) {
-                // Condition met (cancelled or timeline finished).
-                return;
-            }
-
-            // Timed out — check if the effects loop is still alive.
-            let current_heartbeat = heartbeat.load(Ordering::Relaxed);
-            if current_heartbeat == last_heartbeat {
-                stale_count += 1;
-                let current_phase = phase.load(Ordering::Relaxed);
-                let phase_name = match current_phase {
-                    0 => "idle",
-                    1 => "midi_dmx_store_tick",
-                    2 => "midi_advance",
-                    3 => "update_effects",
-                    4 => "update_song_lighting",
-                    5 => "timeline_finished_check",
-                    _ => "unknown",
-                };
-                let current_subphase = update_subphase.load(Ordering::Relaxed);
-                let subphase_name = match current_subphase {
-                    0 => "idle",
-                    1 => "get_song_time",
-                    2 => "acquire_effect_lock",
-                    10 => "fast_path_check",
-                    20 => "state_setup",
-                    30 => "midi_dmx_inject",
-                    40 => "effect_sort",
-                    50 => "effect_process",
-                    60 => "completed_effects",
-                    70 => "persist_state",
-                    80 => "dmx_generate",
-                    _ => "unknown",
-                };
-                if stale_count >= MAX_STALE_CHECKS {
-                    error!(
-                        phase = phase_name,
-                        update_subphase = subphase_name,
-                        "Effects loop heartbeat stale for {}s — assuming dead. \
-                         Forcing timeline_finished to unblock DMX playback.",
-                        CHECK_INTERVAL.as_secs() * u64::from(MAX_STALE_CHECKS),
-                    );
-                    timeline_finished.store(true, Ordering::Relaxed);
-                    return;
-                }
-                warn!(
-                    stale_count,
-                    phase = phase_name,
-                    update_subphase = subphase_name,
-                    "Effects loop heartbeat stale — will force-finish if it persists."
-                );
-            } else {
-                // Heartbeat is advancing; reset stale counter.
-                stale_count = 0;
-                last_heartbeat = current_heartbeat;
-            }
-        }
-    }
-
-    /// Starts a thread to track song time from a specific start time
-    pub fn start_song_time_tracker_from(
-        dmx_engine: Arc<Engine>,
-        cancel_handle: CancelHandle,
-        start_offset: Duration,
-        clock: crate::clock::PlaybackClock,
-    ) -> JoinHandle<()> {
-        Self::start_song_time_tracker_with_section(
-            dmx_engine,
-            cancel_handle,
-            start_offset,
-            clock,
-            None,
-        )
-    }
-
-    fn start_song_time_tracker_with_section(
-        dmx_engine: Arc<Engine>,
-        cancel_handle: CancelHandle,
-        start_offset: Duration,
-        clock: crate::clock::PlaybackClock,
-        section_owns_time: Option<Arc<AtomicBool>>,
-    ) -> JoinHandle<()> {
-        let timeline_finished = dmx_engine.timeline_finished.clone();
-        thread::spawn(move || {
-            while !cancel_handle.is_cancelled() && !timeline_finished.load(Ordering::Relaxed) {
-                // Skip writing when the section loop thread has taken over
-                // song time updates (set when the first section loop triggers).
-                let section_writing = section_owns_time
-                    .as_ref()
-                    .map(|f| f.load(Ordering::Relaxed))
-                    .unwrap_or(false);
-
-                if !section_writing {
-                    let elapsed = clock.elapsed();
-                    let song_time = start_offset + elapsed;
-                    dmx_engine.update_song_time(song_time);
-                }
-
-                thread::sleep(Duration::from_millis(10));
-            }
-        })
     }
 
     /// Sends messages to OLA using the injected client.

--- a/src/dmx/engine/midi_playback.rs
+++ b/src/dmx/engine/midi_playback.rs
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use super::Engine;
+
+impl Engine {
+    /// Advances all MIDI DMX playback cursors to the current song time,
+    /// dispatching events via handle_midi_event_by_id.
+    pub(super) fn advance_midi_dmx_playbacks(&self) {
+        let song_time = match self.get_song_time().checked_sub(self.playback_delay) {
+            Some(t) => t,
+            None => return, // Still within the playback delay period
+        };
+        let mut playbacks = self.midi_dmx_playbacks.lock();
+        for playback in playbacks.iter_mut() {
+            let events = playback.precomputed.events();
+            while playback.cursor < events.len() && events[playback.cursor].time <= song_time {
+                let event = &events[playback.cursor];
+                if playback.midi_channels.is_empty()
+                    || playback.midi_channels.contains(&event.channel)
+                {
+                    self.handle_midi_event_by_id(playback.universe_id, event.message);
+                }
+                playback.cursor += 1;
+            }
+        }
+    }
+
+    /// Returns true if all MIDI DMX playbacks have finished.
+    pub(super) fn midi_dmx_playbacks_finished(&self) -> bool {
+        let playbacks = self.midi_dmx_playbacks.lock();
+        playbacks.iter().all(|p| p.cursor >= p.precomputed.len())
+    }
+}

--- a/src/dmx/engine/playback.rs
+++ b/src/dmx/engine/playback.rs
@@ -1,0 +1,584 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use tracing::{error, info, span, warn, Level};
+
+use crate::{playsync::CancelHandle, songs::Song};
+
+use super::{Engine, MidiDmxPlayback};
+use crate::midi::playback::PrecomputedMidi;
+
+impl Engine {
+    /// Plays the given song through the DMX interface.
+    pub fn play(
+        dmx_engine: Arc<Engine>,
+        song: Arc<Song>,
+        sync: crate::playsync::PlaybackSync,
+    ) -> Result<(), Box<dyn Error>> {
+        let crate::playsync::PlaybackSync {
+            cancel_handle,
+            mut ready_tx,
+            clock,
+            start_time,
+            loop_control,
+        } = sync;
+        let crate::playsync::LoopControl {
+            loop_break,
+            active_section,
+            section_loop_break,
+            ..
+        } = loop_control;
+        let span = span!(Level::INFO, "play song (dmx)");
+        let _enter = span.enter();
+
+        // Check if there are any lighting systems to play
+        let light_shows = song.light_shows();
+        let dsl_lighting_shows = song.dsl_lighting_shows();
+        let has_lighting = !dsl_lighting_shows.is_empty();
+
+        if light_shows.is_empty() && !has_lighting {
+            ready_tx.send();
+            return Ok(());
+        }
+
+        info!(
+            song = song.name(),
+            duration = song.duration_string(),
+            "Playing song DMX."
+        );
+
+        // Register fixtures with the effects engine if lighting system is available
+        if let Err(_e) = dmx_engine.register_venue_fixtures_safe() {
+            // Failed to register venue fixtures, continue without them
+        }
+
+        // Setup song lighting if available - work directly with DSL shows
+        if has_lighting {
+            info!(
+                "Setup lighting timeline with {} DSL light shows",
+                dsl_lighting_shows.len()
+            );
+
+            // Collect cached shows from DSL lighting shows
+            let all_shows: Vec<_> = dsl_lighting_shows
+                .iter()
+                .flat_map(|dsl_show| dsl_show.shows().values().cloned())
+                .collect();
+
+            if !all_shows.is_empty() {
+                let timeline = crate::lighting::timeline::LightingTimeline::new(all_shows);
+                // Set or clear the tempo map — a song without a tempo block must not
+                // inherit one from the previous song.
+                {
+                    let mut effect_engine = dmx_engine.effect_engine.lock();
+                    effect_engine.set_tempo_map(timeline.tempo_map().cloned());
+                }
+                {
+                    let mut current_timeline = dmx_engine.current_song_timeline.lock();
+                    *current_timeline = Some(timeline);
+                }
+            }
+        } else {
+            // Clear lighting state from previous song so MIDI DMX songs
+            // don't inherit a stale tempo map or timeline.
+            {
+                let mut effect_engine = dmx_engine.effect_engine.lock();
+                effect_engine.set_tempo_map(None);
+            }
+            {
+                let mut current_timeline = dmx_engine.current_song_timeline.lock();
+                *current_timeline = None;
+            }
+        }
+
+        // Reset song time to start time for new song BEFORE starting timeline
+        // This ensures the effects loop uses the correct time when updating
+        dmx_engine.update_song_time(start_time);
+
+        // Start the lighting timeline at the specified time
+        dmx_engine.start_lighting_timeline_at(start_time);
+
+        // Start file watcher for hot-reload if broadcast channel is available
+        {
+            let broadcast_tx = dmx_engine.broadcast_tx.lock();
+            if let Some(tx) = broadcast_tx.as_ref() {
+                let file_paths: Vec<std::path::PathBuf> = dsl_lighting_shows
+                    .iter()
+                    .map(|s| s.file_path().to_path_buf())
+                    .collect();
+                if !file_paths.is_empty() {
+                    match crate::dmx::watcher::start_watching(
+                        file_paths,
+                        dmx_engine.effect_engine.clone(),
+                        dmx_engine.current_song_timeline.clone(),
+                        dmx_engine.current_song_time.clone(),
+                        dmx_engine.lighting_system.clone(),
+                        dmx_engine.lighting_config.clone(),
+                        tx.clone(),
+                    ) {
+                        Ok(handle) => {
+                            *dmx_engine.watcher_handle.lock() = Some(handle);
+                        }
+                        Err(e) => {
+                            warn!("Failed to start light show file watcher: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Note: Effects loop is now persistent and started in Engine::new()
+
+        let universe_ids: HashSet<u16> = dmx_engine.universes.keys().cloned().collect();
+
+        let mut dmx_midi_sheets: HashMap<String, (crate::songs::MidiSheet, Vec<u8>)> =
+            HashMap::new();
+        for light_show in song.light_shows().iter() {
+            let universe_name = light_show.universe_name();
+            if let Some(&universe_id) = dmx_engine.universe_name_to_id.get(&universe_name) {
+                if !universe_ids.contains(&universe_id) {
+                    continue;
+                }
+
+                dmx_midi_sheets.insert(
+                    universe_name.clone(),
+                    (light_show.dmx_midi_sheet()?, light_show.midi_channels()),
+                );
+            }
+        }
+
+        if dmx_midi_sheets.is_empty() && !has_lighting {
+            info!(song = song.name(), "Song has no matching light shows.");
+            ready_tx.send();
+            return Ok(());
+        }
+
+        // Build MIDI DMX playbacks and store them for effects-loop dispatch.
+        // Drain the map to take ownership of MidiSheets (avoids cloning event vecs).
+        // This must happen BEFORE resetting timeline_finished to avoid a race where
+        // the effects loop sees empty playbacks + no timeline and sets finished=true.
+        {
+            let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
+            playbacks.clear();
+            for (universe_name, (midi_sheet, channels)) in dmx_midi_sheets.drain() {
+                let midi_channels = HashSet::from_iter(channels);
+                let universe_id = match dmx_engine.universe_name_to_id.get(&universe_name) {
+                    Some(&id) => id,
+                    None => continue,
+                };
+                let events = midi_sheet.precomputed.into_events();
+                // Seek cursor past start_time
+                let cursor = events.partition_point(|e| e.time < start_time);
+                playbacks.push(MidiDmxPlayback {
+                    precomputed: PrecomputedMidi::from_events(events),
+                    cursor,
+                    universe_id,
+                    midi_channels,
+                });
+            }
+        }
+
+        // Reset timeline finished flag for new song AFTER populating playbacks.
+        // This must be set to false before starting the song time tracker, since the
+        // tracker exits when timeline_finished is true.
+        dmx_engine.timeline_finished.store(false, Ordering::Relaxed);
+
+        // Start song time tracking (per-song, tracks elapsed time).
+        // Must start AFTER timeline_finished is reset, otherwise the tracker
+        // sees true from the previous song and exits immediately.
+        // Flag set by the section loop thread when it takes over song time writes.
+        // Until set, the song time tracker writes normally.
+        let section_owns_time = Arc::new(AtomicBool::new(false));
+
+        let song_time_tracker = Self::start_song_time_tracker_with_section(
+            dmx_engine.clone(),
+            cancel_handle.clone(),
+            start_time,
+            clock.clone(),
+            Some(section_owns_time.clone()),
+        );
+
+        // Store the cancel handle so the effects loop can notify when everything finishes
+        {
+            let mut handle = dmx_engine.timeline_cancel_handle.lock();
+            *handle = Some(cancel_handle.clone());
+        }
+
+        // Signal readiness — all setup is complete.
+        ready_tx.send();
+
+        // Wait for the clock to start (the "go" signal from play_files).
+        while clock.elapsed() == Duration::ZERO {
+            if cancel_handle.is_cancelled() {
+                dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
+                if let Err(e) = song_time_tracker.join() {
+                    error!("Error waiting for song time tracker to stop: {:?}", e);
+                }
+                return Ok(());
+            }
+            std::hint::spin_loop();
+        }
+
+        // Wait for the timeline to finish, using a heartbeat-aware loop that
+        // can recover if the effects loop dies.
+        let timeline_watcher = {
+            let cancel_handle = cancel_handle.clone();
+            let timeline_finished = dmx_engine.timeline_finished.clone();
+            let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
+            let phase = dmx_engine.effects_loop_phase.clone();
+            let subphase = dmx_engine.update_subphase.clone();
+            thread::spawn(move || {
+                Self::wait_for_timeline_with_heartbeat(
+                    &cancel_handle,
+                    timeline_finished,
+                    &heartbeat,
+                    &phase,
+                    &subphase,
+                );
+            })
+        };
+
+        // Section loop: continuously update song time to wrap within section bounds.
+        // Runs alongside the timeline watcher and song time tracker. When active,
+        // it overrides the song time tracker's writes with the wrapped time.
+        let section_loop_thread = {
+            let cancel_handle = cancel_handle.clone();
+            let active_section = active_section.clone();
+            let section_loop_break = section_loop_break.clone();
+            let section_owns_time = section_owns_time.clone();
+            let dmx_engine = dmx_engine.clone();
+            let clock = clock.clone();
+            let timeline_finished = dmx_engine.timeline_finished.clone();
+            thread::spawn(move || {
+                let mut section_monitor = crate::section_loop::SectionLoopMonitor::new();
+                let mut iteration_start: Option<Duration> = None;
+                // After loop break: (resume_time, clock_at_break). The thread
+                // keeps writing song time advancing from the resume point.
+                let mut continue_from: Option<(Duration, Duration)> = None;
+
+                loop {
+                    if cancel_handle.is_cancelled() || timeline_finished.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    // Post-break: advance song time from resume point.
+                    if let Some((resume_time, break_clock)) = continue_from {
+                        let since_break = clock.elapsed().saturating_sub(break_clock);
+                        dmx_engine.update_song_time(resume_time + since_break);
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+
+                    // Check for loop break first (before reading active_section,
+                    // which may already be cleared by stop_section_loop).
+                    if section_loop_break.load(Ordering::Relaxed) {
+                        if let Some(section) = section_monitor.cached_section().cloned() {
+                            let elapsed = clock.elapsed();
+                            let current_pos = if let Some(iter_start) = iteration_start {
+                                let time_since = elapsed.saturating_sub(iter_start);
+                                let sd = section.end_time.saturating_sub(section.start_time);
+                                section.start_time + time_since.min(sd)
+                            } else {
+                                section.end_time
+                            };
+                            info!(
+                                position = ?current_pos,
+                                "DMX section loop: breaking, continuing from current position"
+                            );
+                            dmx_engine.update_song_time(current_pos);
+                            dmx_engine.start_lighting_timeline_at(current_pos);
+                            {
+                                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
+                                for playback in playbacks.iter_mut() {
+                                    let events = playback.precomputed.events();
+                                    playback.cursor =
+                                        events.partition_point(|e| e.time < current_pos);
+                                }
+                            }
+                            continue_from = Some((current_pos, elapsed));
+                        } else {
+                            // No cached section — just hand back to tracker.
+                            section_owns_time.store(false, Ordering::Relaxed);
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+
+                    let elapsed = clock.elapsed();
+                    match section_monitor.poll(&active_section, elapsed) {
+                        crate::section_loop::LoopPoll::Waiting(ref section) => {
+                            let section_duration =
+                                section.end_time.saturating_sub(section.start_time);
+                            if section_duration.is_zero() {
+                                break;
+                            }
+                            if let Some(iter_start) = iteration_start {
+                                let time_since = elapsed.saturating_sub(iter_start);
+                                let position = time_since.min(section_duration);
+                                dmx_engine.update_song_time(section.start_time + position);
+                            }
+                        }
+                        crate::section_loop::LoopPoll::Triggered(ref section) => {
+                            info!(
+                                section = section.name,
+                                "DMX section loop: resetting for next iteration"
+                            );
+                            dmx_engine.start_lighting_timeline_at(section.start_time);
+                            {
+                                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
+                                for playback in playbacks.iter_mut() {
+                                    let events = playback.precomputed.events();
+                                    playback.cursor =
+                                        events.partition_point(|e| e.time < section.start_time);
+                                }
+                            }
+                            dmx_engine.update_song_time(section.start_time);
+                            section_owns_time.store(true, Ordering::Relaxed);
+                            iteration_start = Some(elapsed);
+                        }
+                        crate::section_loop::LoopPoll::SectionCleared => {
+                            iteration_start = None;
+                            section_owns_time.store(false, Ordering::Relaxed);
+                        }
+                        crate::section_loop::LoopPoll::NoSection => {
+                            iteration_start = None;
+                            section_owns_time.store(false, Ordering::Relaxed);
+                        }
+                    }
+
+                    thread::sleep(Duration::from_millis(10));
+                }
+            })
+        };
+
+        if let Err(e) = timeline_watcher.join() {
+            error!("Error while joining timeline watcher thread: {:?}", e);
+        }
+
+        // Song playback finished - signal the song time tracker to stop.
+        dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
+
+        if let Err(e) = song_time_tracker.join() {
+            error!("Error waiting for song time tracker to stop: {:?}", e);
+        }
+
+        // Loop if the song has loop_playback enabled.
+        while song.loop_playback()
+            && !cancel_handle.is_cancelled()
+            && !loop_break.load(Ordering::Relaxed)
+        {
+            info!(
+                song = song.name(),
+                "DMX loop: restarting timeline from beginning"
+            );
+
+            // Reset state for new loop iteration.
+            dmx_engine.update_song_time(Duration::ZERO);
+            dmx_engine.start_lighting_timeline_at(Duration::ZERO);
+
+            // Reset MIDI DMX playback cursors to the beginning.
+            {
+                let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
+                for playback in playbacks.iter_mut() {
+                    playback.cursor = 0;
+                }
+            }
+
+            dmx_engine.timeline_finished.store(false, Ordering::Relaxed);
+
+            // Start a new song time tracker for this loop iteration.
+            let loop_time_tracker = Self::start_song_time_tracker_from(
+                dmx_engine.clone(),
+                cancel_handle.clone(),
+                Duration::ZERO,
+                clock.clone(),
+            );
+
+            // Wait for timeline to finish again.
+            let loop_watcher = {
+                let cancel_handle = cancel_handle.clone();
+                let timeline_finished = dmx_engine.timeline_finished.clone();
+                let heartbeat = dmx_engine.effects_loop_heartbeat.clone();
+                let phase = dmx_engine.effects_loop_phase.clone();
+                let subphase = dmx_engine.update_subphase.clone();
+                thread::spawn(move || {
+                    Self::wait_for_timeline_with_heartbeat(
+                        &cancel_handle,
+                        timeline_finished,
+                        &heartbeat,
+                        &phase,
+                        &subphase,
+                    );
+                })
+            };
+
+            if let Err(e) = loop_watcher.join() {
+                error!("Error while joining loop timeline watcher: {:?}", e);
+            }
+
+            dmx_engine.timeline_finished.store(true, Ordering::Relaxed);
+
+            if let Err(e) = loop_time_tracker.join() {
+                error!("Error waiting for loop time tracker to stop: {:?}", e);
+            }
+        }
+
+        // Stop section loop thread.
+        section_loop_break.store(true, Ordering::Relaxed);
+        if let Err(e) = section_loop_thread.join() {
+            error!("Error joining section loop thread: {:?}", e);
+        }
+
+        // Final cleanup.
+        dmx_engine.stop_lighting_timeline();
+        dmx_engine.midi_dmx_playbacks.lock().clear();
+
+        info!("DMX playback stopped.");
+
+        Ok(())
+    }
+
+    /// Waits for the lighting timeline to finish, with a heartbeat check to detect
+    /// a dead effects loop. If the heartbeat stops advancing for 10 seconds, the
+    /// effects loop is assumed dead and the wait is abandoned so `Engine::play()`
+    /// can clean up instead of blocking forever.
+    pub(super) fn wait_for_timeline_with_heartbeat(
+        cancel_handle: &CancelHandle,
+        timeline_finished: Arc<AtomicBool>,
+        heartbeat: &AtomicU64,
+        phase: &AtomicU64,
+        update_subphase: &AtomicU64,
+    ) {
+        // Check every 5 seconds; declare dead after 2 consecutive stale checks (10s).
+        const CHECK_INTERVAL: Duration = Duration::from_secs(5);
+        const MAX_STALE_CHECKS: u32 = 2;
+
+        let mut last_heartbeat = heartbeat.load(Ordering::Relaxed);
+        let mut stale_count: u32 = 0;
+
+        loop {
+            if cancel_handle.wait_with_timeout(timeline_finished.clone(), CHECK_INTERVAL) {
+                // Condition met (cancelled or timeline finished).
+                return;
+            }
+
+            // Timed out — check if the effects loop is still alive.
+            let current_heartbeat = heartbeat.load(Ordering::Relaxed);
+            if current_heartbeat == last_heartbeat {
+                stale_count += 1;
+                let current_phase = phase.load(Ordering::Relaxed);
+                let phase_name = match current_phase {
+                    0 => "idle",
+                    1 => "midi_dmx_store_tick",
+                    2 => "midi_advance",
+                    3 => "update_effects",
+                    4 => "update_song_lighting",
+                    5 => "timeline_finished_check",
+                    _ => "unknown",
+                };
+                let current_subphase = update_subphase.load(Ordering::Relaxed);
+                let subphase_name = match current_subphase {
+                    0 => "idle",
+                    1 => "get_song_time",
+                    2 => "acquire_effect_lock",
+                    10 => "fast_path_check",
+                    20 => "state_setup",
+                    30 => "midi_dmx_inject",
+                    40 => "effect_sort",
+                    50 => "effect_process",
+                    60 => "completed_effects",
+                    70 => "persist_state",
+                    80 => "dmx_generate",
+                    _ => "unknown",
+                };
+                if stale_count >= MAX_STALE_CHECKS {
+                    error!(
+                        phase = phase_name,
+                        update_subphase = subphase_name,
+                        "Effects loop heartbeat stale for {}s — assuming dead. \
+                         Forcing timeline_finished to unblock DMX playback.",
+                        CHECK_INTERVAL.as_secs() * u64::from(MAX_STALE_CHECKS),
+                    );
+                    timeline_finished.store(true, Ordering::Relaxed);
+                    return;
+                }
+                warn!(
+                    stale_count,
+                    phase = phase_name,
+                    update_subphase = subphase_name,
+                    "Effects loop heartbeat stale — will force-finish if it persists."
+                );
+            } else {
+                // Heartbeat is advancing; reset stale counter.
+                stale_count = 0;
+                last_heartbeat = current_heartbeat;
+            }
+        }
+    }
+
+    /// Starts a thread to track song time from a specific start time
+    pub fn start_song_time_tracker_from(
+        dmx_engine: Arc<Engine>,
+        cancel_handle: CancelHandle,
+        start_offset: Duration,
+        clock: crate::clock::PlaybackClock,
+    ) -> JoinHandle<()> {
+        Self::start_song_time_tracker_with_section(
+            dmx_engine,
+            cancel_handle,
+            start_offset,
+            clock,
+            None,
+        )
+    }
+
+    fn start_song_time_tracker_with_section(
+        dmx_engine: Arc<Engine>,
+        cancel_handle: CancelHandle,
+        start_offset: Duration,
+        clock: crate::clock::PlaybackClock,
+        section_owns_time: Option<Arc<AtomicBool>>,
+    ) -> JoinHandle<()> {
+        let timeline_finished = dmx_engine.timeline_finished.clone();
+        thread::spawn(move || {
+            while !cancel_handle.is_cancelled() && !timeline_finished.load(Ordering::Relaxed) {
+                // Skip writing when the section loop thread has taken over
+                // song time updates (set when the first section loop triggers).
+                let section_writing = section_owns_time
+                    .as_ref()
+                    .map(|f| f.load(Ordering::Relaxed))
+                    .unwrap_or(false);
+
+                if !section_writing {
+                    let elapsed = clock.elapsed();
+                    let song_time = start_offset + elapsed;
+                    dmx_engine.update_song_time(song_time);
+                }
+
+                thread::sleep(Duration::from_millis(10));
+            }
+        })
+    }
+}

--- a/src/dmx/engine/timeline.rs
+++ b/src/dmx/engine/timeline.rs
@@ -1,0 +1,211 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+use std::{error::Error, time::Duration};
+
+use tracing::error;
+
+use crate::songs::Song;
+
+use super::Engine;
+
+impl Engine {
+    /// Validates a song's lighting shows against the engine's lighting config.
+    /// Returns an error if any lighting show references invalid groups or fixtures.
+    pub fn validate_song_lighting(&self, song: &Song) -> Result<(), Box<dyn Error>> {
+        let dsl_lighting_shows = song.dsl_lighting_shows();
+
+        if dsl_lighting_shows.is_empty() {
+            return Ok(());
+        }
+
+        // Validate group/fixture references against lighting config
+        if let Some(ref lighting_config) = self.lighting_config {
+            for dsl_show in dsl_lighting_shows {
+                crate::lighting::validation::validate_light_shows(
+                    dsl_show.shows(),
+                    Some(lighting_config),
+                )
+                .map_err(|e| {
+                    format!(
+                        "Light show validation failed for {}: {}",
+                        dsl_show.file_path().display(),
+                        e
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Updates the lighting timeline with the current song time
+    pub fn update_song_lighting(
+        &self,
+        song_time: std::time::Duration,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let timeline_update = {
+            let mut current_timeline = self.current_song_timeline.lock();
+            if let Some(timeline) = current_timeline.as_mut() {
+                timeline.update(song_time)
+            } else {
+                crate::lighting::timeline::TimelineUpdate::default()
+            }
+        };
+
+        self.apply_timeline_update(timeline_update)
+    }
+
+    /// Starts the lighting timeline at a specific time
+    pub fn start_lighting_timeline_at(&self, start_time: Duration) {
+        // Clear effects from previous song before starting new timeline
+        {
+            let mut effect_engine = self.effect_engine.lock();
+            effect_engine.stop_all_effects();
+        }
+        // Clear effect deduplication caches so the new song's first frame is applied
+        for universe in self.universes.values() {
+            universe.clear_effect_cache();
+        }
+
+        let timeline_update = {
+            let mut current_timeline = self.current_song_timeline.lock();
+            if let Some(timeline) = current_timeline.as_mut() {
+                if start_time == Duration::ZERO {
+                    timeline.start();
+                    crate::lighting::timeline::TimelineUpdate::default()
+                } else {
+                    // Process historical cues to ensure deterministic state
+                    timeline.start_at(start_time)
+                }
+            } else {
+                crate::lighting::timeline::TimelineUpdate::default()
+            }
+        };
+
+        // Apply the historical timeline update to ensure deterministic state
+        // This must happen before the effects loop can process new cues to avoid conflicts
+        if start_time > Duration::ZERO {
+            if let Err(e) = self.apply_timeline_update(timeline_update) {
+                error!("Failed to apply historical timeline state: {}", e);
+            }
+        }
+    }
+
+    /// Applies a timeline update (effects and layer commands)
+    pub(super) fn apply_timeline_update(
+        &self,
+        timeline_update: crate::lighting::timeline::TimelineUpdate,
+    ) -> Result<(), Box<dyn Error>> {
+        // Process layer commands first (they affect subsequent effects)
+        if !timeline_update.layer_commands.is_empty() {
+            let mut effects_engine = self.effect_engine.lock();
+            for cmd in &timeline_update.layer_commands {
+                effects_engine.apply_layer_command(cmd);
+            }
+        }
+
+        // Process stop sequence commands
+        if !timeline_update.stop_sequences.is_empty() {
+            let mut effects_engine = self.effect_engine.lock();
+            for sequence_name in &timeline_update.stop_sequences {
+                effects_engine.stop_sequence(sequence_name);
+            }
+        }
+
+        // Start effects with pre-calculated elapsed time (from seeking)
+        // Sort by cue_time to ensure chronological order — later effects properly
+        // conflict with and stop earlier ones
+        let mut effects_sorted: Vec<_> = timeline_update.effects_with_elapsed.values().collect();
+        effects_sorted.sort_by_key(|(effect, _)| effect.cue_time.unwrap_or(Duration::ZERO));
+
+        for (effect, elapsed_time) in effects_sorted {
+            let resolved = self.resolve_effect_groups(effect.clone());
+            let mut effect_engine = self.effect_engine.lock();
+            if let Err(e) = effect_engine.start_effect_with_elapsed(resolved, *elapsed_time) {
+                error!("Failed to start lighting effect with elapsed time: {}", e);
+            }
+        }
+
+        // Handle regular effects (from normal timeline updates).
+        // Sort so sequence effects start before song effects. When a sequence's
+        // last cue (timing anchor) fires at the same time as the next show cue,
+        // starting sequence effects first ensures show-level effects win any
+        // Replace-blend conflicts via the conflict resolution in start_effect().
+        let mut effects = timeline_update.effects;
+        effects.sort_by_key(|e| if e.id.starts_with("seq_") { 0 } else { 1 });
+        for effect in effects {
+            let resolved = self.resolve_effect_groups(effect);
+            if let Err(e) = self.start_effect(resolved) {
+                error!("Failed to start lighting effect: {}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolves group names in an effect's target_fixtures to actual fixture names
+    /// using the lighting system. If no lighting system is available, returns the
+    /// effect unchanged (groups are passed through as-is).
+    pub(super) fn resolve_effect_groups(
+        &self,
+        effect: crate::lighting::EffectInstance,
+    ) -> crate::lighting::EffectInstance {
+        if let Some(lighting_system) = &self.lighting_system {
+            let mut lighting_system = lighting_system.lock();
+            lighting_system.resolve_effect_groups(effect)
+        } else {
+            effect
+        }
+    }
+
+    /// Stops the lighting timeline
+    pub fn stop_lighting_timeline(&self) {
+        let mut current_timeline = self.current_song_timeline.lock();
+        if let Some(timeline) = current_timeline.as_mut() {
+            timeline.stop();
+        }
+
+        // Note: We do NOT stop effects here - they should continue running
+        // until they naturally complete or until the next song starts.
+        // Effects are only cleared when a new song starts (in start_lighting_timeline_at)
+        // or when explicitly stopping playback.
+    }
+
+    /// Updates the current song time
+    pub fn update_song_time(&self, song_time: Duration) {
+        self.current_song_time.store(
+            song_time.as_nanos() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    /// Gets the current song time
+    pub fn get_song_time(&self) -> Duration {
+        Duration::from_nanos(
+            self.current_song_time
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
+    }
+
+    /// Gets all cues from the current timeline with their times and indices
+    pub fn get_timeline_cues(&self) -> Vec<(Duration, usize)> {
+        let timeline = self.current_song_timeline.lock();
+        if let Some(timeline) = timeline.as_ref() {
+            timeline.cues()
+        } else {
+            Vec::new()
+        }
+    }
+}


### PR DESCRIPTION
- engine/playback.rs: play(), song time tracking, timeline wait
- engine/timeline.rs: timeline lifecycle, lighting validation, effect groups
- engine/midi_playback.rs: MIDI DMX playback cursor advancement
- Engine struct fields made pub(super) for submodule access
- Main engine.rs retains constructor, effects loop, MIDI event handling, universe management, public accessors, Drop impl, and all tests