### PR TITLE
fix(e2e): namespace mock WS ids by worker to stop cross-test crosstalk

### DIFF
--- a/src/webui/svelte/e2e/tests/playback-flow.spec.ts
+++ b/src/webui/svelte/e2e/tests/playback-flow.spec.ts
@@ -32,7 +32,9 @@ test.describe("Playback State Transitions", () => {
 
   test.beforeEach(async ({ page }) => {
     // Generate a unique wsId for this test to isolate WebSocket messages.
-    wsId = `playback-${++testCounter}-${Date.now()}`;
+    // The worker index keeps ids unique across parallel workers, whose
+    // per-worker counters can otherwise collide within the same millisecond.
+    wsId = `playback-${test.info().parallelIndex}-${++testCounter}-${Date.now()}`;
 
     // Intercept gRPC calls so play/stop don't fail
     await page.route("**/player.v1.PlayerService/**", async (route) => {

--- a/src/webui/svelte/e2e/tests/section-loop.spec.ts
+++ b/src/webui/svelte/e2e/tests/section-loop.spec.ts
@@ -56,7 +56,9 @@ test.describe("Section Loop Controls", () => {
   let wsId: string;
 
   test.beforeEach(async ({ page }) => {
-    wsId = `section-loop-${++testCounter}-${Date.now()}`;
+    // The worker index keeps ids unique across parallel workers, whose
+    // per-worker counters can otherwise collide within the same millisecond.
+    wsId = `section-loop-${test.info().parallelIndex}-${++testCounter}-${Date.now()}`;
 
     await page.route("**/player.v1.PlayerService/**", async (route) => {
       await route.fulfill({

--- a/src/webui/svelte/e2e/tests/stage-view-interactions.spec.ts
+++ b/src/webui/svelte/e2e/tests/stage-view-interactions.spec.ts
@@ -30,7 +30,9 @@ test.describe("Stage View Interactions", () => {
   let wsId: string;
 
   test.beforeEach(async ({ page }) => {
-    wsId = `stage-${++testCounter}-${Date.now()}`;
+    // The worker index keeps ids unique across parallel workers, whose
+    // per-worker counters can otherwise collide within the same millisecond.
+    wsId = `stage-${test.info().parallelIndex}-${++testCounter}-${Date.now()}`;
     await page.goto(`/?wsId=${wsId}#/`);
     await expect(page.locator(".playback-card__title")).toContainText(
       "Test Song Alpha",

--- a/src/webui/svelte/e2e/tests/track-gain.spec.ts
+++ b/src/webui/svelte/e2e/tests/track-gain.spec.ts
@@ -33,7 +33,9 @@ test.describe("Track Gain Sliders", () => {
   let wsId: string;
 
   test.beforeEach(async ({ page }) => {
-    wsId = `gain-${++testCounter}-${Date.now()}`;
+    // The worker index keeps ids unique across parallel workers, whose
+    // per-worker counters can otherwise collide within the same millisecond.
+    wsId = `gain-${test.info().parallelIndex}-${++testCounter}-${Date.now()}`;
 
     // Stub the gRPC endpoint so gain changes succeed.
     await page.route("**/player.v1.PlayerService/**", async (route) => {


### PR DESCRIPTION
The Playwright mock server routes `/test/send-ws` messages by `wsId`, and specs build
that id as `` `<prefix>-${++testCounter}-${Date.now()}` ``. With `fullyParallel`
enabled, tests of the same file run in separate workers, each with its own
module-level counter starting at 1 - two tests starting in the same millisecond
produce the **same id**, and the mock server then routes one test's playback state to
another test's page.

This turns out to be a major source of the mock suite's long-standing flakiness
(`playback-flow.spec.ts` especially - the more tests a file has, the more likely a
same-millisecond start).

Fix: include `test.info().parallelIndex` in the id so ids are unique across workers.
Applied to the four specs using the pattern: `track-gain`, `playback-flow`,
`section-loop`, `stage-view-interactions`.

Before: `playback-flow.spec.ts` failed 1-4 (varying) tests in most local runs at
 4 workers. After: repeated runs of all four specs together are consistently green.
