### PR TITLE
ci: cross-compile x86_64 macOS release binary on Apple Silicon

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,7 @@ jobs:
             os: ubuntu-22.04-arm
             platform: linux
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
             platform: macos
           - target: aarch64-apple-darwin
             os: macos-14


### PR DESCRIPTION
The `build-binaries` job in `publish.yaml` used the `macos-13` (Intel)
runner for the `x86_64-apple-darwin` target. GitHub is drawing down Intel
macOS capacity and that job sat queued forever without starting.

This builds the x86_64 Mac binary by cross-compiling on the `macos-14`
(Apple Silicon) runner instead. Validated end-to-end in #303 — all four
targets (Linux x86_64/aarch64, macOS Intel/Apple Silicon) build, package,
and upload as ~9 MB artifacts.

Closes the gap from #299 (pre-built binaries for end users).