### PR TITLE
build: add cargo-binstall metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ include = [
     "!src/webui/svelte/.svelte-kit/**",
 ]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "{ name }-{ version }-{ target }/{ bin }{ binary-ext }"
+
 [dependencies]
 clap = { version = "4.5.60", features = ["cargo", "derive"] }
 config = "0.15.19"


### PR DESCRIPTION
Adds `[package.metadata.binstall]` so `cargo binstall mtrack` pulls the
pre-built release binaries published by the `build-binaries` workflow job
rather than compiling from source.

The metadata mirrors the workflow's asset layout:
- tag `v{version}`, asset `mtrack-{version}-{target}.tar.gz` (tgz)
- binary at `mtrack-{version}-{target}/{bin}` inside the archive

Only takes effect once a release with binary assets exists (i.e. the next
tag cut after the workflow landed). Follow-up to #299.