### PR TITLE
fix(lighting): reset layer state on song boundaries and layer clears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Note for show authors: a chase supplies brightness, not colour, so a chase with nothing
   underneath it renders dark rather than white. Put a colour bed on a lower layer.
 
+- **Layer masters and freezes no longer leak across songs**: layer intensity/speed masters and
+  frozen layers survived both song changes and `clear_all_layers`, because the effect engine is
+  reused across songs and nothing ever reset its layer state. A show that ducked a layer and was
+  stopped before its reset cue — the tense beat before a chorus is exactly when an operator
+  stops — left the rig mastered down for the rest of the set, with no way back short of
+  restarting mtrack, and silently changed the meaning of every song loaded afterwards. Layer
+  state is now reset when playback stops or a new song loads, and the `clear` commands reset the
+  masters of the layers they kill. Both song-start paths replay the new show's layer commands
+  from the timeline afterwards, so seeking still rebuilds masters from show history.
+
 ## [0.15.0] - 2026-07-20
 
 ### Added

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -76,6 +76,12 @@ master(layer: foreground, intensity: 50%)        # scale the layer's output
 `master(...)` also accepts `speed:` (scales effect rates) in addition to
 `intensity:`.
 
+Layer masters and freezes last for the song that set them. They are reset when
+playback stops or a new song loads, and when the layer is cleared (`clear(layer:
+…)` resets that layer, `clear()` with no layer resets all of them) — so a show
+stopped between a duck and its reset cue cannot leave the next song mastered
+down.
+
 ### Sequences and inline loops
 
 A `sequence "Name" { … }` block defines a reusable timeline of cues. Inside a

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -100,6 +100,20 @@ impl LayerState {
         }
     }
 
+    /// Reset every layer back to defaults — no masters, nothing frozen.
+    fn reset(&mut self) {
+        self.intensity_masters.clear();
+        self.speed_masters.clear();
+        self.frozen.clear();
+    }
+
+    /// Reset a single layer back to defaults.
+    fn reset_layer(&mut self, layer: EffectLayer) {
+        self.intensity_masters.remove(&layer);
+        self.speed_masters.remove(&layer);
+        self.frozen.remove(&layer);
+    }
+
     fn intensity_master(&self, layer: &EffectLayer) -> f64 {
         *self.intensity_masters.get(layer).unwrap_or(&1.0)
     }
@@ -725,11 +739,17 @@ impl EffectEngine {
         Ok(self.cache.get_cached())
     }
 
-    /// Stop all active effects
+    /// Stop all active effects and reset per-song layer state
     pub fn stop_all_effects(&mut self) {
         self.active_effects.clear();
         self.releasing_effects.clear();
         self.last_merged_states.clear();
+        // Layer masters and freezes belong to the song that set them. The engine is
+        // reused across songs, so without this a show stopped mid-duck leaves the next
+        // song mastered down while its own source looks perfectly correct. Both callers
+        // replay the new song's layer commands from the timeline afterwards, so a seek
+        // rebuilds masters from show history rather than inheriting them.
+        self.layer_state.reset();
         // Clear MIDI DMX values so they don't bleed into the next song.
         // Uses a read lock because MidiDmxStore uses interior mutability
         // (atomics) — no write lock needed.
@@ -771,6 +791,9 @@ impl EffectEngine {
             &mut self.layer_state.frozen,
             layer,
         );
+        // Including the layer's masters — killing a layer that stays mastered down
+        // silently dims whatever is started on it next.
+        self.layer_state.reset_layer(layer);
         self.last_merged_states.clear();
         self.cache.invalidate();
     }
@@ -783,6 +806,9 @@ impl EffectEngine {
             &mut self.releasing_effects,
             &mut self.layer_state.frozen,
         );
+        // Including the layer masters — a panic button that leaves the rig mastered
+        // down is not a panic button.
+        self.layer_state.reset();
         self.last_merged_states.clear();
         self.cache.invalidate();
     }

--- a/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
+++ b/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
@@ -668,3 +668,143 @@ fn test_freeze_unfreeze_with_releasing_effects() {
     // Layer should no longer be frozen (release clears freeze)
     assert!(!engine.is_layer_frozen(EffectLayer::Background));
 }
