### PR TITLE
feat: runtime-adjustable per-output-track gain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +425,33 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -659,6 +698,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1207,6 +1279,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1716,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2025,6 +2117,7 @@ dependencies = [
  "clap",
  "config",
  "cpal",
+ "criterion",
  "crossbeam-channel",
  "crossterm",
  "duration-string",
@@ -2411,6 +2504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,6 +2722,34 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4355,6 +4482,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ futures-util = "0.3"
 tempfile = "3.26.0"
 
 [dev-dependencies]
+criterion = "0.7"
 hound = "3.5.1"
 reqwest = { version = "0.13", features = ["json", "stream"] }
 serial_test = "3.4.0"
@@ -105,6 +106,10 @@ tonic-prost-build = "0.14"
 [lib]
 name = "mtrack"
 path = "src/lib.rs"
+
+[[bench]]
+name = "mixer"
+harness = false
 
 [package.metadata.cargo-shear]
 ignored = ["prost"]

--- a/benches/mixer.rs
+++ b/benches/mixer.rs
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+//! Benchmarks for the audio mixer hot path (`AudioMixer::process_into_output`).
+//!
+//! These measure the per-callback mixing cost for representative live rigs.
+//! Compare against the saved baseline when touching the mixer:
+//!
+//! ```sh
+//! cargo bench --bench mixer -- --save-baseline pre-gain   # before changes
+//! cargo bench --bench mixer -- --baseline pre-gain        # after changes
+//! ```
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+
+use mtrack::audio::mixer::{ActiveSource, AudioMixer};
+use mtrack::audio::sample_source::{
+    ChannelMappedSampleSource, ChannelMappedSource, MemorySampleSource,
+};
+use mtrack::playsync::CancelHandle;
+
+/// Frames per simulated device callback.
+const BUF_FRAMES: usize = 512;
+const SAMPLE_RATE: u32 = 48000;
+
+/// Describes one source in a benchmark scenario: its channel count and the
+/// (label, output channels) mapping for each source channel.
+struct SourceSpec {
+    channels: u16,
+    mappings: Vec<(String, Vec<u16>)>,
+}
+
+fn build_source(spec: &SourceSpec, frames: usize) -> ActiveSource {
+    let samples: Vec<f32> = (0..frames * spec.channels as usize)
+        .map(|i| ((i % 97) as f32 / 97.0) - 0.5)
+        .collect();
+    let memory =
+        MemorySampleSource::from_shared(Arc::new(samples), spec.channels, SAMPLE_RATE, 1.0);
+    let labels: Vec<Vec<String>> = spec
+        .mappings
+        .iter()
+        .map(|(label, _)| vec![label.clone()])
+        .collect();
+    let source: Box<dyn ChannelMappedSampleSource> = Box::new(ChannelMappedSource::new(
+        Box::new(memory),
+        labels,
+        spec.channels,
+    ));
+    let track_mappings: HashMap<String, Vec<u16>> = spec.mappings.iter().cloned().collect();
+
+    ActiveSource {
+        id: 0,
+        source,
+        track_mappings,
+        channel_mappings: Vec::new(),
+        cached_source_channel_count: 0,
+        is_finished: Arc::new(AtomicBool::new(false)),
+        cancel_handle: CancelHandle::new(),
+        start_at_sample: None,
+        cancel_at_sample: None,
+        gain: Default::default(),
+        gain_envelope: None,
+    }
+}
+
+fn build_mixer(specs: &[SourceSpec], output_channels: u16) -> AudioMixer {
+    let mixer = AudioMixer::new(output_channels, SAMPLE_RATE);
+    for (id, spec) in specs.iter().enumerate() {
+        let mut source = build_source(spec, BUF_FRAMES);
+        source.id = id as u64;
+        mixer.add_source(source);
+    }
+    mixer
+}
+
+/// 8 stereo sources routed to a 16-channel interface (typical live rig).
+fn specs_8_stereo_16ch() -> Vec<SourceSpec> {
+    (0..8u16)
+        .map(|i| SourceSpec {
+            channels: 2,
+            mappings: vec![
+                (format!("t{i}-l"), vec![i * 2 + 1]),
+                (format!("t{i}-r"), vec![i * 2 + 2]),
+            ],
+        })
+        .collect()
+}
+
+/// One 16-channel source (single multichannel song file) to 16 outputs.
+fn specs_1x16ch_16ch() -> Vec<SourceSpec> {
+    vec![SourceSpec {
+        channels: 16,
+        mappings: (0..16u16).map(|i| (format!("t{i}"), vec![i + 1])).collect(),
+    }]
+}
+
+/// 32 mono sources to 32 outputs (stress).
+fn specs_32_mono_32ch() -> Vec<SourceSpec> {
+    (0..32u16)
+        .map(|i| SourceSpec {
+            channels: 1,
+            mappings: vec![(format!("t{i}"), vec![i + 1])],
+        })
+        .collect()
+}
+
+fn bench_scenario(c: &mut Criterion, name: &str, specs: Vec<SourceSpec>, output_channels: u16) {
+    let mut group = c.benchmark_group("mixer");
+    group.throughput(Throughput::Elements(BUF_FRAMES as u64));
+    group.bench_function(name, |b| {
+        b.iter_batched(
+            || {
+                let mixer = build_mixer(&specs, output_channels);
+                let output = vec![0.0f32; BUF_FRAMES * output_channels as usize];
+                (mixer, output)
+            },
+            |(mixer, mut output)| {
+                mixer.process_into_output(&mut output, BUF_FRAMES);
+                output
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn mixer_benches(c: &mut Criterion) {
+    bench_scenario(c, "8_stereo_sources_16ch_out", specs_8_stereo_16ch(), 16);
+    bench_scenario(c, "1_source_16ch_16ch_out", specs_1x16ch_16ch(), 16);
+    bench_scenario(c, "32_mono_sources_32ch_out", specs_32_mono_32ch(), 32);
+}
+
+criterion_group!(benches, mixer_benches);
+criterion_main!(benches);

--- a/benches/mixer.rs
+++ b/benches/mixer.rs
@@ -30,6 +30,7 @@ use mtrack::audio::mixer::{ActiveSource, AudioMixer};
 use mtrack::audio::sample_source::{
     ChannelMappedSampleSource, ChannelMappedSource, MemorySampleSource,
 };
+use mtrack::audio::track_gains::TrackGains;
 use mtrack::playsync::CancelHandle;
 
 /// Frames per simulated device callback.
@@ -76,13 +77,62 @@ fn build_source(spec: &SourceSpec, frames: usize) -> ActiveSource {
     }
 }
 
-fn build_mixer(specs: &[SourceSpec], output_channels: u16) -> AudioMixer {
+/// How track gains are exercised by a benchmark scenario.
+#[derive(Clone, Copy)]
+enum GainMode {
+    /// No TrackGains installed: every edge uses the unity slot.
+    None,
+    /// TrackGains installed with non-unity constant values: measures the
+    /// per-batch cached_gain refresh + fast-path inner loop.
+    Constant,
+    /// Gain targets changed after sources are added so every batch ramps:
+    /// measures the per-frame ramp path.
+    Ramping,
+}
+
+impl GainMode {
+    fn suffix(self) -> &'static str {
+        match self {
+            GainMode::None => "",
+            GainMode::Constant => "_gains",
+            GainMode::Ramping => "_ramp",
+        }
+    }
+}
+
+fn build_mixer(specs: &[SourceSpec], output_channels: u16, mode: GainMode) -> AudioMixer {
     let mixer = AudioMixer::new(output_channels, SAMPLE_RATE);
+
+    let track_mappings: HashMap<String, Vec<u16>> = specs
+        .iter()
+        .flat_map(|spec| spec.mappings.iter().cloned())
+        .collect();
+    let gains = match mode {
+        GainMode::None => None,
+        GainMode::Constant | GainMode::Ramping => {
+            let tg = Arc::new(TrackGains::from_config(&track_mappings, None));
+            for name in track_mappings.keys() {
+                tg.set_db(name, -6.0).unwrap();
+            }
+            mixer.set_track_gains(tg.clone());
+            Some(tg)
+        }
+    };
+
     for (id, spec) in specs.iter().enumerate() {
         let mut source = build_source(spec, BUF_FRAMES);
         source.id = id as u64;
         mixer.add_source(source);
     }
+
+    // Sources were added with their gain state initialized at -6 dB; moving
+    // the targets afterwards forces every measured batch to ramp.
+    if let (GainMode::Ramping, Some(tg)) = (mode, gains) {
+        for name in track_mappings.keys() {
+            tg.set_db(name, 3.0).unwrap();
+        }
+    }
+
     mixer
 }
 
@@ -120,20 +170,22 @@ fn specs_32_mono_32ch() -> Vec<SourceSpec> {
 fn bench_scenario(c: &mut Criterion, name: &str, specs: Vec<SourceSpec>, output_channels: u16) {
     let mut group = c.benchmark_group("mixer");
     group.throughput(Throughput::Elements(BUF_FRAMES as u64));
-    group.bench_function(name, |b| {
-        b.iter_batched(
-            || {
-                let mixer = build_mixer(&specs, output_channels);
-                let output = vec![0.0f32; BUF_FRAMES * output_channels as usize];
-                (mixer, output)
-            },
-            |(mixer, mut output)| {
-                mixer.process_into_output(&mut output, BUF_FRAMES);
-                output
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    for mode in [GainMode::None, GainMode::Constant, GainMode::Ramping] {
+        group.bench_function(format!("{name}{}", mode.suffix()), |b| {
+            b.iter_batched(
+                || {
+                    let mixer = build_mixer(&specs, output_channels, mode);
+                    let output = vec![0.0f32; BUF_FRAMES * output_channels as usize];
+                    (mixer, output)
+                },
+                |(mixer, mut output)| {
+                    mixer.process_into_output(&mut output, BUF_FRAMES);
+                    output
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
     group.finish();
 }
 

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let build_time = jiff::Timestamp::now().strftime("%Y-%m-%dT%H:%M:%SZ");
     println!("cargo:rustc-env=MTRACK_BUILD_TIME={build_time}");
 
+    // Re-run when the proto definition changes.
+    println!("cargo:rerun-if-changed=src/proto/player/v1/player.proto");
+
     // Re-run when git HEAD changes.
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs");

--- a/examples/audio_stress.rs
+++ b/examples/audio_stress.rs
@@ -239,6 +239,7 @@ fn create_looping_source(
         cancel_handle: cancel_handle.clone(),
         start_at_sample: None,
         cancel_at_sample: None,
+        gain: Default::default(),
         gain_envelope: None,
     };
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -31,6 +31,7 @@ pub mod mixer;
 pub mod mock;
 pub mod sample_source;
 pub mod tempo_guess;
+pub mod track_gains;
 
 // Re-export the format types for backward compatibility
 pub use context::PlaybackContext;

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -451,6 +451,7 @@ fn build_active_source(
         is_finished,
         start_at_sample: None,
         cancel_at_sample: Some(Arc::new(std::sync::atomic::AtomicU64::new(0))),
+        gain: Default::default(),
         gain_envelope,
     };
     (active, flag)

--- a/src/audio/cpal/manager.rs
+++ b/src/audio/cpal/manager.rs
@@ -246,6 +246,7 @@ mod test {
             is_finished: Arc::new(AtomicBool::new(false)),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         }
     }

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -342,6 +342,7 @@ pub(super) mod test {
             is_finished: Arc::new(AtomicBool::new(false)),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         }
     }

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -13,6 +13,7 @@
 //
 // Core audio mixing logic that can be used by both CPAL and test implementations
 use crate::audio::sample_source::ChannelMappedSampleSource;
+use crate::audio::track_gains::TrackGains;
 use parking_lot::{Mutex, RwLock};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -43,6 +44,9 @@ pub struct AudioMixer {
     sample_rate: u32,
     /// Global sample counter for scheduling (increments each frame processed)
     sample_counter: Arc<AtomicU64>,
+    /// Shared per-output-track gains. Read once per callback (no per-sample
+    /// atomics); `None` until installed at hardware init (e.g. mock devices).
+    track_gains: Arc<RwLock<Option<Arc<TrackGains>>>>,
     /// Performance monitoring (test only)
     #[cfg(test)]
     frame_count: Arc<AtomicUsize>,
@@ -50,6 +54,40 @@ pub struct AudioMixer {
     total_frame_time: Arc<AtomicUsize>, // in microseconds
     #[cfg(test)]
     max_frame_time: Arc<AtomicUsize>, // in microseconds
+}
+
+/// One precomputed (track label -> output channel) mapping edge for a source
+/// channel. Gain is applied per edge: a source channel mapped through two
+/// labels gets one edge per (label, output channel) pair, each scaled by its
+/// own track gain.
+#[derive(Clone, Copy, Debug)]
+pub struct OutputMapping {
+    /// 0-indexed output channel.
+    pub output_index: usize,
+    /// Index into the source's local gain table (`SourceGain`). Entry 0 is a
+    /// synthetic unity slot used for edges with no track gain.
+    pub gain_idx: u32,
+    /// Combined (envelope constant x track) gain folded in once per batch by
+    /// the mixer's constant fast path; not meaningful while a fade or gain
+    /// ramp is active.
+    pub cached_gain: f32,
+}
+
+/// Per-source track gain state, owned by the audio callback.
+///
+/// `slot_ids`, `cur`, and `inc` are parallel arrays indexed by
+/// `OutputMapping::gain_idx`. Entry 0 is a synthetic unity slot
+/// (`cur[0] == 1.0`, `inc[0] == 0.0`, `slot_ids[0]` unused). `cur` ramps
+/// linearly toward the target read from `TrackGains` once per callback batch,
+/// avoiding both per-sample atomic loads and zipper noise.
+#[derive(Default)]
+pub struct SourceGain {
+    /// Local gain table index -> global `TrackGains` slot.
+    pub slot_ids: Vec<usize>,
+    /// Current linear gain per table entry.
+    pub cur: Vec<f32>,
+    /// Per-frame linear gain increment for the current batch.
+    pub inc: Vec<f32>,
 }
 
 /// Represents an active audio source in the mixer
@@ -60,9 +98,11 @@ pub struct ActiveSource {
     pub source: Box<dyn ChannelMappedSampleSource + Send + Sync>,
     /// Track mappings for this source (needed for precomputation)
     pub track_mappings: HashMap<String, Vec<u16>>,
-    /// Precomputed channel mappings: source_channel_index -> Vec<output_channel_index>
+    /// Precomputed channel mappings: source_channel_index -> mapping edges.
     /// This eliminates HashMap lookups during mixing for better performance
-    pub channel_mappings: Vec<Vec<usize>>,
+    pub channel_mappings: Vec<Vec<OutputMapping>>,
+    /// Per-track gain state for this source (filled by `add_source`).
+    pub gain: SourceGain,
     /// Cached source channel count (avoids repeated trait calls)
     pub cached_source_channel_count: u16,
     /// Whether this source has finished playing
@@ -90,6 +130,7 @@ impl AudioMixer {
             num_channels,
             sample_rate,
             sample_counter: Arc::new(AtomicU64::new(0)),
+            track_gains: Arc::new(RwLock::new(None)),
             #[cfg(test)]
             frame_count: Arc::new(AtomicUsize::new(0)),
             #[cfg(test)]
@@ -109,35 +150,72 @@ impl AudioMixer {
         self.sample_counter.clone()
     }
 
-    /// Precomputes channel mappings for optimal performance during mixing
+    /// Installs the shared per-output-track gains. Applies to sources added
+    /// afterwards; sources already playing pick up gain changes (not new
+    /// slot tables) on their next callback.
+    pub fn set_track_gains(&self, track_gains: Arc<TrackGains>) {
+        *self.track_gains.write() = Some(track_gains);
+    }
+
+    /// Precomputes channel mappings for optimal performance during mixing.
+    ///
+    /// Also builds the source's local gain table: one entry per distinct
+    /// track gain slot referenced by this source's labels, with entry 0 as
+    /// the synthetic unity slot. The current gain is initialized from the
+    /// target so sources start at the set gain with no ramp (this is how
+    /// gains set while stopped apply to the next song).
     fn precompute_channel_mappings(
         source: &dyn ChannelMappedSampleSource,
         track_mappings: &HashMap<String, Vec<u16>>,
-    ) -> Vec<Vec<usize>> {
+        track_gains: Option<&TrackGains>,
+    ) -> (Vec<Vec<OutputMapping>>, SourceGain) {
         let source_channel_count = source.source_channel_count() as usize;
         let mut channel_mappings = Vec::with_capacity(source_channel_count);
+        let mut gain = SourceGain {
+            slot_ids: vec![usize::MAX],
+            cur: vec![1.0],
+            inc: vec![0.0],
+        };
+        // Dedup: global TrackGains slot -> local gain table index.
+        let mut local_by_slot: HashMap<usize, u32> = HashMap::new();
 
         for source_channel in 0..source_channel_count {
-            let mut output_channels = Vec::new();
+            let mut output_mappings = Vec::new();
 
             // Get the labels for this source channel
             if let Some(labels) = source.channel_mappings().get(source_channel) {
                 // For each label, find the corresponding output channels
                 for label in labels {
                     if let Some(track_channels) = track_mappings.get(label) {
+                        let gain_idx = match track_gains.and_then(|tg| tg.slot(label)) {
+                            Some(slot) => *local_by_slot.entry(slot).or_insert_with(|| {
+                                let idx = gain.slot_ids.len() as u32;
+                                let target =
+                                    track_gains.expect("slot implies track_gains").linear(slot);
+                                gain.slot_ids.push(slot);
+                                gain.cur.push(target);
+                                gain.inc.push(0.0);
+                                idx
+                            }),
+                            None => 0,
+                        };
                         // Convert 1-indexed track channels to 0-indexed output indices
                         for &track_channel in track_channels {
                             let output_index = (track_channel - 1) as usize;
-                            output_channels.push(output_index);
+                            output_mappings.push(OutputMapping {
+                                output_index,
+                                gain_idx,
+                                cached_gain: gain.cur[gain_idx as usize],
+                            });
                         }
                     }
                 }
             }
 
-            channel_mappings.push(output_channels);
+            channel_mappings.push(output_mappings);
         }
 
-        channel_mappings
+        (channel_mappings, gain)
     }
 
     /// Adds a new audio source to the mixer
@@ -147,9 +225,14 @@ impl AudioMixer {
             source.cached_source_channel_count = source.source.source_channel_count();
         }
         // Precompute channel mappings for optimal performance
-        let channel_mappings =
-            Self::precompute_channel_mappings(source.source.as_ref(), &source.track_mappings);
+        let track_gains = self.track_gains.read().clone();
+        let (channel_mappings, gain) = Self::precompute_channel_mappings(
+            source.source.as_ref(),
+            &source.track_mappings,
+            track_gains.as_deref(),
+        );
         source.channel_mappings = channel_mappings;
+        source.gain = gain;
 
         let mut sources = self.active_sources.write();
         sources.push(Arc::new(Mutex::new(source)));
@@ -249,6 +332,15 @@ impl AudioMixer {
                 source_frame_buffer.resize(source_channel_count, 0.0);
             }
 
+            // Test path: apply track gain targets directly (no ramping) so
+            // frame-level assertions stay simple.
+            if let Some(tg) = self.track_gains.read().as_deref() {
+                for i in 1..active_source.gain.slot_ids.len() {
+                    let target = tg.linear(active_source.gain.slot_ids[i]);
+                    active_source.gain.cur[i] = target;
+                }
+            }
+
             match active_source
                 .source
                 .next_frame(&mut source_frame_buffer[..source_channel_count])
@@ -260,14 +352,15 @@ impl AudioMixer {
                         .enumerate()
                     {
                         // Use precomputed channel mappings for optimal performance
-                        if let Some(output_channels) =
+                        if let Some(output_mappings) =
                             active_source.channel_mappings.get(source_channel)
                         {
                             // Map this sample to all precomputed output channels
-                            for &output_index in output_channels {
-                                if output_index < frame.len() {
+                            for m in output_mappings {
+                                if m.output_index < frame.len() {
                                     // Mix: add new sample to existing
-                                    frame[output_index] += sample;
+                                    frame[m.output_index] +=
+                                        sample * active_source.gain.cur[m.gain_idx as usize];
                                 }
                             }
                         }
@@ -358,6 +451,10 @@ impl AudioMixer {
 
         let mut finished_source_ids: Vec<u64> = Vec::new();
 
+        // Snapshot the shared track gains once per callback. Individual gain
+        // targets are read once per source below — never per sample.
+        let track_gains = self.track_gains.read().clone();
+
         // Process each active source across all frames
         for active_source_arc in sources_to_process.iter() {
             let mut active_source = active_source_arc.lock();
@@ -445,6 +542,23 @@ impl AudioMixer {
             let source_channel_count = active_source.cached_source_channel_count as usize;
             let frames_needed = end_frame - start_frame;
 
+            // Refresh per-track gain ramps for this batch: one relaxed load
+            // per referenced track, then a linear ramp across the batch
+            // toward the target (~10-20ms at typical buffer sizes), which
+            // avoids zipper noise without per-frame atomics.
+            if let Some(ref tg) = track_gains {
+                for i in 1..active_source.gain.slot_ids.len() {
+                    let target = tg.linear(active_source.gain.slot_ids[i]);
+                    let cur = active_source.gain.cur[i];
+                    if (target - cur).abs() < 1e-6 {
+                        active_source.gain.cur[i] = target;
+                        active_source.gain.inc[i] = 0.0;
+                    } else {
+                        active_source.gain.inc[i] = (target - cur) / frames_needed as f32;
+                    }
+                }
+            }
+
             // Safety invariant: BATCH_READ_SCRATCH is reused across source iterations
             // without clearing. This is safe because we only read back
             // `frames_got * source_channel_count` samples from the buffer, and
@@ -474,36 +588,93 @@ impl AudioMixer {
                         let fade_active = envelope.as_ref().is_some_and(|env| !env.is_finished());
                         let constant_gain = envelope.as_ref().map_or(1.0, |env| env.end_gain());
 
-                        for frame_idx in 0..frames_got {
-                            let gain = if fade_active {
-                                // `advance_at` consumes one frame: for a
-                                // sample-anchored envelope it maps the frame's
-                                // global sample to a position; for a render-driven
-                                // one it simply steps the position. Either way the
-                                // ramp tracks the actual audio sample-for-sample.
-                                let env = envelope.as_ref().expect("fade_active implies Some");
-                                let global = current_sample + (start_frame + frame_idx) as u64;
-                                env.advance_at(global, 1)
-                            } else {
-                                constant_gain
-                            };
-                            let src_offset = frame_idx * source_channel_count;
-                            let dst_base = (start_frame + frame_idx) * channels;
-                            for (source_channel, &sample) in batch_buf
-                                [src_offset..src_offset + source_channel_count]
-                                .iter()
-                                .enumerate()
-                            {
-                                if let Some(output_channels) =
-                                    active_source.channel_mappings.get(source_channel)
+                        // Track gain ramping is rare (only the batches right
+                        // after a gain change); everything else takes the
+                        // constant fast path below.
+                        let track_ramp_active =
+                            active_source.gain.inc.iter().any(|&inc| inc != 0.0);
+
+                        if !fade_active && !track_ramp_active {
+                            // Fast path: all gains constant across this batch.
+                            // Fold envelope constant and track gain into each
+                            // mapping edge once, leaving the inner loop a
+                            // single load + FMA per edge.
+                            let src = &mut *active_source;
+                            for mappings in src.channel_mappings.iter_mut() {
+                                for m in mappings.iter_mut() {
+                                    m.cached_gain =
+                                        constant_gain * src.gain.cur[m.gain_idx as usize];
+                                }
+                            }
+                            for frame_idx in 0..frames_got {
+                                let src_offset = frame_idx * source_channel_count;
+                                let dst_base = (start_frame + frame_idx) * channels;
+                                for (source_channel, &sample) in batch_buf
+                                    [src_offset..src_offset + source_channel_count]
+                                    .iter()
+                                    .enumerate()
                                 {
-                                    for &output_index in output_channels {
-                                        if output_index < channels {
-                                            output[dst_base + output_index] += sample * gain;
+                                    if let Some(output_mappings) =
+                                        src.channel_mappings.get(source_channel)
+                                    {
+                                        for m in output_mappings {
+                                            if m.output_index < channels {
+                                                output[dst_base + m.output_index] +=
+                                                    sample * m.cached_gain;
+                                            }
                                         }
                                     }
                                 }
                             }
+                        } else {
+                            for frame_idx in 0..frames_got {
+                                let gain = if fade_active {
+                                    // `advance_at` consumes one frame: for a
+                                    // sample-anchored envelope it maps the frame's
+                                    // global sample to a position; for a render-driven
+                                    // one it simply steps the position. Either way the
+                                    // ramp tracks the actual audio sample-for-sample.
+                                    let env = envelope.as_ref().expect("fade_active implies Some");
+                                    let global = current_sample + (start_frame + frame_idx) as u64;
+                                    env.advance_at(global, 1)
+                                } else {
+                                    constant_gain
+                                };
+                                let src_offset = frame_idx * source_channel_count;
+                                let dst_base = (start_frame + frame_idx) * channels;
+                                let frame_f = frame_idx as f32;
+                                for (source_channel, &sample) in batch_buf
+                                    [src_offset..src_offset + source_channel_count]
+                                    .iter()
+                                    .enumerate()
+                                {
+                                    if let Some(output_mappings) =
+                                        active_source.channel_mappings.get(source_channel)
+                                    {
+                                        for m in output_mappings {
+                                            if m.output_index < channels {
+                                                // Per-edge track gain: current ramp
+                                                // value for this frame. Pure FMA
+                                                // shape — no branches or atomics.
+                                                let idx = m.gain_idx as usize;
+                                                let track_gain = active_source.gain.cur[idx]
+                                                    + active_source.gain.inc[idx] * frame_f;
+                                                output[dst_base + m.output_index] +=
+                                                    sample * gain * track_gain;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Advance gain ramps by the frames actually mixed; a
+                        // full batch lands on the target (snapped exactly on
+                        // the next callback by the |delta| < 1e-6 fast path).
+                        for i in 1..active_source.gain.cur.len() {
+                            let advanced =
+                                active_source.gain.cur[i] + active_source.gain.inc[i] * frames_got as f32;
+                            active_source.gain.cur[i] = advanced;
                         }
 
                         // Auto-finish sources whose fade-out envelope has completed.
@@ -619,6 +790,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         }
     }
@@ -645,6 +817,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -693,6 +866,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -711,6 +885,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -757,6 +932,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -806,6 +982,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: Some(400),
             cancel_at_sample: Some(cancel_at),
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -857,6 +1034,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -898,6 +1076,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: Some(2), // Start at sample 2
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -941,6 +1120,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: Some(cancel_at),
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -981,6 +1161,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -1033,6 +1214,7 @@ mod tests {
             start_at_sample: None,
             // Pre-allocated cancel slot, set below to the loop boundary.
             cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
+            gain: Default::default(),
             gain_envelope: None,
         };
         mixer.add_source(old);
@@ -1053,6 +1235,7 @@ mod tests {
             // Delayed start: first sample plays at the fade_start boundary.
             start_at_sample: Some(fade_start),
             cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
+            gain: Default::default(),
             gain_envelope: Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
                 crossfade_samples,
                 crate::audio::crossfade::CrossfadeCurve::Linear,
@@ -1135,6 +1318,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
+            gain: Default::default(),
             gain_envelope: None,
         };
         mixer.add_source(old);
@@ -1149,6 +1333,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: Some(fade_start),
             cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
+            gain: Default::default(),
             gain_envelope: Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
                 crossfade_samples,
                 crate::audio::crossfade::CrossfadeCurve::Linear,
@@ -1215,6 +1400,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -1233,6 +1419,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -1269,6 +1456,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: Some(2), // Start at sample 2
             cancel_at_sample: Some(cancel_at),
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -1382,6 +1570,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -1442,6 +1631,7 @@ mod tests {
             cancel_handle: CancelHandle::new(),
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 
@@ -1466,16 +1656,21 @@ mod tests {
     mod precompute_channel_mappings_tests {
         use super::*;
 
+        /// Extracts just the output indices for a source channel.
+        fn out_indices(mappings: &[Vec<OutputMapping>], ch: usize) -> Vec<usize> {
+            mappings[ch].iter().map(|m| m.output_index).collect()
+        }
+
         #[test]
         fn single_channel_single_output() {
             let source = create_test_source(vec![0.0], 1, vec![vec!["vocals".to_string()]]);
             let mut track_mappings = HashMap::new();
             track_mappings.insert("vocals".to_string(), vec![1]);
 
-            let mappings =
-                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings);
+            let (mappings, _) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
             assert_eq!(mappings.len(), 1);
-            assert_eq!(mappings[0], vec![0]); // channel 1 → index 0
+            assert_eq!(out_indices(&mappings, 0), vec![0]); // channel 1 → index 0
         }
 
         #[test]
@@ -1485,10 +1680,10 @@ mod tests {
             // Map "mono" to output channels 1 and 2
             track_mappings.insert("mono".to_string(), vec![1, 2]);
 
-            let mappings =
-                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings);
+            let (mappings, _) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
             assert_eq!(mappings.len(), 1);
-            assert_eq!(mappings[0], vec![0, 1]); // channels 1,2 → indices 0,1
+            assert_eq!(out_indices(&mappings, 0), vec![0, 1]); // channels 1,2 → indices 0,1
         }
 
         #[test]
@@ -1496,8 +1691,8 @@ mod tests {
             let source = create_test_source(vec![0.0], 1, vec![vec!["not_in_config".to_string()]]);
             let track_mappings = HashMap::new(); // empty — no labels match
 
-            let mappings =
-                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings);
+            let (mappings, _) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
             assert_eq!(mappings.len(), 1);
             assert!(mappings[0].is_empty());
         }
@@ -1513,11 +1708,11 @@ mod tests {
             track_mappings.insert("left".to_string(), vec![1]);
             track_mappings.insert("right".to_string(), vec![2]);
 
-            let mappings =
-                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings);
+            let (mappings, _) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
             assert_eq!(mappings.len(), 2);
-            assert_eq!(mappings[0], vec![0]); // left → index 0
-            assert_eq!(mappings[1], vec![1]); // right → index 1
+            assert_eq!(out_indices(&mappings, 0), vec![0]); // left → index 0
+            assert_eq!(out_indices(&mappings, 1), vec![1]); // right → index 1
         }
 
         #[test]
@@ -1532,10 +1727,10 @@ mod tests {
             track_mappings.insert("main".to_string(), vec![1]);
             track_mappings.insert("monitor".to_string(), vec![3]);
 
-            let mappings =
-                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings);
+            let (mappings, _) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
             assert_eq!(mappings.len(), 1);
-            assert_eq!(mappings[0], vec![0, 2]); // ch1→0, ch3→2
+            assert_eq!(out_indices(&mappings, 0), vec![0, 2]); // ch1→0, ch3→2
         }
 
         #[test]
@@ -1545,10 +1740,180 @@ mod tests {
             let mut track_mappings = HashMap::new();
             track_mappings.insert("anything".to_string(), vec![1]);
 
-            let mappings =
-                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings);
+            let (mappings, _) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
             assert_eq!(mappings.len(), 1);
             assert!(mappings[0].is_empty());
+        }
+
+        #[test]
+        fn without_track_gains_all_edges_unity() {
+            let source = create_test_source(vec![0.0], 1, vec![vec!["vocals".to_string()]]);
+            let mut track_mappings = HashMap::new();
+            track_mappings.insert("vocals".to_string(), vec![1, 2]);
+
+            let (mappings, gain) =
+                AudioMixer::precompute_channel_mappings(source.as_ref(), &track_mappings, None);
+            assert!(mappings[0].iter().all(|m| m.gain_idx == 0));
+            assert_eq!(gain.cur, vec![1.0]);
+        }
+
+        #[test]
+        fn with_track_gains_edges_get_slots() {
+            use crate::audio::track_gains::TrackGains;
+
+            let source = create_test_source(
+                vec![0.0],
+                1,
+                vec![vec!["main".to_string(), "monitor".to_string()]],
+            );
+            let mut track_mappings = HashMap::new();
+            track_mappings.insert("main".to_string(), vec![1]);
+            track_mappings.insert("monitor".to_string(), vec![3]);
+
+            let tg = TrackGains::from_config(&track_mappings, None);
+            tg.set_db("monitor", -6.0).unwrap();
+
+            let (mappings, gain) = AudioMixer::precompute_channel_mappings(
+                source.as_ref(),
+                &track_mappings,
+                Some(&tg),
+            );
+            // Two edges with distinct, non-unity gain table entries.
+            assert_eq!(mappings[0].len(), 2);
+            assert_ne!(mappings[0][0].gain_idx, mappings[0][1].gain_idx);
+            assert!(mappings[0].iter().all(|m| m.gain_idx != 0));
+            // Current gain initialized from targets (monitor at -6 dB).
+            let monitor_idx = mappings[0][1].gain_idx as usize;
+            assert!((gain.cur[monitor_idx] - 0.5012).abs() < 0.001);
+        }
+    }
+
+    mod track_gain_tests {
+        use super::*;
+        use crate::audio::track_gains::{TrackGains, MIN_GAIN_DB};
+
+        fn t_mappings() -> HashMap<String, Vec<u16>> {
+            HashMap::from([("t".to_string(), vec![1])])
+        }
+
+        fn ones_source(frames: usize) -> Box<dyn ChannelMappedSampleSource> {
+            create_test_source(vec![1.0; frames], 1, vec![vec!["t".to_string()]])
+        }
+
+        fn install_gains(
+            mixer: &AudioMixer,
+            mappings: &HashMap<String, Vec<u16>>,
+        ) -> Arc<TrackGains> {
+            let tg = Arc::new(TrackGains::from_config(mappings, None));
+            mixer.set_track_gains(tg.clone());
+            tg
+        }
+
+        #[test]
+        fn gain_applied_from_source_start() {
+            // Gains set before a source is added apply immediately (no ramp).
+            let mixer = AudioMixer::new(1, 48000);
+            let tg = install_gains(&mixer, &t_mappings());
+            tg.set_db("t", -6.0).unwrap();
+
+            mixer.add_source(make_active_source(1, ones_source(8), t_mappings()));
+            let mut out = vec![0.0f32; 8];
+            mixer.process_into_output(&mut out, 8);
+            for s in out {
+                assert!((s - 0.5012).abs() < 0.001, "expected ~0.5012, got {s}");
+            }
+        }
+
+        #[test]
+        fn min_gain_mutes_exactly() {
+            let mixer = AudioMixer::new(1, 48000);
+            let tg = install_gains(&mixer, &t_mappings());
+            tg.set_db("t", MIN_GAIN_DB).unwrap();
+
+            mixer.add_source(make_active_source(1, ones_source(8), t_mappings()));
+            let mut out = vec![0.0f32; 8];
+            mixer.process_into_output(&mut out, 8);
+            assert!(
+                out.iter().all(|&s| s == 0.0),
+                "expected silence, got {out:?}"
+            );
+        }
+
+        #[test]
+        fn gain_change_ramps_across_batch() {
+            let mixer = AudioMixer::new(1, 48000);
+            let tg = install_gains(&mixer, &t_mappings());
+            mixer.add_source(make_active_source(1, ones_source(2048), t_mappings()));
+
+            // First batch at unity.
+            let mut out = vec![0.0f32; 512];
+            mixer.process_into_output(&mut out, 512);
+            assert!(out.iter().all(|&s| (s - 1.0).abs() < 1e-6));
+
+            // Change gain; the next batch must ramp smoothly, not step.
+            tg.set_db("t", -6.0).unwrap();
+            let mut out = vec![0.0f32; 512];
+            mixer.process_into_output(&mut out, 512);
+            assert!(
+                (out[0] - 1.0).abs() < 0.01,
+                "ramp starts at old gain, got {}",
+                out[0]
+            );
+            assert!(
+                (out[511] - 0.5012).abs() < 0.01,
+                "ramp ends near target, got {}",
+                out[511]
+            );
+            for w in out.windows(2) {
+                assert!(
+                    w[1] <= w[0] + 1e-6,
+                    "ramp must be monotonic: {} -> {}",
+                    w[0],
+                    w[1]
+                );
+            }
+
+            // Following batch sits at the target.
+            let mut out = vec![0.0f32; 512];
+            mixer.process_into_output(&mut out, 512);
+            assert!(out.iter().all(|&s| (s - 0.5012).abs() < 0.001));
+        }
+
+        #[test]
+        fn per_edge_gains_for_multi_label_channel() {
+            // One source channel feeding two tracks: muting one track must
+            // not affect the other edge.
+            let mixer = AudioMixer::new(2, 48000);
+            let mappings: HashMap<String, Vec<u16>> = HashMap::from([
+                ("main".to_string(), vec![1]),
+                ("monitor".to_string(), vec![2]),
+            ]);
+            let tg = install_gains(&mixer, &mappings);
+            tg.set_db("monitor", MIN_GAIN_DB).unwrap();
+
+            let source = create_test_source(
+                vec![1.0; 4],
+                1,
+                vec![vec!["main".to_string(), "monitor".to_string()]],
+            );
+            mixer.add_source(make_active_source(1, source, mappings));
+
+            let mut out = vec![0.0f32; 8];
+            mixer.process_into_output(&mut out, 4);
+            for frame in out.chunks(2) {
+                assert!((frame[0] - 1.0).abs() < 1e-6, "main stays at unity");
+                assert_eq!(frame[1], 0.0, "monitor is muted");
+            }
+        }
+
+        #[test]
+        fn no_track_gains_installed_is_unity() {
+            let mixer = AudioMixer::new(1, 48000);
+            mixer.add_source(make_active_source(1, ones_source(8), t_mappings()));
+            let mut out = vec![0.0f32; 8];
+            mixer.process_into_output(&mut out, 8);
+            assert!(out.iter().all(|&s| (s - 1.0).abs() < 1e-6));
         }
     }
 

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -803,23 +803,11 @@ mod tests {
         let samples = vec![0.5, 0.8]; // 2 frames of 1 channel
         let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
 
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]); // Map to channel 1 only
-                map
-            },
-            channel_mappings: Vec::new(), // Will be precomputed in add_source
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]); // Map to channel 1 only
+            map
+        });
 
         mixer.add_source(active_source);
 
@@ -851,43 +839,19 @@ mod tests {
             vec![vec!["ch0".to_string()], vec!["ch1".to_string()]],
         );
 
-        let active_source1 = ActiveSource {
-            id: 1,
-            source: source1,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("ch0".to_string(), vec![1]);
-                map.insert("ch1".to_string(), vec![2]);
-                map
-            },
-            channel_mappings: Vec::new(), // Will be precomputed in add_source
-            cached_source_channel_count: 2,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source1 = make_active_source(1, source1, {
+            let mut map = HashMap::new();
+            map.insert("ch0".to_string(), vec![1]);
+            map.insert("ch1".to_string(), vec![2]);
+            map
+        });
 
-        let active_source2 = ActiveSource {
-            id: 2,
-            source: source2,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("ch0".to_string(), vec![1]);
-                map.insert("ch1".to_string(), vec![2]);
-                map
-            },
-            channel_mappings: Vec::new(), // Will be precomputed in add_source
-            cached_source_channel_count: 2,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source2 = make_active_source(2, source2, {
+            let mut map = HashMap::new();
+            map.insert("ch0".to_string(), vec![1]);
+            map.insert("ch1".to_string(), vec![2]);
+            map
+        });
 
         mixer.add_source(active_source1);
         mixer.add_source(active_source2);
@@ -917,24 +881,12 @@ mod tests {
             mappings[1] = vec!["ch1".to_string()];
             mappings
         });
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("ch0".to_string(), vec![1]); // Map to channel 1
-                map.insert("ch1".to_string(), vec![2]); // Map to channel 2
-                map
-            },
-            channel_mappings: Vec::new(), // Will be precomputed in add_source
-            cached_source_channel_count: 32,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("ch0".to_string(), vec![1]); // Map to channel 1
+            map.insert("ch1".to_string(), vec![2]); // Map to channel 2
+            map
+        });
 
         mixer.add_source(active_source);
 
@@ -968,23 +920,13 @@ mod tests {
 
         // start_at_sample=400, cancel_at_sample=200 — cancel comes before start
         let cancel_at = Arc::new(AtomicU64::new(200));
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: Some(400),
-            cancel_at_sample: Some(cancel_at),
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
+        active_source.start_at_sample = Some(400);
+        active_source.cancel_at_sample = Some(cancel_at);
 
         mixer.add_source(active_source);
 
@@ -1020,23 +962,11 @@ mod tests {
         let samples = vec![0.5, 0.8, 0.3, 0.6]; // 4 frames of 1 channel
         let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
 
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
 
         mixer.add_source(active_source);
 
@@ -1062,23 +992,12 @@ mod tests {
         let samples = vec![0.1, 0.2, 0.3, 0.4];
         let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
 
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: Some(2), // Start at sample 2
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
+        active_source.start_at_sample = Some(2); // Start at sample 2
 
         mixer.add_source(active_source);
 
@@ -1106,23 +1025,12 @@ mod tests {
         let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
 
         let cancel_at = Arc::new(AtomicU64::new(3)); // Cancel at sample 3
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: Some(cancel_at),
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
+        active_source.cancel_at_sample = Some(cancel_at);
 
         mixer.add_source(active_source);
 
@@ -1147,23 +1055,11 @@ mod tests {
         let samples = vec![0.7, 0.9]; // Only 2 frames of 1 channel
         let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
 
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
 
         mixer.add_source(active_source);
 
@@ -1203,20 +1099,9 @@ mod tests {
         let mut tm = HashMap::new();
         tm.insert("t".to_string(), vec![1]);
 
-        let old = ActiveSource {
-            id: 1,
-            source: old_source,
-            track_mappings: tm.clone(),
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            // Pre-allocated cancel slot, set below to the loop boundary.
-            cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut old = make_active_source(1, old_source, tm.clone());
+        // Pre-allocated cancel slot, set below to the loop boundary.
+        old.cancel_at_sample = Some(Arc::new(AtomicU64::new(0)));
         mixer.add_source(old);
 
         // Incoming source: silence except a distinctive 0.5 impulse at source
@@ -1224,23 +1109,14 @@ mod tests {
         let mut new_samples = vec![0.0f32; 200];
         new_samples[50] = 0.5;
         let new_source = create_test_source(new_samples, 1, vec![vec!["t".to_string()]]);
-        let new = ActiveSource {
-            id: 2,
-            source: new_source,
-            track_mappings: tm,
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            // Delayed start: first sample plays at the fade_start boundary.
-            start_at_sample: Some(fade_start),
-            cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
-            gain: Default::default(),
-            gain_envelope: Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
-                crossfade_samples,
-                crate::audio::crossfade::CrossfadeCurve::Linear,
-            ))),
-        };
+        let mut new = make_active_source(2, new_source, tm);
+        // Delayed start: first sample plays at the fade_start boundary.
+        new.start_at_sample = Some(fade_start);
+        new.cancel_at_sample = Some(Arc::new(AtomicU64::new(0)));
+        new.gain_envelope = Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+            crossfade_samples,
+            crate::audio::crossfade::CrossfadeCurve::Linear,
+        )));
         mixer.add_source(new);
 
         // Schedule the outgoing fade-out (anchored at fade_start) and the cut
@@ -1308,37 +1184,25 @@ mod tests {
 
         // Both sources are constant 1.0. A correct linear crossfade of two unity
         // sources is 1.0 at every sample, so any sample reading 0.0 is a gap.
-        let old = ActiveSource {
-            id: 1,
-            source: create_test_source(vec![1.0f32; 1024], 1, vec![vec!["t".to_string()]]),
-            track_mappings: tm.clone(),
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut old = make_active_source(
+            1,
+            create_test_source(vec![1.0f32; 1024], 1, vec![vec!["t".to_string()]]),
+            tm.clone(),
+        );
+        old.cancel_at_sample = Some(Arc::new(AtomicU64::new(0)));
         mixer.add_source(old);
 
-        let new = ActiveSource {
-            id: 2,
-            source: create_test_source(vec![1.0f32; 1024], 1, vec![vec!["t".to_string()]]),
-            track_mappings: tm,
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: Some(fade_start),
-            cancel_at_sample: Some(Arc::new(AtomicU64::new(0))),
-            gain: Default::default(),
-            gain_envelope: Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
-                crossfade_samples,
-                crate::audio::crossfade::CrossfadeCurve::Linear,
-            ))),
-        };
+        let mut new = make_active_source(
+            2,
+            create_test_source(vec![1.0f32; 1024], 1, vec![vec!["t".to_string()]]),
+            tm,
+        );
+        new.start_at_sample = Some(fade_start);
+        new.cancel_at_sample = Some(Arc::new(AtomicU64::new(0)));
+        new.gain_envelope = Some(Arc::new(crate::audio::crossfade::GainEnvelope::fade_in(
+            crossfade_samples,
+            crate::audio::crossfade::CrossfadeCurve::Linear,
+        )));
         mixer.add_source(new);
 
         mixer.set_gain_envelope(
@@ -1385,43 +1249,19 @@ mod tests {
             vec![vec!["ch0".to_string()], vec!["ch1".to_string()]],
         );
 
-        let active_source1 = ActiveSource {
-            id: 1,
-            source: source1,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("ch0".to_string(), vec![1]);
-                map.insert("ch1".to_string(), vec![2]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 2,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source1 = make_active_source(1, source1, {
+            let mut map = HashMap::new();
+            map.insert("ch0".to_string(), vec![1]);
+            map.insert("ch1".to_string(), vec![2]);
+            map
+        });
 
-        let active_source2 = ActiveSource {
-            id: 2,
-            source: source2,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("ch0".to_string(), vec![1]);
-                map.insert("ch1".to_string(), vec![2]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 2,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source2 = make_active_source(2, source2, {
+            let mut map = HashMap::new();
+            map.insert("ch0".to_string(), vec![1]);
+            map.insert("ch1".to_string(), vec![2]);
+            map
+        });
 
         mixer.add_source(active_source1);
         mixer.add_source(active_source2);
@@ -1442,23 +1282,13 @@ mod tests {
         let source = create_test_source(samples, 1, vec![vec!["test".to_string()]]);
 
         let cancel_at = Arc::new(AtomicU64::new(6)); // Cancel at sample 6
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: Some(2), // Start at sample 2
-            cancel_at_sample: Some(cancel_at),
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
+        active_source.start_at_sample = Some(2); // Start at sample 2
+        active_source.cancel_at_sample = Some(cancel_at);
 
         mixer.add_source(active_source);
 
@@ -1556,23 +1386,12 @@ mod tests {
             Box::new(UnderrunSimSource::new(inner, 1));
 
         let is_finished = Arc::new(AtomicBool::new(false));
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: is_finished.clone(),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let mut active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
+        active_source.is_finished = is_finished.clone();
 
         mixer.add_source(active_source);
 
@@ -1617,23 +1436,11 @@ mod tests {
         let source: Box<dyn ChannelMappedSampleSource + Send + Sync> =
             Box::new(UnderrunSimSource::new(inner, 0));
 
-        let active_source = ActiveSource {
-            id: 1,
-            source,
-            track_mappings: {
-                let mut map = HashMap::new();
-                map.insert("test".to_string(), vec![1]);
-                map
-            },
-            channel_mappings: Vec::new(),
-            cached_source_channel_count: 1,
-            is_finished: Arc::new(AtomicBool::new(false)),
-            cancel_handle: CancelHandle::new(),
-            start_at_sample: None,
-            cancel_at_sample: None,
-            gain: Default::default(),
-            gain_envelope: None,
-        };
+        let active_source = make_active_source(1, source, {
+            let mut map = HashMap::new();
+            map.insert("test".to_string(), vec![1]);
+            map
+        });
 
         mixer.add_source(active_source);
 

--- a/src/audio/track_gains.rs
+++ b/src/audio/track_gains.rs
@@ -18,7 +18,7 @@
 //! `f32` bit patterns in atomics so the callback can read them lock-free.
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use indexmap::IndexMap;
 use tracing::warn;
@@ -68,10 +68,25 @@ pub struct TrackGains {
     slots: HashMap<String, usize>,
     /// Slot index -> track name, in config order (stable for reporting).
     names: Vec<String>,
-    /// Gain in dB, stored as f32 bits.
-    db_bits: Vec<AtomicU32>,
-    /// Linear multiplier, stored as f32 bits. Hot-path reads.
-    linear_bits: Vec<AtomicU32>,
+    /// dB (high 32 bits) and linear multiplier (low 32 bits) packed into a
+    /// single atomic per slot, so concurrent setters can never leave the two
+    /// representations desynced. The mixer hot path reads only the low half.
+    gain_bits: Vec<AtomicU64>,
+}
+
+/// Packs a (dB, linear) gain pair into a single u64.
+fn pack_gain(db: f32, linear: f32) -> u64 {
+    ((db.to_bits() as u64) << 32) | linear.to_bits() as u64
+}
+
+/// The dB half of a packed gain.
+fn unpack_db(bits: u64) -> f32 {
+    f32::from_bits((bits >> 32) as u32)
+}
+
+/// The linear half of a packed gain.
+fn unpack_linear(bits: u64) -> f32 {
+    f32::from_bits(bits as u32)
 }
 
 impl TrackGains {
@@ -96,8 +111,7 @@ impl TrackGains {
         names.extend(mapping_names.into_iter().cloned());
 
         let mut slots = HashMap::with_capacity(names.len());
-        let mut db_bits = Vec::with_capacity(names.len());
-        let mut linear_bits = Vec::with_capacity(names.len());
+        let mut gain_bits = Vec::with_capacity(names.len());
         for (slot, name) in names.iter().enumerate() {
             let configured = track_gains.and_then(|gains| gains.get(name)).copied();
             let db = match configured {
@@ -116,15 +130,13 @@ impl TrackGains {
                 None => 0.0,
             };
             slots.insert(name.clone(), slot);
-            db_bits.push(AtomicU32::new(db.to_bits()));
-            linear_bits.push(AtomicU32::new(db_to_linear(db).to_bits()));
+            gain_bits.push(AtomicU64::new(pack_gain(db, db_to_linear(db))));
         }
 
         Self {
             slots,
             names,
-            db_bits,
-            linear_bits,
+            gain_bits,
         }
     }
 
@@ -149,20 +161,19 @@ impl TrackGains {
             .slot(track)
             .ok_or_else(|| UnknownTrackError(track.to_string()))?;
         let clamped = clamp_db(db);
-        self.db_bits[slot].store(clamped.to_bits(), Ordering::Relaxed);
-        self.linear_bits[slot].store(db_to_linear(clamped).to_bits(), Ordering::Relaxed);
+        self.gain_bits[slot].store(pack_gain(clamped, db_to_linear(clamped)), Ordering::Relaxed);
         Ok(clamped)
     }
 
     /// Gets the gain of a track in dB.
     pub fn get_db(&self, track: &str) -> Option<f32> {
         self.slot(track)
-            .map(|slot| f32::from_bits(self.db_bits[slot].load(Ordering::Relaxed)))
+            .map(|slot| unpack_db(self.gain_bits[slot].load(Ordering::Relaxed)))
     }
 
     /// Gets the linear multiplier for a slot. Hot path: single relaxed load.
     pub fn linear(&self, slot: usize) -> f32 {
-        f32::from_bits(self.linear_bits[slot].load(Ordering::Relaxed))
+        unpack_linear(self.gain_bits[slot].load(Ordering::Relaxed))
     }
 
     /// Snapshots all gains as (name, dB) pairs in slot order.
@@ -173,7 +184,7 @@ impl TrackGains {
             .map(|(slot, name)| {
                 (
                     name.clone(),
-                    f32::from_bits(self.db_bits[slot].load(Ordering::Relaxed)),
+                    unpack_db(self.gain_bits[slot].load(Ordering::Relaxed)),
                 )
             })
             .collect()

--- a/src/audio/track_gains.rs
+++ b/src/audio/track_gains.rs
@@ -1,0 +1,279 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+//! Runtime-adjustable per-output-track gain.
+//!
+//! Gains are expressed in dB at the API/config level and stored alongside a
+//! precomputed linear multiplier for the audio callback. Values are stored as
+//! `f32` bit patterns in atomics so the callback can read them lock-free.
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use indexmap::IndexMap;
+use tracing::warn;
+
+/// Gains at or below this value are treated as -inf (linear 0.0).
+pub const MIN_GAIN_DB: f32 = -60.0;
+/// Maximum allowed boost.
+pub const MAX_GAIN_DB: f32 = 12.0;
+
+/// Clamps a dB gain to the supported range. NaN becomes 0.0 dB (unity).
+pub fn clamp_db(db: f32) -> f32 {
+    if db.is_nan() {
+        return 0.0;
+    }
+    db.clamp(MIN_GAIN_DB, MAX_GAIN_DB)
+}
+
+/// Converts a dB gain to a linear multiplier. At or below `MIN_GAIN_DB` the
+/// track is muted (0.0).
+pub fn db_to_linear(db: f32) -> f32 {
+    if db <= MIN_GAIN_DB {
+        0.0
+    } else {
+        10.0f32.powf(db / 20.0)
+    }
+}
+
+/// Error returned when setting the gain of a track that has no slot.
+#[derive(Debug)]
+pub struct UnknownTrackError(pub String);
+
+impl fmt::Display for UnknownTrackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown track '{}'", self.0)
+    }
+}
+
+impl std::error::Error for UnknownTrackError {}
+
+/// Shared per-output-track gain state.
+///
+/// Built once at hardware init from the active profile's `track_mappings`
+/// and `track_gains`, then shared (via `Arc`) between the player (set/get)
+/// and the audio mixer (lock-free reads in the callback).
+pub struct TrackGains {
+    /// Track name -> slot index.
+    slots: HashMap<String, usize>,
+    /// Slot index -> track name, in config order (stable for reporting).
+    names: Vec<String>,
+    /// Gain in dB, stored as f32 bits.
+    db_bits: Vec<AtomicU32>,
+    /// Linear multiplier, stored as f32 bits. Hot-path reads.
+    linear_bits: Vec<AtomicU32>,
+}
+
+impl TrackGains {
+    /// Builds gain slots from the union of track mapping keys and configured
+    /// gain keys. Tracks without a configured gain start at 0.0 dB (unity).
+    /// Out-of-range configured values are clamped with a warning.
+    pub fn from_config(
+        track_mappings: &HashMap<String, Vec<u16>>,
+        track_gains: Option<&IndexMap<String, f32>>,
+    ) -> Self {
+        // Deterministic order: configured gains first (config order), then
+        // any remaining mapping keys sorted by name.
+        let mut names: Vec<String> = Vec::new();
+        if let Some(gains) = track_gains {
+            names.extend(gains.keys().cloned());
+        }
+        let mut mapping_names: Vec<&String> = track_mappings
+            .keys()
+            .filter(|name| !names.iter().any(|n| n == *name))
+            .collect();
+        mapping_names.sort();
+        names.extend(mapping_names.into_iter().cloned());
+
+        let mut slots = HashMap::with_capacity(names.len());
+        let mut db_bits = Vec::with_capacity(names.len());
+        let mut linear_bits = Vec::with_capacity(names.len());
+        for (slot, name) in names.iter().enumerate() {
+            let configured = track_gains.and_then(|gains| gains.get(name)).copied();
+            let db = match configured {
+                Some(db) => {
+                    let clamped = clamp_db(db);
+                    if clamped != db {
+                        warn!(
+                            track = name.as_str(),
+                            configured = db,
+                            clamped,
+                            "track gain out of range, clamping"
+                        );
+                    }
+                    clamped
+                }
+                None => 0.0,
+            };
+            slots.insert(name.clone(), slot);
+            db_bits.push(AtomicU32::new(db.to_bits()));
+            linear_bits.push(AtomicU32::new(db_to_linear(db).to_bits()));
+        }
+
+        Self {
+            slots,
+            names,
+            db_bits,
+            linear_bits,
+        }
+    }
+
+    /// Returns the slot index for a track name, if known.
+    pub fn slot(&self, track: &str) -> Option<usize> {
+        self.slots.get(track).copied()
+    }
+
+    /// Number of tracks with gain slots.
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
+    /// Whether there are no gain slots.
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+
+    /// Sets the gain of a track in dB, returning the (clamped) applied value.
+    pub fn set_db(&self, track: &str, db: f32) -> Result<f32, UnknownTrackError> {
+        let slot = self
+            .slot(track)
+            .ok_or_else(|| UnknownTrackError(track.to_string()))?;
+        let clamped = clamp_db(db);
+        self.db_bits[slot].store(clamped.to_bits(), Ordering::Relaxed);
+        self.linear_bits[slot].store(db_to_linear(clamped).to_bits(), Ordering::Relaxed);
+        Ok(clamped)
+    }
+
+    /// Gets the gain of a track in dB.
+    pub fn get_db(&self, track: &str) -> Option<f32> {
+        self.slot(track)
+            .map(|slot| f32::from_bits(self.db_bits[slot].load(Ordering::Relaxed)))
+    }
+
+    /// Gets the linear multiplier for a slot. Hot path: single relaxed load.
+    pub fn linear(&self, slot: usize) -> f32 {
+        f32::from_bits(self.linear_bits[slot].load(Ordering::Relaxed))
+    }
+
+    /// Snapshots all gains as (name, dB) pairs in slot order.
+    pub fn snapshot_db(&self) -> Vec<(String, f32)> {
+        self.names
+            .iter()
+            .enumerate()
+            .map(|(slot, name)| {
+                (
+                    name.clone(),
+                    f32::from_bits(self.db_bits[slot].load(Ordering::Relaxed)),
+                )
+            })
+            .collect()
+    }
+
+    /// Snapshots gains for persistence, omitting unity (0.0 dB) entries so
+    /// the serialized config stays minimal.
+    pub fn snapshot_db_map(&self) -> IndexMap<String, f32> {
+        self.snapshot_db()
+            .into_iter()
+            .filter(|(_, db)| *db != 0.0)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mappings(names: &[&str]) -> HashMap<String, Vec<u16>> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.to_string(), vec![i as u16 + 1]))
+            .collect()
+    }
+
+    #[test]
+    fn db_to_linear_conversions() {
+        assert_eq!(db_to_linear(0.0), 1.0);
+        assert!((db_to_linear(-6.0) - 0.5012).abs() < 0.001);
+        assert_eq!(db_to_linear(-60.0), 0.0);
+        assert_eq!(db_to_linear(-80.0), 0.0);
+        assert!((db_to_linear(6.0) - 1.9953).abs() < 0.001);
+    }
+
+    #[test]
+    fn clamp_db_range() {
+        assert_eq!(clamp_db(0.0), 0.0);
+        assert_eq!(clamp_db(20.0), MAX_GAIN_DB);
+        assert_eq!(clamp_db(-100.0), MIN_GAIN_DB);
+        assert_eq!(clamp_db(f32::NAN), 0.0);
+        assert_eq!(clamp_db(f32::INFINITY), MAX_GAIN_DB);
+        assert_eq!(clamp_db(f32::NEG_INFINITY), MIN_GAIN_DB);
+    }
+
+    #[test]
+    fn set_get_round_trip() {
+        let gains = TrackGains::from_config(&mappings(&["click", "keys"]), None);
+        assert_eq!(gains.get_db("click"), Some(0.0));
+
+        let applied = gains.set_db("click", -6.0).unwrap();
+        assert_eq!(applied, -6.0);
+        assert_eq!(gains.get_db("click"), Some(-6.0));
+        let slot = gains.slot("click").unwrap();
+        assert!((gains.linear(slot) - 0.5012).abs() < 0.001);
+
+        // Clamped on the way in.
+        let applied = gains.set_db("keys", 20.0).unwrap();
+        assert_eq!(applied, MAX_GAIN_DB);
+        assert_eq!(gains.get_db("keys"), Some(MAX_GAIN_DB));
+    }
+
+    #[test]
+    fn unknown_track_errors() {
+        let gains = TrackGains::from_config(&mappings(&["click"]), None);
+        assert!(gains.set_db("nope", 0.0).is_err());
+        assert_eq!(gains.get_db("nope"), None);
+        assert_eq!(gains.slot("nope"), None);
+    }
+
+    #[test]
+    fn union_of_mappings_and_configured_gains() {
+        let configured: IndexMap<String, f32> =
+            IndexMap::from([("click".to_string(), -6.0), ("extra".to_string(), 3.0)]);
+        let gains = TrackGains::from_config(&mappings(&["click", "keys"]), Some(&configured));
+
+        assert_eq!(gains.len(), 3);
+        assert_eq!(gains.get_db("click"), Some(-6.0));
+        assert_eq!(gains.get_db("extra"), Some(3.0));
+        assert_eq!(gains.get_db("keys"), Some(0.0));
+    }
+
+    #[test]
+    fn out_of_range_config_clamped() {
+        let configured: IndexMap<String, f32> = IndexMap::from([("click".to_string(), -120.0)]);
+        let gains = TrackGains::from_config(&mappings(&["click"]), Some(&configured));
+        assert_eq!(gains.get_db("click"), Some(MIN_GAIN_DB));
+        assert_eq!(gains.linear(gains.slot("click").unwrap()), 0.0);
+    }
+
+    #[test]
+    fn snapshot_map_omits_unity() {
+        let gains = TrackGains::from_config(&mappings(&["click", "keys", "cue"]), None);
+        gains.set_db("click", -6.0).unwrap();
+        let map = gains.snapshot_db_map();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map["click"], -6.0);
+
+        // Full snapshot includes everything.
+        assert_eq!(gains.snapshot_db().len(), 3);
+    }
+}

--- a/src/config/controller.rs
+++ b/src/config/controller.rs
@@ -53,6 +53,9 @@ fn default_osc_stop_section_loop() -> String {
 fn default_osc_loop_section() -> String {
     "/mtrack/loop_section".to_string()
 }
+fn default_osc_track_gain() -> String {
+    "/mtrack/track/*/gain".to_string()
+}
 fn default_osc_status() -> String {
     "/mtrack/status".to_string()
 }
@@ -339,6 +342,11 @@ pub struct OscController {
     /// The OSC address to loop a specific section by name (takes a string arg).
     #[serde(default = "default_osc_loop_section")]
     loop_section: String,
+    /// The OSC address pattern to set an output track's gain in dB (takes a
+    /// float arg). The `*` segment is the track name; the same pattern (with
+    /// the name substituted) is used for gain feedback broadcasts.
+    #[serde(default = "default_osc_track_gain")]
+    track_gain: String,
     /// The OSC address to broadcast to display the current player status.
     #[serde(default = "default_osc_status")]
     status: String,
@@ -372,6 +380,7 @@ impl Default for OscController {
             section_ack: default_osc_section_ack(),
             stop_section_loop: default_osc_stop_section_loop(),
             loop_section: default_osc_loop_section(),
+            track_gain: default_osc_track_gain(),
             status: default_osc_status(),
             playlist_current: default_osc_playlist_current(),
             playlist_current_song: default_osc_playlist_current_song(),
@@ -444,6 +453,11 @@ impl OscController {
     /// Gets the loop section OSC address.
     pub fn loop_section(&self) -> &str {
         &self.loop_section
+    }
+
+    /// Gets the OSC address pattern for setting an output track's gain.
+    pub fn track_gain(&self) -> &str {
+        &self.track_gain
     }
 
     /// Gets the player status.

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -33,6 +33,35 @@ fn default_active_playlist() -> String {
     "playlist".to_string()
 }
 
+/// Lists the profile YAML files in a profiles directory in load order
+/// (sorted by file name). Shared by config load and by gain persistence so
+/// both sides agree on which file owns the active profile.
+pub(crate) fn list_profile_files(dir: &Path) -> Result<Vec<PathBuf>, ConfigError> {
+    // codeql[rust/path-injection] profiles_dir comes from the local config file on disk.
+    let entries = std::fs::read_dir(dir).map_err(|source| ConfigError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+
+    let mut yaml_paths: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| ConfigError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "yaml" || ext == "yml" {
+                    yaml_paths.push(path);
+                }
+            }
+        }
+    }
+    yaml_paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+    Ok(yaml_paths)
+}
+
 /// The configuration for the multitrack player.
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Player {
@@ -236,28 +265,7 @@ impl Player {
             None => return Ok(()),
         };
 
-        // codeql[rust/path-injection] profiles_dir comes from the local config file on disk.
-        let entries = std::fs::read_dir(&dir_path).map_err(|source| ConfigError::Io {
-            path: dir_path.clone(),
-            source,
-        })?;
-
-        let mut yaml_paths: Vec<PathBuf> = Vec::new();
-        for entry in entries {
-            let entry = entry.map_err(|source| ConfigError::Io {
-                path: dir_path.clone(),
-                source,
-            })?;
-            let path = entry.path();
-            if path.is_file() {
-                if let Some(ext) = path.extension() {
-                    if ext == "yaml" || ext == "yml" {
-                        yaml_paths.push(path);
-                    }
-                }
-            }
-        }
-        yaml_paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        let yaml_paths = list_profile_files(&dir_path)?;
 
         let mut dir_profiles: Vec<Profile> = Vec::new();
         for path in &yaml_paths {

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -231,16 +231,9 @@ impl Player {
     /// Directory profiles replace inline profiles entirely. If the directory is
     /// empty, inline profiles are kept as a fallback.
     fn load_profiles_dir(&mut self, config_path: &Path) -> Result<(), ConfigError> {
-        let profiles_dir_str = match &self.profiles_dir {
-            Some(dir) => dir.clone(),
+        let dir_path = match self.resolved_profiles_dir(config_path) {
+            Some(dir) => dir,
             None => return Ok(()),
-        };
-
-        let dir_path = if Path::new(&profiles_dir_str).is_absolute() {
-            PathBuf::from(&profiles_dir_str)
-        } else {
-            let config_dir = config_path.parent().unwrap_or(Path::new("."));
-            config_dir.join(&profiles_dir_str)
         };
 
         // codeql[rust/path-injection] profiles_dir comes from the local config file on disk.
@@ -437,6 +430,30 @@ impl Player {
                 .collect(),
             None => vec![],
         }
+    }
+
+    /// Resolves the configured profiles directory against the config file
+    /// location, if `profiles_dir` is set.
+    pub fn resolved_profiles_dir(&self, config_path: &Path) -> Option<PathBuf> {
+        let dir = self.profiles_dir.as_ref()?;
+        Some(if Path::new(dir).is_absolute() {
+            PathBuf::from(dir)
+        } else {
+            let config_dir = config_path.parent().unwrap_or(Path::new("."));
+            config_dir.join(dir)
+        })
+    }
+
+    /// Returns a mutable reference to the active profile for the given
+    /// hostname: the first profile whose hostname matches or that has no
+    /// hostname constraint (same selection rule as `profiles`).
+    pub fn active_profile_mut(&mut self, hostname: &str) -> Option<&mut Profile> {
+        self.profiles.as_mut().and_then(|profiles| {
+            profiles.iter_mut().find(|p| match p.hostname() {
+                Some(h) => h == hostname,
+                None => true,
+            })
+        })
     }
 
     /// Returns all profiles without hostname filtering (for verify command).

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -32,6 +32,9 @@ pub struct AudioConfig {
     #[serde(flatten)]
     audio: Audio,
     track_mappings: IndexMap<String, Vec<u16>>,
+    /// Per-output-track gain in dB. Tracks without an entry play at unity.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    track_gains: IndexMap<String, f32>,
 }
 
 impl AudioConfig {
@@ -40,7 +43,18 @@ impl AudioConfig {
         AudioConfig {
             audio,
             track_mappings,
+            track_gains: IndexMap::new(),
         }
+    }
+
+    /// Returns the per-track gains in dB.
+    pub fn track_gains(&self) -> &IndexMap<String, f32> {
+        &self.track_gains
+    }
+
+    /// Replaces the per-track gains.
+    pub fn set_track_gains(&mut self, track_gains: IndexMap<String, f32>) {
+        self.track_gains = track_gains;
     }
 
     /// Returns the audio configuration.
@@ -67,6 +81,25 @@ impl AudioConfig {
                         name
                     ));
                 }
+            }
+        }
+        for (name, &db) in &self.track_gains {
+            if !db.is_finite() {
+                errors.push(format!(
+                    "track_gains '{}': gain must be a finite number",
+                    name
+                ));
+            } else if !(crate::audio::track_gains::MIN_GAIN_DB
+                ..=crate::audio::track_gains::MAX_GAIN_DB)
+                .contains(&db)
+            {
+                errors.push(format!(
+                    "track_gains '{}': gain {} dB out of range [{}, {}]",
+                    name,
+                    db,
+                    crate::audio::track_gains::MIN_GAIN_DB,
+                    crate::audio::track_gains::MAX_GAIN_DB
+                ));
             }
         }
     }
@@ -146,6 +179,11 @@ impl Profile {
     /// Returns the audio configuration, if present.
     pub fn audio_config(&self) -> Option<&AudioConfig> {
         self.audio.as_ref()
+    }
+
+    /// Returns a mutable reference to the audio configuration, if present.
+    pub fn audio_config_mut(&mut self) -> Option<&mut AudioConfig> {
+        self.audio.as_mut()
     }
 
     /// Returns the MIDI configuration.
@@ -252,6 +290,96 @@ mod tests {
     use config::{Config, File, FileFormat};
 
     use super::*;
+
+    #[test]
+    fn test_track_gains_round_trip() {
+        let yaml = r#"
+            audio:
+              device: mock-device
+              track_mappings:
+                click: [1]
+                keys: [2, 3]
+              track_gains:
+                click: -6.0
+                keys: 2.5
+        "#;
+        let profile: Profile = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let audio_config = profile.audio_config().unwrap();
+        assert_eq!(audio_config.track_gains()["click"], -6.0);
+        assert_eq!(audio_config.track_gains()["keys"], 2.5);
+
+        // Round-trips through serialization.
+        let serialized = crate::util::to_yaml_string(&profile).unwrap();
+        assert!(serialized.contains("track_gains"));
+        let reparsed: Profile = Config::builder()
+            .add_source(File::from_str(&serialized, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+        assert_eq!(
+            reparsed.audio_config().unwrap().track_gains()["click"],
+            -6.0
+        );
+    }
+
+    #[test]
+    fn test_track_gains_absent_and_omitted() {
+        let yaml = r#"
+            audio:
+              device: mock-device
+              track_mappings:
+                click: [1]
+        "#;
+        let profile: Profile = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        assert!(profile.audio_config().unwrap().track_gains().is_empty());
+        // Empty map is omitted on serialize to keep configs clean.
+        let serialized = crate::util::to_yaml_string(&profile).unwrap();
+        assert!(!serialized.contains("track_gains"));
+    }
+
+    #[test]
+    fn test_track_gains_validation() {
+        let mut track_mappings = IndexMap::new();
+        track_mappings.insert("click".to_string(), vec![1u16]);
+        let audio = Audio::new("mock-device");
+        let mut audio_config = AudioConfig::new(audio, track_mappings);
+
+        audio_config.set_track_gains(IndexMap::from([("click".to_string(), -120.0f32)]));
+        let mut errors = Vec::new();
+        audio_config.validate(&mut errors);
+        assert!(
+            errors.iter().any(|e| e.contains("track_gains 'click'")),
+            "expected out-of-range error, got {:?}",
+            errors
+        );
+
+        audio_config.set_track_gains(IndexMap::from([("click".to_string(), f32::NAN)]));
+        let mut errors = Vec::new();
+        audio_config.validate(&mut errors);
+        assert!(
+            errors.iter().any(|e| e.contains("finite")),
+            "expected non-finite error, got {:?}",
+            errors
+        );
+
+        audio_config.set_track_gains(IndexMap::from([("click".to_string(), -6.0f32)]));
+        let mut errors = Vec::new();
+        audio_config.validate(&mut errors);
+        assert!(errors.is_empty(), "expected no errors, got {:?}", errors);
+    }
 
     #[test]
     fn test_profile_deserialize() {

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -329,6 +329,42 @@ impl ConfigStore {
         .await
     }
 
+    /// Sets the per-track gains on the active profile (first profile whose
+    /// hostname matches or that has no hostname constraint) and persists them.
+    /// Called internally when gains change at runtime, not from the config
+    /// editor UI, so no checksum is required.
+    ///
+    /// When profiles are loaded from `profiles_dir`, the owning profile file
+    /// is rewritten (inline profiles in the main config are ignored at load
+    /// time in that layout). Rewriting a profile file drops YAML comments.
+    pub async fn set_track_gains(
+        &self,
+        hostname: &str,
+        gains: indexmap::IndexMap<String, f32>,
+    ) -> Result<(), ConfigError> {
+        let mut guard = self.inner.write().await;
+
+        // Update the in-memory active profile so subsequent reads are current.
+        let profile = guard.active_profile_mut(hostname).ok_or_else(|| {
+            ConfigError::Validation(format!("no profile matches hostname '{}'", hostname))
+        })?;
+        let audio = profile.audio_config_mut().ok_or_else(|| {
+            ConfigError::Validation("active profile has no audio config".to_string())
+        })?;
+        audio.set_track_gains(gains.clone());
+
+        if let Some(dir) = guard.resolved_profiles_dir(&self.path) {
+            persist_gains_to_profile_file(&dir, hostname, &gains)?;
+        } else {
+            let new_yaml = to_yaml_string(&*guard)
+                .map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+            atomic_write(&self.path, &new_yaml).map_err(ConfigError::StoreIo)?;
+        }
+
+        let _ = self.change_tx.send(());
+        Ok(())
+    }
+
     /// Sets the active playlist name without requiring a checksum.
     /// This is called internally when switching playlists, not from the
     /// config editor UI, so optimistic concurrency isn't needed.
@@ -341,6 +377,72 @@ impl ConfigStore {
         let _ = self.change_tx.send(());
         Ok(())
     }
+}
+
+/// Persists track gains into the profile file inside `dir` that owns the
+/// active profile: files are visited in the same sorted order used at load
+/// time, and the first profile matching the hostname rule wins.
+fn persist_gains_to_profile_file(
+    dir: &std::path::Path,
+    hostname: &str,
+    gains: &indexmap::IndexMap<String, f32>,
+) -> Result<(), ConfigError> {
+    let entries = std::fs::read_dir(dir).map_err(|source| ConfigError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+
+    let mut yaml_paths: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| ConfigError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "yaml" || ext == "yml" {
+                    yaml_paths.push(path);
+                }
+            }
+        }
+    }
+    yaml_paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+
+    for path in &yaml_paths {
+        let mut profile = config::Config::builder()
+            .add_source(config::File::from(path.as_path()))
+            .build()
+            .and_then(|c| c.try_deserialize::<Profile>())
+            .map_err(|source| ConfigError::ProfileParse {
+                path: path.clone(),
+                source,
+            })?;
+
+        let matches = match profile.hostname() {
+            Some(h) => h == hostname,
+            None => true,
+        };
+        if !matches {
+            continue;
+        }
+
+        let audio = profile.audio_config_mut().ok_or_else(|| {
+            ConfigError::Validation("active profile has no audio config".to_string())
+        })?;
+        audio.set_track_gains(gains.clone());
+
+        let yaml =
+            to_yaml_string(&profile).map_err(|e| ConfigError::StoreSerialization(e.to_string()))?;
+        atomic_write(path, &yaml).map_err(ConfigError::StoreIo)?;
+        return Ok(());
+    }
+
+    Err(ConfigError::Validation(format!(
+        "no profile file in {} matches hostname '{}'",
+        dir.display(),
+        hostname
+    )))
 }
 
 #[cfg(test)]
@@ -686,6 +788,98 @@ profiles:
             "expected round-trip-host in {:?}",
             hostnames
         );
+    }
+
+    #[tokio::test]
+    async fn set_track_gains_inline_profile_persists() {
+        let yaml = r#"
+songs: songs
+profiles:
+  - hostname: gain-host
+    audio:
+      device: mock-device
+      track_mappings:
+        click: [1]
+        keys: [2, 3]
+"#;
+        let player = make_player(yaml);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, yaml).unwrap();
+
+        let store = ConfigStore::new(player, path.clone());
+        let gains = indexmap::IndexMap::from([("click".to_string(), -6.0f32)]);
+        store.set_track_gains("gain-host", gains).await.unwrap();
+
+        // In-memory config reflects the change.
+        let mut config = store.read_config().await;
+        let profile = config.active_profile_mut("gain-host").unwrap();
+        let audio = profile.audio_config().unwrap();
+        assert_eq!(audio.track_gains()["click"], -6.0);
+
+        // On-disk config reflects the change after an independent reload.
+        let mut reloaded = Player::deserialize(&path).unwrap();
+        let profile = reloaded.active_profile_mut("gain-host").unwrap();
+        assert_eq!(profile.audio_config().unwrap().track_gains()["click"], -6.0);
+    }
+
+    #[tokio::test]
+    async fn set_track_gains_profiles_dir_writes_profile_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let profiles_dir = dir.path().join("profiles");
+        std::fs::create_dir(&profiles_dir).unwrap();
+
+        let main_yaml = "songs: songs\nprofiles_dir: profiles\n";
+        let main_path = dir.path().join("config.yaml");
+        std::fs::write(&main_path, main_yaml).unwrap();
+
+        // Two profile files: the first doesn't match the hostname, the second does.
+        std::fs::write(
+            profiles_dir.join("01-other.yaml"),
+            "kind: hardware_profile\nhostname: other-host\naudio:\n  device: a\n  track_mappings:\n    cue: [1]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            profiles_dir.join("02-target.yaml"),
+            "kind: hardware_profile\nhostname: gain-host\naudio:\n  device: b\n  track_mappings:\n    click: [1]\n",
+        )
+        .unwrap();
+
+        let player = Player::deserialize(&main_path).unwrap();
+        let store = ConfigStore::new(player, main_path.clone());
+        let gains = indexmap::IndexMap::from([("click".to_string(), 3.0f32)]);
+        store.set_track_gains("gain-host", gains).await.unwrap();
+
+        // The owning profile file was updated; the other one untouched.
+        let target = std::fs::read_to_string(profiles_dir.join("02-target.yaml")).unwrap();
+        assert!(target.contains("track_gains"), "got: {target}");
+        assert!(target.contains("click: 3"), "got: {target}");
+        let other = std::fs::read_to_string(profiles_dir.join("01-other.yaml")).unwrap();
+        assert!(!other.contains("track_gains"));
+
+        // The main config file was not rewritten with inlined profiles.
+        let main_after = std::fs::read_to_string(&main_path).unwrap();
+        assert_eq!(main_after, main_yaml);
+
+        // A full reload through profiles_dir sees the gains.
+        let mut reloaded = Player::deserialize(&main_path).unwrap();
+        let profile = reloaded.active_profile_mut("gain-host").unwrap();
+        assert_eq!(profile.audio_config().unwrap().track_gains()["click"], 3.0);
+    }
+
+    #[tokio::test]
+    async fn set_track_gains_unknown_hostname_errors() {
+        // The profile is hostname-constrained, so a different hostname matches
+        // no profile and the call must fail.
+        let yaml = "songs: songs\nprofiles:\n  - hostname: only-host\n    audio:\n      device: a\n      track_mappings:\n        click: [1]\n";
+        let player = make_player(yaml);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        let store = ConfigStore::new(player, path);
+
+        let gains = indexmap::IndexMap::from([("click".to_string(), -6.0f32)]);
+        assert!(store.set_track_gains("nope", gains).await.is_err());
     }
 
     #[test]

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -332,7 +332,10 @@ impl ConfigStore {
     /// Sets the per-track gains on the active profile (first profile whose
     /// hostname matches or that has no hostname constraint) and persists them.
     /// Called internally when gains change at runtime, not from the config
-    /// editor UI, so no checksum is required.
+    /// editor UI, so no checksum is required (same model as
+    /// `set_active_playlist`): the mutation runs under the store's write
+    /// lock, and a config-editor save racing it gets a StaleChecksum
+    /// rejection plus a `config_changed` broadcast to re-pull.
     ///
     /// When profiles are loaded from `profiles_dir`, the owning profile file
     /// is rewritten (inline profiles in the main config are ignored at load
@@ -387,28 +390,11 @@ fn persist_gains_to_profile_file(
     hostname: &str,
     gains: &indexmap::IndexMap<String, f32>,
 ) -> Result<(), ConfigError> {
-    let entries = std::fs::read_dir(dir).map_err(|source| ConfigError::Io {
-        path: dir.to_path_buf(),
-        source,
-    })?;
+    let yaml_paths = super::player::list_profile_files(dir)?;
 
-    let mut yaml_paths: Vec<PathBuf> = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|source| ConfigError::Io {
-            path: dir.to_path_buf(),
-            source,
-        })?;
-        let path = entry.path();
-        if path.is_file() {
-            if let Some(ext) = path.extension() {
-                if ext == "yaml" || ext == "yml" {
-                    yaml_paths.push(path);
-                }
-            }
-        }
-    }
-    yaml_paths.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
-
+    // A parse failure aborts (matching load behavior) rather than skipping:
+    // skipping an unparseable file could write the gains into the wrong
+    // profile when the broken file is the active profile's.
     for path in &yaml_paths {
         let mut profile = config::Config::builder()
             .add_source(config::File::from(path.as_path()))

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -521,12 +521,13 @@ impl PlayerService for PlayerServer {
         let applied = self
             .player
             .set_track_gain(&req.track, req.gain_db as f32)
-            .map_err(|e| {
-                let msg = e.to_string();
-                if msg.contains("no audio profile") {
-                    Status::failed_precondition(msg)
-                } else {
-                    Status::invalid_argument(msg)
+            .map_err(|e| match e {
+                crate::player::TrackGainError::NoAudioProfile => {
+                    Status::failed_precondition(e.to_string())
+                }
+                crate::player::TrackGainError::NonFinite(_)
+                | crate::player::TrackGainError::UnknownTrack(_) => {
+                    Status::invalid_argument(e.to_string())
                 }
             })?;
         Ok(Response::new(SetTrackGainResponse {

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -23,12 +23,13 @@ use crate::{
     proto::player::v1::{
         player_service_server::{PlayerService, PlayerServiceServer},
         AddProfileRequest, Cue, GetActiveEffectsRequest, GetActiveEffectsResponse,
-        GetConfigRequest, GetConfigResponse, GetCuesRequest, GetCuesResponse, LoopSectionRequest,
-        LoopSectionResponse, NextRequest, NextResponse, PlayFromRequest, PlayRequest, PlayResponse,
-        PlaySongFromRequest, PreviousRequest, PreviousResponse, RemoveProfileRequest,
-        SectionAckRequest, SectionAckResponse, StatusRequest, StatusResponse, StopRequest,
+        GetConfigRequest, GetConfigResponse, GetCuesRequest, GetCuesResponse, GetTrackGainsRequest,
+        GetTrackGainsResponse, LoopSectionRequest, LoopSectionResponse, NextRequest, NextResponse,
+        PlayFromRequest, PlayRequest, PlayResponse, PlaySongFromRequest, PreviousRequest,
+        PreviousResponse, RemoveProfileRequest, SectionAckRequest, SectionAckResponse,
+        SetTrackGainRequest, SetTrackGainResponse, StatusRequest, StatusResponse, StopRequest,
         StopResponse, StopSamplesRequest, StopSamplesResponse, StopSectionLoopRequest,
-        StopSectionLoopResponse, SwitchToPlaylistRequest, SwitchToPlaylistResponse,
+        StopSectionLoopResponse, SwitchToPlaylistRequest, SwitchToPlaylistResponse, TrackGain,
         UpdateAudioRequest, UpdateConfigResponse, UpdateControllersRequest, UpdateDmxRequest,
         UpdateMidiRequest, UpdateProfileRequest, FILE_DESCRIPTOR_SET,
     },
@@ -511,6 +512,44 @@ impl PlayerService for PlayerServer {
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
         Ok(Response::new(SectionAckResponse {}))
     }
+
+    async fn set_track_gain(
+        &self,
+        request: Request<SetTrackGainRequest>,
+    ) -> Result<Response<SetTrackGainResponse>, Status> {
+        let req = request.into_inner();
+        let applied = self
+            .player
+            .set_track_gain(&req.track, req.gain_db as f32)
+            .map_err(|e| {
+                let msg = e.to_string();
+                if msg.contains("no audio profile") {
+                    Status::failed_precondition(msg)
+                } else {
+                    Status::invalid_argument(msg)
+                }
+            })?;
+        Ok(Response::new(SetTrackGainResponse {
+            applied_gain_db: applied as f64,
+        }))
+    }
+
+    async fn get_track_gains(
+        &self,
+        _: Request<GetTrackGainsRequest>,
+    ) -> Result<Response<GetTrackGainsResponse>, Status> {
+        let gains = self
+            .player
+            .get_track_gains()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(track, gain_db)| TrackGain {
+                track,
+                gain_db: gain_db as f64,
+            })
+            .collect();
+        Ok(Response::new(GetTrackGainsResponse { gains }))
+    }
 }
 
 #[cfg(test)]
@@ -723,6 +762,19 @@ mod test {
         ),
         Box<dyn Error>,
     > {
+        setup_grpc_with_mappings(HashMap::new()).await
+    }
+
+    async fn setup_grpc_with_mappings(
+        track_mappings: HashMap<String, Vec<u16>>,
+    ) -> Result<
+        (
+            Arc<Player>,
+            PlayerServiceClient<Channel>,
+            Arc<crate::audio::mock::Device>,
+        ),
+        Box<dyn Error>,
+    > {
         let songs = songs::get_all_songs(Path::new("assets/songs"))?;
         let pl = Playlist::new(
             "playlist",
@@ -743,7 +795,7 @@ mod test {
                 Some(config::Audio::new("mock-device")),
                 Some(config::Midi::new("mock-midi-device", None)),
                 None,
-                HashMap::new(),
+                track_mappings,
                 "assets/songs",
             ),
             None,
@@ -774,6 +826,79 @@ mod test {
             client.expect("gRPC client connection failed"),
             device,
         ))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_grpc_track_gains() -> Result<(), Box<dyn Error>> {
+        use crate::proto::player::v1::{GetTrackGainsRequest, SetTrackGainRequest};
+
+        let mappings = HashMap::from([
+            ("click".to_string(), vec![1]),
+            ("keys".to_string(), vec![2]),
+        ]);
+        let (_player, mut client, _device) = setup_grpc_with_mappings(mappings).await?;
+
+        // All tracks start at unity.
+        let gains = client
+            .get_track_gains(GetTrackGainsRequest {})
+            .await?
+            .into_inner()
+            .gains;
+        assert_eq!(gains.len(), 2);
+        assert!(gains.iter().all(|g| g.gain_db == 0.0));
+
+        // Set returns the applied value.
+        let resp = client
+            .set_track_gain(SetTrackGainRequest {
+                track: "click".to_string(),
+                gain_db: -6.0,
+            })
+            .await?
+            .into_inner();
+        assert_eq!(resp.applied_gain_db, -6.0);
+
+        // Out-of-range values are clamped.
+        let resp = client
+            .set_track_gain(SetTrackGainRequest {
+                track: "keys".to_string(),
+                gain_db: 20.0,
+            })
+            .await?
+            .into_inner();
+        assert_eq!(resp.applied_gain_db, 12.0);
+
+        // Get reflects the changes.
+        let gains = client
+            .get_track_gains(GetTrackGainsRequest {})
+            .await?
+            .into_inner()
+            .gains;
+        let by_name: HashMap<String, f64> =
+            gains.into_iter().map(|g| (g.track, g.gain_db)).collect();
+        assert_eq!(by_name["click"], -6.0);
+        assert_eq!(by_name["keys"], 12.0);
+
+        // Unknown track is an invalid argument.
+        let status = client
+            .set_track_gain(SetTrackGainRequest {
+                track: "nope".to_string(),
+                gain_db: 0.0,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+        // Non-finite gain is an invalid argument.
+        let status = client
+            .set_track_gain(SetTrackGainRequest {
+                track: "click".to_string(),
+                gain_db: f64::NAN,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -58,6 +58,7 @@ enum OscAction {
     SectionAck,
     StopSectionLoop,
     LoopSection,
+    SetTrackGain,
     Unrecognized,
 }
 
@@ -94,6 +95,11 @@ pub(super) struct OscEvents {
     stop_section_loop: Matcher,
     /// The OSC address to loop a specific section by name.
     loop_section: Matcher,
+    /// The OSC address pattern to set an output track's gain in dB.
+    track_gain: Matcher,
+    /// The raw track gain pattern; the `*` segment carries the track name and
+    /// is substituted for gain feedback broadcasts.
+    track_gain_pattern: String,
     /// The OSC address to use to broadcast the player status.
     status: String,
     /// The OSC address to use to broadcast the current playlist.
@@ -132,6 +138,8 @@ impl Driver {
                 section_ack: Matcher::new(config.section_ack())?,
                 stop_section_loop: Matcher::new(config.stop_section_loop())?,
                 loop_section: Matcher::new(config.loop_section())?,
+                track_gain: Matcher::new(config.track_gain())?,
+                track_gain_pattern: config.track_gain().to_string(),
                 status: config.status().to_string(),
                 playlist_current: config.playlist_current().to_string(),
                 playlist_current_song: config.playlist_current_song().to_string(),
@@ -305,13 +313,27 @@ impl Driver {
         );
         let playlist_songs: Vec<String> = playlist.songs().to_vec();
 
-        let packets = build_broadcast_packets(
+        let mut packets = build_broadcast_packets(
             osc_events,
             song.name(),
             status_string,
             &duration_string,
             &playlist_songs,
         );
+
+        // Per-track gain feedback (motorized faders / TouchOSC). Tracks whose
+        // names can't form a valid OSC address segment are skipped.
+        if let Some(gains) = player.get_track_gains() {
+            for (name, gain_db) in gains {
+                if !osc_addressable(&name) {
+                    continue;
+                }
+                packets.push(OscPacket::Message(OscMessage {
+                    addr: osc_events.track_gain_pattern.replacen('*', &name, 1),
+                    args: vec![OscType::Float(gain_db)],
+                }));
+            }
+        }
 
         for packet in packets {
             tx_sender.send(packet).await?;
@@ -401,6 +423,30 @@ impl Driver {
                     error!("Failed to loop section '{}': {}", section_name, e);
                 }
             }
+            OscAction::SetTrackGain => {
+                let track = extract_track_name(&osc_events.track_gain_pattern, &msg.addr);
+                // Accept any numeric OSC type as dB for controller compatibility.
+                let gain_db = msg.args.first().and_then(|arg| match arg {
+                    OscType::Float(f) => Some(*f),
+                    OscType::Double(d) => Some(*d as f32),
+                    OscType::Int(i) => Some(*i as f32),
+                    _ => None,
+                });
+                match (track, gain_db) {
+                    (Some(track), Some(gain_db)) => {
+                        if let Err(e) = player.set_track_gain(&track, gain_db) {
+                            error!("Failed to set gain for track '{}': {}", track, e);
+                        }
+                    }
+                    (None, _) => error!(
+                        addr = msg.addr,
+                        "track_gain OSC message: could not extract track name"
+                    ),
+                    (_, None) => {
+                        error!("track_gain OSC message missing numeric gain argument")
+                    }
+                }
+            }
             OscAction::Unrecognized => return Ok(false),
         }
         Ok(true)
@@ -430,9 +476,47 @@ fn classify_message(osc_events: &OscEvents, addr: &str) -> Result<OscAction, Box
         Ok(OscAction::StopSectionLoop)
     } else if osc_events.loop_section.match_address(&address) {
         Ok(OscAction::LoopSection)
+    } else if osc_events.track_gain.match_address(&address) {
+        Ok(OscAction::SetTrackGain)
     } else {
         Ok(OscAction::Unrecognized)
     }
+}
+
+/// Extracts the track name from an OSC address by structurally diffing it
+/// against the configured pattern: the single wildcard segment in the
+/// pattern carries the track name. Returns None if the shapes don't line up
+/// or the pattern has no (or more than one) wildcard segment.
+///
+/// Note: track names containing `/`, spaces, or OSC pattern metacharacters
+/// cannot be addressed this way.
+fn extract_track_name(pattern: &str, addr: &str) -> Option<String> {
+    let pattern_segments: Vec<&str> = pattern.split('/').collect();
+    let addr_segments: Vec<&str> = addr.split('/').collect();
+    if pattern_segments.len() != addr_segments.len() {
+        return None;
+    }
+
+    let mut name = None;
+    for (pattern_segment, addr_segment) in pattern_segments.iter().zip(addr_segments.iter()) {
+        if pattern_segment.contains(['*', '?', '[', '{']) {
+            if name.is_some() {
+                return None;
+            }
+            name = Some(addr_segment.to_string());
+        } else if pattern_segment != addr_segment {
+            return None;
+        }
+    }
+    name
+}
+
+/// Whether a track name can appear as a single OSC address segment.
+fn osc_addressable(name: &str) -> bool {
+    !name.is_empty()
+        && !name.chars().any(|c| {
+            c.is_whitespace() || matches!(c, '/' | '#' | '*' | ',' | '?' | '[' | ']' | '{' | '}')
+        })
 }
 
 /// Formats a playlist's song list with 1-based numbering.
@@ -951,6 +1035,8 @@ mod test {
             section_ack: Matcher::new(config.section_ack()).unwrap(),
             stop_section_loop: Matcher::new(config.stop_section_loop()).unwrap(),
             loop_section: Matcher::new(config.loop_section()).unwrap(),
+            track_gain: Matcher::new(config.track_gain()).unwrap(),
+            track_gain_pattern: config.track_gain().to_string(),
             status: config.status().to_string(),
             playlist_current: config.playlist_current().to_string(),
             playlist_current_song: config.playlist_current_song().to_string(),
@@ -1038,6 +1124,105 @@ mod test {
             let events = make_default_osc_events();
             // OSC addresses must start with /
             assert!(classify_message(&events, "no_leading_slash").is_err());
+        }
+
+        #[test]
+        fn recognizes_track_gain() {
+            let events = make_default_osc_events();
+            assert_eq!(
+                classify_message(&events, "/mtrack/track/click/gain").unwrap(),
+                OscAction::SetTrackGain
+            );
+            // Missing track segment doesn't match.
+            assert_eq!(
+                classify_message(&events, "/mtrack/track/gain").unwrap(),
+                OscAction::Unrecognized
+            );
+        }
+    }
+
+    mod track_gain_tests {
+        use super::*;
+        use crate::controller::osc::{extract_track_name, osc_addressable};
+
+        #[test]
+        fn extract_track_name_basics() {
+            let pattern = "/mtrack/track/*/gain";
+            assert_eq!(
+                extract_track_name(pattern, "/mtrack/track/click/gain").as_deref(),
+                Some("click")
+            );
+            assert_eq!(extract_track_name(pattern, "/mtrack/track/gain"), None);
+            assert_eq!(extract_track_name(pattern, "/other/track/click/gain"), None);
+            // Custom pattern with the wildcard at the end.
+            assert_eq!(
+                extract_track_name("/gain/*", "/gain/keys").as_deref(),
+                Some("keys")
+            );
+        }
+
+        #[test]
+        fn osc_addressable_names() {
+            assert!(osc_addressable("click"));
+            assert!(osc_addressable("backing-track-l"));
+            assert!(!osc_addressable("lead vocal"));
+            assert!(!osc_addressable("a/b"));
+            assert!(!osc_addressable("what?"));
+            assert!(!osc_addressable(""));
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn handle_message_sets_gain() -> Result<(), Box<dyn Error>> {
+            let songs = songs::get_all_songs(Path::new("assets/songs"))?;
+            let pl = Playlist::new(
+                "playlist",
+                &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
+                songs.clone(),
+            )?;
+            let mut playlists = HashMap::new();
+            playlists.insert(
+                "all_songs".to_string(),
+                playlist::from_songs(songs.clone())?,
+            );
+            playlists.insert("playlist".to_string(), pl);
+            let player = Player::new(
+                playlists,
+                "playlist".to_string(),
+                &config::Player::new(
+                    vec![],
+                    Some(config::Audio::new("mock-device")),
+                    None,
+                    None,
+                    HashMap::from([("click".to_string(), vec![1])]),
+                    "assets/songs",
+                ),
+                None,
+            )?;
+            player.await_hardware_ready().await;
+
+            let events = Arc::new(make_default_osc_events());
+            let msg = OscMessage {
+                addr: "/mtrack/track/click/gain".to_string(),
+                args: vec![OscType::Float(-6.0)],
+            };
+            let recognized = Driver::handle_message(&player, &events, &msg).await?;
+            assert!(recognized);
+
+            let gains: HashMap<String, f32> =
+                player.get_track_gains().unwrap().into_iter().collect();
+            assert_eq!(gains["click"], -6.0);
+
+            // Integer args are accepted too.
+            let msg = OscMessage {
+                addr: "/mtrack/track/click/gain".to_string(),
+                args: vec![OscType::Int(3)],
+            };
+            Driver::handle_message(&player, &events, &msg).await?;
+            let gains: HashMap<String, f32> =
+                player.get_track_gains().unwrap().into_iter().collect();
+            assert_eq!(gains["click"], 3.0);
+
+            Ok(())
         }
     }
 

--- a/src/notification/engine.rs
+++ b/src/notification/engine.rs
@@ -214,6 +214,7 @@ impl NotificationEngine {
             is_finished,
             start_at_sample: None,
             cancel_at_sample: None,
+            gain: Default::default(),
             gain_envelope: None,
         };
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -100,6 +100,9 @@ pub trait SongChangeNotifier: Send + Sync {
 struct HardwareState {
     device: Option<Arc<dyn audio::Device>>,
     mappings: Option<Arc<HashMap<String, Vec<u16>>>>,
+    /// Shared per-output-track gains, built from the active profile's
+    /// track_mappings and track_gains. Also installed into the device mixer.
+    track_gains: Option<Arc<crate::audio::track_gains::TrackGains>>,
     midi_device: Option<Arc<dyn midi::Device>>,
     dmx_engine: Option<Arc<dmx::engine::Engine>>,
     sample_engine: Option<Arc<RwLock<SampleEngine>>>,
@@ -274,6 +277,10 @@ pub struct Player {
     reactive_loop_state: Arc<parking_lot::RwLock<ReactiveLoopState>>,
     /// Notification engine for section loop audio feedback.
     notification_engine: Arc<crate::notification::NotificationEngine>,
+    /// Pending debounced task persisting track gains to the config store.
+    /// Aborted and replaced on every gain change so rapid fader moves
+    /// produce a single disk write.
+    gain_persist_task: Arc<parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 /// Bounds of an active section loop.
@@ -412,9 +419,22 @@ impl Player {
             None => ClockSource::Wall,
         };
 
+        // Build track gains from the mapping keys (all at 0 dB) so gain
+        // controls work in test/mock-device setups too.
+        let track_gains = devices.mappings.as_ref().map(|m| {
+            let tg = Arc::new(crate::audio::track_gains::TrackGains::from_config(m, None));
+            if let Some(ref audio_device) = devices.audio {
+                if let Some(mixer) = audio_device.mixer() {
+                    mixer.set_track_gains(tg.clone());
+                }
+            }
+            tg
+        });
+
         let hw = HardwareState {
             device: devices.audio,
             mappings: devices.mappings,
+            track_gains,
             midi_device: devices.midi,
             dmx_engine: devices.dmx_engine,
             sample_engine: devices.sample_engine,
@@ -456,6 +476,7 @@ impl Player {
             init_done_tx: Arc::new(init_done_tx),
             state_tx: Arc::new(parking_lot::Mutex::new(None)),
             transport_tx: Arc::new(tokio::sync::watch::channel(TransportSnapshot::default()).0),
+            gain_persist_task: Arc::new(parking_lot::Mutex::new(None)),
             locked: Arc::new(AtomicBool::new(true)),
             controller: Arc::new(parking_lot::Mutex::new(None)),
             loop_break: Arc::new(AtomicBool::new(false)),
@@ -656,6 +677,56 @@ impl Player {
     /// Returns the track-to-output-channel mappings, if audio is configured.
     pub fn track_mappings(&self) -> Option<Arc<HashMap<String, Vec<u16>>>> {
         self.hardware.read().mappings.clone()
+    }
+
+    /// Sets the gain of an output track in dB, returning the (clamped)
+    /// applied value. Takes effect on the next audio callback for playing
+    /// sources and at source start otherwise, so gains can be preset while
+    /// stopped. Allowed while locked — this is a performance control, like
+    /// play/stop.
+    ///
+    /// The new gains are persisted to the active profile after a short
+    /// debounce so rapid fader moves produce a single disk write.
+    pub fn set_track_gain(&self, track: &str, gain_db: f32) -> Result<f32, Box<dyn Error>> {
+        if !gain_db.is_finite() {
+            return Err(format!("gain must be a finite number, got {}", gain_db).into());
+        }
+
+        let (track_gains, hostname) = {
+            let hw = self.hardware.read();
+            (hw.track_gains.clone(), hw.hostname.clone())
+        };
+        let track_gains = track_gains.ok_or("no audio profile active")?;
+        let applied = track_gains.set_db(track, gain_db)?;
+
+        // Debounced persistence: replace any pending save with a fresh timer.
+        if let Some(store) = self.config_store() {
+            if let Some(hostname) = hostname {
+                let gains = track_gains.snapshot_db_map();
+                let mut pending = self.gain_persist_task.lock();
+                if let Some(task) = pending.take() {
+                    task.abort();
+                }
+                *pending = Some(tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(750)).await;
+                    if let Err(e) = store.set_track_gains(&hostname, gains).await {
+                        error!(err = %e, "Failed to persist track gains");
+                    }
+                }));
+            }
+        }
+
+        Ok(applied)
+    }
+
+    /// Returns all output track gains as (name, dB) pairs, or None when no
+    /// audio profile is active.
+    pub fn get_track_gains(&self) -> Option<Vec<(String, f32)>> {
+        self.hardware
+            .read()
+            .track_gains
+            .as_ref()
+            .map(|tg| tg.snapshot_db())
     }
 
     /// Returns true if the player is in locked mode (state-altering operations blocked).
@@ -2606,6 +2677,62 @@ mod test {
         // Test songs don't have loop_playback set, so this should be false.
         assert!(!player.is_current_song_looping());
 
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_track_gain_set_and_get() -> Result<(), Box<dyn Error>> {
+        let songs = songs::get_all_songs(Path::new("assets/songs"))?;
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
+            songs.clone(),
+        )?;
+        let mappings: HashMap<String, Vec<u16>> = HashMap::from([
+            ("click".to_string(), vec![1]),
+            ("keys".to_string(), vec![2]),
+        ]);
+        let devices = PlayerDevices {
+            audio: None,
+            mappings: Some(Arc::new(mappings)),
+            midi: None,
+            dmx_engine: None,
+            sample_engine: None,
+            trigger_engine: None,
+        };
+        let player = Player::new_with_devices(
+            devices,
+            test_playlists(playlist, songs),
+            "playlist".to_string(),
+            None,
+        )?;
+
+        // All tracks start at unity.
+        let gains = player.get_track_gains().unwrap();
+        assert_eq!(gains.len(), 2);
+        assert!(gains.iter().all(|(_, db)| *db == 0.0));
+
+        // Set, clamp, and read back.
+        assert_eq!(player.set_track_gain("click", -6.0)?, -6.0);
+        assert_eq!(player.set_track_gain("keys", 20.0)?, 12.0);
+        let gains: HashMap<String, f32> = player.get_track_gains().unwrap().into_iter().collect();
+        assert_eq!(gains["click"], -6.0);
+        assert_eq!(gains["keys"], 12.0);
+
+        // Unknown track and non-finite gain are rejected.
+        assert!(player.set_track_gain("nope", 0.0).is_err());
+        assert!(player.set_track_gain("click", f32::NAN).is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_track_gain_without_audio_errors() -> Result<(), Box<dyn Error>> {
+        let player = make_test_player().await?;
+        // make_test_player has no track mappings → no gain state.
+        if player.get_track_gains().is_none() {
+            assert!(player.set_track_gain("click", 0.0).is_err());
+        }
         Ok(())
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -283,6 +283,19 @@ pub struct Player {
     gain_persist_task: Arc<parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
+/// Errors from setting an output track gain. Variants are matched by the
+/// gRPC layer to choose status codes, so controllers never classify errors
+/// by message text.
+#[derive(Debug, thiserror::Error)]
+pub enum TrackGainError {
+    #[error("gain must be a finite number, got {0}")]
+    NonFinite(f32),
+    #[error("no audio profile active")]
+    NoAudioProfile,
+    #[error(transparent)]
+    UnknownTrack(#[from] crate::audio::track_gains::UnknownTrackError),
+}
+
 /// Bounds of an active section loop.
 ///
 /// Used together with `section_loop_break: Arc<AtomicBool>` to form a
@@ -687,16 +700,16 @@ impl Player {
     ///
     /// The new gains are persisted to the active profile after a short
     /// debounce so rapid fader moves produce a single disk write.
-    pub fn set_track_gain(&self, track: &str, gain_db: f32) -> Result<f32, Box<dyn Error>> {
+    pub fn set_track_gain(&self, track: &str, gain_db: f32) -> Result<f32, TrackGainError> {
         if !gain_db.is_finite() {
-            return Err(format!("gain must be a finite number, got {}", gain_db).into());
+            return Err(TrackGainError::NonFinite(gain_db));
         }
 
         let (track_gains, hostname) = {
             let hw = self.hardware.read();
             (hw.track_gains.clone(), hw.hostname.clone())
         };
-        let track_gains = track_gains.ok_or("no audio profile active")?;
+        let track_gains = track_gains.ok_or(TrackGainError::NoAudioProfile)?;
         let applied = track_gains.set_db(track, gain_db)?;
 
         // Debounced persistence: replace any pending save with a fresh timer.

--- a/src/player.rs
+++ b/src/player.rs
@@ -33,7 +33,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, span, warn, Level, Span};
+use tracing::{debug, error, info, span, warn, Level, Span};
 
 use crate::samples::SampleEngine;
 use crate::songs::Songs;
@@ -700,8 +700,8 @@ impl Player {
         let applied = track_gains.set_db(track, gain_db)?;
 
         // Debounced persistence: replace any pending save with a fresh timer.
-        if let Some(store) = self.config_store() {
-            if let Some(hostname) = hostname {
+        match (self.config_store(), hostname) {
+            (Some(store), Some(hostname)) => {
                 let gains = track_gains.snapshot_db_map();
                 let mut pending = self.gain_persist_task.lock();
                 if let Some(task) = pending.take() {
@@ -713,6 +713,13 @@ impl Player {
                         error!(err = %e, "Failed to persist track gains");
                     }
                 }));
+            }
+            _ => {
+                debug!(
+                    track,
+                    gain_db = applied,
+                    "track gain applied but not persisted (no config store or hostname)"
+                );
             }
         }
 

--- a/src/player/hardware.rs
+++ b/src/player/hardware.rs
@@ -145,9 +145,22 @@ impl Player {
                     None => ClockSource::Wall,
                 };
 
+                // Build the shared track gains from the profile config and
+                // install them into the device mixer so the audio callback
+                // can read them lock-free. Rebuilt on every (re)load from
+                // the persisted config, so gains survive restarts.
+                let track_gains = Arc::new(crate::audio::track_gains::TrackGains::from_config(
+                    &mappings,
+                    profile.audio_config().map(|ac| ac.track_gains()),
+                ));
+                if let Some(mixer) = device.mixer() {
+                    mixer.set_track_gains(track_gains.clone());
+                }
+
                 let mut hw = self.hardware.write();
                 hw.device = Some(device.clone());
                 hw.mappings = Some(Arc::new(mappings.clone()));
+                hw.track_gains = Some(track_gains);
                 hw.clock_source = clock_source;
                 (Some(device), Some(mappings), Some(resolved_audio))
             }
@@ -335,6 +348,7 @@ impl Player {
         *self.hardware.write() = HardwareState {
             device: None,
             mappings: None,
+            track_gains: None,
             midi_device: None,
             dmx_engine: None,
             sample_engine: None,

--- a/src/proto/player/v1/player.proto
+++ b/src/proto/player/v1/player.proto
@@ -271,6 +271,38 @@ message SectionAckRequest {}
 // SectionAckResponse is returned after acknowledging a section.
 message SectionAckResponse {}
 
+// TrackGain is the gain of a single output track.
+message TrackGain {
+    // The output track name (a track_mappings key).
+    string track = 1;
+    // The gain in dB, in [-60, +12]. -60 and below mutes the track.
+    double gain_db = 2;
+}
+
+// SetTrackGainRequest sets the gain of a single output track.
+message SetTrackGainRequest {
+    // The output track name (a track_mappings key).
+    string track = 1;
+    // The gain in dB. Values outside [-60, +12] are clamped; -60 and below
+    // mutes the track.
+    double gain_db = 2;
+}
+
+// SetTrackGainResponse is returned after setting a track gain.
+message SetTrackGainResponse {
+    // The applied gain in dB after clamping.
+    double applied_gain_db = 1;
+}
+
+// GetTrackGainsRequest requests the gains of all output tracks.
+message GetTrackGainsRequest {}
+
+// GetTrackGainsResponse contains the gains of all output tracks.
+message GetTrackGainsResponse {
+    // The gains of all output tracks.
+    repeated TrackGain gains = 1;
+}
+
 // PlayerService is a service for controlling the mtrack player.
 service PlayerService {
     // Play will play the current song in the playlist if no other songs
@@ -342,4 +374,10 @@ service PlayerService {
     // SectionAck acknowledges the current section in reactive looping mode,
     // arming the loop so it engages at the section end.
     rpc SectionAck(SectionAckRequest) returns (SectionAckResponse);
+
+    // SetTrackGain sets the gain of a single output track in dB.
+    rpc SetTrackGain(SetTrackGainRequest) returns (SetTrackGainResponse);
+
+    // GetTrackGains returns the gains of all output tracks in dB.
+    rpc GetTrackGains(GetTrackGainsRequest) returns (GetTrackGainsResponse);
 }

--- a/src/samples/engine.rs
+++ b/src/samples/engine.rs
@@ -337,6 +337,7 @@ impl SampleEngine {
             cancel_handle: source_cancel_handle,
             start_at_sample: Some(start_at_sample),
             cancel_at_sample: Some(source_cancel_at_sample),
+            gain: Default::default(),
             gain_envelope: None,
         };
 

--- a/src/webui/state.rs
+++ b/src/webui/state.rs
@@ -68,6 +68,10 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
         let (song_name, song_duration_ms, tracks, beat_grid, looping, available_sections) =
             if let Some(current_song) = playlist.current() {
                 let mappings = player.track_mappings();
+                let track_gains: std::collections::HashMap<String, f32> = player
+                    .get_track_gains()
+                    .map(|gains| gains.into_iter().collect())
+                    .unwrap_or_default();
                 let tracks: Vec<serde_json::Value> = current_song
                     .tracks()
                     .iter()
@@ -80,6 +84,7 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
                         json!({
                             "name": t.name(),
                             "output_channels": output_channels,
+                            "gain_db": track_gains.get(t.name()).copied().unwrap_or(0.0),
                         })
                     })
                     .collect();
@@ -953,6 +958,12 @@ mod test {
         assert_eq!(parsed["is_playing"], false);
         assert!(parsed["playlist_songs"].is_array());
         assert!(parsed["tracks"].is_array());
+        for track in parsed["tracks"].as_array().unwrap() {
+            assert!(
+                track["gain_db"].is_number(),
+                "track entries include gain_db: {track}"
+            );
+        }
 
         handle.abort();
     }

--- a/src/webui/svelte/e2e/mock-server/test-data.ts
+++ b/src/webui/svelte/e2e/mock-server/test-data.ts
@@ -191,9 +191,9 @@ export const PLAYBACK_STATE = {
   playlist_position: 0,
   playlist_songs: ["Test Song Alpha", "Test Song Beta"],
   tracks: [
-    { name: "kick", output_channels: [0, 1] },
-    { name: "snare", output_channels: [2, 3] },
-    { name: "bass", output_channels: [4, 5] },
+    { name: "kick", output_channels: [0, 1], gain_db: 0 },
+    { name: "snare", output_channels: [2, 3], gain_db: -6 },
+    { name: "bass", output_channels: [4, 5], gain_db: -60 },
   ],
   available_playlists: ["all_songs", "setlist"],
   persisted_playlist_name: "setlist",

--- a/src/webui/svelte/e2e/pages/dashboard.page.ts
+++ b/src/webui/svelte/e2e/pages/dashboard.page.ts
@@ -28,6 +28,8 @@ export class DashboardPage {
   readonly playlistSongs: Locator;
   readonly trackRows: Locator;
   readonly trackCount: Locator;
+  readonly gainSliders: Locator;
+  readonly gainReadouts: Locator;
 
   constructor(private page: Page) {
     this.grid = page.locator(".playback-card");
@@ -49,6 +51,8 @@ export class DashboardPage {
     this.playlistSongs = page.locator(".playlist-card__list li");
     this.trackRows = page.locator(".tracks-card__row");
     this.trackCount = page.locator(".tracks-card__title");
+    this.gainSliders = page.locator(".gain-slider__input");
+    this.gainReadouts = page.locator(".gain-slider__db");
   }
 
   async goto() {

--- a/src/webui/svelte/e2e/tests/track-gain.spec.ts
+++ b/src/webui/svelte/e2e/tests/track-gain.spec.ts
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import { test, expect } from "@playwright/test";
+import { DashboardPage } from "../pages/dashboard.page.js";
+import { PLAYBACK_STATE } from "../mock-server/test-data.js";
+
+let testCounter = 0;
+
+async function sendWsMessage(
+  page: import("@playwright/test").Page,
+  wsId: string,
+  msg: object,
+) {
+  await page.request.post("http://127.0.0.1:3111/test/send-ws", {
+    data: { ...msg, _wsId: wsId },
+  });
+}
+
+test.describe("Track Gain Sliders", () => {
+  let dashboard: DashboardPage;
+  let wsId: string;
+
+  test.beforeEach(async ({ page }) => {
+    wsId = `gain-${++testCounter}-${Date.now()}`;
+
+    // Stub the gRPC endpoint so gain changes succeed.
+    await page.route("**/player.v1.PlayerService/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "content-type": "application/grpc-web+proto",
+          "grpc-status": "0",
+        },
+        body: Buffer.alloc(0),
+      });
+    });
+
+    dashboard = new DashboardPage(page);
+    await page.goto(`/?wsId=${wsId}#/`);
+    await expect(dashboard.trackRows.first()).toBeVisible();
+  });
+
+  test("renders a slider per track with dB readouts", async () => {
+    await expect(dashboard.gainSliders).toHaveCount(3);
+    // Mock data: kick 0 dB, snare -6 dB, bass -60 dB (muted → -∞).
+    await expect(dashboard.gainReadouts.nth(0)).toHaveText("0.0 dB");
+    await expect(dashboard.gainReadouts.nth(1)).toHaveText("-6.0 dB");
+    await expect(dashboard.gainReadouts.nth(2)).toHaveText("-∞");
+  });
+
+  test("adjusting a slider fires SetTrackGain and updates the readout", async ({
+    page,
+  }) => {
+    const requestPromise = page.waitForRequest((req) =>
+      req.url().includes("/player.v1.PlayerService/SetTrackGain"),
+    );
+
+    // Keyboard interaction reliably moves a range input and fires both
+    // input and change events.
+    const kick = dashboard.gainSliders.nth(0);
+    await kick.focus();
+    await kick.press("ArrowUp");
+
+    await requestPromise;
+    await expect(dashboard.gainReadouts.nth(0)).toHaveText("+0.5 dB");
+  });
+
+  test("double-click resets gain to 0 dB", async ({ page }) => {
+    const requestPromise = page.waitForRequest((req) =>
+      req.url().includes("/player.v1.PlayerService/SetTrackGain"),
+    );
+
+    const snare = dashboard.gainSliders.nth(1);
+    await expect(dashboard.gainReadouts.nth(1)).toHaveText("-6.0 dB");
+    await snare.dblclick();
+
+    await requestPromise;
+    await expect(dashboard.gainReadouts.nth(1)).toHaveText("0.0 dB");
+  });
+
+  test("server-pushed gain updates the slider when idle", async ({ page }) => {
+    await sendWsMessage(page, wsId, {
+      ...PLAYBACK_STATE,
+      tracks: [
+        { name: "kick", output_channels: [0, 1], gain_db: 3 },
+        { name: "snare", output_channels: [2, 3], gain_db: -6 },
+        { name: "bass", output_channels: [4, 5], gain_db: -60 },
+      ],
+    });
+
+    await expect(dashboard.gainReadouts.nth(0)).toHaveText("+3.0 dB");
+  });
+});

--- a/src/webui/svelte/src/components/GainSlider.svelte
+++ b/src/webui/svelte/src/components/GainSlider.svelte
@@ -102,6 +102,7 @@
     class="gain-slider__db mono"
     class:gain-slider__db--muted={muted}
     title={$t("tracks.gainReset")}
+    aria-label={$t("tracks.gainReset")}
     onclick={reset}
   >
     {formatDb(shown)}

--- a/src/webui/svelte/src/components/GainSlider.svelte
+++ b/src/webui/svelte/src/components/GainSlider.svelte
@@ -1,0 +1,189 @@
+<!-- *     * Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+     *
+     * This program is free software: you can redistribute it and/or modify it under
+     * the terms of the GNU General Public License as published by the Free Software
+     * Foundation, version 3.
+     *
+     * This program is distributed in the hope that it will be useful, but WITHOUT
+     * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+     * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+     *
+     * You should have received a copy of the GNU General Public License along with
+     * this program. If not, see <https://www.gnu.org/licenses/>.
+     *
+     * -->
+<script lang="ts">
+  import { GAIN_MIN, GAIN_MAX, GAIN_STEP, formatDb } from "../lib/gain";
+  import { t } from "svelte-i18n";
+
+  interface Props {
+    /** Server-pushed gain value in dB. */
+    value?: number;
+    /** Accessible label for the slider. */
+    label: string;
+    /** Called (throttled upstream) while dragging. */
+    oninput: (db: number) => void;
+    /** Called with the final value on commit (change/reset). */
+    oncommit: (db: number) => void;
+  }
+
+  let { value = 0, label, oninput, oncommit }: Props = $props();
+
+  // Optimistic local state: show the local value while dragging and until
+  // the server echoes (within epsilon) or a timeout passes, so the 5 Hz
+  // playback poller can't snap the thumb backwards mid-interaction.
+  const ECHO_EPSILON = 0.01;
+  const ECHO_TIMEOUT_MS = 1500;
+
+  let dragging = $state(false);
+  let localDb = $state(0);
+  let lastSent: number | null = $state(null);
+  let holdUntil = $state(0);
+
+  const shown = $derived(
+    dragging ||
+      (lastSent !== null &&
+        Date.now() < holdUntil &&
+        Math.abs(value - lastSent) > ECHO_EPSILON)
+      ? localDb
+      : value,
+  );
+  const muted = $derived(shown <= GAIN_MIN);
+  const fillPct = $derived(((shown - GAIN_MIN) / (GAIN_MAX - GAIN_MIN)) * 100);
+
+  function beginDrag() {
+    if (!dragging) {
+      localDb = shown;
+      dragging = true;
+    }
+  }
+
+  function handleInput(e: Event) {
+    beginDrag();
+    localDb = Number((e.currentTarget as HTMLInputElement).value);
+    oninput(localDb);
+  }
+
+  function commit(db: number) {
+    localDb = db;
+    lastSent = db;
+    holdUntil = Date.now() + ECHO_TIMEOUT_MS;
+    dragging = false;
+    oncommit(db);
+  }
+
+  function handleChange(e: Event) {
+    commit(Number((e.currentTarget as HTMLInputElement).value));
+  }
+
+  function reset() {
+    commit(0);
+  }
+</script>
+
+<div class="gain-slider">
+  <input
+    type="range"
+    class="gain-slider__input"
+    min={GAIN_MIN}
+    max={GAIN_MAX}
+    step={GAIN_STEP}
+    value={shown}
+    style="--fill: {fillPct}%"
+    aria-label={label}
+    aria-valuetext={formatDb(shown)}
+    onpointerdown={beginDrag}
+    oninput={handleInput}
+    onchange={handleChange}
+    ondblclick={reset}
+  />
+  <button
+    type="button"
+    class="gain-slider__db mono"
+    class:gain-slider__db--muted={muted}
+    title={$t("tracks.gainReset")}
+    onclick={reset}
+  >
+    {formatDb(shown)}
+  </button>
+</div>
+
+<style>
+  .gain-slider {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+  }
+  .gain-slider__input {
+    flex: 1;
+    min-width: 0;
+    appearance: none;
+    -webkit-appearance: none;
+    height: 28px;
+    padding: 12px 0;
+    margin: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+  .gain-slider__input::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(
+      to right,
+      var(--nc-cyan-500) var(--fill),
+      var(--card-border) var(--fill)
+    );
+  }
+  .gain-slider__input::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(
+      to right,
+      var(--nc-cyan-500) var(--fill),
+      var(--card-border) var(--fill)
+    );
+  }
+  .gain-slider__input::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    margin-top: -5px;
+    border-radius: 50%;
+    border: none;
+    background: var(--nc-cyan-400);
+  }
+  .gain-slider__input::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: none;
+    background: var(--nc-cyan-400);
+  }
+  .gain-slider__input:focus-visible {
+    outline: none;
+  }
+  .gain-slider__input:focus-visible::-webkit-slider-thumb {
+    box-shadow: var(--nc-glow-cyan);
+  }
+  .gain-slider__input:focus-visible::-moz-range-thumb {
+    box-shadow: var(--nc-glow-cyan);
+  }
+  .gain-slider__db {
+    flex: 0 0 64px;
+    text-align: right;
+    font-size: 11px;
+    color: var(--nc-fg-2);
+    background: none;
+    border: none;
+    padding: 4px 0;
+    cursor: pointer;
+  }
+  .gain-slider__db:hover {
+    color: var(--nc-cyan-400);
+  }
+  .gain-slider__db--muted {
+    color: var(--nc-fg-3);
+  }
+</style>

--- a/src/webui/svelte/src/components/cards/TracksCard.svelte
+++ b/src/webui/svelte/src/components/cards/TracksCard.svelte
@@ -15,6 +15,8 @@
 <script lang="ts">
   import { playbackStore, waveformStore } from "../../lib/ws/stores";
   import type { TrackInfo } from "../../lib/ws/stores";
+  import GainSlider from "../GainSlider.svelte";
+  import { sendTrackGain, sendTrackGainThrottled } from "../../lib/gain";
   import { t } from "svelte-i18n";
   import { get } from "svelte/store";
 
@@ -119,23 +121,31 @@
     <div class="tracks-card__list">
       {#each $playbackStore.tracks as track, i (`${i}:${track.name}`)}
         <div class="tracks-card__row">
-          <div class="tracks-card__info">
-            <div class="tracks-card__name">{track.name}</div>
-            <div
-              class="mono tracks-card__channels"
-              class:tracks-card__channels--unmapped={isUnmapped(track)}
-            >
-              {formatChannels(track)}
+          <div class="tracks-card__main">
+            <div class="tracks-card__info">
+              <div class="tracks-card__name">{track.name}</div>
+              <div
+                class="mono tracks-card__channels"
+                class:tracks-card__channels--unmapped={isUnmapped(track)}
+              >
+                {formatChannels(track)}
+              </div>
             </div>
+            <!-- svelte-ignore a11y_no_interactive_element_to_noninteractive_role -->
+            <canvas
+              class="tracks-card__waveform"
+              bind:this={canvasRefs[track.name]}
+              height={WAVEFORM_HEIGHT}
+              role="img"
+              aria-label="Waveform for {track.name}"
+            ></canvas>
           </div>
-          <!-- svelte-ignore a11y_no_interactive_element_to_noninteractive_role -->
-          <canvas
-            class="tracks-card__waveform"
-            bind:this={canvasRefs[track.name]}
-            height={WAVEFORM_HEIGHT}
-            role="img"
-            aria-label="Waveform for {track.name}"
-          ></canvas>
+          <GainSlider
+            value={track.gain_db ?? 0}
+            label={$t("tracks.gainFor", { values: { name: track.name } })}
+            oninput={(db) => sendTrackGainThrottled(track.name, db)}
+            oncommit={(db) => sendTrackGain(track.name, db)}
+          />
         </div>
       {/each}
     </div>
@@ -174,13 +184,18 @@
   }
   .tracks-card__row {
     display: flex;
-    align-items: center;
-    gap: 12px;
+    flex-direction: column;
+    gap: 4px;
     padding: 12px 20px;
     border-bottom: 1px solid var(--card-border);
   }
   .tracks-card__row:last-child {
     border-bottom: none;
+  }
+  .tracks-card__main {
+    display: flex;
+    align-items: center;
+    gap: 12px;
   }
   .tracks-card__info {
     flex: 0 0 132px;

--- a/src/webui/svelte/src/lib/gain.ts
+++ b/src/webui/svelte/src/lib/gain.ts
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import { playerClient } from "./grpc/client";
+
+export const GAIN_MIN = -60;
+export const GAIN_MAX = 12;
+export const GAIN_STEP = 0.5;
+
+/** Throttle interval for slider drags. */
+const THROTTLE_MS = 75;
+
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+const pending = new Map<string, number>();
+
+/** Formats a dB value for display; GAIN_MIN and below shows as -inf. */
+export function formatDb(db: number): string {
+  if (db <= GAIN_MIN) return "-∞";
+  return `${db > 0 ? "+" : ""}${db.toFixed(1)} dB`;
+}
+
+/** Immediately sends a track gain, cancelling any pending throttled send. */
+export async function sendTrackGain(
+  track: string,
+  gainDb: number,
+): Promise<void> {
+  const timer = timers.get(track);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timers.delete(track);
+  }
+  pending.delete(track);
+  try {
+    await playerClient.setTrackGain({ track, gainDb });
+  } catch (e) {
+    console.error(`Failed to set gain for track "${track}":`, e);
+  }
+}
+
+/**
+ * Trailing-throttled gain send for use while dragging, keyed per track so
+ * concurrent sliders never starve each other. The final value should be
+ * flushed with `sendTrackGain` on commit (change/pointerup).
+ */
+export function sendTrackGainThrottled(track: string, gainDb: number): void {
+  pending.set(track, gainDb);
+  if (timers.has(track)) return;
+  timers.set(
+    track,
+    setTimeout(() => {
+      timers.delete(track);
+      const value = pending.get(track);
+      pending.delete(track);
+      if (value !== undefined) {
+        void sendTrackGain(track, value);
+      }
+    }, THROTTLE_MS),
+  );
+}

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -13,17 +13,16 @@
   "nav.connection.disconnected": "Disconnected",
   "nav.connection.serverConnected": "Server connected",
   "nav.connection.serverDisconnected": "Server disconnected",
-  "nav.connection.banner": "Connection lost \u2014 data may be stale",
-  "nav.health.ok": "All subsystems healthy \u2014 click for details",
-  "nav.health.warn": "Some subsystems degraded \u2014 click for details",
-  "nav.health.error": "A required subsystem is down \u2014 click for details",
-  "nav.health.unknown": "Subsystem health unknown \u2014 click for details",
-  "nav.live.locked": "LIVE \u2014 locked",
+  "nav.connection.banner": "Connection lost — data may be stale",
+  "nav.health.ok": "All subsystems healthy — click for details",
+  "nav.health.warn": "Some subsystems degraded — click for details",
+  "nav.health.error": "A required subsystem is down — click for details",
+  "nav.health.unknown": "Subsystem health unknown — click for details",
+  "nav.live.locked": "LIVE — locked",
   "nav.live.unlockPrompt": "Unlock during a live session?",
-  "nav.theme.system": "Theme: matches system \u2014 click for light",
-  "nav.theme.light": "Theme: light \u2014 click for dark",
-  "nav.theme.dark": "Theme: dark \u2014 click to follow system",
-
+  "nav.theme.system": "Theme: matches system — click for light",
+  "nav.theme.light": "Theme: light — click for dark",
+  "nav.theme.dark": "Theme: dark — click to follow system",
   "common.save": "Save",
   "common.saving": "Saving...",
   "common.saved": "Saved",
@@ -58,10 +57,8 @@
   "common.imported": "Imported",
   "common.uploading": "Uploading...",
   "common.rename": "Rename",
-
   "notFound.title": "Not Found",
   "notFound.message": "The page you're looking for doesn't exist.",
-
   "playback.title": "Playback",
   "playback.noSong": "No song",
   "playback.playing": "Playing",
@@ -85,23 +82,19 @@
   "playback.error.stopSectionLoop": "Failed to stop section loop",
   "playback.stopLoop": "Stop Loop",
   "playback.sections": "Sections",
-
   "playlist.title": "Playlist",
-
   "tracks.title": "Tracks",
   "tracks.count": "{count} tracks",
   "tracks.noTracks": "No tracks",
   "tracks.unmapped": "(unmapped)",
-
+  "tracks.gainFor": "Gain for {name}",
+  "tracks.gainReset": "Reset gain to 0 dB",
   "effects.title": "Active Effects",
   "effects.noEffects": "No active effects",
-
   "logs.title": "Logs",
-
   "stage.title": "Stage",
   "stage.label": "STAGE",
   "stage.reloaded": "Reloaded",
-
   "status.title": "Status",
   "status.failedToLoad": "Failed to load status: {error}",
   "status.buildInfo": "Build Info",
@@ -131,7 +124,6 @@
   "status.fix": "Fix",
   "status.configureSubsystem": "Configure {name}",
   "status.fixSubsystem": "Fix {name}",
-
   "config.loadingConfig": "Loading configuration...",
   "config.hardwareProfiles": "Hardware Profiles",
   "config.addProfile": "Add Profile",
@@ -151,7 +143,6 @@
   "config.samplesExternalBanner": "Samples loaded from {file}. Edit the file directly to make changes.",
   "config.profileFilenamePrompt": "Profile filename (without extension):",
   "config.defaultProfile": "Default Profile",
-
   "profile.hostname": "Hostname",
   "profile.hostnamePlaceholder": "Leave empty for default profile",
   "profile.hostnameHint": "Matches against system hostname. Empty = matches any host.",
@@ -163,7 +154,6 @@
   "profile.removeLightingDetail": "This will delete {count, plural, one {# universe} other {# universes}} and all lighting settings.",
   "profile.removeControllersDetail": "This will delete {count, plural, one {# controller} other {# controllers}}.",
   "profile.removeTriggerDetail": "This will delete {count, plural, one {# trigger input} other {# trigger inputs}}.",
-
   "profile.tabs.audio": "Audio",
   "profile.tabs.midi": "MIDI",
   "profile.tabs.lighting": "Lighting",
@@ -171,7 +161,6 @@
   "profile.tabs.controllers": "Controllers",
   "profile.tabs.notifications": "Notifications",
   "profile.tabs.statusEvents": "Status Events",
-
   "audio.device": "Device",
   "audio.devicePlaceholder": "Type or select a device",
   "audio.sampleRate": "Sample Rate",
@@ -187,7 +176,6 @@
   "audio.trackMappings": "Track Mappings",
   "audio.trackNamePlaceholder": "Track name",
   "audio.channelMappingError": "Channels must be comma-separated positive numbers (e.g., 1, 2)",
-
   "midi.device": "Device",
   "midi.devicePlaceholder": "Type or select a device",
   "midi.playbackDelay": "Playback Delay",
@@ -206,7 +194,6 @@
   "midi.convertToNotes": "Output Notes",
   "midi.inputController": "Input CC",
   "midi.convertToControllers": "Output CCs",
-
   "dmx.olaPort": "OLA Port",
   "dmx.dimSpeedModifier": "Dim Speed Modifier",
   "dmx.playbackDelay": "Playback Delay",
@@ -215,7 +202,6 @@
   "dmx.universes": "Universes",
   "dmx.universePlaceholder": "Universe #",
   "dmx.namePlaceholder": "Name",
-
   "trigger.audioInputDevice": "Audio Input Device",
   "trigger.audioInputPlaceholder": "Only needed for audio triggers",
   "trigger.sampleRate": "Sample Rate",
@@ -260,7 +246,6 @@
   "trigger.midiChannel": "Channel",
   "trigger.keyCC": "Key / CC#",
   "trigger.midiSample": "Sample",
-
   "trigger.cal.calibrateChannel": "Calibrate Channel {channel}",
   "trigger.cal.device": "Device",
   "trigger.cal.channel": "Channel",
@@ -281,7 +266,6 @@
   "trigger.cal.dynThreshold": "Dyn. threshold:",
   "trigger.cal.maxHitAmplitude": "Max hit amplitude:",
   "trigger.cal.noHits": "No hits detected. Try again with stronger hits or lower noise.",
-
   "controllers.port": "Port",
   "controllers.broadcastAddresses": "Broadcast Addresses",
   "controllers.broadcastPlaceholder": "192.168.1.255:43235",
@@ -304,7 +288,6 @@
   "controllers.addGrpc": "Add gRPC",
   "controllers.addOsc": "Add OSC",
   "controllers.addMidi": "Add MIDI",
-
   "notifications.hint": "Override the default notification audio with custom sound files. Paths are relative to the config directory.",
   "notifications.loopArmed": "Loop Armed",
   "notifications.breakRequested": "Break Requested",
@@ -317,7 +300,6 @@
   "notifications.browse": "Browse filesystem",
   "notifications.dropAudio": "Drop audio file here or click to upload",
   "notifications.uploaded": "Uploaded {name}",
-
   "lighting.fixtureTypes": "Fixture Types",
   "lighting.venues": "Venues",
   "lighting.profileSettings": "Profile Settings",
@@ -381,7 +363,6 @@
   "lighting.maxCount": "Max Count",
   "lighting.fallbackTo": "Fallback To",
   "lighting.allowEmptyLabel": "Allow Empty",
-
   "samples.noSamples": "No samples configured.",
   "samples.addSampleHint": "Add a sample to define audio files for trigger playback.",
   "samples.addSample": "Add Sample",
@@ -415,7 +396,6 @@
   "samples.layerFilePlaceholder": "path/to/layer-file.wav",
   "samples.confirmRemove": "Remove sample \"{name}\"?",
   "samples.uploadedFile": "Uploaded {name}",
-
   "songs.title": "Songs",
   "songs.newSong": "New Song",
   "songs.importFromFilesystem": "Import from Filesystem",
@@ -429,15 +409,12 @@
   "songs.trackCount": "{count} track{count, plural, one {} other {s}}",
   "songs.currentPlaying": "Playing",
   "songs.currentLoaded": "Loaded",
-
   "songs.create.placeholder": "Song name or path (e.g. Artist/Song)",
   "songs.create.alreadyExists": "Song already exists",
   "songs.create.failed": "Failed to create song",
-
   "songs.detail.allSongs": "All Songs",
   "songs.detail.tabs.samples": "Samples",
   "songs.detail.noSamples": "No per-song sample overrides. Samples configured here override the global samples config for this song only.",
-
   "songs.detail.excludeChannels": "Exclude MIDI Channels",
   "songs.detail.excludeChannelsHint": "Check channels to exclude from MIDI file playback. Commonly used to skip channel 10 (drums) or channels used for lighting data.",
   "songs.detail.excludeNone": "None",
@@ -477,7 +454,6 @@
   "songs.detail.uploadedFiles": "Uploaded {count} file{count, plural, one {} other {s}}",
   "songs.detail.confirmReplace": "The following file{count, plural, one {} other {s}} will be replaced:\n{names}\n\nContinue?",
   "songs.detail.confirmMidiReplace": "\"{name}\" already exists and will be replaced.\n\nContinue?",
-
   "songs.tracks.noTracks": "No tracks configured",
   "songs.tracks.name": "Name",
   "songs.tracks.file": "File",
@@ -487,7 +463,6 @@
   "songs.tracks.removeTrack": "Remove track",
   "songs.tracks.addTrack": "+ Add Track",
   "songs.tracks.browseFilesystemBtn": "Browse Filesystem...",
-
   "songs.import.title": "Import Song from Directory",
   "songs.import.hint": "Navigate to a directory containing your song files. Audio, MIDI, and lighting files will be detected automatically. Stereo and multichannel audio files will be split into per-channel tracks.",
   "songs.import.noAudio": "No audio files in this directory",
@@ -506,7 +481,6 @@
   "songs.import.midiFileCount": "{count} MIDI",
   "songs.import.lightingFileCount": "{count} lighting",
   "songs.import.songExists": "song.yaml already exists in this directory",
-
   "playlists.title": "Playlists",
   "playlists.new": "New",
   "playlists.namePlaceholder": "Playlist name",
@@ -520,7 +494,6 @@
   "playlists.noSongsInPlaylist": "No songs in this playlist. Add songs from the right.",
   "playlists.availableSongs": "Available Songs",
   "playlists.searchSongs": "Search songs...",
-
   "lightingEditor.songs": "Songs",
   "lightingEditor.noSongs": "No songs found.",
   "lightingEditor.selectSong": "Select a song to edit its lighting.",
@@ -540,7 +513,6 @@
   "lightingEditor.importFromFs": "Import from Filesystem",
   "lightingEditor.browseServer": "Browse Server Filesystem...",
   "lightingEditor.discardSwitch": "You have unsaved changes. Discard and switch songs?",
-
   "songLighting.notConnected": "Not connected to server — playback controls unavailable",
   "songLighting.dslLabel": "DSL",
   "songLighting.midiDmxLabel": "MIDI DMX",
@@ -563,26 +535,22 @@
   "songLighting.confirmRemove": "Remove \"{name}\" from this song and delete the file?",
   "songLighting.parseError": "parse error",
   "songLighting.removeFile": "Remove light file",
-
   "lightingSummary.desktopOnly": "Edit on a laptop. The timeline needs more room than a phone screen has — here's a quick read of what's configured.",
   "lightingSummary.shows": "Shows",
   "lightingSummary.sequences": "Sequences",
   "lightingSummary.effects": "Effect types in this song",
   "lightingSummary.empty": "No lighting cues configured for this song.",
-
   "fileBrowser.emptyDir": "Empty directory",
   "fileBrowser.selected": "{count} selected",
   "fileBrowser.fileCount": "{count} file{count, plural, one {} other {s}}",
   "fileBrowser.selectAll": "Select All",
   "fileBrowser.deselectAll": "Deselect All",
   "fileBrowser.select": "Select ({count})",
-
   "timeline.noShows": "No shows. Click \"+ Show\" to get started.",
   "timeline.selectCue": "Select a cue to edit, or double-click a lane to create one.",
   "timeline.editOffset": "Edit Offset",
   "timeline.measures": "measures",
   "timeline.addOffsetMeasures": "Add Offset (measures)",
-
   "timeline.toolbar.goToStart": "Go to start",
   "timeline.toolbar.stopReset": "Stop (reset to start)",
   "timeline.toolbar.pause": "Pause",
@@ -597,11 +565,9 @@
   "timeline.toolbar.measure": "Measure",
   "timeline.toolbar.addShow": "+ Show",
   "timeline.toolbar.addSequence": "+ Sequence",
-
   "timeline.cueBlock.empty": "empty",
   "timeline.cueBlock.cmdCount": "{count} cmd",
   "timeline.cueBlock.seqCount": "{count} seq",
-
   "timeline.properties.effects": "Effects",
   "timeline.properties.commands": "Commands",
   "timeline.properties.sequences": "Sequences",
@@ -611,7 +577,6 @@
   "timeline.properties.noCommands": "No commands.",
   "timeline.properties.addSequence": "+ Sequence",
   "timeline.properties.noSequences": "No sequence references.",
-
   "timeline.showGroup.deleteShow": "Delete show",
   "timeline.showGroup.foreground": "FG",
   "timeline.showGroup.midground": "MG",
@@ -619,18 +584,15 @@
   "timeline.showGroup.cmds": "Cmds",
   "timeline.showGroup.seqs": "Seqs",
   "timeline.showLane.deleteLane": "Delete {type}",
-
   "timeline.tempo": "Tempo",
   "timeline.waveform": "Waveform",
   "timeline.noFixtures": "No fixtures configured",
   "timeline.reset": "reset",
-
   "timeline.sequenceEditor.title": "Sequence: \"{name}\"",
   "timeline.sequenceEditor.cueCount": "{count} cues",
   "timeline.sequenceEditor.hint": "Double-click to add cues. Drag to reposition.",
   "timeline.sequenceEditor.deleteSequence": "Delete Sequence",
   "timeline.sequenceEditor.selectCue": "Select a cue to edit, or double-click the lane to create one.",
-
   "cue.comment": "Comment",
   "cue.commentPlaceholder": "Cue description...",
   "cue.addComment": "+ Comment",
@@ -645,14 +607,12 @@
   "cue.addCue": "+ Cue",
   "cue.moveUp": "Move up",
   "cue.moveDown": "Move down",
-
   "timestamp.time": "Time",
   "timestamp.measure": "Measure",
   "timestamp.minutes": "Minutes",
   "timestamp.seconds": "Seconds",
   "timestamp.milliseconds": "Milliseconds",
   "timestamp.beat": "Beat",
-
   "effect.group": "group",
   "effect.collapse": "Collapse",
   "effect.expand": "Expand",
@@ -683,24 +643,20 @@
   "effect.hold": "Hold",
   "effect.down": "Down",
   "effect.removeEffect": "Remove effect",
-
   "effect.command.command": "Command",
   "effect.command.layer": "Layer",
   "effect.command.time": "Time",
   "effect.command.intensity": "Intensity",
   "effect.command.speed": "Speed",
   "effect.command.removeCommand": "Remove command",
-
   "effect.color.removeColor": "Remove color",
   "effect.color.addColor": "+ Color",
-
   "sequenceRef.sequence": "Sequence",
   "sequenceRef.select": "-- select --",
   "sequenceRef.namePlaceholder": "sequence name",
   "sequenceRef.loop": "Loop",
   "sequenceRef.stop": "Stop",
   "sequenceRef.remove": "Remove",
-
   "tempo.title": "Tempo",
   "tempo.bpm": "BPM",
   "tempo.timeSignature": "Time Signature",
@@ -711,7 +667,6 @@
   "tempo.at": "At",
   "tempo.timeSig": "Time Sig",
   "tempo.transition": "Transition",
-
   "midiEvent.type": "Type",
   "midiEvent.channel": "Channel",
   "midiEvent.key": "Key",
@@ -727,7 +682,6 @@
   "midiEvent.programChange": "Program Change",
   "midiEvent.channelAftertouch": "Channel Aftertouch",
   "midiEvent.pitchBend": "Pitch Bend",
-
   "statusEvents.title": "Status Events",
   "statusEvents.hint": "MIDI events emitted when the player state changes. Used to drive external indicators like LEDs on a MIDI controller.",
   "statusEvents.description": "Configure MIDI events that are sent when the player transitions between off, idling, and playing states.",
@@ -738,30 +692,24 @@
   "statusEvents.idlingEvents": "Idling Events",
   "statusEvents.playingEvents": "Playing Events",
   "statusEvents.noEvents": "No events configured.",
-
   "tooltips.statusEvents.offEvents": "MIDI events sent to clear the status indicator. Typically turns off LEDs or resets controller state.",
   "tooltips.statusEvents.idlingEvents": "MIDI events sent when the player is idle and waiting for input. Can drive a steady LED or status display.",
   "tooltips.statusEvents.playingEvents": "MIDI events sent when the player is actively playing a song. Can drive a different LED color or blinking state.",
-
   "tooltips.profile.hostname": "System hostname this profile applies to. When mtrack starts, it matches the machine's hostname to select the correct profile. Leave empty for a default profile that matches any host.",
-
   "tooltips.audio.bufferSize": "Number of audio frames per hardware callback. Lower values reduce latency but increase CPU load. Leave empty to use the device default.",
   "tooltips.audio.streamBufferSize": "Size of the internal stream buffer between the decoder and audio callback. Enter a number of frames, 'min' for minimum size, or leave empty for the default.",
   "tooltips.audio.bufferThreads": "Number of threads used to decode and buffer audio tracks in parallel. Default is 2.",
   "tooltips.audio.resampler": "Algorithm used when the source sample rate differs from the device. Sinc is higher quality; FFT may be faster for some configurations.",
   "tooltips.audio.playbackDelay": "Delay before audio playback starts, e.g. '500ms'. Used to synchronize audio with other subsystems like DMX or MIDI.",
   "tooltips.audio.trackMappings": "Maps named audio tracks to specific output channels on your audio device. The track name must match a track in your song, and channels are 1-indexed device output channels. Use 'mtrack:looping' to route the section loop confirmation tone. Reload hardware after changing mappings.",
-
   "tooltips.midi.playbackDelay": "Delay before MIDI playback starts, e.g. '500ms'. Used to synchronize MIDI output with audio and lighting.",
   "tooltips.midi.beatClock": "Sends MIDI Beat Clock messages to the output device during playback. External gear can sync its tempo to this clock.",
   "tooltips.midi.midiToDmx": "Maps MIDI channels from the song's MIDI file to DMX universes. Notes and CCs on the mapped channel are converted to DMX values. Transformers can remap note/CC numbers before output.",
-
   "tooltips.dmx.olaPort": "Port number for the Open Lighting Architecture (OLA) server. OLA must be running to send DMX data. Default is 9010.",
   "tooltips.dmx.dimSpeedModifier": "Multiplier that scales the speed of all dimming transitions. Values above 1.0 speed up fades; below 1.0 slows them down.",
   "tooltips.dmx.playbackDelay": "Delay before DMX playback starts, e.g. '200ms'. Used to synchronize lighting with audio.",
   "tooltips.dmx.nullClient": "Run the DMX engine without connecting to OLA. Useful for testing lighting shows without hardware.",
   "tooltips.dmx.universes": "DMX universes to output to. Each universe maps to an OLA universe number and an optional descriptive name.",
-
   "tooltips.trigger.audioInputDevice": "Audio input device used for trigger detection (e.g. a drum trigger interface). Only needed if you have audio-type trigger inputs.",
   "tooltips.trigger.bufferSize": "Audio input buffer size in frames. Smaller buffers detect triggers faster but use more CPU.",
   "tooltips.trigger.crosstalkWindow": "Time window in milliseconds during which only the loudest trigger fires. Prevents one physical hit from triggering multiple channels.",
@@ -777,15 +725,12 @@
   "tooltips.trigger.dynThresholdMs": "Decay time for dynamic threshold tracking. After a hit, the threshold temporarily rises then decays over this period, preventing false retrigs from signal ringing.",
   "tooltips.trigger.noiseFloorSens": "Sensitivity multiplier for noise floor tracking. Higher values make the detector more aggressive at rejecting background noise.",
   "tooltips.trigger.fixedVelocity": "MIDI velocity value (0-127) used for every trigger hit when velocity curve is set to Fixed.",
-
   "tooltips.config.maxSampleVoices": "Maximum number of sample voices that can play simultaneously across all samples. Oldest voices are stopped when the limit is reached. Default is 32.",
-
   "tooltips.notifications.loopArmed": "Audio file played when a section loop is armed (player acknowledges the section). Overrides the built-in notification tone.",
   "tooltips.notifications.breakRequested": "Audio file played when a break out of the section loop is requested. Overrides the built-in notification tone.",
   "tooltips.notifications.loopExited": "Audio file played when the player exits a section loop and resumes normal playback.",
   "tooltips.notifications.sectionEntering": "Default audio file played when entering any section. Individual sections can be overridden below.",
   "tooltips.notifications.sections": "Override the section entering sound for specific named sections. The section name must match a section defined in the song.",
-
   "tooltips.controllers.grpcPort": "TCP port for the gRPC control server. The web UI and other clients connect to this port. Default is 43234.",
   "tooltips.controllers.oscPort": "UDP port to listen for incoming OSC messages. Default is 43235.",
   "tooltips.controllers.broadcastAddresses": "IP addresses to broadcast OSC status updates to (e.g. '192.168.1.255:43235'). Enables external apps like TouchOSC to receive state updates.",
@@ -793,10 +738,9 @@
   "tooltips.controllers.morningstarModel": "The Morningstar controller model. Determines the device ID byte in the SysEx message.",
   "tooltips.controllers.morningstarSave": "When enabled, the bank name is saved to flash. When disabled, the name is temporary and resets on power cycle.",
   "tooltips.controllers.morningstarCustomModelId": "The SysEx device ID byte for a custom/unlisted Morningstar model (0-127).",
-  "tooltips.controllers.addGrpc": "Add gRPC controller \u2014 remote control via network API",
-  "tooltips.controllers.addOsc": "Add OSC controller \u2014 Open Sound Control for hardware controllers",
-  "tooltips.controllers.addMidi": "Add MIDI controller \u2014 control via MIDI hardware",
-
+  "tooltips.controllers.addGrpc": "Add gRPC controller — remote control via network API",
+  "tooltips.controllers.addOsc": "Add OSC controller — Open Sound Control for hardware controllers",
+  "tooltips.controllers.addMidi": "Add MIDI controller — control via MIDI hardware",
   "tooltips.samples.outputChannels": "Device output channels for this sample, as comma-separated numbers (e.g. '1, 2'). If both output channels and output track are empty, uses the default stereo output.",
   "tooltips.samples.outputTrack": "Name of a track mapping (defined in Audio settings) to route this sample's output. Overrides output channels if set.",
   "tooltips.samples.releaseBehavior": "What happens when a release event fires for this sample. 'Play to Completion' ignores the release; 'Stop' cuts immediately; 'Fade' fades out over the fade time.",
@@ -806,7 +750,6 @@
   "tooltips.samples.velocityMode": "How trigger velocity affects playback. 'Ignore' plays at full volume; 'Scale' adjusts volume by velocity; 'Layers' selects different audio files by velocity range.",
   "tooltips.samples.defaultVelocity": "Velocity value (0-127) used when the trigger source does not provide velocity information.",
   "tooltips.samples.scaleByVelocity": "When enabled with layers, the selected layer's volume is also scaled by velocity. Otherwise each layer plays at full volume.",
-
   "tooltips.lighting.currentVenue": "The venue whose fixture layout is used for this profile. Logical groups resolve fixtures from this venue's definitions.",
   "tooltips.lighting.inlineFixtures": "Quick fixture definitions without a full venue file. Format: 'FixtureType @ universe:start_channel'. These override venue fixtures with the same name.",
   "tooltips.lighting.logicalGroups": "Named groups that resolve to venue fixtures using tag-based constraints. Lighting shows reference groups by name, so the same show works across venues.",

--- a/src/webui/svelte/src/lib/ws/stores.ts
+++ b/src/webui/svelte/src/lib/ws/stores.ts
@@ -20,6 +20,8 @@ import { connect, on, onConnectionStatus } from "./connection";
 export interface TrackInfo {
   name: string;
   output_channels: number[];
+  /** Output track gain in dB; absent on older backends (treat as 0). */
+  gain_db?: number;
 }
 
 export interface BeatGrid {


### PR DESCRIPTION
## Summary

Adds runtime gain control on output tracks (the `track_mappings` keys), adjustable live from the web UI, gRPC, and OSC, and persisted per hardware profile.

### Engine
- New `audio::track_gains::TrackGains`: lock-free shared gain state (atomic dB + linear f32 bit pairs), built at hardware init from the active profile and installed into the device mixer.
- Mixer mapping edges (`OutputMapping`) carry per-edge gain indices, so a source channel routed through multiple track labels keeps independent gains per track — including tracks summed into the same output channel.
- Gain changes ramp linearly across one audio batch (~10–20 ms at typical buffer sizes): no zipper noise, no per-sample atomics.
- A constant-gain fast path folds envelope × track gain into each edge once per batch, leaving the inner loop a single load + FMA per edge.

### Performance (relates to #170)
A criterion harness for the mixer hot path is included (`cargo bench --bench mixer`). Against the pre-change baseline, the gain-enabled mixer measures at or better than before (the fast path's tighter inner loop more than pays for the gain lookups): 8 stereo sources → 16ch ≈ 10% faster; 1×16ch → 16ch ≈ 5% faster; 32 mono → 32ch unchanged. Absolute mixing cost is ~0.5–2% of the 512-frame callback budget, so explicit SIMD remains unjustified by measurement; the harness is there to keep the hot path honest.

### Config & persistence
- Optional `track_gains:` map (dB, −60..+12; ≤ −60 mutes) in the profile `audio:` section, sibling of `track_mappings`.
- Gain changes persist after a 750 ms debounce. With `profiles_dir` layouts the owning profile file is rewritten (note: rewriting drops YAML comments in that file), so gains survive restarts in both layouts.

### Surfaces
- **gRPC**: `SetTrackGain` / `GetTrackGains` RPCs (values clamped server-side; unknown track → `INVALID_ARGUMENT`).
- **OSC**: configurable `/mtrack/track/*/gain` command (track name in the wildcard segment, dB as float/double/int arg), plus per-track gain feedback in the 500 ms broadcast loop for motorized faders/TouchOSC. Track names containing spaces or OSC metacharacters can't be addressed via OSC and are skipped in broadcasts.
- **WebSocket**: playback message track entries now include `gain_db`.
- **Web UI**: `GainSlider` under each track in the Tracks card — 0.5 dB steps, −∞ at mute, double-click/readout-click resets to 0 dB, 75 ms throttled sends while dragging, optimistic hold-until-echo so the 5 Hz poller can't snap the thumb back.

Also fixes `build.rs` missing a `rerun-if-changed` for `player.proto` (proto edits previously didn't regenerate the Rust stubs).

## Test plan
- `cargo test`: 2,981 passing (new coverage: TrackGains unit tests, mixer gain/ramp/mute/per-edge tests, config round-trip + store persistence for both inline and `profiles_dir` layouts, player API, gRPC and OSC handler tests, WS message shape).
- `cargo clippy --all-targets` and `cargo fmt --check` clean.
- UI: `npm run check`, prettier clean; 461 Playwright mock tests passing including 4 new `track-gain` specs.
- Manually verified on real hardware: two tracks routed to the same output channel adjust independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)