### PR TITLE
feat(player): per-track mute; keep the active playlist on song jump

### DIFF
--- a/docs/src/interfaces/web-ui.md
+++ b/docs/src/interfaces/web-ui.md
@@ -74,7 +74,10 @@ The dashboard is the landing page, providing an at-a-glance view of the player s
   playlist's songs are listed below. Songs are clickable to jump directly to a song during
   playback.
 - **Waveform** — Per-track waveform peak display for the current song, rendered with DPR
-  scaling for crisp display on HiDPI/Retina screens.
+  scaling for crisp display on HiDPI/Retina screens. Each track row also has a gain slider
+  (double-click resets to 0 dB) and an **M** mute button. Muting silences the track
+  immediately without touching the fader value, so unmuting restores the exact gain you
+  had — mute state is runtime-only and resets on player restart.
 - **Stage view** — Interactive canvas showing fixture positions organized by tags (left, right,
   front, back), with real-time RGB color rendering, glow effects, and strobe animation. Drag
   fixtures to rearrange the layout — positions persist in localStorage across page reloads.

--- a/src/audio/track_gains.rs
+++ b/src/audio/track_gains.rs
@@ -18,7 +18,7 @@
 //! `f32` bit patterns in atomics so the callback can read them lock-free.
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use indexmap::IndexMap;
 use tracing::warn;
@@ -72,6 +72,9 @@ pub struct TrackGains {
     /// single atomic per slot, so concurrent setters can never leave the two
     /// representations desynced. The mixer hot path reads only the low half.
     gain_bits: Vec<AtomicU64>,
+    /// Per-slot mute flags. Kept separate from the gain so muting preserves
+    /// the fader value and is never persisted to the profile.
+    muted: Vec<AtomicBool>,
 }
 
 /// Packs a (dB, linear) gain pair into a single u64.
@@ -133,10 +136,12 @@ impl TrackGains {
             gain_bits.push(AtomicU64::new(pack_gain(db, db_to_linear(db))));
         }
 
+        let muted = names.iter().map(|_| AtomicBool::new(false)).collect();
         Self {
             slots,
             names,
             gain_bits,
+            muted,
         }
     }
 
@@ -171,9 +176,38 @@ impl TrackGains {
             .map(|slot| unpack_db(self.gain_bits[slot].load(Ordering::Relaxed)))
     }
 
-    /// Gets the linear multiplier for a slot. Hot path: single relaxed load.
+    /// Gets the linear multiplier for a slot, honoring the mute flag.
+    /// Hot path: two relaxed loads.
     pub fn linear(&self, slot: usize) -> f32 {
+        if self.muted[slot].load(Ordering::Relaxed) {
+            return 0.0;
+        }
         unpack_linear(self.gain_bits[slot].load(Ordering::Relaxed))
+    }
+
+    /// Mutes or unmutes a track without touching its gain, returning the
+    /// applied state. Mute state is runtime-only and never persisted.
+    pub fn set_muted(&self, track: &str, muted: bool) -> Result<bool, UnknownTrackError> {
+        let slot = self
+            .slot(track)
+            .ok_or_else(|| UnknownTrackError(track.to_string()))?;
+        self.muted[slot].store(muted, Ordering::Relaxed);
+        Ok(muted)
+    }
+
+    /// Gets the mute state of a track.
+    pub fn get_muted(&self, track: &str) -> Option<bool> {
+        self.slot(track)
+            .map(|slot| self.muted[slot].load(Ordering::Relaxed))
+    }
+
+    /// Snapshots all mute states as (name, muted) pairs in slot order.
+    pub fn snapshot_muted(&self) -> Vec<(String, bool)> {
+        self.names
+            .iter()
+            .enumerate()
+            .map(|(slot, name)| (name.clone(), self.muted[slot].load(Ordering::Relaxed)))
+            .collect()
     }
 
     /// Snapshots all gains as (name, dB) pairs in slot order.
