### PR TITLE
deps(webui): prettier-plugin-svelte 3→4

### DIFF
--- a/src/webui/svelte/package-lock.json
+++ b/src/webui/svelte/package-lock.json
@@ -26,7 +26,7 @@
         "express": "^5.2.1",
         "globals": "^17.4.0",
         "prettier": "^3.8.1",
-        "prettier-plugin-svelte": "^3.5.0",
+        "prettier-plugin-svelte": "^4",
         "svelte": "^5",
         "svelte-check": "^4",
         "tsx": "^4.21.0",
@@ -3402,14 +3402,17 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.2.tgz",
-      "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.0.1.tgz",
+      "integrity": "sha512-oDVmtKi+M8bJeUoMfPvulUqZYcuXrs5AmhhLYPKtBeg6hcpMdx7UYYisVCqEaLQuKtiPSYFpotfwp4cZK3D4xw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/proxy-addr": {

--- a/src/webui/svelte/package.json
+++ b/src/webui/svelte/package.json
@@ -28,7 +28,7 @@
     "express": "^5.2.1",
     "globals": "^17.4.0",
     "prettier": "^3.8.1",
-    "prettier-plugin-svelte": "^3.5.0",
+    "prettier-plugin-svelte": "^4",
     "svelte": "^5",
     "svelte-check": "^4",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary

Third and final deferred webui major bump (follow-up to #310, sibling of #311 and #312). Upgrades **prettier-plugin-svelte** 3 → 4.

Clean drop-in: peers (`prettier ^3`, `svelte ^5`) were already satisfied, and the v4 formatter produces **no reformatting churn** — every file still conforms.

## Verification

- `npm run format:check` (`prettier --check .`) — **all matched files use Prettier code style** (no diff)
- `npm audit` — 0 vulnerabilities

Formatting tool only; no build/type/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)