### PR TITLE
deps(webui): typescript 5→6

### DIFF
--- a/src/webui/svelte/package-lock.json
+++ b/src/webui/svelte/package-lock.json
@@ -30,7 +30,7 @@
         "svelte": "^5",
         "svelte-check": "^4",
         "tsx": "^4.21.0",
-        "typescript": "^5",
+        "typescript": "^6",
         "typescript-eslint": "^8.56.1",
         "vite": "^6",
         "ws": "^8.19.0"
@@ -4560,9 +4560,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/webui/svelte/package.json
+++ b/src/webui/svelte/package.json
@@ -32,7 +32,7 @@
     "svelte": "^5",
     "svelte-check": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5",
+    "typescript": "^6",
     "typescript-eslint": "^8.56.1",
     "vite": "^6",
     "ws": "^8.19.0"

--- a/src/webui/svelte/src/vite-env.d.ts
+++ b/src/webui/svelte/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

Second deferred webui major bump (follow-up to #310, sibling of #311). Upgrades **typescript** 5 → 6.

No blockers: `typescript-eslint` (peer `<6.1.0`) and `svelte-check` (peer `>=5.0.0`) both already accept TS 6, so nothing else needed bumping.

## Breaking change handled

TS 6 tightened side-effect imports of non-code assets. This surfaced one error:

```
src/main.ts 20:8 Cannot find module or type declarations for side-effect import of './app.css'.
```

The project never referenced Vite's ambient client types (no `vite-env.d.ts` existed), so TS 5 silently tolerated `import "./app.css"`. The fix is the standard Vite ambient-types file:

```ts
/// <reference types="vite/client" />
```

added as `src/vite-env.d.ts` — this declares `*.css`, asset imports, and `import.meta.env`.

## Verification

- `npm run check` (svelte-check) — **0 errors, 0 warnings** (388 files)
- `npm run build` — succeeds with **identical output** (TS only affects type-checking; Vite/esbuild does transpilation, so runtime is unchanged)
- `npm audit` — 0 vulnerabilities

## Remaining deferred bump

- prettier-plugin-svelte 3 → 4 (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)