@@ -219,6 +253,26 @@ mod tests {
         assert_eq!(db_to_linear(-60.0), 0.0);
         assert_eq!(db_to_linear(-80.0), 0.0);
         assert!((db_to_linear(6.0) - 1.9953).abs() < 0.001);
+    }
+
+    #[test]
+    fn mute_preserves_gain() {
+        let gains = TrackGains::from_config(&mappings(&["click"]), None);
+        let slot = gains.slot("click").unwrap();
+        gains.set_db("click", -6.0).unwrap();
+        assert!(gains.linear(slot) > 0.0);
+
+        assert!(gains.set_muted("click", true).unwrap());
+        assert_eq!(gains.linear(slot), 0.0);
+        assert_eq!(gains.get_muted("click"), Some(true));
+        // The fader value survives the mute...
+        assert_eq!(gains.get_db("click"), Some(-6.0));
+        // ...and persistence snapshots are unaffected by mute state.
+        assert_eq!(gains.snapshot_db_map().get("click"), Some(&-6.0));
+
+        assert!(!gains.set_muted("click", false).unwrap());
+        assert!(gains.linear(slot) > 0.0);
+        assert!(gains.set_muted("nope", true).is_err());
     }
 
     #[test]

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -27,11 +27,12 @@ use crate::{
         GetTrackGainsResponse, LoopSectionRequest, LoopSectionResponse, NextRequest, NextResponse,
         PlayFromRequest, PlayRequest, PlayResponse, PlaySongFromRequest, PreviousRequest,
         PreviousResponse, RemoveProfileRequest, SectionAckRequest, SectionAckResponse,
-        SetTrackGainRequest, SetTrackGainResponse, StatusRequest, StatusResponse, StopRequest,
-        StopResponse, StopSamplesRequest, StopSamplesResponse, StopSectionLoopRequest,
-        StopSectionLoopResponse, SwitchToPlaylistRequest, SwitchToPlaylistResponse, TrackGain,
-        UpdateAudioRequest, UpdateConfigResponse, UpdateControllersRequest, UpdateDmxRequest,
-        UpdateMidiRequest, UpdateProfileRequest, FILE_DESCRIPTOR_SET,
+        SetTrackGainRequest, SetTrackGainResponse, SetTrackMuteRequest, SetTrackMuteResponse,
+        StatusRequest, StatusResponse, StopRequest, StopResponse, StopSamplesRequest,
+        StopSamplesResponse, StopSectionLoopRequest, StopSectionLoopResponse,
+        SwitchToPlaylistRequest, SwitchToPlaylistResponse, TrackGain, UpdateAudioRequest,
+        UpdateConfigResponse, UpdateControllersRequest, UpdateDmxRequest, UpdateMidiRequest,
+        UpdateProfileRequest, FILE_DESCRIPTOR_SET,
     },
 };
 
@@ -535,16 +536,43 @@ impl PlayerService for PlayerServer {
         }))
     }
 
