### PR TITLE
fix: first-profile setup flow; release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-10
+
+### Added
+
+- **Runtime-adjustable per-output-track gain**: Each output track (a `track_mappings` key) can
+  now carry a gain in dB via an optional `track_gains` map in the profile audio section
+  (-60 to +12 dB; values at or below -60 mute). Gains are adjustable live from the web UI
+  (per-track slider in the Tracks card), gRPC (`SetTrackGain` / `GetTrackGains`), and OSC
+  (`/mtrack/track/*/gain`, with per-track feedback in the broadcast loop for motorized
+  faders). Gain state is lock-free and changes ramp across one audio batch to avoid zipper
+  noise, with a constant-gain fast path that keeps the mixer inner loop at a single
+  load + FMA per mapping edge (criterion benchmark added in `benches/mixer.rs`). Runtime
+  adjustments persist to the active profile after a short debounce — in both inline-profile
+  and `profiles_dir` layouts — so they survive restarts.
+
+### Changed
+
+- **Configs are validated at load**: the player config and profile files now run semantic
+  validation when loaded, so errors like a missing audio device, channel `0` in
+  `track_mappings`, or out-of-range `track_gains` fail fast at startup with readable
+  messages instead of surfacing as endless device-retry loops or cryptic playback errors.
+
+### Fixed
+
+- **First-profile setup in the web UI**: creating the first hardware profile through the
+  config editor was nearly impossible. Switching to another section (e.g. track mappings)
+  before the first save silently turned the new profile into an update of a nonexistent
+  backend profile ("Invalid profile index 0 (have 0 profiles)"); saving without track
+  mappings failed with a raw "missing field `track_mappings`" parse error; and saving
+  without a device produced an equally cryptic "missing field `device`". New profiles now
+  stay new across section switches and back-navigation, `track_mappings` is optional while
+  a profile is being set up (playing a song with no mappings gives a descriptive error
+  instead), a missing device reports "audio device must not be empty", file-based profile
+  saves (`profiles_dir` layouts) are validated server-side before being written, and the
+  web UI now surfaces the backend's full validation error list on save failures.
+
 ## [0.13.0] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"

--- a/docs/src/configuration/hardware-profiles.md
+++ b/docs/src/configuration/hardware-profiles.md
@@ -23,6 +23,10 @@ profiles:
         backing-track-l: [3]
         backing-track-r: [4]
         keys: [5, 6]
+      # Optional per-track gain in dB. Tracks without an entry play at unity.
+      track_gains:
+        click: -6.0
+        keys: 2.5
     midi:
       device: "Behringer WING"
       playback_delay: 500ms
@@ -73,6 +77,13 @@ profiles:
   - If absent from a profile → skipped for that host (player proceeds without it)
 - A profile can define any combination of subsystems, enabling dedicated roles such as
   lighting-only nodes, MIDI-only controllers, or full audio + MIDI + DMX setups.
+
+**Per-track gain (`track_gains`):** an optional map of output-track names (the keys of
+`track_mappings`) to gain in dB, from -60 to +12 (values at or below -60 mute the track;
+tracks without an entry play at unity). Gains are adjustable live from the web UI Tracks
+card, gRPC (`SetTrackGain` / `GetTrackGains`), and OSC (`/mtrack/track/*/gain`). Runtime
+changes are written back to the owning profile after a short debounce, so they survive
+restarts.
 
 Profiles with a `hostname` constraint only apply on hosts whose hostname matches. Profiles
 without a hostname constraint match any host. Set the `MTRACK_HOSTNAME` environment variable

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -168,6 +168,11 @@ pub fn get_device(config: Option<config::Audio>) -> Result<Arc<dyn Device>, Audi
     };
 
     let device = config.device();
