### PR TITLE
fix(lighting): route static and chase levels through the virtual dimmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`static` no longer discards its level on fixtures without a dimmer channel**: the level was
+  passed through only when its name matched a real DMX channel, so on an RGB-only fixture (an
+  Astera PixelBrick, say) both `intensity:` and `dimmer:` were dropped and the colour rendered
+  at full — with no error and nothing in the logs. The level now routes through the fixture
+  profile, landing on the dedicated dimmer where one exists and on the RGB multiplier where it
+  doesn't, so an authored intensity ladder survives the venue. `intensity` is also now accepted
+  as a synonym for `dimmer` on `static`, as the reference documents.
+
+- **`chase` modulates instead of overwriting on fixtures without a dimmer channel**: a chase on
+  an RGB-only fixture wrote its value straight into red, green and blue, so the chase value
+  *became* the colour — always white — and every fixture off the chase was driven to zero,
+  wiping the layer beneath. It now goes to a chase multiplier the same way it already used the
+  dimmer channel on dimmer-equipped fixtures, making it a moving brightness mask over whatever
+  colour the lower layers provide. The same show now looks the same in both venues.
+
+  Note for show authors: a chase supplies brightness, not colour, so a chase with nothing
+  underneath it renders dark rather than white. Put a colour bed on a lower layer.
+
 ## [0.15.0] - 2026-07-20
 
 ### Added

--- a/docs/src/lighting/effects.md
+++ b/docs/src/lighting/effects.md
@@ -10,9 +10,13 @@ Sets fixed parameter values for fixtures. Useful for solid colors, fixed dimmer 
 
 **Parameters:**
 - `color`: Color name (e.g., `"red"`, `"blue"`), hex (`#FF0000`), or RGB (`rgb(255,0,0)`)
-- `dimmer`: Dimmer level (0-100% or 0.0-1.0)
+- `dimmer` or `intensity`: Dimmer level (0-100% or 0.0-1.0)
 - `red`, `green`, `blue`, `white`: Individual color channel levels (0-100% or 0.0-1.0)
 - `duration`: **Required.** Duration after which effect stops (e.g., `5s`, `2measures`)
+
+The level applies on every fixture, not just those with a dimmer channel. On a
+fixture with a dedicated dimmer it drives that channel; on an RGB-only fixture it
+scales the color instead, so the same show dims the same way in either venue.
 
 **Example:**
 ```light
@@ -62,10 +66,15 @@ all_lights: strobe frequency: 1beat, duration: 4measures
 Smoothly pulses the dimmer level up and down, creating a breathing effect.
 
 **Parameters:**
-- `base_level`: Base dimmer level (0-100% or 0.0-1.0)
+- `base_level`: Base dimmer level (0-100% or 0.0-1.0). Defaults to 50%
 - `pulse_amplitude` or `intensity`: Amplitude of the pulse (0-100% or 0.0-1.0)
 - `frequency`: Pulses per second (Hz), or tempo-aware (e.g., `2`, `1beat`)
 - `duration`: **Required.** Duration of the pulse effect
+
+The amplitude is added *on top of* the base level: the pulse sweeps
+`base_level` to `base_level + amplitude`, it does not modulate around the level
+underneath. So `pulse intensity: 16%` with the default base level sweeps 50% to 66%,
+not ±16%. Set `base_level` explicitly to place the pulse where you want it.
 
 **Example:**
 ```light
@@ -84,10 +93,16 @@ Moves an effect pattern across multiple fixtures in a spatial pattern.
 - `transition`: `snap` or `fade` for transitions between fixtures
 - `duration`: **Required.** Duration of the chase effect (e.g., `10s`, `8measures`)
 
+A chase is a moving brightness mask, not a color. It dims the fixtures it is not
+currently on and passes through the ones it is, so the color comes from a lower
+layer — put a bed underneath it rather than expecting the chase to light the rig by
+itself.
+
 **Example:**
 ```light
 @00:25.000
-movers: chase pattern: linear, speed: 2.0, direction: left_to_right, transition: fade, duration: 10s
+movers: static color: "red", duration: 10s, layer: background
+movers: chase pattern: linear, speed: 2.0, direction: left_to_right, transition: fade, duration: 10s, layer: midground
 ```
 
 ### Dimmer Effect

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -33,11 +33,11 @@ show "Optional Name" {
 
 | Effect    | Required params                                        | Notes |
 |-----------|--------------------------------------------------------|-------|
-| `static`  | `duration`                                             | Hold a color/intensity. Use `color`, `dimmer`. |
+| `static`  | `duration`                                             | Hold a color/intensity. Use `color`, and `intensity` or `dimmer` for the level. |
 | `cycle`   | one or more `color:`, `duration`                       | Iterates colors. Optional `speed`, `direction`. |
 | `strobe`  | `frequency`, `duration`                                | Hz strobe. Optional `intensity`. |
 | `pulse`   | `frequency`, `duration`                                | Sinusoidal pulse. Optional `intensity`. |
-| `chase`   | `speed`, `duration`                                    | Optional `direction`, `pattern: linear|snake|random`. |
+| `chase`   | `speed`, `duration`                                    | A moving brightness mask over the layers beneath — needs a color bed under it. Optional `direction`, `pattern: linear|snake|random`. |
 | `dimmer`  | `start_level`, `end_level`, `duration`                 | Linear ramp; `curve: linear` optional. |
 | `rainbow` | `duration`                                             | Hue sweep. Optional `speed`. |
 

--- a/src/lighting/effects.rs
+++ b/src/lighting/effects.rs
@@ -28,6 +28,7 @@ pub use color::Color;
 pub use error::EffectError;
 pub use fixture::{
     multiplier_key, FixtureCapabilities, FixtureInfo, FixtureProfile, StrobeStrategy,
+    MULTIPLIER_PREFIXES,
 };
 pub use instance::EffectInstance;
 pub use state::{is_multiplier_channel, ChannelState, DmxCommand, FixtureState};

--- a/src/lighting/effects/fixture.rs
+++ b/src/lighting/effects/fixture.rs
@@ -28,6 +28,14 @@ fn layer_suffix(layer: EffectLayer) -> &'static str {
     }
 }
 