+
+// ── Layer master lifetime (#343) ───────────────────────────────────
+
+fn static_dimmer_effect(id: &str, layer: EffectLayer, level: f64) -> EffectInstance {
+    let mut effect = EffectInstance::new(
+        id.to_string(),
+        EffectType::Static {
+            parameters: {
+                let mut p = HashMap::new();
+                p.insert("dimmer".to_string(), level);
+                p
+            },
+            duration: Duration::from_secs(30),
+        },
+        vec!["test_fixture".to_string()],
+        None,
+        Some(Duration::from_secs(30)),
+        None,
+    );
+    effect.layer = layer;
+    effect
+}
+
+/// The panic button has to clear the masters too, or the rig stays mastered down
+/// with no way back short of restarting mtrack.
+#[test]
+fn test_clear_all_layers_resets_layer_masters() {
+    let mut engine = EffectEngine::new();
+    engine.register_fixture(create_test_fixture("test_fixture", 1, 1));
+
+    engine.set_layer_intensity_master(EffectLayer::Background, 0.15);
+    engine.set_layer_speed_master(EffectLayer::Midground, 2.0);
+    assert_eq!(
+        engine.get_layer_intensity_master(EffectLayer::Background),
+        0.15
+    );
+    assert_eq!(engine.get_layer_speed_master(EffectLayer::Midground), 2.0);
+
+    engine.clear_all_layers();
+
+    assert_eq!(
+        engine.get_layer_intensity_master(EffectLayer::Background),
+        1.0
+    );
+    assert_eq!(engine.get_layer_speed_master(EffectLayer::Midground), 1.0);
+}
+
+/// Killing a single layer resets that layer's masters, and leaves the others alone.
+#[test]
+fn test_clear_layer_resets_only_that_layers_masters() {
+    let mut engine = EffectEngine::new();
+    engine.register_fixture(create_test_fixture("test_fixture", 1, 1));
+
+    engine.set_layer_intensity_master(EffectLayer::Background, 0.15);
+    engine.set_layer_intensity_master(EffectLayer::Foreground, 0.5);
+
+    engine.clear_layer(EffectLayer::Background);
+
+    assert_eq!(
+        engine.get_layer_intensity_master(EffectLayer::Background),
+        1.0
+    );
+    assert_eq!(
+        engine.get_layer_intensity_master(EffectLayer::Foreground),
+        0.5,
+        "clearing one layer must not touch another's master"
+    );
+}
+
+/// Masters belong to the song that set them. The engine is reused across songs, so
+/// stopping a show mid-duck must not carry the duck into the next song.
+#[test]
+fn test_stop_all_effects_resets_layer_masters() {
+    let mut engine = EffectEngine::new();
+    engine.register_fixture(create_test_fixture("test_fixture", 1, 1));
+
+    engine.set_layer_intensity_master(EffectLayer::Background, 0.15);
+    engine.set_layer_speed_master(EffectLayer::Background, 0.5);
+    engine.freeze_layer(EffectLayer::Foreground);
+
+    engine.stop_all_effects();
+
+    assert_eq!(
+        engine.get_layer_intensity_master(EffectLayer::Background),
+        1.0
+    );
+    assert_eq!(engine.get_layer_speed_master(EffectLayer::Background), 1.0);
+    assert!(
+        !engine.is_layer_frozen(EffectLayer::Foreground),
+        "a frozen layer must not stay frozen into the next song"
+    );
+}
+
+/// The live symptom from #343, at the DMX level: song A ducks the background layer
+/// and is stopped before its reset cue; song B must not play at 15%.
+#[test]
+fn test_duck_does_not_leak_into_the_next_song() {
+    let mut engine = EffectEngine::new();
+    engine.register_fixture(create_test_fixture("test_fixture", 1, 1));
+
+    // Song A: a full-level background bed, ducked to 15% by a master.
+    engine
+        .start_effect(static_dimmer_effect(
+            "song_a_bed",
+            EffectLayer::Background,
+            1.0,
+        ))
+        .unwrap();
+    engine.set_layer_intensity_master(EffectLayer::Background, 0.15);
+
+    let commands = engine.update(Duration::from_millis(0), None).unwrap();
+    let ducked = commands
+        .iter()
+        .find(|cmd| cmd.channel == 1)
+        .expect("dimmer command");
+    assert_eq!(
+        ducked.value, 38,
+        "song A should be ducked to 15% (255 * 0.15)"
+    );
+
+    // Operator stops playback inside the duck window, then song B starts.
+    engine.stop_all_effects();
+    engine
+        .start_effect(static_dimmer_effect(
+            "song_b_bed",
+            EffectLayer::Background,
+            1.0,
+        ))
+        .unwrap();
+
+    let commands = engine.update(Duration::from_millis(10), None).unwrap();
+    let fresh = commands
+        .iter()
+        .find(|cmd| cmd.channel == 1)
+        .expect("dimmer command");
+    assert_eq!(
+        fresh.value, 255,
+        "song B must play at its own level, not song A's leftover duck"
+    );
+}