+    if device.trim().is_empty() {
+        return Err(AudioError::DeviceNotFound(
+            "audio device name is empty; set 'device' in the audio config".to_string(),
+        ));
+    }
     if device.starts_with("mock") {
         return Ok(Arc::new(mock::Device::get(device)));
     };

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -85,11 +85,16 @@ fn validate_channel_count(
     song_name: &str,
     device_name: &str,
 ) -> Result<(), Box<dyn Error>> {
-    let num_channels = *mappings
-        .iter()
-        .flat_map(|entry| entry.1)
-        .max()
-        .ok_or("no max channel found")?;
+    let num_channels = match mappings.iter().flat_map(|entry| entry.1).max() {
+        Some(max) => *max,
+        None => {
+            return Err(format!(
+                "no track mappings configured for audio device {} — map at least one track to an output channel before playing",
+                device_name
+            )
+            .into())
+        }
+    };
 
     if max_channels < num_channels {
         return Err(format!(
@@ -1190,10 +1195,14 @@ mod test {
         }
 
         #[test]
-        fn fails_on_empty_mappings() {
+        fn fails_on_empty_mappings_with_descriptive_error() {
             let mappings: HashMap<String, Vec<u16>> = HashMap::new();
             let result = validate_channel_count(&mappings, 8, "song", "device");
-            assert!(result.is_err());
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("no track mappings configured"),
+                "error should explain that mappings are missing, got: {err}"
+            );
         }
 
         #[test]

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -50,7 +50,9 @@ pub enum StreamBufferSize {
 /// A YAML representation of the audio configuration.
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Audio {
-    /// The audio device.
+    /// The audio device. Defaults to empty rather than failing
+    /// deserialization so validate() can report a readable error.
+    #[serde(default)]
     device: String,
 
     /// Controls how long to wait before playback of an audio file starts.

--- a/src/config/player.rs
+++ b/src/config/player.rs
@@ -188,6 +188,9 @@ impl Player {
             .try_deserialize::<Player>()?;
         player.load_profiles_dir(path)?;
         player.normalize();
+        player
+            .validate()
+            .map_err(|errors| ConfigError::Validation(errors.join("; ")))?;
         Ok(player)
     }
 
@@ -739,6 +742,25 @@ mod tests {
         let mut temp = tempfile::NamedTempFile::with_suffix(".yaml").unwrap();
         temp.write_all(yaml.as_bytes()).unwrap();
         Player::deserialize(temp.path()).expect("Failed to deserialize")
+    }
+
+    #[test]
+    fn test_deserialize_rejects_invalid_profile() {
+        // A profile missing its audio device must fail at load with a
+        // readable validation error, not spin in device-retry at startup.
+        let mut temp = tempfile::NamedTempFile::with_suffix(".yaml").unwrap();
+        temp.write_all(
+            b"songs: songs\nprofiles:\n  - audio:\n      track_mappings:\n        click: [1]\n",
+        )
+        .unwrap();
+        let err = match Player::deserialize(temp.path()) {
+            Ok(_) => panic!("expected validation error for missing device"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("audio device must not be empty"),
+            "expected device validation error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -31,6 +31,10 @@ use super::trigger::TriggerConfig;
 pub struct AudioConfig {
     #[serde(flatten)]
     audio: Audio,
+    /// Output channel routing per track. May be empty for a profile that is
+    /// still being set up; playback requires at least one mapping and fails
+    /// with a descriptive error otherwise.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     track_mappings: IndexMap<String, Vec<u16>>,
     /// Per-output-track gain in dB. Tracks without an entry play at unity.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
@@ -348,6 +352,59 @@ mod tests {
         // Empty map is omitted on serialize to keep configs clean.
         let serialized = crate::util::to_yaml_string(&profile).unwrap();
         assert!(!serialized.contains("track_gains"));
+    }
+
+    #[test]
+    fn test_track_mappings_absent_and_omitted() {
+        // A profile mid-setup may have an audio device but no mappings yet;
+        // this must parse rather than fail with "missing field track_mappings".
+        let yaml = r#"
+            audio:
+              device: mock-device
+        "#;
+        let profile: Profile = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let audio_config = profile.audio_config().unwrap();
+        assert!(audio_config.track_mappings().is_empty());
+
+        let mut errors = Vec::new();
+        audio_config.validate(&mut errors);
+        assert!(
+            errors.is_empty(),
+            "empty mappings should validate: {errors:?}"
+        );
+
+        // Empty map is omitted on serialize to keep configs clean.
+        let serialized = crate::util::to_yaml_string(&profile).unwrap();
+        assert!(!serialized.contains("track_mappings"));
+    }
+
+    #[test]
+    fn test_missing_device_parses_and_fails_validation() {
+        // A missing device must surface as a readable validation error,
+        // not a serde "missing field" parse failure.
+        let yaml = r#"
+            audio:
+              track_mappings:
+                click: [1]
+        "#;
+        let profile: Profile = Config::builder()
+            .add_source(File::from_str(yaml, FileFormat::Yaml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let errors = profile.validate().unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.contains("audio device")),
+            "expected audio device error, got {errors:?}"
+        );
     }
 
     #[test]

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -183,6 +183,10 @@ pub(super) async fn put_profile(
             .into_response()
     })?;
 
+    if let Err(errors) = profile.validate() {
+        return Err((StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response());
+    }
+
     let yaml = crate::util::to_yaml_string(&profile).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/webui/svelte/src/lib/api/config.ts
+++ b/src/webui/svelte/src/lib/api/config.ts
@@ -12,7 +12,16 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-import { get, post, put, del, uploadFile, putText, postText } from "./rest";
+import {
+  get,
+  post,
+  put,
+  del,
+  uploadFile,
+  putText,
+  postText,
+  apiError,
+} from "./rest";
 
 // Calibration types
 export interface NoiseFloorResult {
@@ -96,10 +105,7 @@ export async function addProfile(
     "/config/profiles",
     JSON.stringify({ expected_checksum: checksum, profile }),
   );
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Failed to add profile: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to add profile");
   return res.json();
 }
 
@@ -112,10 +118,7 @@ export async function updateProfile(
     `/config/profiles/${index}`,
     JSON.stringify({ expected_checksum: checksum, profile }),
   );
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Failed to update profile: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to update profile");
   return res.json();
 }
 
@@ -126,10 +129,7 @@ export async function deleteProfile(
   const res = await del(
     `/config/profiles/${index}?expected_checksum=${encodeURIComponent(checksum)}`,
   );
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Failed to delete profile: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to delete profile");
   return res.json();
 }
 
@@ -155,10 +155,7 @@ export async function fetchProfileFile(
   filename: string,
 ): Promise<{ profile: object; yaml: string }> {
   const res = await get(`/profiles/${encodeURIComponent(filename)}`);
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to fetch profile: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to fetch profile");
   return res.json();
 }
 
@@ -170,18 +167,12 @@ export async function saveProfileFile(
     `/profiles/${encodeURIComponent(filename)}`,
     JSON.stringify(profile),
   );
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to save profile: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to save profile");
 }
 
 export async function deleteProfileFile(filename: string): Promise<void> {
   const res = await del(`/profiles/${encodeURIComponent(filename)}`);
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to delete profile: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to delete profile");
 }
 
 // Samples API
@@ -199,10 +190,7 @@ export async function updateSamples(
     body.max_sample_voices = maxSampleVoices;
   }
   const res = await put("/config/samples", JSON.stringify(body));
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Failed to update samples: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to update samples");
   return res.json();
 }
 
@@ -219,10 +207,7 @@ export async function uploadSampleFile(
     `/samples/upload/${encodeURIComponent(file.name)}`,
     file,
   );
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Failed to upload sample: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to upload sample");
   return res.json();
 }
 
@@ -236,27 +221,18 @@ export async function startCalibration(
   const body: Record<string, unknown> = { device, channel };
   if (duration !== undefined) body.duration = duration;
   const res = await post("/calibrate/start", JSON.stringify(body));
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data.error || `Calibration start failed: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Calibration start failed");
   return res.json();
 }
 
 export async function startCapture(): Promise<void> {
   const res = await post("/calibrate/capture");
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data.error || `Capture start failed: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Capture start failed");
 }
 
 export async function stopCapture(): Promise<ChannelCalibration> {
   const res = await post("/calibrate/stop");
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data.error || `Capture stop failed: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Capture stop failed");
   return res.json();
 }
 
@@ -293,12 +269,7 @@ export async function fetchFixtureTypes(
 ): Promise<Record<string, FixtureTypeData>> {
   const params = dir ? `?dir=${encodeURIComponent(dir)}` : "";
   const res = await get(`/lighting/fixture-types${params}`);
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(
-      data.error || `Failed to fetch fixture types: ${res.status}`,
-    );
-  }
+  if (!res.ok) throw await apiError(res, "Failed to fetch fixture types");
   const data = await res.json();
   return data.fixture_types;
 }
@@ -311,12 +282,7 @@ export async function fetchFixtureType(
   const res = await get(
     `/lighting/fixture-types/${encodeURIComponent(name)}${params}`,
   );
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(
-      data.error || `Failed to fetch fixture type: ${res.status}`,
-    );
-  }
+  if (!res.ok) throw await apiError(res, "Failed to fetch fixture type");
   return res.json();
 }
 
@@ -335,10 +301,7 @@ export async function saveFixtureType(
     `/lighting/fixture-types/${encodeURIComponent(name)}${params}`,
     JSON.stringify(data),
   );
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to save fixture type: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to save fixture type");
 }
 
 export async function deleteFixtureType(
@@ -349,12 +312,7 @@ export async function deleteFixtureType(
   const res = await del(
     `/lighting/fixture-types/${encodeURIComponent(name)}${params}`,
   );
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(
-      data.error || `Failed to delete fixture type: ${res.status}`,
-    );
-  }
+  if (!res.ok) throw await apiError(res, "Failed to delete fixture type");
 }
 
 export async function fetchVenues(
@@ -362,10 +320,7 @@ export async function fetchVenues(
 ): Promise<Record<string, VenueData>> {
   const params = dir ? `?dir=${encodeURIComponent(dir)}` : "";
   const res = await get(`/lighting/venues${params}`);
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data.error || `Failed to fetch venues: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to fetch venues");
   const data = await res.json();
   return data.venues;
 }
@@ -378,10 +333,7 @@ export async function fetchVenue(
   const res = await get(
     `/lighting/venues/${encodeURIComponent(name)}${params}`,
   );
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data.error || `Failed to fetch venue: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to fetch venue");
   return res.json();
 }
 
@@ -404,10 +356,7 @@ export async function saveVenue(
     `/lighting/venues/${encodeURIComponent(name)}${params}`,
     JSON.stringify(data),
   );
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to save venue: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to save venue");
 }
 
 export async function deleteVenue(name: string, dir?: string): Promise<void> {
@@ -415,10 +364,7 @@ export async function deleteVenue(name: string, dir?: string): Promise<void> {
   const res = await del(
     `/lighting/venues/${encodeURIComponent(name)}${params}`,
   );
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({}));
-    throw new Error(data.error || `Failed to delete venue: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to delete venue");
 }
 
 // ---- Playlist CRUD ----
@@ -455,26 +401,17 @@ export async function savePlaylist(
     `/playlists/${encodeURIComponent(name)}`,
     JSON.stringify({ songs }),
   );
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to save playlist: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to save playlist");
 }
 
 export async function deletePlaylist(name: string): Promise<void> {
   const res = await del(`/playlists/${encodeURIComponent(name)}`);
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to delete playlist: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to delete playlist");
 }
 
 export async function activatePlaylist(name: string): Promise<void> {
   const res = await post(`/playlists/${encodeURIComponent(name)}/activate`);
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to activate playlist: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to activate playlist");
 }
 
 // ---- Lighting Show Files ----
@@ -504,19 +441,12 @@ export async function saveLightingFile(
   content: string,
 ): Promise<void> {
   const res = await putText(`/lighting/${encodeURIComponent(name)}`, content);
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    const errors = d.errors ? d.errors.join("; ") : d.error;
-    throw new Error(errors || `Failed to save lighting file: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to save lighting file");
 }
 
 export async function deleteLightingFile(name: string): Promise<void> {
   const res = await del(`/lighting/${encodeURIComponent(name)}`);
-  if (!res.ok) {
-    const d = await res.json().catch(() => ({}));
-    throw new Error(d.error || `Failed to delete lighting file: ${res.status}`);
-  }
+  if (!res.ok) throw await apiError(res, "Failed to delete lighting file");
 }
 
 export async function validateLighting(

--- a/src/webui/svelte/src/lib/api/rest.ts
+++ b/src/webui/svelte/src/lib/api/rest.ts
@@ -64,6 +64,22 @@ export async function del(path: string): Promise<Response> {
   return request("DELETE", path);
 }
 
+// Builds an Error from a failed response, preferring the body's single
+// `error` string, then a joined `errors` validation list, then the fallback
+// message with the HTTP status appended.
+export async function apiError(
+  res: Response,
+  fallback: string,
+): Promise<Error> {
+  const body: { error?: string; errors?: string[] } = await res
+    .json()
+    .catch(() => ({}));
+  const msg =
+    body.error ||
+    (Array.isArray(body.errors) ? body.errors.join("; ") : undefined);
+  return new Error(msg || `${fallback}: ${res.status}`);
+}
+
 export async function putYaml(path: string, body: string): Promise<Response> {
   return fetch(`${BASE}${path}`, {
     method: "PUT",

--- a/src/webui/svelte/src/pages/ConfigEditor.svelte
+++ b/src/webui/svelte/src/pages/ConfigEditor.svelte
@@ -219,6 +219,30 @@
     }
   }
 
+  // --- Draft (unsaved new profile) lifecycle ---
+
+  // Marks the current selection as a brand-new unsaved draft and syncs the
+  // URL. The selection-sync effect runs once before currentHash catches up
+  // with the hashchange event, so suppress that stale cycle — otherwise it
+  // clears the fresh selection and its isNew flag.
+  function startDraft(urlName: string) {
+    isNew = true;
+    dirty = false;
+    saveMsg = "";
+    saveOk = false;
+    suppressAutoSelect = true;
+    updateConfigUrl(urlName);
+  }
+
+  // Drops an unsaved draft from the inline profiles list so it can't be
+  // re-selected and saved via the update path (the backend never had it).
+  // File-mode drafts live only in scratch state, so there's nothing to drop.
+  function discardDraft() {
+    if (isNew && selectedIndex !== null && !profilesDir) {
+      profiles.splice(selectedIndex, 1);
+    }
+  }
+
   // --- File-based profile operations ---
 
   async function selectFileProfile(filename: string, section?: string) {
@@ -246,11 +270,7 @@
     profiles = [empty];
     selectedIndex = 0;
     selectedFilename = name;
-    isNew = true;
-
-    dirty = false;
-    saveMsg = "";
-    saveOk = false;
+    startDraft(name.replace(/\.\w+$/, ""));
   }
 
   async function saveFileProfile() {
@@ -330,16 +350,13 @@
     const empty: any = {};
     profiles.push(empty);
     selectedIndex = profiles.length - 1;
-    isNew = true;
-
-    dirty = false;
-    saveMsg = "";
-    saveOk = false;
+    startDraft(`Profile #${selectedIndex}`);
   }
 
   async function goBack() {
     if (dirty && !(await showConfirm(get(t)("config.discardUnsaved")))) return;
     suppressAutoSelect = true;
+    discardDraft();
     selectedIndex = null;
     isNew = false;
     dirty = false;
@@ -556,6 +573,8 @@
     if (!routeProfile) {
       // URL is #/config with no profile — clear selection to show list view.
       if (selectedIndex !== null || selectedFilename !== null) {
+        // e.g. browser Back during creation.
+        discardDraft();
         selectedIndex = null;
         selectedFilename = null;
         isNew = false;
@@ -574,12 +593,14 @@
         selectFileProfile(match.filename, routeSection);
       }
     } else {
-      // Inline: match by hostname or index
+      // Inline: match by hostname or index. Skip re-selecting the current
+      // profile — selectProfile resets isNew/dirty, which would turn an
+      // unsaved new profile into a bogus update of a nonexistent index.
       const idx = profiles.findIndex(
         (p: any) =>
           (p.hostname || `Profile #${profiles.indexOf(p)}`) === routeProfile,
       );
-      if (idx >= 0) {
+      if (idx >= 0 && idx !== selectedIndex) {
         selectProfile(idx, routeSection);
       }
     }


### PR DESCRIPTION
## Summary

Fixes the broken first-profile setup flow in the web UI config editor (reported by a first-time user), hardens config validation end to end, and cuts the 0.14.0 release (changelog, version bump, and docs for the track-gain feature shipped in #316).

### Config editor fixes (`ConfigEditor.svelte`)

- The URL-sync effect reset `isNew`/`dirty` on every section change, turning an unsaved draft profile into an update of a nonexistent backend index — saving track mappings then failed with **"Invalid profile index 0 (have 0 profiles)"**. The inline branch now skips re-selecting the already-selected profile (mirroring the existing file-mode guard).
- The add-profile paths now sync the URL so the effect's no-profile branch can't clear a fresh draft, with the one stale-hash effect cycle suppressed (`currentHash` only updates on the async `hashchange` event).
- Unsaved drafts are discarded on back-navigation/browser-Back instead of lingering as phantom list entries that route saves down the update path.
- Draft lifecycle is centralized in `startDraft()`/`discardDraft()` helpers.

### Validation / error-message fixes

- `track_mappings` is now optional in the profile audio config — a mid-setup profile with no mappings yet saves cleanly instead of failing with a raw ``missing field `track_mappings` `` serde error. Playing a song with no mappings fails with a descriptive error ("no track mappings configured for audio device …") instead of "no max channel found".
- A missing audio device now reports **"audio device must not be empty"** (validation) instead of ``missing field `device` `` (serde). `get_device()` also fast-fails on an empty device name as defense in depth.
- `Player::deserialize` now runs semantic validation at load, so hand-edited configs fail fast at startup with readable messages instead of spinning forever in the device retry loop.
- File-based profile saves (`PUT /api/profiles/:filename`) now run `Profile::validate()` instead of writing unvalidated YAML to disk.
- The web UI surfaces `{errors: [...]}` validation lists via a shared `apiError()` helper in `rest.ts`, applied across all 24 error sites in `config.ts`.

### Release 0.14.0

- Changelog section covering per-output-track gain (#316), load-time validation, and the fixes above.
- Version bump to 0.14.0 (Cargo.toml + Cargo.lock).
- Docs for `track_gains` (shipped in #316 without docs) in the hardware profiles page.

## Test plan

- [x] Full Rust suite: 2984 passed (includes new regression tests for empty `track_mappings` parse/serialize, missing-device validation message, load-time validation, and the empty-mappings playback error)
- [x] `cargo clippy` / `cargo fmt` clean
- [x] `svelte-check` 0 errors, eslint + prettier clean
- [x] Manual pass of the first-profile flow (add profile → switch to Tracks tab → save creates; second save updates; save without device shows "audio device must not be empty")

🤖 Generated with [Claude Code](https://claude.com/claude-code)