+/// Prefixes of the internal per-layer multiplier channels.
+///
+/// Effects that scale brightness route their level through one of these on fixtures
+/// with no dedicated dimmer channel, so the level modulates whatever colour the
+/// layers beneath provide instead of overwriting RGB. Every prefix listed here must
+/// also be resolved by `state::effective_channel_value`.
+pub const MULTIPLIER_PREFIXES: [&str; 3] = ["dimmer", "pulse", "chase"];
+
 /// Build a multiplier channel key (e.g. "_dimmer_mult_bg", "_pulse_mult_fg")
 #[inline]
 pub fn multiplier_key(prefix: &str, layer: EffectLayer) -> String {
@@ -157,7 +165,7 @@ pub enum PulseStrategy {
 pub enum ChaseStrategy {
     /// Use dedicated dimmer channel (RGB+dimmer fixtures)
     DedicatedDimmer,
-    /// Use RGB channels directly (RGB-only fixtures)
+    /// Multiply RGB channels to preserve color (RGB-only fixtures)
     RgbChannels,
     /// Use brightness control (fallback)
     BrightnessControl,
@@ -421,27 +429,24 @@ impl FixtureProfile {
     }
 
     /// Apply chase control using the fixture's strategy
+    ///
+    /// A chase is a moving brightness mask, not a colour. On a fixture with no dimmer
+    /// channel the value goes to the chase multiplier rather than straight into RGB,
+    /// so the chase modulates the colour the layers beneath provide instead of
+    /// painting white over them and zeroing every inactive fixture.
     pub fn apply_chase(
         &self,
         chase_value: f64,
         layer: EffectLayer,
         blend_mode: BlendMode,
     ) -> HashMap<String, ChannelState> {
-        let mut result = HashMap::new();
-
-        match self.chase_strategy {
-            ChaseStrategy::DedicatedDimmer | ChaseStrategy::BrightnessControl => {
-                result.insert(
-                    "dimmer".to_string(),
-                    ChannelState::new(chase_value, layer, blend_mode),
-                );
-            }
-            ChaseStrategy::RgbChannels => {
-                insert_rgb(&mut result, chase_value, layer, blend_mode);
-            }
-        }
-
-        result
+        Self::apply_dimmer_or_multiplier(
+            self.chase_strategy != ChaseStrategy::RgbChannels,
+            "chase",
+            chase_value,
+            layer,
+            blend_mode,
+        )
     }
 }
 
@@ -887,12 +892,20 @@ mod tests {
     }
 
     #[test]
-    fn apply_chase_rgb_channels() {
+    fn apply_chase_rgb_uses_multiplier_not_rgb_channels() {
         let p = rgb_fixture().profile().clone();
         let result = p.apply_chase(0.5, EffectLayer::Foreground, BlendMode::Replace);
-        assert!(result.contains_key("red"));
-        assert!(result.contains_key("green"));
-        assert!(result.contains_key("blue"));
+
+        // A chase is a brightness mask. Writing it into RGB would make the chase value
+        // the colour (always white) and zero every inactive fixture on the layer.
+        assert!(!result.contains_key("red"));
+        assert!(!result.contains_key("green"));
+        assert!(!result.contains_key("blue"));
+
+        let key = multiplier_key("chase", EffectLayer::Foreground);
+        let state = result.get(&key).expect("chase multiplier");
+        assert_eq!(state.value, 0.5);
+        assert_eq!(state.blend_mode, BlendMode::Multiply);
     }
 
     // ── FixtureInfo accessors ────────────────────────────────────────

--- a/src/lighting/effects/state.rs
+++ b/src/lighting/effects/state.rs
@@ -14,14 +14,22 @@
 
 use std::collections::HashMap;
 
-use super::fixture::FixtureInfo;
+use super::fixture::{FixtureInfo, MULTIPLIER_PREFIXES};
 use super::types::{BlendMode, EffectLayer};
 
-/// Check if a channel name is a multiplier channel (dimmer or pulse)
+/// Check if a channel name is a multiplier channel (dimmer, pulse or chase)
 /// These are special internal channels used for RGB-only fixtures
 #[inline]
 pub fn is_multiplier_channel(channel_name: &str) -> bool {
-    channel_name.starts_with("_dimmer_mult") || channel_name.starts_with("_pulse_mult")
+    // Real channel names never start with an underscore, so this bails out
+    // immediately for the overwhelmingly common case.
+    let Some(rest) = channel_name.strip_prefix('_') else {
+        return false;
+    };
+    MULTIPLIER_PREFIXES.iter().any(|prefix| {
+        rest.strip_prefix(prefix)
+            .is_some_and(|tail| tail.starts_with("_mult"))
+    })
 }
 
 /// DMX command for sending to fixtures
@@ -157,8 +165,12 @@ impl FixtureState {
                 read("_dimmer_mult_bg") * read("_dimmer_mult_mid") * read("_dimmer_mult_fg");
             let pulse_mult =
                 read("_pulse_mult_bg") * read("_pulse_mult_mid") * read("_pulse_mult_fg");
-            let combined_multiplier = (dimmer_mult * pulse_mult).clamp(0.0, 1.0);
-            let fg_multiplier = (read("_dimmer_mult_fg") * read("_pulse_mult_fg")).clamp(0.0, 1.0);
+            let chase_mult =
+                read("_chase_mult_bg") * read("_chase_mult_mid") * read("_chase_mult_fg");
+            let combined_multiplier = (dimmer_mult * pulse_mult * chase_mult).clamp(0.0, 1.0);
+            let fg_multiplier =
+                (read("_dimmer_mult_fg") * read("_pulse_mult_fg") * read("_chase_mult_fg"))
+                    .clamp(0.0, 1.0);
 
             let effective_multiplier = if state.layer == EffectLayer::Foreground
                 && state.blend_mode == BlendMode::Replace
@@ -219,10 +231,67 @@ mod tests {
     }
 
     #[test]
+    fn is_multiplier_chase_fg() {
+        assert!(is_multiplier_channel("_chase_mult_fg"));
+    }
+
+    #[test]
     fn is_multiplier_regular_channel() {
         assert!(!is_multiplier_channel("red"));
         assert!(!is_multiplier_channel("dimmer"));
         assert!(!is_multiplier_channel("strobe"));
+    }
+
+    #[test]
+    fn is_multiplier_rejects_lookalikes() {
+        assert!(!is_multiplier_channel("_dimmer"));
+        assert!(!is_multiplier_channel("_chase_bg"));
+        assert!(!is_multiplier_channel("dimmer_mult_bg"));
+        assert!(!is_multiplier_channel("_unknown_mult_bg"));
+    }
+
+    #[test]
+    fn effective_value_with_chase_multiplier() {
+        let mut fs = FixtureState::new();
+        let red = ChannelState::new(1.0, EffectLayer::Background, BlendMode::Replace);
+        fs.set_channel("red".to_string(), red);
+        fs.set_channel(
+            "_chase_mult_mid".to_string(),
+            ChannelState::new(0.5, EffectLayer::Midground, BlendMode::Multiply),
+        );
+        assert!((fs.effective_channel_value("red", &red, false) - 0.5).abs() < 1e-9);
+    }
+
+    /// Dimmer, pulse and chase multipliers compose rather than clobbering each other,
+    /// so a chase over a dimmed bed lands at the product of the two.
+    #[test]
+    fn effective_value_composes_chase_with_dimmer() {
+        let mut fs = FixtureState::new();
+        let red = ChannelState::new(1.0, EffectLayer::Background, BlendMode::Replace);
+        fs.set_channel("red".to_string(), red);
+        fs.set_channel(
+            "_dimmer_mult_bg".to_string(),
+            ChannelState::new(0.5, EffectLayer::Background, BlendMode::Multiply),
+        );
+        fs.set_channel(
+            "_chase_mult_mid".to_string(),
+            ChannelState::new(0.4, EffectLayer::Midground, BlendMode::Multiply),
+        );
+        assert!((fs.effective_channel_value("red", &red, false) - 0.2).abs() < 1e-9);
+    }
+
+    /// Multiplier channels are internal — a fixture with a real dimmer channel gets
+    /// its level on that channel instead, so RGB must not be scaled twice.
+    #[test]
+    fn effective_value_ignores_multipliers_with_dedicated_dimmer() {
+        let mut fs = FixtureState::new();
+        let red = ChannelState::new(1.0, EffectLayer::Background, BlendMode::Replace);
+        fs.set_channel("red".to_string(), red);
+        fs.set_channel(
+            "_chase_mult_mid".to_string(),
+            ChannelState::new(0.5, EffectLayer::Midground, BlendMode::Multiply),
+        );
+        assert!((fs.effective_channel_value("red", &red, true) - 1.0).abs() < 1e-9);
     }
 
     // ── ChannelState::new ──────────────────────────────────────────

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -684,13 +684,16 @@ impl EffectEngine {
 
             if let Some(effect) = self.active_effects.remove(&effect_id) {
                 // Clean up per-layer multipliers for completed effects
-                let dimmer_key = multiplier_key("dimmer", effect.layer);
-                let pulse_key = multiplier_key("pulse", effect.layer);
+                let multiplier_keys: Vec<String> = MULTIPLIER_PREFIXES
+                    .iter()
+                    .map(|prefix| multiplier_key(prefix, effect.layer))
+                    .collect();
 
                 for fixture_name in &effect.target_fixtures {
                     if let Some(current_state) = current_fixture_states.get_mut(fixture_name) {
-                        current_state.channels.remove(&dimmer_key);
-                        current_state.channels.remove(&pulse_key);
+                        for key in &multiplier_keys {
+                            current_state.channels.remove(key);
+                        }
                     }
                 }
             }

--- a/src/lighting/engine/processing.rs
+++ b/src/lighting/engine/processing.rs
@@ -249,10 +249,16 @@ fn apply_static_effect(
     // Calculate crossfade multiplier
     let crossfade_multiplier = effect.calculate_crossfade_multiplier(elapsed);
 
+    // The level goes through the fixture profile rather than being matched against a
+    // channel name, so on a fixture with no dimmer channel it lands on the RGB
+    // multiplier instead of being dropped and rendering at full.
+    let level = parameters.get("dimmer").copied();
+
     let fixture_states =
-        build_fixture_states_with_info(fixture_registry, effect, |fixture, _profile| {
+        build_fixture_states_with_info(fixture_registry, effect, |fixture, profile| {
             let channels = parameters
                 .iter()
+                .filter(|(param_name, _)| param_name.as_str() != "dimmer")
                 .filter(|(param_name, _)| fixture.channels.contains_key(*param_name))
                 .map(|(param_name, value)| {
                     let faded_value = *value * crossfade_multiplier;
@@ -261,7 +267,19 @@ fn apply_static_effect(
                         ChannelState::new(faded_value, effect.layer, effect.blend_mode),
                     )
                 });
-            FixtureState::from_channels(channels)
+            let mut state = FixtureState::from_channels(channels);
+
+            if let Some(level) = level {
+                for (channel_name, channel_state) in profile.apply_brightness(
+                    level * crossfade_multiplier,
+                    effect.layer,
+                    effect.blend_mode,
+                ) {
+                    state.set_channel(channel_name, channel_state);
+                }
+            }
+
+            state
         });
 
     Ok(Some(fixture_states))

--- a/src/lighting/layering_tests/chase_tests.rs
+++ b/src/lighting/layering_tests/chase_tests.rs
@@ -503,11 +503,8 @@ fn test_chase_single_fixture() {
     let fixture_cmd = commands.iter().find(|cmd| cmd.channel == 1).unwrap();
     assert_eq!(fixture_cmd.value, 255); // Should be ON
 }
-#[test]
-fn test_chase_rgb_only_fixtures() {
-    let mut engine = EffectEngine::new();
-
-    // Create RGB-only fixtures
+/// Register three RGB-only fixtures (no dimmer channel) at addresses 1, 4 and 7.
+fn register_rgb_only_fixtures(engine: &mut EffectEngine) {
     for i in 1..=3 {
         let mut channels = HashMap::new();
         channels.insert("red".to_string(), 1);
@@ -525,8 +522,10 @@ fn test_chase_rgb_only_fixtures() {
         );
         engine.register_fixture(fixture);
     }
+}
 
-    let chase_effect = create_effect_with_layering(
+fn rgb_only_chase() -> EffectInstance {
+    create_effect_with_layering(
         "chase_rgb".to_string(),
         EffectType::Chase {
             pattern: ChasePattern::Linear,
@@ -540,31 +539,98 @@ fn test_chase_rgb_only_fixtures() {
             "rgb_fixture_2".to_string(),
             "rgb_fixture_3".to_string(),
         ],
+        EffectLayer::Midground,
+        BlendMode::Replace,
+    )
+}
+
+/// A chase on a fixture with no dimmer channel must not write colour. It is a
+/// brightness mask, so on its own — with no colour bed underneath — it emits nothing
+/// rather than painting white. Regression test for #345.
+#[test]
+fn test_chase_rgb_only_fixtures_emit_no_color_of_their_own() {
+    let mut engine = EffectEngine::new();
+    register_rgb_only_fixtures(&mut engine);
+    engine.start_effect(rgb_only_chase()).unwrap();
+
+    let commands = engine.update(Duration::from_millis(0), None).unwrap();
+
+    // The chase multiplier is an internal channel with no DMX mapping, so a bare
+    // chase over RGB-only fixtures produces no output at all.
+    assert!(
+        commands.iter().all(|cmd| cmd.value == 0),
+        "chase alone should not light RGB-only fixtures, got {:?}",
+        commands
+            .iter()
+            .filter(|cmd| cmd.value > 0)
+            .map(|cmd| (cmd.channel, cmd.value))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// With a colour bed underneath, the chase modulates that colour instead of
+/// replacing it: the active fixture shows the bed's colour, not white. Regression
+/// test for #345.
+#[test]
+fn test_chase_rgb_only_fixtures_modulate_the_layer_beneath() {
+    let mut engine = EffectEngine::new();
+    register_rgb_only_fixtures(&mut engine);
+
+    // A red bed on the background layer, under the chase on midground.
+    let mut parameters = HashMap::new();
+    parameters.insert("red".to_string(), 1.0);
+    parameters.insert("green".to_string(), 0.0);
+    parameters.insert("blue".to_string(), 0.0);
+    let bed = create_effect_with_layering(
+        "red_bed".to_string(),
+        EffectType::Static {
+            parameters,
+            duration: Duration::from_secs(10),
+        },
+        vec![
+            "rgb_fixture_1".to_string(),
+            "rgb_fixture_2".to_string(),
+            "rgb_fixture_3".to_string(),
+        ],
         EffectLayer::Background,
         BlendMode::Replace,
     );
 
-    engine.start_effect(chase_effect).unwrap();
+    engine.start_effect(bed).unwrap();
+    engine.start_effect(rgb_only_chase()).unwrap();
 
-    // Test that RGB channels are used for chase (white chase)
+    // t=0: fixture_1 is the active chase position.
     let commands = engine.update(Duration::from_millis(0), None).unwrap();
+    let value_at = |channel: u16| {
+        commands
+            .iter()
+            .find(|cmd| cmd.channel == channel)
+            .map(|cmd| cmd.value)
+            .unwrap_or(0)
+    };
 
-    // fixture_1 should have all RGB channels ON
-    let red_cmd = commands.iter().find(|cmd| cmd.channel == 1).unwrap();
-    let green_cmd = commands.iter().find(|cmd| cmd.channel == 2).unwrap();
-    let blue_cmd = commands.iter().find(|cmd| cmd.channel == 3).unwrap();
-    assert_eq!(red_cmd.value, 255);
-    assert_eq!(green_cmd.value, 255);
-    assert_eq!(blue_cmd.value, 255);
+    // The chase renders the bed's red, not white — green and blue stay dark.
+    assert_eq!(value_at(1), 255, "fixture_1 red should be at full");
+    assert_eq!(value_at(2), 0, "chase must not add green");
+    assert_eq!(value_at(3), 0, "chase must not add blue");
 
-    // At t=167ms (1/3 cycle) - fixture_2 should be ON
+    // Inactive fixtures are masked to black by the chase multiplier.
+    assert_eq!(value_at(4), 0, "fixture_2 is not the active chase position");
+    assert_eq!(value_at(7), 0, "fixture_3 is not the active chase position");
+
+    // At t=167ms (1/3 cycle) the mask has moved to fixture_2, still red.
     let commands = engine.update(Duration::from_millis(167), None).unwrap();
-    let red_cmd = commands.iter().find(|cmd| cmd.channel == 4).unwrap(); // fixture_2 red
-    let green_cmd = commands.iter().find(|cmd| cmd.channel == 5).unwrap(); // fixture_2 green
-    let blue_cmd = commands.iter().find(|cmd| cmd.channel == 6).unwrap(); // fixture_2 blue
-    assert_eq!(red_cmd.value, 255);
-    assert_eq!(green_cmd.value, 255);
-    assert_eq!(blue_cmd.value, 255);
+    let value_at = |channel: u16| {
+        commands
+            .iter()
+            .find(|cmd| cmd.channel == channel)
+            .map(|cmd| cmd.value)
+            .unwrap_or(0)
+    };
+    assert_eq!(value_at(4), 255, "fixture_2 red should be at full");
+    assert_eq!(value_at(5), 0, "chase must not add green");
+    assert_eq!(value_at(6), 0, "chase must not add blue");
+    assert_eq!(value_at(1), 0, "fixture_1 is no longer the active position");
 }
 #[test]
 fn test_chase_effect_crossfade() {
@@ -684,9 +750,27 @@ fn test_random_chase_pattern_visibility() {
         Some(Duration::from_secs(4)), // hold_time: 4 seconds
         None,
     );
-    random_chase.layer = EffectLayer::Background;
+    random_chase.layer = EffectLayer::Midground;
     random_chase.blend_mode = BlendMode::Replace;
 
+    // A chase modulates the colour beneath it rather than supplying its own (#345),
+    // so the visibility this test measures needs a bed on a lower layer.
+    let mut parameters = HashMap::new();
+    parameters.insert("red".to_string(), 1.0);
+    parameters.insert("green".to_string(), 1.0);
+    parameters.insert("blue".to_string(), 1.0);
+    let bed = create_effect_with_layering(
+        "white_bed".to_string(),
+        EffectType::Static {
+            parameters,
+            duration: Duration::from_secs(10),
+        },
+        (1..=8).map(|i| format!("Brick{}", i)).collect(),
+        EffectLayer::Background,
+        BlendMode::Replace,
+    );
+
+    engine.start_effect(bed).unwrap();
     engine.start_effect(random_chase).unwrap();
 
     // Update engine and check that we get DMX commands

--- a/src/lighting/layering_tests/dimmer_tests.rs
+++ b/src/lighting/layering_tests/dimmer_tests.rs
@@ -1028,20 +1028,12 @@ fn test_chase_effect_without_dimmer_channel() {
     // Update engine to generate commands
     let commands = engine.update(Duration::from_millis(100), None).unwrap();
 
-    // Should have RGB commands (not dimmer commands)
-    let red_cmd = commands.iter().find(|cmd| cmd.channel == 1);
-    let green_cmd = commands.iter().find(|cmd| cmd.channel == 2);
-    let blue_cmd = commands.iter().find(|cmd| cmd.channel == 3);
-
-    assert!(red_cmd.is_some(), "Should have red channel command");
-    assert!(green_cmd.is_some(), "Should have green channel command");
-    assert!(blue_cmd.is_some(), "Should have blue channel command");
-
-    // All RGB channels should have the same value (white chase)
-    if let (Some(red), Some(green), Some(blue)) = (red_cmd, green_cmd, blue_cmd) {
-        assert_eq!(red.value, green.value);
-        assert_eq!(green.value, blue.value);
-    }
+    // The chase routes through the chase multiplier rather than writing RGB directly
+    // (#345), so on its own it contributes no colour — it masks whatever is beneath.
+    assert!(
+        commands.iter().all(|cmd| cmd.value == 0),
+        "chase on an RGB-only fixture should not paint colour of its own"
+    );
 }
 #[test]
 fn test_chase_effect_with_dimmer_channel() {

--- a/src/lighting/layering_tests/integration_tests.rs
+++ b/src/lighting/layering_tests/integration_tests.rs
@@ -1834,3 +1834,74 @@ fn test_example_files_parse() {
         );
     }
 }
+
+/// End-to-end reproduction of the show that surfaced #345 and #346: a red bed with
+/// an authored intensity, plus a chase over the top, on Astera PixelBricks (RGB +
+/// strobe, no dimmer channel).
+///
+/// Before the fix the bed rendered at full because `intensity:` was discarded, and
+/// the chase painted white over it because it wrote RGB directly. This drives the
+/// real parser so both the DSL spelling and the render path are covered.
+#[test]
+fn test_bed_plus_chase_on_dimmerless_fixtures() {
+    use super::super::parser::parse_light_shows;
+    use super::super::timeline::LightingTimeline;
+
+    // Note the doubled hashes: the colour literal contains `"#`.
+    let dsl_content = r##"show "Legions" {
+    @00:00.000
+    all_wash: static color: "#C40000", intensity: 45%, duration: 7s, layer: background
+    all_wash: chase pattern: linear, speed: 2.0, direction: left_to_right, duration: 7s, layer: midground
+}"##;
+
+    let shows = parse_light_shows(dsl_content).expect("show should parse");
+    let show = shows.get("Legions").expect("show by name");
+
+    let mut engine = EffectEngine::new();
+    for i in 1..=2 {
+        let mut channels = HashMap::new();
+        channels.insert("red".to_string(), 1);
+        channels.insert("green".to_string(), 2);
+        channels.insert("blue".to_string(), 3);
+        channels.insert("strobe".to_string(), 4);
+        engine.register_fixture(FixtureInfo::new(
+            format!("Brick{}", i),
+            1,
+            (i - 1) * 4 + 1,
+            "Astera-PixelBrick".to_string(),
+            channels,
+            Some(25.0),
+        ));
+    }
+
+    // The DSL targets the "all_wash" group; retarget onto the registered fixtures.
+    for cue in &show.cues {
+        for effect in &cue.effects {
+            let mut instance = LightingTimeline::create_effect_instance(effect, cue.time);
+            instance.target_fixtures = vec!["Brick1".to_string(), "Brick2".to_string()];
+            engine.start_effect(instance).unwrap();
+        }
+    }
+
+    let commands = engine.update(Duration::from_millis(0), None).unwrap();
+    let value_at = |channel: u16| {
+        commands
+            .iter()
+            .find(|cmd| cmd.channel == channel)
+            .map(|cmd| cmd.value)
+            .unwrap_or(0)
+    };
+
+    // Brick1 is the active chase position, so it shows the bed's colour at the
+    // authored level: red 0xC4 (196) scaled to 45% is 88.
+    assert_eq!(
+        value_at(1),
+        88,
+        "active fixture should render the red bed at 45%, not full and not white"
+    );
+    assert_eq!(value_at(2), 0, "chase must not add green");
+    assert_eq!(value_at(3), 0, "chase must not add blue");
+
+    // Brick2 is masked off by the chase.
+    assert_eq!(value_at(5), 0, "inactive fixture should be dark");
+}

--- a/src/lighting/layering_tests/static_effect_tests.rs
+++ b/src/lighting/layering_tests/static_effect_tests.rs
@@ -803,3 +803,128 @@ fn test_static_effect_fade_out() {
 
     println!("✅ Static effect fade-out test completed");
 }
+
+/// Build an Astera-PixelBrick-style fixture: RGB plus strobe, no dimmer channel.
+fn dimmerless_rgb_fixture(name: &str, address: u16) -> FixtureInfo {
+    let mut channels = HashMap::new();
+    channels.insert("red".to_string(), 1);
+    channels.insert("green".to_string(), 2);
+    channels.insert("blue".to_string(), 3);
+    channels.insert("strobe".to_string(), 4);
+
+    FixtureInfo::new(
+        name.to_string(),
+        1,
+        address,
+        "Astera-PixelBrick".to_string(),
+        channels,
+        Some(20.0),
+    )
+}
+
+fn static_with_level(level: f64, green: f64) -> EffectInstance {
+    let mut parameters = HashMap::new();
+    parameters.insert("red".to_string(), 0.0);
+    parameters.insert("green".to_string(), green);
+    parameters.insert("blue".to_string(), 0.0);
+    parameters.insert("dimmer".to_string(), level);
+
+    create_effect_with_layering(
+        "back_wash".to_string(),
+        EffectType::Static {
+            parameters,
+            duration: Duration::from_secs(8),
+        },
+        vec!["back_wash".to_string()],
+        EffectLayer::Background,
+        BlendMode::Replace,
+    )
+}
+
+/// A static level must dim a fixture that has no dimmer channel, rather than being
+/// filtered out and rendering at full. Regression test for #346.
+#[test]
+fn test_static_level_dims_a_dimmerless_fixture() {
+    let mut engine = EffectEngine::new();
+    engine.register_fixture(dimmerless_rgb_fixture("back_wash", 1));
+
+    // The case from the issue: green at full, level 22%.
+    engine.start_effect(static_with_level(0.22, 1.0)).unwrap();
+
+    let commands = engine.update(Duration::from_millis(0), None).unwrap();
+    let green = commands
+        .iter()
+        .find(|cmd| cmd.channel == 2)
+        .expect("green channel command");
+
+    // 255 * 0.22 = 56.1, truncated to 56 on the way to DMX.
+    assert_eq!(
+        green.value, 56,
+        "static level must scale the colour, not be discarded"
+    );
+}
+
+/// The same show on a fixture that does have a dimmer channel keeps using it, so the
+/// level lands in one place per fixture type rather than being applied twice.
+#[test]
+fn test_static_level_uses_the_dimmer_channel_when_present() {
+    let mut engine = EffectEngine::new();
+
+    let mut channels = HashMap::new();
+    channels.insert("red".to_string(), 1);
+    channels.insert("green".to_string(), 2);
+    channels.insert("blue".to_string(), 3);
+    channels.insert("dimmer".to_string(), 4);
+    engine.register_fixture(FixtureInfo::new(
+        "back_wash".to_string(),
+        1,
+        1,
+        "RGB_Dimmer_Par".to_string(),
+        channels,
+        None,
+    ));
+
+    engine.start_effect(static_with_level(0.22, 1.0)).unwrap();
+
+    let commands = engine.update(Duration::from_millis(0), None).unwrap();
+    let value_at = |channel: u16| {
+        commands
+            .iter()
+            .find(|cmd| cmd.channel == channel)
+            .map(|cmd| cmd.value)
+            .unwrap_or(0)
+    };
+
+    // Colour stays at full on the RGB channels; the level goes to the dimmer.
+    assert_eq!(value_at(2), 255, "green should carry the colour, undimmed");
+    assert_eq!(value_at(4), 56, "dimmer should carry the level");
+}
+
+/// A static with no level at all is unaffected — it still renders at full.
+#[test]
+fn test_static_without_a_level_still_renders_full() {
+    let mut engine = EffectEngine::new();
+    engine.register_fixture(dimmerless_rgb_fixture("back_wash", 1));
+
+    let mut parameters = HashMap::new();
+    parameters.insert("green".to_string(), 1.0);
+    engine
+        .start_effect(create_effect_with_layering(
+            "back_wash".to_string(),
+            EffectType::Static {
+                parameters,
+                duration: Duration::from_secs(8),
+            },
+            vec!["back_wash".to_string()],
+            EffectLayer::Background,
+            BlendMode::Replace,
+        ))
+        .unwrap();
+
+    let commands = engine.update(Duration::from_millis(0), None).unwrap();
+    let green = commands
+        .iter()
+        .find(|cmd| cmd.channel == 2)
+        .expect("green channel command");
+    assert_eq!(green.value, 255);
+}

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -317,7 +317,9 @@ pub(crate) fn apply_parameters_to_effect_type(
         } => {
             for (key, value) in parameters {
                 match key.as_str() {
-                    "dimmer" => {
+                    // `intensity` is the documented common parameter, `dimmer` the
+                    // static-specific spelling. They mean the same level.
+                    "dimmer" | "intensity" => {
                         if let Ok(val) = parse_percentage_to_f64(value) {
                             static_params.insert("dimmer".to_string(), val);
                         }
@@ -715,6 +717,26 @@ mod tests {
         let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["dimmer"] - 0.5).abs() < 1e-9);
+        } else {
+            panic!("Expected Static");
+        }
+    }
+
+    /// `intensity` is documented as a common parameter applying to all effects, and
+    /// used to be dropped on the floor by static's catch-all (it isn't a bare f64).
+    /// Regression test for #346.
+    #[test]
+    fn apply_static_intensity_is_a_synonym_for_dimmer() {
+        let et = EffectType::Static {
+            parameters: HashMap::new(),
+            duration: Duration::ZERO,
+        };
+        let mut params = HashMap::new();
+        params.insert("intensity".to_string(), "22%".to_string());
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        if let EffectType::Static { parameters, .. } = result {
+            assert!((parameters["dimmer"] - 0.22).abs() < 1e-9);
+            assert!(!parameters.contains_key("intensity"));
         } else {
             panic!("Expected Static");
         }

--- a/src/lighting/visual_consistency_tests.rs
+++ b/src/lighting/visual_consistency_tests.rs
@@ -301,10 +301,10 @@ mod tests {
         // Test at a specific time point
         let commands = engine.update(Duration::from_millis(100), None).unwrap();
 
-        // All fixtures should have appropriate commands based on their capabilities
-        // RGB-only fixture: should use RGB channels
+        // All fixtures should modulate rather than paint, based on their capabilities:
         // RGB+dimmer fixture: should use dimmer channel
         // Dimmer-only fixture: should use dimmer channel
+        // RGB-only fixture: should use _chase_multiplier (no direct DMX commands)
 
         // Find commands for each fixture
         // RGB-only fixture: universe 1, channels 1-3 (RGB at address 1)
@@ -321,15 +321,17 @@ mod tests {
             .iter()
             .find(|cmd| cmd.channel == 20 && cmd.universe == 1);
 
-        // RGB-only fixture should use RGB channels for chase
-        assert!(
-            !rgb_commands.is_empty(),
-            "RGB-only fixture should use RGB channels for chase"
-        );
-
         // RGB+dimmer and dimmer-only fixtures should use dimmer channel (prioritized over RGB)
         assert!(rgb_dimmer_cmd.is_some());
         assert!(dimmer_cmd.is_some());
+
+        // RGB-only fixture should have no direct DMX commands (uses _chase_multiplier).
+        // Writing the chase value into RGB would make the chase its own colour — always
+        // white — and zero every inactive fixture on the layer. See #345.
+        assert!(
+            rgb_commands.is_empty(),
+            "RGB-only fixture should use _chase_multiplier, not direct DMX commands"
+        );
     }
 
     /// Test that the same lighting show produces equivalent results across fixture types


### PR DESCRIPTION
Fixes #346
Fixes #345

Both issues are the same root cause: `static` and `chase` assume a DMX channel exists rather than using the virtual-dimmer multiplier path that `pulse` already uses correctly. A show authored against a rig with dimmers renders differently on an RGB-only rig.

## `static` silently discards its level (#346)

The level was passed through only when its name matched a real DMX channel:

```rust
.filter(|(param_name, _)| fixture.channels.contains_key(*param_name))
```

On a fixture whose channel map is `red/green/blue/strobe`, neither `intensity` nor `dimmer` is a key, so both were filtered out and the colour rendered at full — no error, nothing in the logs, invisible from the source, from `validate_lighting`, and from `get_active_effects`.

**There were two defects here, not one.** `intensity` never reached the renderer at all: static's parser catch-all does `value.parse::<f64>()`, and `"22%"` is not a bare f64, so it was dropped at parse time before the render-path filter ever saw it. Both are fixed:

- The level now routes through `FixtureProfile::apply_brightness`, landing on the dedicated dimmer where one exists and on the RGB multiplier where it doesn't.
- `intensity` is accepted as a synonym for `dimmer` on `static`, as `lighting_dsl_reference` already documented.

## `chase` overwrites RGB instead of modulating (#345)

On a fixture with a dimmer channel, `chase` modulates — it writes to `dimmer`, so the colour comes from whatever is underneath. On an RGB-only fixture it wrote the value straight into red, green and blue, so the chase value *became* the colour (always white) and every inactive fixture on the layer was driven to zero, wiping the layer beneath.

`apply_chase` now uses `apply_dimmer_or_multiplier` with a `chase` prefix, so it is a moving brightness mask in both cases — the same shape as `pulse`.

## Shared cleanup

The multiplier prefixes are now a single `MULTIPLIER_PREFIXES` constant. `is_multiplier_channel`, `effective_channel_value`, and the completed-effect cleanup in `engine.rs` each hardcoded their own copy of the list; adding a third prefix to three independent lists is how this class of bug recurs. The rewritten `is_multiplier_channel` is allocation-free and still exits immediately on the common case (real channel names never start with `_`).

The `/ws` state feed already resolves multipliers through `effective_channel_value` before filtering, so per-fixture values reported there stay accurate — which matters, since reading that feed is how both bugs were caught.

## Behaviour change

**A chase over RGB-only fixtures with no colour bed beneath it now renders dark rather than white.** That is the intended semantics — a mask over nothing is nothing, and it matches how `pulse` already behaves on the same fixtures — but it does change what such a show looks like. Documented in the changelog, `docs/src/lighting/effects.md`, and the MCP `dsl_reference.md`, whose `chase` row would otherwise be actively misleading.

No shipped example show is affected: every example venue (`main_stage`, `small_club`) uses `RGBW_Par` and `MovingHead`, both of which have dimmer channels. Notably, the comments in `comprehensive_show.light` and `main_show.light` already describe chase as "no color - applies to existing fixtures" — they were written for the corrected semantics.

## Testing

An end-to-end test drives the real parser with the show from #345 — `#C40000` at 45% plus a linear chase, on Astera PixelBricks — and asserts red 88 on the active fixture (196 × 0.45), zero green and blue, and zero on the fixture the chase is not on. Before the fix that rendered 255/255/255 and zeroed the bed.

Also added: parser coverage for the `intensity` synonym, static level on both dimmered and dimmerless fixtures (including that a static with no level still renders full), multiplier composition and the dedicated-dimmer escape, and prefix-matching lookalikes. Five existing tests asserted the old chase behaviour and were rewritten to assert modulation.

Full suite: 3029 passing. 10 failures, all pre-existing and environmental — 4 chmod-based tests that don't work as root, 6 web UI tests needing built assets — each confirmed against a clean stash of this branch. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Not addressed

Static's crossfade is applied twice on dimmer-equipped fixtures — once to RGB and once to the dimmer channel, which the physical fixture then multiplies. This is pre-existing and affects only the fade ramp shape, not steady state. I matched that behaviour on the dimmerless path rather than diverging the two; worth its own issue.

Also worth a separate look, from #346: `pulse`'s `intensity` sets `pulse_amplitude` *on top of* `base_level`, so `intensity: 16%` sweeps 50%–66% rather than modulating ±16%. Left as-is and documented rather than changed, since shows depend on the current curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA7ctcTi1KbXLgV8ayfNS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA7ctcTi1KbXLgV8ayfNS5)_