### PR DESCRIPTION
Fixes #343

Layer intensity/speed masters and frozen layers outlived the song that set them. `LayerState::new()` runs only at `EffectEngine` construction and the engine is reused across songs, so nothing ever put them back.

Stop a show in the one-beat window between a duck and its reset cue — the tense moment before a chorus, which is exactly when an operator stops — and the background layer stays at 15% for the rest of the set. The next song then plays ducked while its own source looks perfectly correct, and `clear_all_layers`, documented as *"a kill all or panic button for everything"*, didn't clear it either.

## Frozen layers had the same leak

Worth noting beyond the filed issue: `stop_all_effects` touched **no** layer state at all, so a frozen layer also stayed frozen into the next song. `clear_all_layers` did clear `frozen` but not the masters — so the two halves of layer state were being reset in different places, and neither covered a song change. Splitting them that way is what let the gap persist.

Layer state resetting now lives in one place, `LayerState::{reset, reset_layer}`, called from `stop_all_effects` and the clear commands.

## Why `stop_all_effects` is the right home

Both of its production callers are song boundaries — `start_lighting_timeline_at` (`dmx/engine/timeline.rs`) and the file watcher's reload path — and it already does song-boundary cleanup for exactly this reason, with the rationale in its existing comment:

```rust
// Clear MIDI DMX values so they don't bleed into the next song.
```

Layer state belongs there on the same grounds.

Importantly, **both** callers replay the new show's layer commands from the timeline immediately after `stop_all_effects` (via `apply_timeline_update` for a seek, and directly in `watcher.rs` for a reload). So resetting doesn't lose anything on a seek — masters get rebuilt from show history rather than inherited from whatever the previous song left behind, which makes a seek deterministic where it previously wasn't. On a live `.light` edit it also means the reload reflects the edited file instead of stale runtime state.

## Beyond the literal ask

The issue named `clear_all_layers` and song load. I also made `clear_layer` reset its own layer's masters: it's the same defect with a smaller blast radius, and leaving it out would mean clear-all resets masters while clear-one doesn't. Easy to drop if you'd rather keep per-layer masters as a console-style persistent control — it's one line.

I did **not** implement the opt-out you floated (a persistent house master). That's a feature with a config surface, not part of this fix, and the default you described — leaving a song leaves its layer state behind — is what's implemented here.

## Testing

Four new tests, including a DMX-level reproduction of the live symptom: song A's background bed ducked to 15% renders 38, playback stops mid-duck, song B's identical bed then renders 255 rather than inheriting the duck. Plus per-command coverage for `clear_all_layers`, `clear_layer` (asserting it leaves *other* layers' masters alone), and `stop_all_effects` including the frozen-layer case.

No existing test depended on the old leaking behaviour — nothing needed rewriting.

Full suite: 3033 passing. 10 failures, all pre-existing and environmental (4 chmod-based tests that don't work as root, 6 web UI tests needing built assets), confirmed against a clean checkout of `main`. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

The MCP `dsl_reference.md` now states master lifetime explicitly, since "how long does this last" was previously unanswerable from the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA7ctcTi1KbXLgV8ayfNS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA7ctcTi1KbXLgV8ayfNS5)_