### PR TITLE
fix(audio): surface single-source dropouts in the logs

### DIFF
--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -702,10 +702,13 @@ impl AudioMixer {
                             }
                         }
                     }
-                    Err(_) => {
-                        debug!(
+                    Err(e) => {
+                        // A read error drops just this source while the mix
+                        // keeps going — worth a warning, not just a debug line.
+                        tracing::warn!(
                             source_id = active_source.id,
-                            "mixer: source marked finished (read_frames error)"
+                            "mixer: source dropped mid-playback (read_frames error): {}",
+                            e
                         );
                         active_source.is_finished.store(true, Ordering::Relaxed);
                         finished_source_ids.push(active_source.id);

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -254,7 +254,17 @@ impl BufferedSampleSource {
                 // Decode one frame outside the producer's critical path.
                 let done = {
                     let mut g = inner.lock().unwrap();
-                    !matches!(g.next_frame(&mut local_frame[..]), Ok(Some(_)))
+                    match g.next_frame(&mut local_frame[..]) {
+                        Ok(Some(_)) => false,
+                        Ok(None) => true,
+                        Err(e) => {
+                            // A decode error permanently ends just this source
+                            // while the rest of the mix continues — make sure
+                            // that leaves a trace in the logs.
+                            tracing::warn!("Audio source ended early due to decode error: {}", e);
+                            true
+                        }
+                    }
                 };
 
                 if done {


### PR DESCRIPTION
 When a sample source hits a decode/read error mid-song, mtrack ends just that source
 while the rest of the mix continues - which is the right behavior live, but every path
 was silent at the default log level. A track that vanishes mid-song was undiagnosable
 after the fact.

 - Decode errors in the buffered source's fill task now `warn!` with the error before
   the source is treated as ended.
 - Read errors in the mixer now `warn!` with the failing source's tracks.

 No behavior change to audio: errors still end only the affected source.

 Motivation: we lost a backing track mid-song at a live show and could not tell from
 the logs what happened or when. With this change the dropout and its cause are visible
 at the default log level (and in the web UI log panel).
