### PR TITLE
release: 0.13.0 — changelog, version bump, MCP docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-29
+
+### Added
+
+- **MCP (Model Context Protocol) server**: A new `kind: mcp` controller exposes mtrack to
+  MCP-compatible clients such as Claude Desktop and Claude Code over a Streamable HTTP
+  transport mounted at `/mcp` (default port 43237, localhost-only). It offers ~45 tools
+  spanning playback control (play, stop, next/previous, play-from, section looping),
+  configuration editing, and song / playlist / lighting authoring — every write is
+  parse-validated before it touches disk, and patch-style string-replacement edits are
+  supported alongside full-file writes. Two live resources, `mtrack://status` and
+  `mtrack://config`, can be subscribed to for push updates. An optional `bearer_token`
+  enforces `Authorization: Bearer` (constant-time comparison) for non-localhost binds, and
+  idle sessions are evicted after a configurable timeout (`idle_session_timeout_secs`,
+  default 4 hours). See the new
+  [MCP Control](https://github.com/mdwn/mtrack/blob/main/docs/src/interfaces/mcp.md)
+  documentation.
+- **Pre-built release binaries**: Tagged releases now build and attach binaries for x86_64 and
+  aarch64 Linux and Intel/Apple Silicon macOS, packaged as tarballs with SHA-256 checksums.
+- **`cargo binstall` support**: `cargo binstall mtrack` fetches the pre-built release binaries
+  instead of compiling from source.
+
+### Changed
+
+- **Audio decoding migrated to Symphonia 0.6**: Adopts Symphonia's reorganized decode/seek API
+  and strengthens decode coverage with cross-format sample-value tests (lossless formats must
+  decode bit-exactly) so the migration is trustworthy across WAV, FLAC, MP3, Ogg Vorbis, and AAC.
+- **Lock-free audio read path**: `BufferedSampleSource` now uses an `rtrb` single-producer/
+  single-consumer ring instead of a mutex+Condvar, so the realtime cpal callback holds no buffer
+  lock and is no longer exposed to priority inversion.
+- **Dependency updates**: Routine refresh of the Rust and web-UI dependency trees, including
+  rubato 1→3, Tokio, rustls, vite 6→8 (Rolldown bundler), TypeScript 5→6, and
+  `@sveltejs/vite-plugin-svelte` 5→7. Resolves all outstanding `cargo audit` and `npm audit`
+  advisories.
+
+### Fixed
+
+- **Sample-accurate, glitch-free section loops**: One-measure section loops now restart exactly
+  on the measure boundary with a single clean downbeat, eliminating the audible jitter and stutter
+  at the loop point. Loop-back sources are prebuilt off-thread and speculatively prewarmed so the
+  boundary is hit precisely the instant a loop is armed.
+- **Sample-accurate seeking for lossy and block codecs**: Seeking now lands sample-accurately
+  across WAV, FLAC, MP3, Ogg Vorbis, and AAC by pre-rolling a margin before the target to warm the
+  decoder and anchoring the discard to the first decoded packet's timestamp. Previously MP3/AAC
+  showed a few ms of warmup corruption and Vorbis a persistent ~6 ms position offset after a seek.
+
 ## [0.12.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mtrack://config`, can be subscribed to for push updates. An optional `bearer_token`
   enforces `Authorization: Bearer` (constant-time comparison) for non-localhost binds, and
   idle sessions are evicted after a configurable timeout (`idle_session_timeout_secs`,
-  default 4 hours). See the new
-  [MCP Control](https://github.com/mdwn/mtrack/blob/main/docs/src/interfaces/mcp.md)
-  documentation.
+  default 4 hours). See the new MCP Control documentation.
 - **Pre-built release binaries**: Tagged releases now build and attach binaries for x86_64 and
   aarch64 Linux and Intel/Apple Silicon macOS, packaged as tarballs with SHA-256 checksums.
 - **`cargo binstall` support**: `cargo binstall mtrack` fetches the pre-built release binaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Terminal UI (TUI)](interfaces/tui.md)
 - [gRPC Control](interfaces/grpc.md)
 - [OSC Control](interfaces/osc.md)
+- [MCP Control](interfaces/mcp.md)
 
 # Configuration Reference
 

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -116,6 +116,7 @@ dmx:
 # - grpc
 # - midi
 # - osc
+# - mcp
 controllers:
 # The gRPC server configuration.
 - kind: grpc
@@ -230,6 +231,27 @@ controllers:
     # Whether to save the bank name to flash (true) or keep it temporary (false).
     # Temporary names reset on power cycle. Default: false.
     # save: false