+    async fn set_track_mute(
+        &self,
+        request: Request<SetTrackMuteRequest>,
+    ) -> Result<Response<SetTrackMuteResponse>, Status> {
+        let req = request.into_inner();
+        let muted = self
+            .player
+            .set_track_mute(&req.track, req.muted)
+            .map_err(|e| match e {
+                crate::player::TrackGainError::NoAudioProfile => {
+                    Status::failed_precondition(e.to_string())
+                }
+                crate::player::TrackGainError::NonFinite(_)
+                | crate::player::TrackGainError::UnknownTrack(_) => {
+                    Status::invalid_argument(e.to_string())
+                }
+            })?;
+        Ok(Response::new(SetTrackMuteResponse { muted }))
+    }
+
     async fn get_track_gains(
         &self,
         _: Request<GetTrackGainsRequest>,
     ) -> Result<Response<GetTrackGainsResponse>, Status> {
+        let mutes: std::collections::HashMap<String, bool> = self
+            .player
+            .get_track_mutes()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
         let gains = self
             .player
             .get_track_gains()
             .unwrap_or_default()
             .into_iter()
             .map(|(track, gain_db)| TrackGain {
+                muted: mutes.get(&track).copied().unwrap_or(false),
                 track,
                 gain_db: gain_db as f64,
             })

--- a/src/player.rs
+++ b/src/player.rs
@@ -2537,8 +2537,55 @@ mod test {
         assert_eq!(result.unwrap().name(), "Song 2");
         eventually(|| device.is_playing(), "Song never started playing");
 
-        // Switches to all_songs (session-only) for the duration of playback
+        // Song 2 is not in the active playlist, so this switches to
+        // all_songs (session-only) for the duration of playback.
         assert_eq!(player.get_playlist().name(), "all_songs");
+
+        player.stop().await;
+        eventually(|| !device.is_playing(), "Song never stopped");
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn play_song_from_keeps_active_playlist() -> Result<(), Box<dyn Error>> {
+        let songs = songs::get_all_songs(Path::new("assets/songs"))?;
+        let playlist = Playlist::new(
+            "playlist",
+            &config::Playlist::deserialize(Path::new("assets/playlist.yaml"))?,
+            songs.clone(),
+        )?;
+        let player = Player::new(
+            test_playlists(playlist, songs.clone()),
+            "playlist".to_string(),
+            &config::Player::new(
+                vec![],
+                Some(config::Audio::new("mock-device")),
+                Some(config::Midi::new("mock-midi-device", None)),
+                None,
+                HashMap::new(),
+                "assets/songs",
+            ),
+            None,
+        )?;
+        player.await_hardware_ready().await;
+        let device = player.audio_device().expect("audio device").to_mock()?;
+
+        // Song 3 is in the active playlist: jumping to it must not switch
+        // the player to all_songs.
+        let result = player
+            .play_song_from("Song 3", std::time::Duration::ZERO)
+            .await?;
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name(), "Song 3");
+        eventually(|| device.is_playing(), "Song never started playing");
+        assert_eq!(player.get_playlist().name(), "playlist");
+        assert_eq!(
+            player
+                .get_playlist()
+                .current()
+                .map(|s| s.name().to_string()),
+            Some("Song 3".to_string())
+        );
 
         player.stop().await;
         eventually(|| !device.is_playing(), "Song never stopped");

--- a/src/player.rs
+++ b/src/player.rs
@@ -749,6 +749,31 @@ impl Player {
             .map(|tg| tg.snapshot_db())
     }
 
+    /// Mutes or unmutes an output track without changing its gain, returning
+    /// the applied state. Mute is a runtime performance control and is never
+    /// persisted — a restart starts unmuted.
+    pub fn set_track_mute(&self, track: &str, muted: bool) -> Result<bool, TrackGainError> {
+        let track_gains = self
+            .hardware
+            .read()
+            .track_gains
+            .clone()
+            .ok_or(TrackGainError::NoAudioProfile)?;
+        let applied = track_gains.set_muted(track, muted)?;
+        info!(track, muted = applied, "track mute changed");
+        Ok(applied)
+    }
+
+    /// Returns all output track mute states as (name, muted) pairs, or None
+    /// when no audio profile is active.
+    pub fn get_track_mutes(&self) -> Option<Vec<(String, bool)>> {
+        self.hardware
+            .read()
+            .track_gains
+            .as_ref()
+            .map(|tg| tg.snapshot_muted())
+    }
+
     /// Returns true if the player is in locked mode (state-altering operations blocked).
     pub fn is_locked(&self) -> bool {
         self.locked.load(Ordering::Relaxed)

--- a/src/player/navigation.rs
+++ b/src/player/navigation.rs
@@ -28,8 +28,10 @@ use super::{Player, PlaylistDirection};
 
 impl Player {
     /// Plays a specific song by name, starting from the given time.
-    /// Switches to the all_songs playlist (session-only, not persisted) and
-    /// navigates to the song before calling play_from.
+    /// If the song is in the active playlist, navigates to it there — jumping
+    /// to a song never kicks you out of the playlist you chose. Only songs
+    /// outside the active playlist switch to the all_songs playlist
+    /// (session-only, not persisted).
     /// Returns an error if the song is not found.
     pub async fn play_song_from(
         &self,
@@ -47,13 +49,15 @@ impl Player {
             return Ok(None);
         }
 
-        let all_songs = self
-            .get_all_songs_playlist()
-            .ok_or_else(|| -> Box<dyn Error> { "all_songs playlist not available".into() })?;
-        if all_songs.navigate_to(song_name).is_none() {
-            return Err(format!("Song '{}' not found", song_name).into());
+        if self.get_playlist().navigate_to(song_name).is_none() {
+            let all_songs = self
+                .get_all_songs_playlist()
+                .ok_or_else(|| -> Box<dyn Error> { "all_songs playlist not available".into() })?;
+            if all_songs.navigate_to(song_name).is_none() {
+                return Err(format!("Song '{}' not found", song_name).into());
+            }
+            *self.active_playlist.write() = "all_songs".to_string();
         }
-        *self.active_playlist.write() = "all_songs".to_string();
 
         // Start playback with the lock already held.
         self.play_from_locked(start_time, &mut join).await

--- a/src/proto/player/v1/player.proto
+++ b/src/proto/player/v1/player.proto
@@ -277,6 +277,8 @@ message TrackGain {
     string track = 1;
     // The gain in dB, in [-60, +12]. -60 and below mutes the track.
     double gain_db = 2;
+    // Whether the track is currently muted (independently of the gain).
+    bool muted = 3;
 }
 
 // SetTrackGainRequest sets the gain of a single output track.
@@ -292,6 +294,21 @@ message SetTrackGainRequest {
 message SetTrackGainResponse {
     // The applied gain in dB after clamping.
     double applied_gain_db = 1;
+}
+
+// SetTrackMuteRequest mutes or unmutes a single output track without
+// changing its gain. Mute state is runtime-only and never persisted.
+message SetTrackMuteRequest {
+    // The output track name (a track_mappings key).
+    string track = 1;
+    // True to mute, false to unmute.
+    bool muted = 2;
+}
+
+// SetTrackMuteResponse is returned after setting a track mute.
+message SetTrackMuteResponse {
+    // The applied mute state.
+    bool muted = 1;
 }
 
 // GetTrackGainsRequest requests the gains of all output tracks.
@@ -377,6 +394,10 @@ service PlayerService {
 
     // SetTrackGain sets the gain of a single output track in dB.
     rpc SetTrackGain(SetTrackGainRequest) returns (SetTrackGainResponse);
+
+    // SetTrackMute mutes or unmutes an output track without changing its
+    // gain. Mute state is runtime-only and never persisted.
+    rpc SetTrackMute(SetTrackMuteRequest) returns (SetTrackMuteResponse);
 
     // GetTrackGains returns the gains of all output tracks in dB.
     rpc GetTrackGains(GetTrackGainsRequest) returns (GetTrackGainsResponse);

--- a/src/webui/state.rs
+++ b/src/webui/state.rs
@@ -72,6 +72,10 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
                     .get_track_gains()
                     .map(|gains| gains.into_iter().collect())
                     .unwrap_or_default();
+                let track_mutes: std::collections::HashMap<String, bool> = player
+                    .get_track_mutes()
+                    .map(|mutes| mutes.into_iter().collect())
+                    .unwrap_or_default();
                 let tracks: Vec<serde_json::Value> = current_song
                     .tracks()
                     .iter()
@@ -85,6 +89,7 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
                             "name": t.name(),
                             "output_channels": output_channels,
                             "gain_db": track_gains.get(t.name()).copied().unwrap_or(0.0),
+                            "muted": track_mutes.get(t.name()).copied().unwrap_or(false),
                         })
                     })
                     .collect();

--- a/src/webui/svelte/e2e/tests/track-gain.spec.ts
+++ b/src/webui/svelte/e2e/tests/track-gain.spec.ts
@@ -90,6 +90,33 @@ test.describe("Track Gain Sliders", () => {
     await expect(dashboard.gainReadouts.nth(1)).toHaveText("0.0 dB");
   });
 
+  test("mute button fires SetTrackMute and lights up from server state", async ({
+    page,
+  }) => {
+    const muteButtons = page.locator(".tracks-card__mute");
+    await expect(muteButtons).toHaveCount(3);
+    await expect(muteButtons.nth(0)).toHaveAttribute("aria-pressed", "false");
+
+    const requestPromise = page.waitForRequest((req) =>
+      req.url().includes("/player.v1.PlayerService/SetTrackMute"),
+    );
+    await muteButtons.nth(0).click();
+    await requestPromise;
+
+    // Mute state is server-authoritative: the button reflects the next
+    // WS frame, and the gain readout is untouched.
+    await sendWsMessage(page, wsId, {
+      ...PLAYBACK_STATE,
+      tracks: [
+        { name: "kick", output_channels: [0, 1], gain_db: 0, muted: true },
+        { name: "snare", output_channels: [2, 3], gain_db: -6 },
+        { name: "bass", output_channels: [4, 5], gain_db: -60 },
+      ],
+    });
+    await expect(muteButtons.nth(0)).toHaveAttribute("aria-pressed", "true");
+    await expect(dashboard.gainReadouts.nth(0)).toHaveText("0.0 dB");
+  });
+
   test("server-pushed gain updates the slider when idle", async ({ page }) => {
     await sendWsMessage(page, wsId, {
       ...PLAYBACK_STATE,

--- a/src/webui/svelte/src/components/cards/TracksCard.svelte
+++ b/src/webui/svelte/src/components/cards/TracksCard.svelte
@@ -16,7 +16,11 @@
   import { playbackStore, waveformStore } from "../../lib/ws/stores";
   import type { TrackInfo } from "../../lib/ws/stores";
   import GainSlider from "../GainSlider.svelte";
-  import { sendTrackGain, sendTrackGainThrottled } from "../../lib/gain";
+  import {
+    sendTrackGain,
+    sendTrackGainThrottled,
+    sendTrackMute,
+  } from "../../lib/gain";
   import { t } from "svelte-i18n";
   import { get } from "svelte/store";
 
@@ -120,8 +124,22 @@
   {:else}
     <div class="tracks-card__list">
       {#each $playbackStore.tracks as track, i (`${i}:${track.name}`)}
-        <div class="tracks-card__row">
+        <div
+          class="tracks-card__row"
+          class:tracks-card__row--muted={track.muted}
+        >
           <div class="tracks-card__main">
+            <button
+              class="tracks-card__mute mono"
+              class:tracks-card__mute--active={track.muted}
+              title={track.muted
+                ? $t("tracks.unmute", { values: { name: track.name } })
+                : $t("tracks.mute", { values: { name: track.name } })}
+              aria-pressed={track.muted ?? false}
+              onclick={() => sendTrackMute(track.name, !track.muted)}
+            >
+              M
+            </button>
             <div class="tracks-card__info">
               <div class="tracks-card__name">{track.name}</div>
               <div
@@ -196,6 +214,31 @@
     display: flex;
     align-items: center;
     gap: 12px;
+  }
+  .tracks-card__mute {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--card-border);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--nc-fg-3);
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    line-height: 1;
+  }
+  .tracks-card__mute--active {
+    background: var(--nc-pink-600);
+    border-color: var(--nc-pink-600);
+    color: #fff;
+  }
+  :global(.nc--dark) .tracks-card__mute--active {
+    background: var(--nc-pink-500);
+    border-color: var(--nc-pink-500);
+  }
+  .tracks-card__row--muted .tracks-card__waveform {
+    opacity: 0.35;
   }
   .tracks-card__info {
     flex: 0 0 132px;

--- a/src/webui/svelte/src/lib/gain.ts
+++ b/src/webui/svelte/src/lib/gain.ts
@@ -48,6 +48,18 @@ export async function sendTrackGain(
   }
 }
 
+/** Mutes or unmutes a track without touching its gain value. */
+export async function sendTrackMute(
+  track: string,
+  muted: boolean,
+): Promise<void> {
+  try {
+    await playerClient.setTrackMute({ track, muted });
+  } catch (e) {
+    console.error(`Failed to set mute for track "${track}":`, e);
+  }
+}
+
 /**
  * Trailing-throttled gain send for use while dragging, keyed per track so
  * concurrent sliders never starve each other. The final value should be

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -88,6 +88,8 @@
   "tracks.noTracks": "No tracks",
   "tracks.unmapped": "(unmapped)",
   "tracks.gainFor": "Gain for {name}",
+  "tracks.mute": "Mute {name}",
+  "tracks.unmute": "Unmute {name}",
   "tracks.gainReset": "Reset gain to 0 dB",
   "effects.title": "Active Effects",
   "effects.noEffects": "No active effects",

--- a/src/webui/svelte/src/lib/ws/stores.ts
+++ b/src/webui/svelte/src/lib/ws/stores.ts
@@ -22,6 +22,9 @@ export interface TrackInfo {
   output_channels: number[];
   /** Output track gain in dB; absent on older backends (treat as 0). */
   gain_db?: number;
+  /** Whether the track is muted (independently of the gain); absent on
+   * older backends (treat as false). */
+  muted?: boolean;
 }
 
 export interface BeatGrid {


### PR DESCRIPTION
**Commit 1 - per-track mute.** A runtime-only mute flag next to the gain slots:

 - `TrackGains` gains `set_muted`/`snapshot_muted`; muting silences the track in the
    mixer without touching the fader value or the persisted gains, and resets on restart
   (a restart always starts unmuted - intentional for live safety).
 - New `SetTrackMute` RPC (proto + gRPC service), `muted` flag on WS track frames, and
   an **M** button per track row in the web UI next to the gain slider.
 - Playwright coverage in `track-gain.spec.ts`; docs updated (web-ui.md).

 **Commit 2 - playlist navigation fix.** `play_song_from` now navigates within the
 active playlist when the requested song is a member, and only falls back to the
 session-only `all_songs` playlist for songs outside it. Clicking a song on the
 dashboard no longer resets the selected playlist. Covered by a new
 `play_song_from_keeps_active_playlist` test; the existing fallback behavior keeps its
 test.
