### PR TITLE
release: 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-20
+
+### Added
+
+- **Per-track mute**: each output track can now be muted live without touching its fader
+  value or persisted gain. Mute is a runtime-only flag — it silences the track in the mixer
+  and resets on restart — exposed as a `SetTrackMute` gRPC call, a `muted` flag on the web UI
+  track frames, and an `M` button per track row in the Tracks card.
+
+### Changed
+
+- **Jumping to a song keeps the active playlist**: clicking a song in the dashboard now
+  navigates within the active playlist when the song is one of its members, only falling back
+  to the session-only all-songs playlist for songs outside it. Previously any song jump reset
+  the selected playlist.
+
+### Fixed
+
+- **Single-source dropouts are now visible in the logs**: a decode or read error ends just
+  that one source while the rest of the mix continues (by design), but every path was silent
+  at the default log level, making a track that vanished mid-song impossible to diagnose after
+  the fact. Decode errors in the buffer-fill task and read errors in the mixer now warn.
+
 ## [0.14.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "mtrack"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mtrack"
 description = "A multitrack audio and MIDI player for live performances."
 license = "GPL-3.0"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Michael Wilson <mike@mdwn.dev>"]
 edition = "2021"
 repository = "https://github.com/mdwn/mtrack"


### PR DESCRIPTION
Cuts the 0.15.0 release: bumps the version (`Cargo.toml` / `Cargo.lock`) and adds the changelog section for the work since 0.14.0.

## Included since 0.14.0
- **Added** — per-track mute (#320)
- **Changed** — jumping to a song keeps the active playlist (#320)
- **Fixed** — single-source dropouts are now surfaced in the logs (#318)

The test-only e2e fix (#319) is intentionally omitted from the user-facing changelog.

## After merge
Push the `v0.15.0` tag to trigger `publish.yaml` (crates.io publish + GitHub release + binary builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)