+
+# The MCP (Model Context Protocol) server configuration. Exposes mtrack to
+# MCP-compatible clients (Claude Desktop, Claude Code, ...) over HTTP at /mcp.
+# See the MCP Control interface documentation for details.
+- kind: mcp
+
+  # The port the MCP server should be hosted on. Defaults to 43237.
+  port: 43237
+
+  # The bind address. Defaults to 127.0.0.1 (localhost-only). Set to 0.0.0.0
+  # to expose the server on the network.
+  bind_address: 127.0.0.1
+
+  # Optional bearer token. When set, every request must carry an
+  # `Authorization: Bearer <token>` header. Recommended whenever bind_address
+  # is not localhost.
+  # bearer_token: "your-secret-token"
+
+  # Idle session timeout in seconds. Defaults to 14400 (4 hours). Set to null
+  # to disable idle eviction.
+  # idle_session_timeout_secs: 14400
 
 # Mappings of track names to output channels.
 track_mappings:

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -1,0 +1,82 @@
+# MCP Control
+
+mtrack can expose its running player and project files to [Model Context
+Protocol](https://modelcontextprotocol.io) (MCP) clients — such as Claude Desktop or Claude
+Code — letting an AI assistant inspect playback, drive the player, and author configuration and
+lighting shows on your behalf.
+
+The MCP server is enabled by adding an `mcp` controller to the
+[player configuration](../configuration/player-config.md). It runs over a Streamable HTTP
+transport mounted at `/mcp` on its own listener, kept separate from the web UI so the two can be
+enabled, disabled, and bound independently.
+
+## Configuration
+
+```yaml
+controllers:
+  - kind: mcp
+    # Port to listen on. Defaults to 43237.
+    port: 43237
+
+    # Bind address. Defaults to 127.0.0.1 (localhost-only).
+    # Set to 0.0.0.0 to expose the server on the network.
+    bind_address: 127.0.0.1
+
+    # Optional bearer token. When set, every request must carry an
+    # `Authorization: Bearer <token>` header or it is rejected with HTTP 401.
+    # Strongly recommended whenever bind_address is not localhost.
+    # bearer_token: "your-secret-token"
+
+    # Idle session timeout in seconds. A session whose inbound and outbound
+    # traffic is quiet for this long is closed and its resources released.
+    # Defaults to 14400 (4 hours). Set to null to disable eviction.
+    # idle_session_timeout_secs: 14400
+```
+
+The endpoint is then reachable at `http://<bind_address>:<port>/mcp`.
+
+## Connecting a client
+
+For a local client such as Claude Code, point it at the HTTP endpoint:
+
+```
+claude mcp add --transport http mtrack http://127.0.0.1:43237/mcp
+```
+
+If a `bearer_token` is configured, supply it as an `Authorization: Bearer <token>` header in your
+client's MCP server settings.
+
+## What it exposes
+
+### Tools
+
+Roughly 45 tools are available. They fall into a few groups:
+
+- **Status & discovery** — current playback status, host/runtime info, and listings of songs,
+  playlists, groups, venues, and fixture types.
+- **Playback control** — play, stop, next/previous, play-from-a-time, play-a-named-song-from-a-time,
+  switch playlist, stop triggered samples, and section-loop control (loop a section, stop the loop,
+  acknowledge the current section in reactive looping).
+- **Configuration editing** — read the full config and update the `audio`, `midi`, `dmx`, and
+  `controllers` subsections, plus add / update / remove hardware profiles.
+- **Song & playlist authoring** — read, write, and patch `song.yaml` and playlist files, plus
+  detailed song metadata and beat-grid queries.
+- **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
+  and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
+
+Every write and patch tool validates its input (YAML schema or `.light` DSL parse) **before** it
+writes to disk, so a malformed edit is rejected rather than corrupting a project file.
+
+### Resources
+
+Two resources can be subscribed to (via `resources/subscribe`) for live push updates:
+
+- `mtrack://status` — a snapshot of player state (active playlist, current song, playback position).
+- `mtrack://config` — the current configuration as YAML, plus a checksum.
+
+## Security
+
+There is no authentication unless you configure a `bearer_token`. The server binds to localhost by
+default; if you change `bind_address` to expose it on a network, set a `bearer_token` so the surface
+is not reachable unauthenticated. As with the other control interfaces, running mtrack on a wide-open
+network is not advised — see [Service Hardening](../deployment/security.md).


### PR DESCRIPTION
## Summary

Prepares the **0.13.0** release. This is the changelog + version-bump + docs PR; the actual release is cut by tagging `v0.13.0` after this merges.

### Version
- `Cargo.toml` / `Cargo.lock`: 0.12.0 → **0.13.0**

### Changelog
New `## [0.13.0]` section covering everything since 0.12.0:
- **Added**: MCP (Model Context Protocol) server (#301), pre-built release binaries (#302), `cargo binstall` support (#306)
- **Changed**: Symphonia 0.6 migration (#308), lock-free SPSC audio read path (#300), dependency refresh (rubato 3, vite 8, TypeScript 6, …; all audit advisories resolved)
- **Fixed**: glitch-free section loops (#305), sample-accurate seeking for lossy/block codecs (#307)

### Documentation
The MCP controller (#301) shipped **without docs** — this fills that gap:
- New `docs/src/interfaces/mcp.md` — configuration, connecting a client, the ~45-tool / 2-resource surface, and security guidance
- Added to `SUMMARY.md` and to the `player-config.md` controller list (valid kinds + an example `kind: mcp` block)

## Verification
- `cargo build` — clean at 0.13.0
- `mdbook build` — clean, no broken links
- Changelog section parses as keep-a-changelog (same format the release-notes extractor consumes)

## Cutting the release (after merge)
Tagging `v0.13.0` triggers `publish.yaml`: crates.io publish + GitHub release (notes auto-extracted from this changelog section) + Linux/macOS binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)