### PR TITLE
fix(dmx): apply playback_delay to the DSL lighting path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   masters of the layers they kill. Both song-start paths replay the new show's layer commands
   from the timeline afterwards, so seeking still rebuilds masters from show history.
 
+- **`dmx.playback_delay` now applies to DSL light shows**: the delay was implemented for the
+  MIDI-based DMX path but never consumed by the DSL path, so latency compensation configured for
+  what the docs call the primary lighting system silently did nothing — cues fired at their
+  nominal times no matter what the profile said. Audio leaves late (decode/transcode, the
+  CPAL/ALSA stream buffer, device latency) while DMX frames go out with only frame time and
+  fixture response in the way, so uncompensated lighting runs early against what the audience
+  hears; on fast material a few tens of milliseconds is a visible fraction of a subdivision. Both
+  DMX paths now share one compensation knob, applied to cue dispatch, to the tempo base that
+  tempo-aware effects resolve against, and to the state reconstructed when seeking.
+
 ## [0.15.0] - 2026-07-20
 
 ### Added

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -107,7 +107,13 @@ dmx:
   # PC5 * 0.25 dim speed modifier = 1.25 second dim time
   dim_speed_modifier: 0.25
 
-  # (Optional) Once a song is started, mtrack will wait this amount before triggering the DMX playback.
+  # (Optional) Once a song is started, mtrack will wait this amount before triggering the DMX
+  # playback. This applies to both DMX paths — MIDI-based DMX and DSL `.light` shows.
+  #
+  # Audio leaves late (decode, the output stream buffer, device latency) while DMX frames go out
+  # with only frame time and fixture response in the way, so lights driven straight off the
+  # transport clock fire early relative to what the audience hears. This is the knob that pulls
+  # them back into line.
   playback_delay: 500ms
 
   # Universes here map OLA universe numbers into light show names.

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -317,11 +317,15 @@ impl Engine {
             error!("Error updating effects: {}", e);
         }
 
-        // Update song lighting timeline with actual song time
+        // Update song lighting timeline with the delay-compensated song time. Holding
+        // off entirely inside the delay window matters: clamping to zero instead would
+        // fire the @00:00.000 cues at true zero, which is the early firing the delay
+        // exists to correct.
         self.effects_loop_phase.store(4, Ordering::Relaxed);
