### PR TITLE
Looping sections drop down doesn't stretch the playback card.

### DIFF
--- a/src/webui/svelte/e2e/tests/playback-flow.spec.ts
+++ b/src/webui/svelte/e2e/tests/playback-flow.spec.ts
@@ -225,7 +225,7 @@ test.describe("Playback State Transitions", () => {
     await expect(currentSong).toContainText("Test Song Beta");
   });
 
-  test("section buttons appear when playing song with sections", async ({
+  test("sections button appears when playing song with sections", async ({
     page,
   }) => {
     // Send playing state with available_sections.
@@ -249,14 +249,23 @@ test.describe("Playback State Transitions", () => {
       active_section: null,
     });
 
-    // Section buttons should appear.
-    await expect(page.locator(".section-controls")).toBeVisible();
-    await expect(page.getByRole("button", { name: "verse" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "chorus" })).toBeVisible();
+    // Sections dropdown button should appear in the header.
+    const sectionsBtn = page.getByRole("button", { name: "Sections" });
+    await expect(sectionsBtn).toBeVisible();
+
+    // Clicking it should reveal section items in the dropdown.
+    await sectionsBtn.click();
+    await expect(page.locator(".section-menu")).toBeVisible();
+    await expect(
+      page.locator(".section-menu-item", { hasText: "verse" }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".section-menu-item", { hasText: "chorus" }),
+    ).toBeVisible();
   });
 
-  test("section buttons hidden when not playing", async ({ page }) => {
-    // Stopped state with sections — buttons should NOT appear.
+  test("sections button hidden when not playing", async ({ page }) => {
+    // Stopped state with sections — button should NOT appear.
     await sendWsMessage(page, wsId, {
       type: "playback",
       is_playing: false,
@@ -274,10 +283,14 @@ test.describe("Playback State Transitions", () => {
       active_section: null,
     });
 
-    await expect(page.locator(".section-controls")).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sections" }),
+    ).not.toBeVisible();
   });
 
-  test("active section shows name and stop button", async ({ page }) => {
+  test("active section shows name and stop button in dropdown", async ({
+    page,
+  }) => {
     // Send playing state with an active section loop.
     await sendWsMessage(page, wsId, {
       type: "playback",
@@ -299,11 +312,14 @@ test.describe("Playback State Transitions", () => {
       active_section: { name: "verse", start_ms: 0, end_ms: 8000 },
     });
 
-    // Should show the active section name and a Stop Loop button.
-    await expect(page.locator(".section-active")).toContainText("verse");
+    // The button should show the active section name.
+    const sectionsBtn = page.locator(".btn-loop-active");
+    await expect(sectionsBtn).toBeVisible();
+    await expect(sectionsBtn).toContainText("verse");
+
+    // Clicking it should show the dropdown with a Stop Loop option.
+    await sectionsBtn.click();
     await expect(page.getByRole("button", { name: "Stop Loop" })).toBeVisible();
-    // Individual section buttons should be replaced by the active state.
-    await expect(page.getByRole("button", { name: "verse" })).not.toBeVisible();
   });
 
   test("section buttons hidden when no sections available", async ({

--- a/src/webui/svelte/e2e/tests/section-loop.spec.ts
+++ b/src/webui/svelte/e2e/tests/section-loop.spec.ts
@@ -80,13 +80,15 @@ test.describe("Section Loop Controls", () => {
   }) => {
     // Put into playing state with sections.
     await sendWsMessage(page, wsId, playbackWithSections(wsId));
-    await expect(page.locator(".section-controls")).toBeVisible();
+    const sectionsBtn = page.getByRole("button", { name: "Sections" });
+    await expect(sectionsBtn).toBeVisible();
 
-    // Click verse section button and wait for gRPC call.
+    // Open dropdown and click verse section button.
+    await sectionsBtn.click();
     const requestPromise = page.waitForRequest((req) =>
       req.url().includes("LoopSection"),
     );
-    await page.getByRole("button", { name: "verse" }).click();
+    await page.locator(".section-menu-item", { hasText: "verse" }).click();
     await requestPromise;
   });
 
@@ -101,6 +103,11 @@ test.describe("Section Loop Controls", () => {
         active_section: { name: "verse", start_ms: 0, end_ms: 8000 },
       }),
     );
+    const loopBtn = page.locator(".btn-loop-active");
+    await expect(loopBtn).toBeVisible();
+
+    // Open dropdown and click Stop Loop.
+    await loopBtn.click();
     await expect(page.getByRole("button", { name: "Stop Loop" })).toBeVisible();
 
     const requestPromise = page.waitForRequest((req) =>
@@ -110,7 +117,7 @@ test.describe("Section Loop Controls", () => {
     await requestPromise;
   });
 
-  test("section buttons re-appear after stopping a loop", async ({ page }) => {
+  test("sections button reverts after stopping a loop", async ({ page }) => {
     // Start with active loop.
     await sendWsMessage(
       page,
@@ -119,7 +126,7 @@ test.describe("Section Loop Controls", () => {
         active_section: { name: "verse", start_ms: 0, end_ms: 8000 },
       }),
     );
-    await expect(page.locator(".section-active")).toBeVisible();
+    await expect(page.locator(".btn-loop-active")).toBeVisible();
 
     // Simulate stop — server clears active section.
     await sendWsMessage(
@@ -127,11 +134,10 @@ test.describe("Section Loop Controls", () => {
       wsId,
       playbackWithSections(wsId, { active_section: null }),
     );
-    await expect(page.locator(".section-active")).not.toBeVisible();
-    await expect(page.getByRole("button", { name: "verse" })).toBeVisible({
+    await expect(page.locator(".btn-loop-active")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Sections" })).toBeVisible({
       timeout: 10000,
     });
-    await expect(page.getByRole("button", { name: "chorus" })).toBeVisible();
   });
 
   test("active section shows name", async ({ page }) => {
@@ -142,12 +148,11 @@ test.describe("Section Loop Controls", () => {
         active_section: { name: "chorus", start_ms: 8000, end_ms: 16000 },
       }),
     );
-    await expect(page.locator(".section-active")).toContainText("chorus");
+    const loopBtn = page.locator(".btn-loop-active");
+    await expect(loopBtn).toContainText("chorus");
   });
 
-  test("section controls hidden when song has no sections", async ({
-    page,
-  }) => {
+  test("sections button hidden when song has no sections", async ({ page }) => {
     await sendWsMessage(page, wsId, {
       type: "playback",
       is_playing: true,
@@ -165,6 +170,8 @@ test.describe("Section Loop Controls", () => {
       active_section: null,
     });
 
-    await expect(page.locator(".section-controls")).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sections" }),
+    ).not.toBeVisible();
   });
 });

--- a/src/webui/svelte/src/components/cards/PlaybackCard.svelte
+++ b/src/webui/svelte/src/components/cards/PlaybackCard.svelte
@@ -91,8 +91,18 @@
   }
 
   let loading = $state(false);
+  let sectionMenuOpen = $state(false);
+
+  function toggleSectionMenu() {
+    sectionMenuOpen = !sectionMenuOpen;
+  }
+
+  function closeSectionMenu() {
+    sectionMenuOpen = false;
+  }
 
   async function loopSection(name: string) {
+    sectionMenuOpen = false;
     try {
       await playerClient.loopSection({ sectionName: name });
     } catch (e) {
@@ -102,6 +112,7 @@
   }
 
   async function stopSectionLoop() {
+    sectionMenuOpen = false;
     try {
       await playerClient.stopSectionLoop({});
     } catch (e) {
@@ -233,6 +244,47 @@
 <div class="card card-full">
   <div class="card-header">
     <span class="card-title">{$t("playback.title")}</span>
+    {#if $playbackStore.is_playing && $playbackStore.available_sections.length > 0}
+      <div class="section-menu-anchor">
+        <button
+          class="btn btn-sm"
+          class:btn-loop-active={$playbackStore.active_section != null}
+          onclick={toggleSectionMenu}
+          title={$playbackStore.active_section
+            ? `Looping: ${$playbackStore.active_section.name}`
+            : $t("playback.sections")}
+        >
+          {#if $playbackStore.active_section}
+            <span class="loop-icon">&#x21BB;</span>
+            {$playbackStore.active_section.name}
+          {:else}
+            {$t("playback.sections")}
+          {/if}
+        </button>
+        {#if sectionMenuOpen}
+          <button class="section-menu-backdrop" onclick={closeSectionMenu}
+          ></button>
+          <div class="section-menu">
+            {#if $playbackStore.active_section}
+              <button
+                class="section-menu-item section-menu-stop"
+                onclick={stopSectionLoop}>{$t("playback.stopLoop")}</button
+              >
+            {/if}
+            {#each $playbackStore.available_sections as section (section.name)}
+              <button
+                class="section-menu-item"
+                class:section-menu-item-active={$playbackStore.active_section
+                  ?.name === section.name}
+                onclick={() => loopSection(section.name)}
+                title="m{section.start_measure}-{section.end_measure}"
+                >{section.name}</button
+              >
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
   </div>
   <div class="transport">
     <div class="transport-info">
@@ -314,27 +366,6 @@
         title={$t("playback.nextTooltip")}>{$t("playback.next")}</button
       >
     </div>
-    {#if $playbackStore.is_playing && $playbackStore.available_sections.length > 0}
-      <div class="section-controls">
-        {#if $playbackStore.active_section}
-          <span class="section-active"
-            >{$playbackStore.active_section.name}</span
-          >
-          <button class="btn btn-sm" onclick={stopSectionLoop}
-            >{$t("playback.stopLoop")}</button
-          >
-        {:else}
-          {#each $playbackStore.available_sections as section (section.name)}
-            <button
-              class="btn btn-sm"
-              onclick={() => loopSection(section.name)}
-              title="Loop {section.name} (m{section.start_measure}-{section.end_measure})"
-              >{section.name}</button
-            >
-          {/each}
-        {/if}
-      </div>
-    {/if}
   </div>
   {#if errorMsg}
     <div class="playback-error" role="alert">
@@ -349,6 +380,9 @@
 </div>
 
 <style>
+  .card-header {
+    min-height: 28px;
+  }
   .transport {
     display: grid;
     grid-template-columns: auto 1fr auto;
@@ -381,18 +415,67 @@
     font-family: var(--mono);
     color: var(--text-dim);
   }
-  .section-controls {
-    grid-column: 1 / -1;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    flex-wrap: wrap;
+  .section-menu-anchor {
+    position: relative;
   }
-  .section-active {
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 600;
+  .section-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    background: transparent;
+    border: none;
+    z-index: 99;
+    cursor: default;
+  }
+  .section-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 100;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    min-width: 120px;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .section-menu-item {
+    background: none;
+    border: none;
+    color: var(--text);
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: var(--radius);
+    cursor: pointer;
+    text-align: left;
+    white-space: nowrap;
+  }
+  .section-menu-item:hover {
+    background: var(--bg-hover);
+  }
+  .section-menu-item-active {
     color: var(--accent);
+    font-weight: 600;
+  }
+  .section-menu-stop {
+    color: var(--red);
+    border-bottom: 1px solid var(--border);
+    border-radius: var(--radius) var(--radius) 0 0;
+    padding-bottom: 8px;
+    margin-bottom: 2px;
+  }
+  .btn-loop-active {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+  }
+  .btn-loop-active:hover {
+    opacity: 0.85;
+  }
+  .loop-icon {
+    font-size: 14px;
   }
   .loop-badge {
     margin-left: 8px;

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -73,6 +73,7 @@
   "playback.error.loopSection": "Failed to activate section loop",
   "playback.error.stopSectionLoop": "Failed to stop section loop",
   "playback.stopLoop": "Stop Loop",
+  "playback.sections": "Sections",
 
   "playlist.title": "Playlist",
 


### PR DESCRIPTION
The playback card is now unaffected by the presence of the sections drop down. This will prevent looping from affecting the playback progress bar, which gets confusing.