### PR TITLE
fix(systemd-test): install Node 22 in Docker builder for Vite 8

### DIFF
--- a/tests/systemd/Dockerfile
+++ b/tests/systemd/Dockerfile
@@ -25,8 +25,14 @@ FROM ubuntu:24.04 AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl build-essential pkg-config libasound2-dev \
     protobuf-compiler libprotobuf-dev git \
-    nodejs npm \
     ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 24.04 ships Node.js 18, which is too old for Vite 8 (requires
+# Node 20.19+/22.12+). Install Node.js 22.x from NodeSource; this package
+# bundles npm.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
## Summary

Fixes the systemd integration test (`make test-systemd`) which broke after the Vite 6→8 upgrade (#311).

## Root cause

The builder stage (`FROM ubuntu:24.04`) installed `nodejs npm` from Ubuntu's apt repo, which ships **Node 18.19.1**. Vite 8 requires **Node 20.19+ / 22.12+**. The build emitted an `EBADENGINE` warning during `npm ci`, then crashed during `npm run build`:

```
You are using Node.js 18.19.1. Vite requires Node.js version 20.19+ or 22.12+.
ReferenceError: CustomEvent is not defined
    at CAC.parse (.../vite/dist/node/cli.js:533:28)
```

(`CustomEvent` only became a global in Node 19.)

## Fix

Install **Node 22.x from NodeSource** in the builder stage instead of the distro package. This matches `node-version: '22'` already used by every GitHub Actions job (which is why the PR CI passed but the Docker-based systemd test did not). The NodeSource `nodejs` package bundles npm, so `nodejs npm` is dropped from the apt line.

## Verification

- ✅ All GitHub Actions jobs already pin Node 22 — no other Node-18 build paths exist in the repo.
- ⚠️ **Not built locally** — no Docker daemon in my environment. Please run `make test-systemd` to confirm the image builds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)