-        let song_time = self.get_song_time();
-        if let Err(e) = self.update_song_lighting(song_time) {
-            error!("Error updating song lighting: {}", e);
+        if let Some(song_time) = self.delayed_song_time() {
+            if let Err(e) = self.update_song_lighting(song_time) {
+                error!("Error updating song lighting: {}", e);
+            }
         }
 
         // Check if all lighting has finished (DSL timeline cues + MIDI DMX playbacks)
@@ -420,9 +424,13 @@ impl Engine {
     pub fn update_effects(&self) -> Result<(), Box<dyn std::error::Error>> {
         // Update the effects engine with a frame time matching Universe TARGET_HZ
         let dt = Duration::from_secs_f64(1.0 / super::universe::TARGET_HZ);
-        // Subphase 1: about to acquire current_song_time lock
+        // Subphase 1: about to acquire current_song_time lock.
+        // Tempo-aware effects resolve their speeds against this, so it has to sit in
+        // the same delayed time base as the cues that started them. Clamped rather
+        // than skipped: the render also carries MIDI DMX store values, which do their
+        // own delay handling in advance_midi_dmx_playbacks and must keep flowing.
         self.update_subphase.store(1, Ordering::Relaxed);
-        let song_time = self.get_song_time();
+        let song_time = self.to_delayed_song_time(self.get_song_time());
         // Subphase 2: about to acquire effect_engine lock
         self.update_subphase.store(2, Ordering::Relaxed);
         let mut effect_engine = match self.effect_engine.try_lock_for(Duration::from_secs(2)) {
@@ -2461,13 +2469,179 @@ mod test {
 
             // Update at t=0 — cue hasn't fired yet
             engine.update_song_lighting(std::time::Duration::ZERO)?;
+            assert_eq!(
+                engine.effect_engine.lock().active_effects_count(),
+                0,
+                "cue at t=1s must not fire at t=0"
+            );
 
             // Update at t=2s — cue should fire
             engine.update_song_lighting(std::time::Duration::from_secs(2))?;
 
-            let effect_engine = engine.effect_engine.lock();
-            let active = effect_engine.format_active_effects();
-            assert!(!active.is_empty(), "Cue effect should be active at t=2s");
+            // Counted, not string-checked: format_active_effects() returns the literal
+            // "No active effects" when there are none, so is_empty() is never true and
+            // the old assertion here passed whether or not the cue ever fired.
+            assert_eq!(
+                engine.effect_engine.lock().active_effects_count(),
+                1,
+                "Cue effect should be active at t=2s"
+            );
+            Ok(())
+        }
+    }
+
+    /// The DSL lighting path has to honour `dmx.playback_delay` the same way the
+    /// MIDI-based DMX path already does — otherwise latency compensation configured
+    /// for the primary lighting system silently does nothing. See #336.
+    mod dsl_playback_delay_tests {
+        use super::*;
+
+        fn engine_with_delay(delay: &str) -> Result<Arc<Engine>, Box<dyn Error>> {
+            let config = config::Dmx::new(
+                Some(1.0),
+                Some(delay.to_string()),
+                Some(9091),
+                vec![config::Universe::new(5, "universe1".to_string())],
+                None,
+            );
+            let ola_client = crate::dmx::ola_client::OlaClientFactory::create_mock_client();
+            Ok(Arc::new(Engine::new(&config, None, None, ola_client)?))
+        }
+
+        /// A cue at t=0 fires once the transport reaches the delay, not before.
+        fn timeline_with_cue_at_zero(engine: &Engine) {
+            let mut channels = std::collections::HashMap::new();
+            channels.insert("dimmer".to_string(), 1);
+            {
+                let mut effect_engine = engine.effect_engine.lock();
+                effect_engine.register_fixture(crate::lighting::effects::FixtureInfo::new(
+                    "test_fixture".to_string(),
+                    1,
+                    1,
+                    "Generic".to_string(),
+                    channels,
+                    None,
+                ));
+            }
+
+            use crate::lighting::parser::{Cue, Effect};
+            let cue = Cue {
+                time: std::time::Duration::ZERO,
+                effects: vec![Effect {
+                    sequence_name: None,
+                    groups: vec!["test_fixture".to_string()],
+                    effect_type: crate::lighting::effects::EffectType::Static {
+                        parameters: {
+                            let mut p = std::collections::HashMap::new();
+                            p.insert("dimmer".to_string(), 0.5);
+                            p
+                        },
+                        duration: Duration::from_secs(30),
+                    },
+                    up_time: None,
+                    hold_time: Some(Duration::from_secs(30)),
+                    down_time: None,
+                    layer: None,
+                    blend_mode: None,
+                }],
+                layer_commands: vec![],
+                stop_sequences: vec![],
+                start_sequences: vec![],
+            };
+
+            let mut timeline = engine.current_song_timeline.lock();
+            let mut tl = crate::lighting::timeline::LightingTimeline::new_with_cues(vec![cue]);
+            tl.start();
+            *timeline = Some(tl);
+        }
+
+        // Note: format_active_effects() returns the literal "No active effects" when
+        // there are none, so an is_empty() check on it is always false. Count instead.
+        fn has_active_effects(engine: &Engine) -> bool {
+            engine.effect_engine.lock().active_effects_count() > 0
+        }
+
+        #[test]
+        fn delayed_song_time_holds_inside_the_window() -> Result<(), Box<dyn Error>> {
+            let engine = engine_with_delay("200ms")?;
+
+            engine.update_song_time(Duration::from_millis(100));
+            assert_eq!(engine.delayed_song_time(), None);
+
+            engine.update_song_time(Duration::from_millis(200));
+            assert_eq!(engine.delayed_song_time(), Some(Duration::ZERO));
+
+            engine.update_song_time(Duration::from_millis(350));
+            assert_eq!(engine.delayed_song_time(), Some(Duration::from_millis(150)));
+            Ok(())
+        }
+
+        #[test]
+        fn zero_delay_is_a_passthrough() -> Result<(), Box<dyn Error>> {
+            let engine = engine_with_delay("0ms")?;
+            engine.update_song_time(Duration::from_millis(500));
+            assert_eq!(
+                engine.delayed_song_time(),
+                Some(Duration::from_millis(500)),
+                "an unconfigured delay must not shift anything"
+            );
+            Ok(())
+        }
+
+        /// The regression this issue is about: cues used to fire at their nominal
+        /// times regardless of the configured delay.
+        #[test]
+        fn cue_at_zero_waits_for_the_delay() -> Result<(), Box<dyn Error>> {
+            let engine = engine_with_delay("200ms")?;
+            timeline_with_cue_at_zero(&engine);
+
+            // Inside the delay window the timeline must not advance at all. Clamping
+            // to zero here instead of holding would fire the cue immediately.
+            engine.update_song_time(Duration::from_millis(100));
+            engine.effects_loop_tick();
+            assert!(
+                !has_active_effects(&engine),
+                "cue fired during the delay window — the delay was ignored"
+            );
+
+            // Past the window, the cue fires.
+            engine.update_song_time(Duration::from_millis(250));
+            engine.effects_loop_tick();
+            assert!(
+                has_active_effects(&engine),
+                "cue should fire once the transport passes the delay"
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn cue_at_zero_fires_immediately_without_a_delay() -> Result<(), Box<dyn Error>> {
+            let engine = engine_with_delay("0ms")?;
+            timeline_with_cue_at_zero(&engine);
+
+            engine.update_song_time(Duration::from_millis(10));
+            engine.effects_loop_tick();
+            assert!(
+                has_active_effects(&engine),
+                "with no delay configured the cue should fire right away"
+            );
+            Ok(())
+        }
+
+        /// Seeking reconstructs show state at the delayed time, so the live loop
+        /// picks up from the same point rather than jumping by the delay.
+        #[test]
+        fn timeline_start_shifts_the_reconstruction_point() -> Result<(), Box<dyn Error>> {
+            let engine = engine_with_delay("200ms")?;
+            assert_eq!(
+                engine.to_delayed_song_time(Duration::from_secs(10)),
+                Duration::from_millis(9800)
+            );
+            // A seek shallower than the delay clamps rather than underflowing.
+            assert_eq!(
+                engine.to_delayed_song_time(Duration::from_millis(50)),
+                Duration::ZERO
+            );
             Ok(())
         }
     }

--- a/src/dmx/engine/midi_playback.rs
+++ b/src/dmx/engine/midi_playback.rs
@@ -18,7 +18,7 @@ impl Engine {
     /// Advances all MIDI DMX playback cursors to the current song time,
     /// dispatching events via handle_midi_event_by_id.
     pub(super) fn advance_midi_dmx_playbacks(&self) {
-        let song_time = match self.get_song_time().checked_sub(self.playback_delay) {
+        let song_time = match self.delayed_song_time() {
             Some(t) => t,
             None => return, // Still within the playback delay period
         };

--- a/src/dmx/engine/timeline.rs
+++ b/src/dmx/engine/timeline.rs
@@ -68,7 +68,11 @@ impl Engine {
     }
 
     /// Starts the lighting timeline at a specific time
+    ///
+    /// `start_time` is song-absolute; it is shifted into the delayed lighting time
+    /// base so the reconstructed state matches what the live loop advances from.
     pub fn start_lighting_timeline_at(&self, start_time: Duration) {
+        let start_time = self.to_delayed_song_time(start_time);
         // Clear effects from previous song before starting new timeline
         {
             let mut effect_engine = self.effect_engine.lock();
@@ -197,6 +201,28 @@ impl Engine {
             self.current_song_time
                 .load(std::sync::atomic::Ordering::Relaxed),
         )
+    }
+
+    /// Song time with the configured `dmx.playback_delay` applied, or `None` while
+    /// still inside the delay window.
+    ///
+    /// Audio leaves late — decode/transcode, the CPAL/ALSA stream buffer, device
+    /// latency — while DMX frames go out with only frame time and fixture response
+    /// in the way. So lights driven straight off the transport clock fire early
+    /// relative to what the audience hears, and this is the knob that pulls them
+    /// back. `None` means the show has not started yet as far as the lights are
+    /// concerned: hold, don't fire at zero.
+    pub(crate) fn delayed_song_time(&self) -> Option<Duration> {
+        self.get_song_time().checked_sub(self.playback_delay)
+    }
+
+    /// Shift a song-absolute time into the delayed lighting time base.
+    ///
+    /// Used for the reconstruction points that don't come from the live clock
+    /// (playback start, section-loop restart), so a seek lands on the same show
+    /// state the live loop will go on to advance from.
+    pub(crate) fn to_delayed_song_time(&self, song_time: Duration) -> Duration {
+        song_time.saturating_sub(self.playback_delay)
     }
 
     /// Gets all cues from the current timeline with their times and indices


### PR DESCRIPTION
Fixes #336

`dmx.playback_delay` was implemented for MIDI-based DMX and never consumed by the DSL path, so latency compensation configured for what the docs call the primary lighting system silently did nothing — cues fired at their nominal times whatever the profile said.

Audio leaves late: decode/transcode, the CPAL/ALSA stream buffer, device latency. DMX frames go out with only frame time and fixture response in the way. So lights driven straight off the transport clock run early against what the audience hears, and on fast material a few tens of milliseconds is a visible fraction of a subdivision.

## Where the delay is applied

Both DMX paths now share one knob, via `delayed_song_time()` / `to_delayed_song_time()` on the engine, applied at the three points where song time enters the lighting subsystem:

| Entry point | Treatment | Why |
|---|---|---|
| Cue dispatch (`effects_loop_tick`) | **Hold** inside the window | Clamping to zero would fire the `@00:00.000` cues at true zero — exactly the early firing the delay exists to correct |
| Tempo base for tempo-aware effects (`update_effects`) | **Clamp** to zero | Keeps effects in phase with the cues that started them. Held would be wrong here: that same render carries MIDI DMX store values, which do their own delay handling in `advance_midi_dmx_playbacks` and must keep flowing |
| Reconstruction on seek (`start_lighting_timeline_at`) | **Clamp** to zero | A seek or section-loop restart lands where the live loop then advances from, instead of jumping by the delay |

The hold-vs-clamp distinction in the first two rows is the part worth a second look in review — they genuinely need to differ.

`midi_playback.rs` now calls the shared accessor rather than open-coding the same `checked_sub`, so the two paths can't drift.

## A vacuous assertion, fixed while here

`update_with_timeline_processes_cues` asserted:

```rust
let active = effect_engine.format_active_effects();
assert!(!active.is_empty(), "Cue effect should be active at t=2s");
```

`format_active_effects()` returns the literal string `"No active effects"` when there are none, so that assertion held whether or not the cue ever fired — the test would have passed with cue dispatch entirely broken, which is the failure mode described in #332. It now counts active effects, and also checks the cue does *not* fire early. (I hit this myself: my first version of the new test used the same predicate and passed when it should have failed.)

## Testing

Five new tests: the delay window boundary, zero-delay passthrough, the reconstruction shift including the clamp for a seek shallower than the delay, and — the actual regression — a cue at `t=0` with a 200ms delay that must not fire at 100ms and must fire at 250ms, driven through `effects_loop_tick` rather than the accessor directly.

Full suite: 3038 passing. 10 failures, all pre-existing and environmental (4 chmod-based tests that don't work as root, 6 web UI tests needing built assets), confirmed against a clean checkout of `main`. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Not implemented

The `lighting.sync_offset` you floated — a separate knob accepting negative values to push lights either direction. That's a new config surface rather than part of making the existing knob work, so it wants its own issue if you still want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA7ctcTi1KbXLgV8ayfNS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA7ctcTi1KbXLgV8ayfNS5)_