### PR TITLE
release: build and upload binaries for Linux + macOS on tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,3 +48,72 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES: ${{ steps.extract-release-notes.outputs.release_notes }}
         run: gh release create --notes "$RELEASE_NOTES" --title "${{ github.ref_name }}" "${{ github.ref_name }}"
+
+  # Builds release binaries for each supported platform and uploads them to the
+  # GitHub release. Linux binaries are built on the oldest supported Ubuntu LTS
+  # so the resulting glibc-linked binary runs on newer distros as well.
+  build-binaries:
+    name: Build binary (${{ matrix.target }})
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+            platform: linux
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
+            platform: linux
+          - target: x86_64-apple-darwin
+            os: macos-13
+            platform: macos
+          - target: aarch64-apple-darwin
+            os: macos-14
+            platform: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev pkg-config libssl-dev protobuf-compiler
+      - name: Install macOS system dependencies
+        if: matrix.platform == 'macos'
+        run: brew install pkg-config protobuf
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-${{ matrix.target }}"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@v5
+        with:
+          path: src/webui/svelte/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: node-modules-${{ runner.os }}-
+      - name: Build frontend
+        run: make build-ui
+      - name: Build binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Package binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          STAGE="mtrack-${VERSION}-${{ matrix.target }}"
+          mkdir "$STAGE"
+          cp "target/${{ matrix.target }}/release/mtrack" "$STAGE/"
+          cp README.md LICENSE CHANGELOG.md "$STAGE/"
+          tar czf "${STAGE}.tar.gz" "$STAGE"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${STAGE}.tar.gz" > "${STAGE}.tar.gz.sha256"
+          else
+            shasum -a 256 "${STAGE}.tar.gz" > "${STAGE}.tar.gz.sha256"
+          fi
+      - name: Upload to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" mtrack-*.tar.gz mtrack-*.tar.gz.sha256 --clobber

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ a phone, or any device with a browser — so you never have to babysit a compute
 
 ## Quick Start
 
-Install via cargo:
+Download a pre-built binary from the [latest release](https://github.com/mdwn/mtrack/releases/latest)
+for your platform (Linux x86_64/aarch64, macOS Intel/Apple Silicon), extract it, and put
+`mtrack` somewhere on your `PATH`. On Linux you'll need `libasound2` and `libudev1`
+installed (present by default on most desktop distros; `sudo apt install libasound2 libudev1`
+on a minimal server).
+
+Alternatively, install from source via cargo — this requires a Rust toolchain and a
+handful of system libraries; see [Building](#building) below:
 
 ```
 $ cargo install mtrack --locked


### PR DESCRIPTION
Adds a matrix `build-binaries` job to publish.yaml that builds release binaries for x86_64/aarch64 Linux (Ubuntu 22.04 runners for max glibc compatibility) and Intel/Apple Silicon macOS, packages them as tarballs with SHA-256 checksums alongside README/LICENSE/CHANGELOG, and uploads to the GitHub release.

Updates README Quick Start to lead with the binary download. Cargo install is kept as a from-source alternative.

Addresses #299.