### PR TITLE
 fix(player): don't stamp play_start_time for a cancelled playback

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -1269,6 +1269,26 @@ mod test {
         Ok(player)
     }
 
+    /// Waits until the player reports an elapsed position, and returns it.
+    ///
+    /// `play_start_time` is set inside `play_files` just after `clock.start()`,
+    /// while the mock device raises `is_playing` before it signals readiness — so
+    /// `elapsed()` can still be `None` for a moment after `is_playing` turns true.
+    /// Waiting for the mock device is not enough on a loaded machine.
+    async fn elapsed_eventually(player: &Arc<Player>) -> Result<Duration, Box<dyn Error>> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            if let Some(elapsed) = player.elapsed().await? {
+                return Ok(elapsed);
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "player never reported an elapsed position"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     /// Helper to create a player with the standard test assets (audio + MIDI).
     async fn make_test_player() -> Result<Arc<Player>, Box<dyn Error>> {
         make_test_player_with_config(
@@ -1329,20 +1349,7 @@ mod test {
 
         player.play().await?;
         eventually(|| device.is_playing(), "Song never started playing");
-
-        // play_start_time is set inside play_files after clock.start(),
-        // so there may be a brief gap after is_playing becomes true.
-        let deadline = std::time::Instant::now() + Duration::from_secs(3);
-        loop {
-            if player.elapsed().await?.is_some() {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "elapsed should have a value while playing"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        elapsed_eventually(&player).await?;
 
         player.stop().await;
         eventually(|| !device.is_playing(), "Song never stopped playing");
@@ -1612,7 +1619,7 @@ mod test {
         player.seek_to(Duration::from_millis(200)).await?;
         eventually(|| device.is_playing(), "Song never resumed after seek");
 
-        let elapsed = player.elapsed().await?.expect("elapsed after seek");
+        let elapsed = elapsed_eventually(&player).await?;
         assert!(
             elapsed >= Duration::from_millis(200),
             "elapsed after seek should be at least the seek target, got {:?}",
@@ -1641,7 +1648,7 @@ mod test {
         player.play().await?;
         eventually(|| device.is_playing(), "Song never started playing");
         assert!(player.pending_start().is_none());
-        let elapsed = player.elapsed().await?.expect("elapsed after play");
+        let elapsed = elapsed_eventually(&player).await?;
         assert!(
             elapsed >= Duration::from_millis(150),
             "elapsed should start at the pending position, got {:?}",

--- a/src/player/playback.rs
+++ b/src/player/playback.rs
@@ -408,9 +408,17 @@ impl Player {
         // Set play_start_time NOW, at the exact moment playback begins.
         // Offset backwards by start_time so elapsed() reflects song position.
         // We use blocking_lock because we're in a spawn_blocking context.
+        //
+        // Skip it if this playback was cancelled during startup: stop() and
+        // seek_to() clear play_start_time themselves (both cancel while holding
+        // this lock), so stamping it afterwards would leave a stale position
+        // behind — a seek would briefly report the pre-seek offset, and a stop
+        // would report a position while nothing is playing.
         {
             let mut pst = play_start_time.blocking_lock();
-            *pst = Some(SystemTime::now() - start_time);
+            if !cancel_handle.is_cancelled() {
+                *pst = Some(SystemTime::now() - start_time);
+            }
         }
 
         if let Some(audio_join_handle) = audio_join_handle {
@@ -460,12 +468,12 @@ impl Player {
         };
         info!(song = song.name(), "Stopping playback.");
 
-        play_handles.cancel.cancel();
-
         // Reset play start time — the cleanup task skips this when cancelled
-        // so we must do it here.
+        // so we must do it here. Cancel while holding the lock so a playback
+        // still in startup can't stamp play_start_time after we clear it.
         {
             let mut play_start_time = self.play_start_time.lock().await;
+            play_handles.cancel.cancel();
             *play_start_time = None;
         }
 

--- a/src/player/seek.rs
+++ b/src/player/seek.rs
@@ -63,10 +63,14 @@ impl Player {
         // Fade the audio to avoid a click, then cancel playback. The cleanup
         // task observes the cancellation and takes the StopCancelled path,
         // leaving player state to us.
+        // Cancel while holding the play_start_time lock: a playback still in
+        // startup stamps play_start_time under that lock and skips the stamp
+        // when cancelled, so this ordering keeps it from writing the pre-seek
+        // position back after we clear it.
         self.fade_out_current_audio();
-        handles.cancel.cancel();
         {
             let mut play_start_time = self.play_start_time.lock().await;
+            handles.cancel.cancel();
             *play_start_time = None;
         }
 


### PR DESCRIPTION
CI on my metronome branch hit this in `main`'s own suite:
  
  ```
  ---- player::test::test_seek_while_stopped_sets_pending_start stdout ----
  panicked at src/player.rs:1644:47: elapsed after play
  ```
  
  It reproduces on a clean `main`: running 16 copies of that single test in parallel
  fails ~12% of the time (15/128 runs), and 0/40 when the machine is idle — so it only
  surfaces on a loaded runner. `test_seek_while_playing_restarts_at_position` fails the
  same way at ~2% (4/160), with `elapsed` coming back as ~250µs after a 200ms seek. 
  
  ### Commit 1 — the player bug
  
  `play_files` stamps `play_start_time` just after the readiness barrier and
  `clock.start()`, while `stop()` and `seek_to()` clear it from the outside. A playback
  cancelled *during startup* still reached the stamp and wrote it back after the clear,
  so for a moment:
  
  - after a seek, `elapsed()` reports the **pre-seek** position (~0 instead of the seek
    target) — a playhead that jumps back for a frame in the web UI, and
    `loop_section`'s "playback has already passed the section end" check reads the same
    value;
  - after a stop, `elapsed()` can report a position while nothing is playing.
  
  `play_files` now skips the stamp if its playback is already cancelled, and
  `stop()`/`seek_to()` cancel while holding the `play_start_time` lock, so the check
  can't interleave with the clear.
  
  I confirmed the restart itself was never wrong by recording the `start_time` each
  `play_from` received: `[0, 200]` on the failing runs, exactly as expected. Only the
  bookkeeping was stale.
  
  ### Commit 2 — the test bug
  
  The mock audio device raises `is_playing` *before* it signals readiness, so
  `play_start_time` can still be `None` right after `eventually(|| device.is_playing())`
  returns — which is the CI failure above. `test_elapsed_while_playing` already polled
  around this gap; that loop is now a shared `elapsed_eventually()` helper used by both
  seek tests as well.
 
 ### Verification
  
  192 parallel runs of both seek tests on this branch: 0 failures (against 15/128 and
  4/160 on unpatched `main`). Full `cargo test --all-features` green; clippy warning
  count unchanged.
