### PR TITLE
fix(audio): recover from device loss, and stop the song when the callback dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sitting right there refusing to open will still be refusing in an hour, and needs a person:
   usually a sample rate, format or buffer size the interface won't accept, or another process
   holding it exclusively. Deciding to stop retrying a failure that can never succeed is a broader
-  change — it applies equally to MIDI and DMX — and is left for its own.
+  change than this — it applies equally to MIDI and DMX — and is left for its own.
+
+- **Audio status reports whether audio is actually flowing, not just whether the device opened**:
+  the audio subsystem reported `connected` purely on having constructed a device object at
+  startup, and nothing was recorded about the output callback afterwards. A rig could sit there
+  with an open stream, a stalled callback or a silent mix, and every observable said healthy. The
+  output callback now records liveness — lock-free, no allocation, one clock read per callback —
+  and `hardware_status` gains an `audio_output` section reporting whether the callback is running,
+  whether non-silent audio is being written, and how long since each was last true.
+
+  The snapshot reports facts rather than a verdict, because silence is correct whenever nothing is
+  playing. Where playback *is* running, the monitor loop turns a stalled callback into a distinct
+  `ERROR` in the journal, and logs again when it comes back — that is the one place that knows
+  audio is supposed to be coming out.
+
+  This deliberately carries no output level. A level sampled by a status poller sees roughly one
+  callback in several hundred, which makes a poor meter and adds nothing to the health question;
+  metering is a separate feature with a reader of its own.
+
+  None of it can detect a device that accepts every buffer and produces no sound — nothing
+  host-side can. What it gives you is the other half of the diagnosis: if mtrack says it is
+  writing signal and the room is quiet, the fault is downstream.
 
 - **Concurrent device enumeration can no longer destroy mtrack's stdout**: enumeration silences
   ALSA's chatter by redirecting the process's file descriptors and restoring them afterwards. Two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   DMX paths now share one compensation knob, applied to cue dispatch, to the tempo base that
   tempo-aware effects resolve against, and to the state reconstructed when seeking.
 
+- **The audio output thread survives a device that goes away and comes back**: any failure to
+  build the output stream killed the output thread outright. Two distinct consequences. On the
+  *first* build the failure was swallowed — `start_output_thread` returned `Ok`, so the device
+  reported as `connected` with no live stream behind it and the perpetual retry in
+  `player::hardware` never re-ran, because it only retries on an `Err`. On a *later* build, after
+  a backend error, the single immediate retry was the only one: power-cycling a USB interface
+  mid-set raises the error at once but re-enumeration takes seconds, so that one attempt lands
+  while the card is still absent, and audio was then gone until mtrack itself was restarted.
+  A first-build failure is now reported to the caller so the existing retry loop covers it
+  (re-running device discovery, which is what a not-yet-present device needs), and later
+  failures retry in-thread with backoff until the device returns or shutdown is requested. After
+  a successful start the thread can no longer exit on its own, so "connected" can no longer mean
+  "connected to nothing".
+
+  A rebuild that fails also re-resolves the device by name before giving up. ALSA keys a device by
+  name, so the original handle reopens a power-cycled interface fine — but CoreAudio keys it by
+  device id and WASAPI by endpoint, and a re-plugged interface comes back under a new one, leaving
+  the retry loop hammering a handle that can never work again.
+
+  Because that retry runs twice a second forever, it now says which situation it is in: opening a
+  device that was located but would not open reports `audio device 'X' was found but could not be
+  opened`, distinct from `no device found with name X`. An absent device may still be enumerating
+  and the retry will pick it up on its own — that is what the perpetual retry is for. A device
+  sitting right there refusing to open will still be refusing in an hour, and needs a person:
+  usually a sample rate, format or buffer size the interface won't accept, or another process
+  holding it exclusively. Deciding to stop retrying a failure that can never succeed is a broader
+  change — it applies equally to MIDI and DMX — and is left for its own.
+
+- **Concurrent device enumeration can no longer destroy mtrack's stdout**: enumeration silences
+  ALSA's chatter by redirecting the process's file descriptors and restoring them afterwards. Two
+  threads doing that at once interleave the save and restore and the real stdout is lost for the
+  life of the process — a failure that, by construction, prints nothing at all. Enumeration paths
+  now serialise on a single lock.
+
 ## [0.15.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,8 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the retry loop hammering a handle that can never work again.
 
   Because that retry runs twice a second forever, it now says which situation it is in: opening a
-  device that was located but would not open reports `audio device 'X' was found but could not be
-  opened`, distinct from `no device found with name X`. An absent device may still be enumerating
+  device that was located but would not open reports `'X' was found but could not be opened`,
+  distinct from `no device found with name X`. An absent device may still be enumerating
   and the retry will pick it up on its own — that is what the perpetual retry is for. A device
   sitting right there refusing to open will still be refusing in an hour, and needs a person:
   usually a sample rate, format or buffer size the interface won't accept, or another process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,9 +153,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whether non-silent audio is being written, and how long since each was last true.
 
   The snapshot reports facts rather than a verdict, because silence is correct whenever nothing is
-  playing. Where playback *is* running, the monitor loop turns a stalled callback into a distinct
-  `ERROR` in the journal, and logs again when it comes back — that is the one place that knows
-  audio is supposed to be coming out.
+  playing. Where playback *is* running, the monitor loop is the one place that knows audio is
+  supposed to be coming out — and there, a callback that stops now **ends the song**, with a
+  distinct `ERROR` naming it.
+
+  Ending it is the point. The transport is driven by the callback's sample counter, so an outage
+  freezes it rather than advancing it: audio, MIDI and cues stop together and would resume from the
+  bar they froze on. On stage that is worse than stopping — the band has just played through the
+  gap with no click and no tracks, so they are not where the frozen transport thinks they are, and
+  audio reappearing mid-song hands them a second, confidently wrong reference. Nothing host-side
+  can recover the state that actually matters, which is where the *band* is, so resuming cannot be
+  made correct. (Fast-forwarding to a wall clock fails the same way: it assumes the band held tempo
+  through the one moment they had nothing to hold it to.) The device layer keeps rebuilding so the
+  next song can start the instant the interface returns; the song that was playing does not come
+  back on its own. The `ERROR` is for working out afterwards what happened — in the moment there is
+  nothing to read and nothing to do.
 
   This deliberately carries no output level. A level sampled by a status poller sees roughly one
   callback in several hundred, which makes a poor meter and adds nothing to the health question;

--- a/harness/src/checks.rs
+++ b/harness/src/checks.rs
@@ -84,6 +84,7 @@ const WORLD_LEVEL: &[&str] = &[
     "absent_dmx_is_skipped_not_fatal",
     "bogus_midi_device_degrades_gracefully",
     "bogus_audio_device_degrades_gracefully",
+    "unopenable_audio_device_is_distinguished_from_a_missing_one",
     "first_profile_wins",
     "generated_show_passes_validation",
     "malformed_show_is_rejected",
@@ -260,6 +261,14 @@ pub fn all() -> Vec<Check> {
             "bogus_audio_device_degrades_gracefully",
             "An unresolvable audio device must degrade, not panic.",
             subsystems::bogus_audio_device_degrades_gracefully
+        ),
+        entry!(
+            "subsystems",
+            "unopenable_audio_device_is_distinguished_from_a_missing_one",
+            "A device that is present but will not open must say so, and must never\n  \
+             report connected. Reporting it as missing sends an operator waiting out a\n  \
+             retry that can never succeed.",
+            subsystems::unopenable_audio_device_is_distinguished_from_a_missing_one
         ),
         entry!(
             "subsystems",

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -211,6 +211,89 @@ pub async fn bogus_audio_device_degrades_gracefully() -> CheckOutcome {
     Ok(())
 }
 
+/// A device that is present but will not open says so, distinctly from one that
+/// is not there.
+///
+/// `retry_until_ready` re-runs device discovery twice a second, forever, and
+/// logs each attempt. The two failures behind those lines want opposite
+/// responses from an operator: a device that is still enumerating gets picked up
+/// by the next retry, which is the whole reason the retry is perpetual, while
+/// one that is sitting right there refusing to open will still be refusing in an
+/// hour. Reporting both the same way leaves the person on the receiving end
+/// waiting out a retry that can never succeed.
+///
+/// This also covers the #350 regression from the other side: an audio device
+/// that could not be opened used to be reported as `connected`, because the
+/// output thread swallowed the first build failure and `get_device` returned
+/// `Ok`. The status assertion below fails against that build.
+///
+/// The lever is `bits_per_sample: 24` with the default integer format, which
+/// `stream.rs` rejects outright rather than handing to the backend. That makes
+/// the failure deterministic and independent of what the interface supports --
+/// an unsupported *sample rate* would not do, because ALSA's plug layer
+/// converts silently and the stream would open. If 24-bit integer output is
+/// ever implemented, this check starts failing, which is the correct way to
+/// find out that its lever needs replacing.
+pub async fn unopenable_audio_device_is_distinguished_from_a_missing_one() -> CheckOutcome {
+    crate::runner::require_area("subsystems")?;
+
+    if Capabilities::get().audio_out.is_none() {
+        skip!("no audio output device was detected, so there is nothing present to fail to open");
+    }
+
+    // Sabotage removes the device rather than the assertion: with a name that
+    // resolves to nothing, mtrack correctly reports it missing, and a check that
+    // cannot tell "missing" from "unopenable" passes anyway.
+    //
+    // Note the argument order against the neighbouring bogus-device check, which
+    // is the reverse of this one: there the *real* case is the missing device
+    // and sabotage restores a working one. `pick` takes (real, broken).
+    let mut profile = ProfileSpec::detected("01-e2e").with_audio_key("bits_per_sample", "24");
+    profile.audio = crate::sabotage::pick(
+        Subsystem::Detected,
+        Subsystem::Bogus("e2e-nonexistent-audio-device".to_string()),
+    );
+
+    let project = ProjectBuilder::new()
+        .profiles(vec![profile])
+        .songs(crate::checks::standard_songs())
+        .build()?;
+    let server = Server::start_degraded(&project).await?;
+    let client = Client::connect_http_only(&server).await?;
+
+    let seen = watch_subsystem(&client, "audio").await?;
+    check!(
+        !seen.iter().any(|s| s == "connected"),
+        "an audio device that cannot be opened was reported as connected \
+         (statuses seen: {seen:?})"
+    );
+
+    // Read after the settle window: the retry logs on every attempt, so waiting
+    // guarantees at least one line rather than racing the first one.
+    let log = server.log();
+    check!(
+        log.contains("was found but could not be opened"),
+        "a device that was located but would not open did not say so.\n--- log ---\n{log}"
+    );
+    check!(
+        !log.contains("no device found with name"),
+        "a device that is present was reported as missing, which sends an operator \
+         looking for the wrong fault.\n--- log ---\n{log}"
+    );
+    check!(
+        !log.contains("panicked at"),
+        "an unopenable audio device panicked the player.\n--- log ---\n{log}"
+    );
+
+    crate::outcome::record(format!(
+        "unopenable audio device: statuses over {}s were {seen:?}, never connected, \
+         reported as found-but-unopenable rather than missing",
+        SETTLE.as_secs()
+    ));
+
+    Ok(())
+}
+
 /// Only the first matching profile is active, and it is the one applied.
 ///
 /// Profiles are sorted by filename, so a second profile pointing at a

--- a/harness/src/project.rs
+++ b/harness/src/project.rs
@@ -68,6 +68,8 @@ pub struct ProfileSpec {
     pub dmx: Subsystem,
     /// Track name to output channel list. Empty means "derive from the songs".
     pub track_mappings: BTreeMap<String, Vec<u16>>,
+    /// Extra `audio:` keys, e.g. `bits_per_sample: 24`.
+    pub audio_extra: BTreeMap<String, String>,
     /// Extra `midi:` keys, e.g. `beat_clock: true`.
     pub midi_extra: BTreeMap<String, String>,
     /// Whether to emit a `dmx.lighting` block referencing the generated venue.
@@ -84,9 +86,16 @@ impl ProfileSpec {
             midi: Subsystem::Detected,
             dmx: Subsystem::Detected,
             track_mappings: BTreeMap::new(),
+            audio_extra: BTreeMap::new(),
             midi_extra: BTreeMap::new(),
             lighting: false,
         }
+    }
+
+    /// Sets an `audio:` key such as `bits_per_sample`.
+    pub fn with_audio_key(mut self, key: &str, value: &str) -> ProfileSpec {
+        self.audio_extra.insert(key.to_string(), value.to_string());
+        self
     }
 
     /// Sets a `midi:` key such as `beat_clock`.
@@ -172,6 +181,12 @@ impl ProfileSpec {
                 };
                 let _ = writeln!(out, "  sample_rate: {chosen}");
             }
+        }
+
+        // After the pinned rate, so a case that deliberately overrides one of
+        // these wins over the value chosen for openability above.
+        for (key, value) in &self.audio_extra {
+            let _ = writeln!(out, "  {key}: {value}");
         }
 
         out.push_str("  track_mappings:\n");

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -26,6 +26,7 @@ pub mod context;
 pub mod cpal;
 pub mod crossfade;
 pub mod format;
+pub mod health;
 pub mod metronome;
 pub mod midi_tempo;
 pub mod mixer;
@@ -115,6 +116,17 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
     /// Sets player-level default metronome sounds, applied to songs that
     /// don't override them. Devices that don't play the metronome ignore it.
     fn set_metronome_defaults(&self, _defaults: Option<config::metronome::MetronomeSounds>) {}
+
+    /// Liveness facts from the output callback, for devices that have one.
+    /// `None` means the device cannot report — not that it is unhealthy.
+    ///
+    /// A device reporting a live callback and recent signal means mtrack is handing
+    /// non-silent audio to the driver. It does not mean sound reached the room: a
+    /// device can accept every buffer and produce nothing, and that is not
+    /// detectable from here. The value of this is ruling mtrack out.
+    fn output_health(&self) -> Option<health::OutputHealthSnapshot> {
+        None
+    }
 
     #[cfg(test)]
     fn to_mock(&self) -> Result<Arc<mock::Device>, AudioError>;

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -128,6 +128,16 @@ pub trait Device: Any + fmt::Display + std::marker::Send + std::marker::Sync {
         None
     }
 
+    /// How long the output callback may be silent before it counts as stopped.
+    ///
+    /// Devices that know their callback period size this from it; everything
+    /// else gets the floor. Exposed on the trait so the status snapshot judges
+    /// liveness by the same window the playback monitor does, rather than the
+    /// two disagreeing about whether a device is alive.
+    fn liveness_window(&self) -> std::time::Duration {
+        health::LIVENESS_WINDOW
+    }
+
     #[cfg(test)]
     fn to_mock(&self) -> Result<Arc<mock::Device>, AudioError>;
 }

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -876,7 +876,13 @@ impl AudioDevice for Device {
                 // song all share this handle, and without it they would sit on a
                 // frozen clock waiting to be joined, then resume together when
                 // the device came back.
-                cancel_handle.cancel();
+                //
+                // Marked as a *failure* cancellation, not a deliberate one. The
+                // player's cleanup skips its work when a playback was cancelled
+                // on the grounds that whoever asked for it — stop(), a seek —
+                // has already done that work and may have started a new playback
+                // to protect. Nothing asked for this one.
+                cancel_handle.cancel_due_to_failure();
                 return Err(crate::audio::AudioError::Stream(format!(
                     "audio output callback stopped after {} callbacks; song '{}' ended",
                     health.callbacks,

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -353,6 +353,10 @@ pub struct Device {
     output_manager: Arc<OutputManager>,
     /// Audio configuration for buffering and performance tuning.
     audio_config: config::Audio,
+    /// The output buffer size actually resolved for the stream, in frames.
+    /// `None` when the backend was left to choose and did not say, which is what
+    /// `BufferSize::Default` gives. Used only to size the liveness window.
+    output_buffer_size: Option<u32>,
     /// Player-level default metronome sounds, set at hardware init.
     metronome_defaults: parking_lot::Mutex<Option<config::metronome::MetronomeSounds>>,
 }
@@ -441,6 +445,7 @@ impl Device {
                 output_manager: temp_output_manager,
                 audio_config: config::Audio::new("default"), // Default config for listing
                 metronome_defaults: parking_lot::Mutex::new(None),
+                output_buffer_size: None,
             })
         }
 
@@ -483,6 +488,7 @@ impl Device {
             output_manager,
             audio_config: config::Audio::new("default"),
             metronome_defaults: parking_lot::Mutex::new(None),
+            output_buffer_size: None,
         }))
     }
 
@@ -565,6 +571,7 @@ impl Device {
 
         device.output_manager = Arc::new(output_manager);
         device.audio_config = config;
+        device.output_buffer_size = output_buffer_size;
 
         Ok(device)
     }
@@ -630,6 +637,15 @@ fn build_active_source(
 impl AudioDevice for Device {
     fn output_health(&self) -> Option<crate::audio::health::OutputHealthSnapshot> {
         Some(self.output_manager.health())
+    }
+
+    /// Sized from the resolved buffer, so a rig configured with an enormous one
+    /// isn't judged against a window shorter than a single callback.
+    fn liveness_window(&self) -> Duration {
+        crate::audio::health::liveness_window(crate::audio::health::callback_period(
+            self.output_buffer_size,
+            self.target_format.sample_rate,
+        ))
     }
 
     fn set_metronome_defaults(&self, defaults: Option<config::metronome::MetronomeSounds>) {
@@ -858,7 +874,7 @@ impl AudioDevice for Device {
             // sound still looks alive from here, and nothing host-side can tell
             // the difference. What this catches is the callback going away.
             let health = self.output_manager.health();
-            if !health.callback_alive(crate::audio::health::LIVENESS_WINDOW) {
+            if !health.callback_alive(self.liveness_window()) {
                 error!(
                     song = song.name(),
                     // 0 means the callback never ran at all; `callbacks`

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -508,8 +508,10 @@ impl Device {
                 // format or buffer size the interface won't accept, or another
                 // process holding it exclusively; either way it needs a person.
                 Device::open(device, config).map_err(|e| -> Box<dyn Error> {
-                    format!("audio device '{resolved}' was found but could not be opened: {e}")
-                        .into()
+                    // No "audio device" prefix: the retry loop and the AudioError
+                    // wrapper both add one already, and a line that says it three
+                    // times before saying anything is harder to read at 2Hz.
+                    format!("'{resolved}' was found but could not be opened: {e}").into()
                 })
             }
             None => Err(format!("no device found with name {}", name).into()),

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -186,9 +186,101 @@ fn max_output_channels(configs: &[cpal::SupportedStreamConfigRange]) -> u16 {
     configs.iter().map(|c| c.channels()).max().unwrap_or(0)
 }
 
+/// Serialises the stdout/stderr redirection that silences ALSA's enumeration
+/// chatter.
+///
+/// `shh` swaps the process's file descriptors and restores them on drop. Two
+/// threads doing that at once interleave the save and restore, and the process
+/// loses its real stdout permanently — a failure that, by construction, prints
+/// nothing at all. Enumeration used to happen only during init and from the web
+/// UI's device picker, which made a collision unlikely but never impossible; the
+/// output thread now re-resolves a device during stream recovery, so this is a
+/// lock rather than a hope.
+///
+/// Held for as long as the guards are, so callers take it first and drop it last.
+static ENUMERATION_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+/// One output device, resolved by name.
+pub(super) struct ResolvedOutputDevice {
+    /// The device id it was matched on, untrimmed.
+    pub(super) name: String,
+    pub(super) host_id: cpal::HostId,
+    pub(super) device: cpal::Device,
+    pub(super) configs: Vec<cpal::SupportedStreamConfigRange>,
+}
+
+/// Scans every host for one output device by name, holding no others open.
+///
+/// Deliberately not `list_cpal_devices().find(...)`. Every `Device` in that list
+/// holds an open ALSA handle, and ALSA will not describe devices while its
+/// siblings are held: building the full list makes the list *shrink*. Measured on
+/// the test rig, in one process, alternating the two enumeration paths: 19
+/// devices, then 8, then 7, then 3. So a search over that list could fail to find
+/// a device the web UI had legitimately advertised, and the operator saw "no
+/// device found with name ..." for a device that was right there in the dropdown
+/// (#357).
+///
+/// Scanning and keeping only the match holds exactly one handle, which is the
+/// same shape as [`crate::audio::find_input_device`].
+pub(super) fn resolve_output_device(
+    name: &str,
+) -> Result<Option<ResolvedOutputDevice>, Box<dyn Error>> {
+    // Suppress noisy output here. Declared before the guards so the lock outlives
+    // them — see ENUMERATION_LOCK.
+    let _enumerating = ENUMERATION_LOCK.lock();
+    let _shh_stdout = shh::stdout()?;
+    let _shh_stderr = shh::stderr()?;
+
+    for host_id in cpal::available_hosts() {
+        let host_devices = match cpal::host_from_id(host_id)?.devices() {
+            Ok(host_devices) => host_devices,
+            Err(e) => {
+                error!(
+                    err = e.to_string(),
+                    host = host_id.name(),
+                    "Unable to list devices for host"
+                );
+                continue;
+            }
+        };
+
+        for device in host_devices {
+            // Name first: a non-match is dropped here, before its configurations
+            // are queried and before anything is built from it, so its handle is
+            // released immediately.
+            let device_id = match device.id() {
+                Ok(id) => id.to_string(),
+                Err(_) => continue,
+            };
+            if device_id.trim() != name.trim() {
+                continue;
+            }
+
+            let Some(configs) = output_configs(&device) else {
+                debug!(
+                    device_name = %device_id,
+                    "Device matched by name but reports no output configurations"
+                );
+                continue;
+            };
+
+            return Ok(Some(ResolvedOutputDevice {
+                name: device_id,
+                host_id,
+                device,
+                configs,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
 /// Lists audio devices as simple info structs (no trait objects).
 pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, Box<dyn Error>> {
-    // Suppress noisy output here.
+    // Suppress noisy output here. Declared before the guards so the lock outlives
+    // them — see ENUMERATION_LOCK.
+    let _enumerating = ENUMERATION_LOCK.lock();
     let _shh_stdout = shh::stdout()?;
     let _shh_stderr = shh::stderr()?;
 
@@ -291,7 +383,9 @@ impl Device {
 
     /// Lists cpal devices.
     fn list_cpal_devices() -> Result<Vec<Device>, Box<dyn Error>> {
-        // Suppress noisy output here.
+        // Suppress noisy output here. Declared before the guards so the lock
+        // outlives them — see ENUMERATION_LOCK.
+        let _enumerating = ENUMERATION_LOCK.lock();
         let _shh_stdout = shh::stdout()?;
         let _shh_stderr = shh::stderr()?;
 
@@ -363,140 +457,114 @@ impl Device {
         matches!(Device::find_cpal_device(name), Ok(Some(_)))
     }
 
-    /// Finds one output device by name, holding no others open.
+    /// Finds one output device by name and wraps it in a `Device`.
     ///
-    /// Deliberately not `list_cpal_devices().find(...)`. Every `Device` in that
-    /// list holds an open ALSA handle, and ALSA will not describe devices while
-    /// its siblings are held: building the full list makes the list *shrink*.
-    /// Measured on the test rig, in one process, alternating the two
-    /// enumeration paths: 19 devices, then 8, then 7, then 3. So a search over
-    /// that list could fail to find a device the web UI had legitimately
-    /// advertised, and the operator saw "no device found with name ..." for a
-    /// device that was right there in the dropdown (#357).
-    ///
-    /// Scanning and keeping only the match holds exactly one handle, which is
-    /// the same shape as [`crate::audio::find_input_device`].
+    /// See [`resolve_output_device`] for why this scans rather than searching
+    /// `list_cpal_devices()`.
     fn find_cpal_device(name: &str) -> Result<Option<Device>, Box<dyn Error>> {
-        // Suppress noisy output here.
-        let _shh_stdout = shh::stdout()?;
-        let _shh_stderr = shh::stderr()?;
+        let Some(resolved) = resolve_output_device(name)? else {
+            return Ok(None);
+        };
 
-        for host_id in cpal::available_hosts() {
-            let host_devices = match cpal::host_from_id(host_id)?.devices() {
-                Ok(host_devices) => host_devices,
-                Err(e) => {
-                    error!(
-                        err = e.to_string(),
-                        host = host_id.name(),
-                        "Unable to list devices for host"
-                    );
-                    continue;
-                }
-            };
+        let max_channels = max_output_channels(&resolved.configs);
+        let default_format = TargetFormat::new(44100, SampleFormat::Int, 32)?;
+        let output_manager = Arc::new(OutputManager::new(
+            max_channels,
+            default_format.sample_rate,
+        )?);
 
-            for device in host_devices {
-                // Name first: a non-match is dropped here, before its
-                // configurations are queried and before anything is built from
-                // it, so its handle is released immediately.
-                let device_id = match device.id() {
-                    Ok(id) => id.to_string(),
-                    Err(_) => continue,
-                };
-                if device_id.trim() != name.trim() {
-                    continue;
-                }
-
-                let Some(configs) = output_configs(&device) else {
-                    debug!(
-                        device_name = %device_id,
-                        "Device matched by name but reports no output configurations"
-                    );
-                    continue;
-                };
-                let max_channels = max_output_channels(&configs);
-                let default_format = TargetFormat::new(44100, SampleFormat::Int, 32)?;
-                let output_manager = Arc::new(OutputManager::new(
-                    max_channels,
-                    default_format.sample_rate,
-                )?);
-
-                return Ok(Some(Device {
-                    name: device_id,
-                    playback_delay: Duration::ZERO,
-                    max_channels,
-                    host_id,
-                    device,
-                    target_format: default_format,
-                    output_manager,
-                    audio_config: config::Audio::new("default"),
-                    metronome_defaults: parking_lot::Mutex::new(None),
-                }));
-            }
-        }
-
-        Ok(None)
+        Ok(Some(Device {
+            name: resolved.name,
+            playback_delay: Duration::ZERO,
+            max_channels,
+            host_id: resolved.host_id,
+            device: resolved.device,
+            target_format: default_format,
+            output_manager,
+            audio_config: config::Audio::new("default"),
+            metronome_defaults: parking_lot::Mutex::new(None),
+        }))
     }
 
     /// Gets the given cpal device.
     pub fn get(config: config::Audio) -> Result<Device, Box<dyn Error>> {
-        let name = config.device();
+        let name = config.device().to_string();
         debug!(
             device_name = %name,
             device_name_len = name.len(),
             device_name_trimmed = %name.trim(),
             "Searching for audio device"
         );
-        match Device::find_cpal_device(name)? {
-            Some(mut device) => {
-                device.playback_delay = config.playback_delay()?;
-
-                device.target_format = TargetFormat::new(
-                    config.sample_rate(),
-                    config.sample_format()?,
-                    config.bits_per_sample(),
-                )?;
-
-                // Initialize the output manager
-                let mut output_manager =
-                    OutputManager::new(device.max_channels, device.target_format.sample_rate)?;
-
-                // Resolve stream buffer size for CPAL (default / min / fixed)
-                let min_size = min_supported_buffer_size(
-                    &device.device,
-                    &device.target_format,
-                    device.max_channels,
-                );
-                let output_buffer_size = resolve_buffer_size(
-                    config.stream_buffer_size(),
-                    config.buffer_size() as u32,
-                    min_size,
-                );
-                if let (Some(StreamBufferSize::Min), Some(s)) =
-                    (config.stream_buffer_size(), output_buffer_size)
-                {
-                    if min_size.is_some() {
-                        info!(
-                            stream_buffer_size = s,
-                            "Using minimum supported stream buffer size (low latency)"
-                        );
-                    }
-                }
-
-                // Start the output thread with resolved buffer size
-                let factory = Box::new(CpalOutputStreamFactory::new(
-                    device.device.clone(),
-                    device.target_format.clone(),
-                    output_buffer_size,
-                ));
-                output_manager.start_output_thread(factory)?;
-
-                device.output_manager = Arc::new(output_manager);
-                device.audio_config = config;
-
-                Ok(device)
+        match Device::find_cpal_device(&name)? {
+            Some(device) => {
+                let resolved = device.name.clone();
+                // Say which of the two situations this is. `retry_until_ready`
+                // re-runs this twice a second forever and logs the same line each
+                // time, so without the distinction an operator cannot tell a
+                // device that is still enumerating — which the retry picks up on
+                // its own, and which is why the retry is perpetual — from one
+                // that is sitting right there refusing to open, and will still be
+                // refusing in an hour. The latter is usually a sample rate,
+                // format or buffer size the interface won't accept, or another
+                // process holding it exclusively; either way it needs a person.
+                Device::open(device, config).map_err(|e| -> Box<dyn Error> {
+                    format!("audio device '{resolved}' was found but could not be opened: {e}")
+                        .into()
+                })
             }
             None => Err(format!("no device found with name {}", name).into()),
         }
+    }
+
+    /// Configures a resolved device and starts its output stream.
+    ///
+    /// Split from [`Device::get`] so every failure past the point where the
+    /// device was located shares one "found it, couldn't open it" message.
+    fn open(mut device: Device, config: config::Audio) -> Result<Device, Box<dyn Error>> {
+        device.playback_delay = config.playback_delay()?;
+
+        device.target_format = TargetFormat::new(
+            config.sample_rate(),
+            config.sample_format()?,
+            config.bits_per_sample(),
+        )?;
+
+        // Initialize the output manager
+        let mut output_manager =
+            OutputManager::new(device.max_channels, device.target_format.sample_rate)?;
+
+        // Resolve stream buffer size for CPAL (default / min / fixed)
+        let min_size =
+            min_supported_buffer_size(&device.device, &device.target_format, device.max_channels);
+        let output_buffer_size = resolve_buffer_size(
+            config.stream_buffer_size(),
+            config.buffer_size() as u32,
+            min_size,
+        );
+        if let (Some(StreamBufferSize::Min), Some(s)) =
+            (config.stream_buffer_size(), output_buffer_size)
+        {
+            if min_size.is_some() {
+                info!(
+                    stream_buffer_size = s,
+                    "Using minimum supported stream buffer size (low latency)"
+                );
+            }
+        }
+
+        // Start the output thread with resolved buffer size
+        let factory = Box::new(CpalOutputStreamFactory::new(
+            device.device.clone(),
+            device.name.clone(),
+            device.target_format.clone(),
+            output_buffer_size,
+        ));
+        output_manager.start_output_thread(factory)?;
+
+        device.output_manager = Arc::new(output_manager);
+        device.audio_config = config;
+
+        Ok(device)
     }
 }
 

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -826,47 +826,62 @@ impl AudioDevice for Device {
         // DIAGNOSTIC: per-swap counter to compare the first loop against later ones.
         let mut loop_iteration: u64 = 0;
 
-        // Whether the stall below has already been reported for the current
-        // outage, so a wedged device logs once rather than at the 100Hz poll rate.
-        let mut stall_reported = false;
-
         'monitor: loop {
             if cancel_handle.is_cancelled() || loop_break.load(Ordering::Relaxed) {
                 break;
             }
 
-            // Audio is supposed to be coming out of the interface right now. The
-            // health snapshot itself reports facts and no verdict, because silence
-            // is correct whenever nothing is playing — this loop is the one place
-            // that knows something *is* playing, so it is where a stalled callback
-            // becomes a fault worth saying out loud. Without this the operator's
-            // only signal is a quiet room.
+            // The callback has stopped while a song is playing. End the song.
+            //
+            // Not a recoverable condition, and deliberately not treated as one.
+            // The transport is driven by the callback's sample counter, so an
+            // outage freezes it rather than advancing it: audio, MIDI and cues
+            // all stop together and, when the device returns, would resume from
+            // the bar they froze on rather than from where the room now is.
+            //
+            // On stage that is worse than stopping. The band has just played
+            // through the outage with no click and no tracks, so they are not
+            // where the frozen transport thinks they are, and audio reappearing
+            // mid-song gives them a second, confidently wrong reference to
+            // follow. Nothing host-side can recover the one piece of state that
+            // matters, which is where the *band* is, so resuming cannot be made
+            // correct — only quieter or louder about being wrong.
+            //
+            // Fast-forwarding to a wall clock has the same flaw: it assumes the
+            // band held tempo through the moment they had nothing to hold it to.
+            //
+            // So the device layer keeps rebuilding, and this ends the song. The
+            // ERROR is for the operator afterwards; in the moment there is
+            // nothing to read and nothing to do.
             //
             // Note the limit: a device that accepts every buffer and produces no
-            // sound still looks alive from here, and nothing host-side can tell the
-            // difference. What this catches is the callback going away.
+            // sound still looks alive from here, and nothing host-side can tell
+            // the difference. What this catches is the callback going away.
             let health = self.output_manager.health();
-            if health.callback_alive(crate::audio::health::LIVENESS_WINDOW) {
-                if stall_reported {
-                    stall_reported = false;
-                    warn!(
-                        callbacks = health.callbacks,
-                        "Audio output callback resumed"
-                    );
-                }
-            } else if !stall_reported {
-                stall_reported = true;
+            if !health.callback_alive(crate::audio::health::LIVENESS_WINDOW) {
                 error!(
-                    // 0 means the callback has never run at all; `callbacks`
+                    song = song.name(),
+                    // 0 means the callback never ran at all; `callbacks`
                     // separates that from a callback that ran and then stopped.
                     since_last_callback_ms = health
                         .since_last_callback
                         .map(|d| d.as_millis() as u64)
                         .unwrap_or(0),
                     callbacks = health.callbacks,
-                    "Audio output callback stalled during playback: the stream is \
-                     open but no samples are being produced"
+                    "Audio output callback stopped during playback; ending the song. \
+                     The transport is frozen, so resuming would re-enter the song at \
+                     the point it stopped rather than where the performance now is"
                 );
+                // Cancel before returning: the sources, MIDI and DMX for this
+                // song all share this handle, and without it they would sit on a
+                // frozen clock waiting to be joined, then resume together when
+                // the device came back.
+                cancel_handle.cancel();
+                return Err(crate::audio::AudioError::Stream(format!(
+                    "audio output callback stopped after {} callbacks; song '{}' ended",
+                    health.callbacks,
+                    song.name()
+                )));
             }
 
             // Apply any deferred loop_time_consumed bumps whose sample has

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -626,6 +626,10 @@ fn build_active_source(
 }
 
 impl AudioDevice for Device {
+    fn output_health(&self) -> Option<crate::audio::health::OutputHealthSnapshot> {
+        Some(self.output_manager.health())
+    }
+
     fn set_metronome_defaults(&self, defaults: Option<config::metronome::MetronomeSounds>) {
         *self.metronome_defaults.lock() = defaults;
     }
@@ -820,9 +824,47 @@ impl AudioDevice for Device {
         // DIAGNOSTIC: per-swap counter to compare the first loop against later ones.
         let mut loop_iteration: u64 = 0;
 
+        // Whether the stall below has already been reported for the current
+        // outage, so a wedged device logs once rather than at the 100Hz poll rate.
+        let mut stall_reported = false;
+
         'monitor: loop {
             if cancel_handle.is_cancelled() || loop_break.load(Ordering::Relaxed) {
                 break;
+            }
+
+            // Audio is supposed to be coming out of the interface right now. The
+            // health snapshot itself reports facts and no verdict, because silence
+            // is correct whenever nothing is playing — this loop is the one place
+            // that knows something *is* playing, so it is where a stalled callback
+            // becomes a fault worth saying out loud. Without this the operator's
+            // only signal is a quiet room.
+            //
+            // Note the limit: a device that accepts every buffer and produces no
+            // sound still looks alive from here, and nothing host-side can tell the
+            // difference. What this catches is the callback going away.
+            let health = self.output_manager.health();
+            if health.callback_alive(crate::audio::health::LIVENESS_WINDOW) {
+                if stall_reported {
+                    stall_reported = false;
+                    warn!(
+                        callbacks = health.callbacks,
+                        "Audio output callback resumed"
+                    );
+                }
+            } else if !stall_reported {
+                stall_reported = true;
+                error!(
+                    // 0 means the callback has never run at all; `callbacks`
+                    // separates that from a callback that ran and then stopped.
+                    since_last_callback_ms = health
+                        .since_last_callback
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0),
+                    callbacks = health.callbacks,
+                    "Audio output callback stalled during playback: the stream is \
+                     open but no samples are being produced"
+                );
             }
 
             // Apply any deferred loop_time_consumed bumps whose sample has

--- a/src/audio/cpal/manager.rs
+++ b/src/audio/cpal/manager.rs
@@ -12,15 +12,15 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use parking_lot::{Condvar, Mutex};
-use std::{
-    error::Error,
-    fmt,
-    sync::{Arc, Barrier},
-    thread,
-    time::Duration,
-};
+use std::{error::Error, fmt, sync::Arc, thread, time::Duration};
 
 use tracing::{error, info};
+
+/// First delay before retrying a stream rebuild after a backend error.
+const REBUILD_BACKOFF_START: Duration = Duration::from_millis(250);
+/// Ceiling for the rebuild retry backoff. Bounded so a device that comes back
+/// after a long absence is picked up promptly rather than after a doubling gap.
+const REBUILD_BACKOFF_MAX: Duration = Duration::from_secs(5);
 
 use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
 
@@ -112,6 +112,19 @@ impl OutputManager {
     /// Starts the output thread that creates and manages the audio stream.
     /// Uses direct callback mode — no intermediate ring buffer for lowest latency.
     /// On backend errors (e.g. ALSA POLLERR), the stream is recreated automatically.
+    ///
+    /// Returning `Ok(())` means a live stream exists. A first-build failure is
+    /// reported to the caller rather than swallowed, so `get_device` returns `Err`
+    /// and the perpetual `retry_until_ready` loop in `player::hardware` covers it —
+    /// that loop re-runs the whole device lookup, which is what a device that is not
+    /// present yet actually needs.
+    ///
+    /// A *later* build failure is retried in-thread with backoff instead, because
+    /// nothing upstream is watching once initialization has succeeded. This is the
+    /// case that matters live: when a USB interface is power-cycled mid-set, the
+    /// backend errors immediately but re-enumeration takes seconds, so the first
+    /// rebuild attempt lands while the card is still absent. Retrying lets the
+    /// stream come back on its own once the device does.
     pub(super) fn start_output_thread(
         &mut self,
         factory: Box<dyn OutputStreamFactory>,
@@ -127,14 +140,20 @@ impl OutputManager {
         // Shared shutdown signal so drop can wake the output thread.
         let shutdown = self.shutdown_notify.clone();
 
-        // Use a barrier to ensure the first stream is created before we return.
-        let barrier = Arc::new(Barrier::new(2));
-        let barrier_clone = barrier.clone();
+        // Carries the first build's outcome back to the caller. A channel rather than
+        // a barrier, so "the thread got as far as returning to us" and "the thread has
+        // a live stream" can no longer be confused for each other.
+        let (first_result_tx, first_result_rx) = std::sync::mpsc::sync_channel::<Option<String>>(1);
 
         let output_thread = thread::spawn(move || {
             let mut first_run = true;
+            let mut backoff = REBUILD_BACKOFF_START;
 
             loop {
+                if *shutdown.0.lock() {
+                    return;
+                }
+
                 let stream_result = factory.build_stream(
                     mixer.clone(),
                     source_rx.clone(),
@@ -144,11 +163,12 @@ impl OutputManager {
 
                 match stream_result {
                     Ok(stream) => {
+                        backoff = REBUILD_BACKOFF_START;
                         if first_run {
                             info!(
                                 "Audio output stream started successfully (direct callback mode)"
                             );
-                            barrier_clone.wait();
+                            let _ = first_result_tx.send(None);
                             first_run = false;
                         } else {
                             info!("Audio output stream recovered after backend error");
@@ -180,21 +200,56 @@ impl OutputManager {
                         drop(stream);
                     }
                     Err(e) => {
-                        error!("Failed to create audio stream: {}", e);
                         if first_run {
-                            barrier_clone.wait();
+                            // Hand the failure to the caller and stop. The outer retry
+                            // re-runs device discovery, which a first build needs.
+                            error!("Failed to create audio stream: {}", e);
+                            let _ = first_result_tx.send(Some(e.to_string()));
+                            return;
                         }
-                        return;
+
+                        error!(
+                            "Failed to recreate audio stream: {} (retrying in {:?})",
+                            e, backoff
+                        );
+                        if Self::sleep_unless_shutdown(&shutdown, backoff) {
+                            return;
+                        }
+                        backoff = (backoff * 2).min(REBUILD_BACKOFF_MAX);
                     }
                 }
             }
         });
 
-        // Wait for first stream to be created.
-        barrier.wait();
+        // Wait for the first build to report its outcome.
+        match first_result_rx.recv() {
+            Ok(None) => {
+                self.output_thread = Some(output_thread);
+                Ok(())
+            }
+            Ok(Some(e)) => {
+                let _ = output_thread.join();
+                Err(format!("failed to create audio stream: {}", e).into())
+            }
+            // The thread died without reporting — treat as failure rather than
+            // reporting a device that has no stream behind it.
+            Err(_) => {
+                let _ = output_thread.join();
+                Err("audio output thread exited before creating a stream".into())
+            }
+        }
+    }
 
-        self.output_thread = Some(output_thread);
-        Ok(())
+    /// Sleeps for `duration`, waking early if shutdown is signalled.
+    /// Returns true if shutdown was requested.
+    fn sleep_unless_shutdown(shutdown: &CondvarNotify, duration: Duration) -> bool {
+        let (mutex, condvar) = &**shutdown;
+        let mut guard = mutex.lock();
+        if *guard {
+            return true;
+        }
+        condvar.wait_for(&mut guard, duration);
+        *guard
     }
 }
 
@@ -280,18 +335,92 @@ mod test {
             );
         }
 
+        /// A first-build failure must reach the caller. Returning Ok here left the
+        /// device reported as connected with a dead output thread behind it, and the
+        /// perpetual retry in player::hardware never re-ran because it only retries
+        /// on Err. See #350.
         #[test]
-        fn handles_build_failure() {
+        fn first_build_failure_is_reported_to_the_caller() {
             let mut manager = OutputManager::new(2, 44100).unwrap();
 
-            // Should not panic even though the factory fails.
             let result = manager.start_output_thread(Box::new(FailingOutputStreamFactory));
             assert!(
-                result.is_ok(),
-                "start_output_thread should return Ok even if build fails"
+                result.is_err(),
+                "a first build that failed must not be reported as success"
             );
-            // Thread was spawned but exited after failure.
-            assert!(manager.output_thread.is_some());
+            assert!(
+                manager.output_thread.is_none(),
+                "no thread handle should be retained for a stream that was never created"
+            );
+        }
+
+        /// The case that strands a rig mid-set: a USB interface is power-cycled, the
+        /// backend errors immediately, but the card takes seconds to re-enumerate so
+        /// the first rebuild attempts fail. The thread has to keep trying — it used to
+        /// return on the first failed rebuild, killing audio until mtrack restarted.
+        #[test]
+        fn rebuild_retries_while_the_device_is_away() {
+            let (factory, handle) = ErrorCapturingFactory::new();
+            let mut manager = OutputManager::new(2, 44100).unwrap();
+
+            manager
+                .start_output_thread(Box::new(factory))
+                .expect("should start");
+            assert_eq!(handle.build_count(), 1);
+
+            // Device disappears: the next two rebuild attempts fail, then it is back.
+            handle.fail_next_builds(2);
+            handle.trigger_error();
+
+            // Wait on the build count, not on is_alive — the original stream is still
+            // alive at this point, so an is_alive check would pass before the thread
+            // has even woken up.
+            //
+            // Backoff is 250ms then 500ms, so allow room for both failed retries plus
+            // the successful third build.
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while std::time::Instant::now() < deadline && handle.build_count() < 4 {
+                thread::sleep(Duration::from_millis(25));
+            }
+
+            assert!(
+                handle.is_alive(),
+                "stream should come back on its own once the device returns"
+            );
+            assert!(
+                handle.build_count() >= 4,
+                "expected the initial build plus retries, got {}",
+                handle.build_count()
+            );
+
+            drop(manager);
+        }
+
+        /// Retrying must not outlive the manager — a device that never comes back
+        /// should not keep a thread spinning past shutdown.
+        #[test]
+        fn rebuild_retry_stops_on_shutdown() {
+            let (factory, handle) = ErrorCapturingFactory::new();
+            let mut manager = OutputManager::new(2, 44100).unwrap();
+
+            manager
+                .start_output_thread(Box::new(factory))
+                .expect("should start");
+
+            // Device never returns.
+            handle.fail_next_builds(u32::MAX);
+            handle.trigger_error();
+            thread::sleep(Duration::from_millis(100));
+
+            // Drop joins the output thread; if the backoff sleep ignored shutdown this
+            // would hang rather than return.
+            let start = std::time::Instant::now();
+            drop(manager);
+            assert!(
+                start.elapsed() < Duration::from_secs(2),
+                "shutdown should interrupt the retry backoff, took {:?}",
+                start.elapsed()
+            );
         }
 
         #[test]

--- a/src/audio/cpal/manager.rs
+++ b/src/audio/cpal/manager.rs
@@ -24,6 +24,8 @@ const REBUILD_BACKOFF_MAX: Duration = Duration::from_secs(5);
 
 use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
 
+use crate::audio::health::{OutputHealth, OutputHealthSnapshot};
+
 use super::stream::OutputStreamFactory;
 use super::CondvarNotify;
 
@@ -39,6 +41,9 @@ pub(super) struct OutputManager {
     output_thread: Option<thread::JoinHandle<()>>,
     /// Shared shutdown signal: set to true and notify condvar to stop the output thread.
     shutdown_notify: CondvarNotify,
+    /// Liveness and signal-level facts recorded by the output callback. Shared with
+    /// each stream, and outliving any individual stream so a rebuild doesn't reset it.
+    health: Arc<OutputHealth>,
 }
 
 impl fmt::Display for OutputManager {
@@ -98,6 +103,7 @@ impl OutputManager {
             source_rx,
             output_thread: None,
             shutdown_notify: Arc::new((Mutex::new(false), Condvar::new())),
+            health: Arc::new(OutputHealth::new()),
         };
 
         Ok(manager)
@@ -139,6 +145,7 @@ impl OutputManager {
 
         // Shared shutdown signal so drop can wake the output thread.
         let shutdown = self.shutdown_notify.clone();
+        let health = self.health.clone();
 
         // Carries the first build's outcome back to the caller. A channel rather than
         // a barrier, so "the thread got as far as returning to us" and "the thread has
@@ -159,6 +166,7 @@ impl OutputManager {
                     source_rx.clone(),
                     num_channels,
                     stream_error_notify.clone(),
+                    health.clone(),
                 );
 
                 match stream_result {
@@ -238,6 +246,11 @@ impl OutputManager {
                 Err("audio output thread exited before creating a stream".into())
             }
         }
+    }
+
+    /// Current output health facts.
+    pub(super) fn health(&self) -> OutputHealthSnapshot {
+        self.health.snapshot()
     }
 
     /// Sleeps for `duration`, waking early if shutdown is signalled.

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -12,12 +12,14 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 use std::error::Error;
+use std::sync::Arc;
 use std::time::Instant;
 
 use cpal::traits::{DeviceTrait, StreamTrait};
 use tracing::{error, info};
 
 use crate::audio::format::{SampleFormat, TargetFormat};
+use crate::audio::health::{has_output_signal, OutputHealth};
 use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
 use crate::thread_priority::{
     callback_thread_priority, env_flag, promote_to_realtime, rt_audio_enabled,
@@ -48,6 +50,7 @@ pub(crate) trait OutputStreamFactory: Send + 'static {
         source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
         num_channels: u16,
         error_notify: CondvarNotify,
+        health: Arc<OutputHealth>,
     ) -> Result<Box<dyn OutputStream>, Box<dyn Error>>;
 }
 
@@ -109,8 +112,8 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
     /// device by name, so the original handle reopens the interface fine after a
     /// power cycle — but CoreAudio keys it by `AudioDeviceID` and WASAPI by
     /// endpoint, and a re-plugged interface comes back under a *new* one. There
-    /// the handle is dead for good, and the recovery loop above would retry it
-    /// forever without this.
+    /// the handle is dead for good, and the recovery loop in `OutputManager`
+    /// would retry it forever without this.
     ///
     /// Re-resolution only happens after a build has already failed, so the
     /// working path costs nothing and never enumerates.
@@ -120,6 +123,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
         source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
         num_channels: u16,
         error_notify: CondvarNotify,
+        health: Arc<OutputHealth>,
     ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
         let device = self.device.lock().clone();
         let first_err = match self.build_on(
@@ -128,6 +132,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
             source_rx.clone(),
             num_channels,
             error_notify.clone(),
+            health.clone(),
         ) {
             Ok(stream) => return Ok(stream),
             Err(e) => e,
@@ -154,6 +159,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
             source_rx,
             num_channels,
             error_notify,
+            health,
         )?;
         info!(
             device = %self.device_name,
@@ -173,6 +179,7 @@ impl CpalOutputStreamFactory {
         source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
         num_channels: u16,
         error_notify: CondvarNotify,
+        health: Arc<OutputHealth>,
     ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
         // Finalize config with actual channel count / sample rate from mixer.
         let config = cpal::StreamConfig {
@@ -183,7 +190,7 @@ impl CpalOutputStreamFactory {
         let max_samples = self.max_samples.max(num_channels as usize * 4096);
 
         let stream = if self.target_format.sample_format == SampleFormat::Float {
-            let mut callback = create_direct_f32_callback(mixer, source_rx, num_channels);
+            let mut callback = create_direct_f32_callback(mixer, source_rx, num_channels, health);
             let notify = error_notify;
             device.build_output_stream(
                 &config,
@@ -210,6 +217,7 @@ impl CpalOutputStreamFactory {
                         source_rx,
                         num_channels,
                         max_samples,
+                        health,
                     );
                     let notify = error_notify;
                     device.build_output_stream(
@@ -236,6 +244,7 @@ impl CpalOutputStreamFactory {
                         source_rx,
                         num_channels,
                         max_samples,
+                        health,
                     );
                     let notify = error_notify;
                     device.build_output_stream(
@@ -277,33 +286,49 @@ pub(super) fn drain_pending_sources(
     }
 }
 
-/// Core f32 mixing logic: drains pending sources, mixes into the output buffer, and profiles.
+/// What observes one callback: timing, which is opt-in and env-gated, and
+/// liveness, which is always on.
+///
+/// Bundled rather than passed separately so the mixing functions don't take
+/// another argument every time something wants to watch the callback.
+pub(super) struct CallbackInstruments<'a> {
+    pub(super) profiler: &'a mut CallbackProfiler,
+    pub(super) health: &'a OutputHealth,
+}
+
+/// Core f32 mixing logic: drains pending sources, mixes into the output buffer,
+/// profiles, and records liveness.
 pub(super) fn process_f32_callback(
     data: &mut [f32],
     mixer: &AudioMixer,
     source_rx: &crossbeam_channel::Receiver<MixerActiveSource>,
     num_channels: u16,
-    profiler: &mut CallbackProfiler,
+    instruments: CallbackInstruments<'_>,
 ) {
+    let CallbackInstruments { profiler, health } = instruments;
     drain_pending_sources(mixer, source_rx);
     let num_frames = data.len() / num_channels as usize;
     let start = profiler.on_cb_start();
     mixer.process_into_output(data, num_frames);
     profiler.on_mix_done(start);
     profiler.maybe_log_float();
+    // Checked after mixing, so it reflects what the device is actually handed.
+    health.record_callback(has_output_signal(data));
 }
 
 /// Core integer mixing logic: drains pending sources, mixes into a temp f32 buffer,
-/// converts to the target integer type, and profiles. `temp_buffer` must be pre-allocated
-/// to the max expected sample count to avoid allocations in the callback.
+/// converts to the target integer type, profiles, and records liveness.
+/// `temp_buffer` must be pre-allocated to the max expected sample count to avoid
+/// allocations in the callback.
 pub(super) fn process_int_callback<T: cpal::Sample + cpal::FromSample<f32>>(
     data: &mut [T],
     mixer: &AudioMixer,
     source_rx: &crossbeam_channel::Receiver<MixerActiveSource>,
     num_channels: u16,
     temp_buffer: &mut [f32],
-    profiler: &mut CallbackProfiler,
+    instruments: CallbackInstruments<'_>,
 ) {
+    let CallbackInstruments { profiler, health } = instruments;
     drain_pending_sources(mixer, source_rx);
     // Never allocate in the callback: clamp to pre-allocated size. If the backend
     // ever sends a larger buffer, we mix only the first max_samples and zero the rest.
@@ -323,6 +348,10 @@ pub(super) fn process_int_callback<T: cpal::Sample + cpal::FromSample<f32>>(
     }
     profiler.on_convert_done(start_convert);
     profiler.maybe_log_int();
+    // Taken from the f32 buffer rather than the converted integers: the silence
+    // floor is expressed in float terms, so it needs no per-format scaling and
+    // means the same thing at every bit depth.
+    health.record_callback(has_output_signal(temp_slice));
 }
 
 /// f32 callback: read directly into CPAL buffer (true zero-copy)
@@ -331,6 +360,7 @@ fn create_direct_f32_callback(
     mixer: AudioMixer,
     source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
     num_channels: u16,
+    health: Arc<OutputHealth>,
 ) -> impl FnMut(&mut [f32], &cpal::OutputCallbackInfo) + Send + 'static {
     let callback_priority = callback_thread_priority();
     let rt_audio = rt_audio_enabled();
@@ -340,7 +370,16 @@ fn create_direct_f32_callback(
 
     move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
         promote_to_realtime(callback_priority, rt_audio, &mut priority_set);
-        process_f32_callback(data, &mixer, &source_rx, num_channels, &mut profiler);
+        process_f32_callback(
+            data,
+            &mixer,
+            &source_rx,
+            num_channels,
+            CallbackInstruments {
+                profiler: &mut profiler,
+                health: &health,
+            },
+        );
     }
 }
 
@@ -352,6 +391,7 @@ fn create_direct_int_callback<T: cpal::Sample + cpal::FromSample<f32> + std::fmt
     source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
     num_channels: u16,
     max_samples: usize,
+    health: Arc<OutputHealth>,
 ) -> impl FnMut(&mut [T], &cpal::OutputCallbackInfo) + Send + 'static
 where
     f32: cpal::FromSample<T>,
@@ -371,13 +411,18 @@ where
             &source_rx,
             num_channels,
             &mut temp_buffer,
-            &mut profiler,
+            CallbackInstruments {
+                profiler: &mut profiler,
+                health: &health,
+            },
         );
     }
 }
 
 #[cfg(test)]
 pub(super) mod test {
+    use crate::audio::health::{LIVENESS_WINDOW, SIGNAL_WINDOW};
+
     use super::super::CondvarNotify;
     use super::*;
     use crate::audio::mixer::AudioMixer;
@@ -456,6 +501,7 @@ pub(super) mod test {
             _source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
             _num_channels: u16,
             _error_notify: CondvarNotify,
+            _health: Arc<OutputHealth>,
         ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
             self.alive.store(true, Ordering::Relaxed);
             Ok(Box::new(MockOutputStream {
@@ -474,6 +520,7 @@ pub(super) mod test {
             _source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
             _num_channels: u16,
             _error_notify: CondvarNotify,
+            _health: Arc<OutputHealth>,
         ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
             Err("mock build failure".into())
         }
@@ -547,6 +594,7 @@ pub(super) mod test {
             _source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
             _num_channels: u16,
             error_notify: CondvarNotify,
+            _health: Arc<OutputHealth>,
         ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
             self.state.build_count.fetch_add(1, Ordering::Relaxed);
             if self
@@ -592,13 +640,27 @@ pub(super) mod test {
             (mixer, rx)
         }
 
+        /// Bundles a throwaway profiler and health recorder for a test callback.
+        fn instruments<'a>(
+            profiler: &'a mut CallbackProfiler,
+            health: &'a OutputHealth,
+        ) -> CallbackInstruments<'a> {
+            CallbackInstruments { profiler, health }
+        }
+
         #[test]
         fn f32_callback_mixes_into_buffer() {
             let (mixer, rx) = setup(2);
-            let mut profiler = CallbackProfiler::new(false);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut output = vec![0.0f32; 8]; // 4 frames * 2 channels
 
-            process_f32_callback(&mut output, &mixer, &rx, 2, &mut profiler);
+            process_f32_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                2,
+                instruments(&mut profiler, &health),
+            );
 
             // Source should have been drained from channel and mixed in.
             assert!(rx.try_recv().is_err(), "channel should be empty");
@@ -609,14 +671,92 @@ pub(super) mod test {
             );
         }
 
+        /// Through the real mixing path: playing audio must register as signal, and
+        /// an idle device must not. This is the distinction that lets "mtrack is
+        /// silent" be told apart from "the device is silent".
+        #[test]
+        fn f32_callback_records_signal_in_health() {
+            let (mixer, rx) = setup(2);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
+            let mut output = vec![0.0f32; 8];
+
+            process_f32_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                2,
+                instruments(&mut profiler, &health),
+            );
+
+            let snap = health.snapshot();
+            assert_eq!(snap.callbacks, 1);
+            assert!(snap.callback_alive(LIVENESS_WINDOW));
+            assert!(snap.writing_signal(SIGNAL_WINDOW));
+        }
+
+        /// An open device with nothing playing is alive but not signalling. Silence
+        /// here is correct, not a fault — which is why the health snapshot reports
+        /// facts and leaves the verdict to a caller that knows the playback state.
+        #[test]
+        fn f32_callback_idle_is_alive_but_silent() {
+            let (_tx, rx) = crossbeam_channel::bounded::<MixerActiveSource>(64);
+            let mixer = AudioMixer::new(2, 44100);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
+            let mut output = vec![1.0f32; 8];
+
+            process_f32_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                2,
+                instruments(&mut profiler, &health),
+            );
+
+            let snap = health.snapshot();
+            assert!(snap.callback_alive(LIVENESS_WINDOW));
+            assert!(
+                !snap.writing_signal(SIGNAL_WINDOW),
+                "an idle device writes silence and must not report signal"
+            );
+        }
+
+        /// The integer path tests the f32 buffer before conversion, so the silence
+        /// floor means the same thing regardless of bit depth.
+        #[test]
+        fn int_callback_records_signal_in_health() {
+            let (mixer, rx) = setup(2);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
+            let mut temp = vec![0.0f32; 4096];
+            let mut output = vec![0i16; 8];
+
+            process_int_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                2,
+                &mut temp,
+                instruments(&mut profiler, &health),
+            );
+
+            let snap = health.snapshot();
+            assert_eq!(snap.callbacks, 1);
+            assert!(snap.writing_signal(SIGNAL_WINDOW));
+        }
+
         #[test]
         fn f32_callback_produces_silence_with_no_sources() {
             let (_tx, rx) = crossbeam_channel::bounded::<MixerActiveSource>(64);
             let mixer = AudioMixer::new(2, 44100);
-            let mut profiler = CallbackProfiler::new(false);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut output = vec![1.0f32; 8];
 
-            process_f32_callback(&mut output, &mixer, &rx, 2, &mut profiler);
+            process_f32_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                2,
+                instruments(&mut profiler, &health),
+            );
 
             assert!(output.iter().all(|&s| s == 0.0), "output should be silence");
         }
@@ -624,11 +764,18 @@ pub(super) mod test {
         #[test]
         fn int_callback_converts_to_i16() {
             let (mixer, rx) = setup(1);
-            let mut profiler = CallbackProfiler::new(false);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut temp_buffer = vec![0.0f32; 4];
             let mut output = vec![0i16; 4];
 
-            process_int_callback(&mut output, &mixer, &rx, 1, &mut temp_buffer, &mut profiler);
+            process_int_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                1,
+                &mut temp_buffer,
+                instruments(&mut profiler, &health),
+            );
 
             assert!(rx.try_recv().is_err(), "channel should be empty");
             assert!(
@@ -640,11 +787,18 @@ pub(super) mod test {
         #[test]
         fn int_callback_converts_to_i32() {
             let (mixer, rx) = setup(1);
-            let mut profiler = CallbackProfiler::new(false);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut temp_buffer = vec![0.0f32; 4];
             let mut output = vec![0i32; 4];
 
-            process_int_callback(&mut output, &mixer, &rx, 1, &mut temp_buffer, &mut profiler);
+            process_int_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                1,
+                &mut temp_buffer,
+                instruments(&mut profiler, &health),
+            );
 
             assert!(rx.try_recv().is_err(), "channel should be empty");
             assert!(
@@ -656,12 +810,19 @@ pub(super) mod test {
         #[test]
         fn int_callback_clamps_to_temp_buffer_size() {
             let (mixer, rx) = setup(1);
-            let mut profiler = CallbackProfiler::new(false);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             // temp_buffer smaller than output — extra samples should be zeroed.
             let mut temp_buffer = vec![0.0f32; 2];
             let mut output = vec![99i16; 4];
 
-            process_int_callback(&mut output, &mixer, &rx, 1, &mut temp_buffer, &mut profiler);
+            process_int_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                1,
+                &mut temp_buffer,
+                instruments(&mut profiler, &health),
+            );
 
             // The last 2 samples should be zeroed since they exceed the temp buffer.
             assert_eq!(output[2], 0);
@@ -684,10 +845,16 @@ pub(super) mod test {
                 tx.send(source).unwrap();
             }
 
-            let mut profiler = CallbackProfiler::new(false);
+            let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut output = vec![0.0f32; 4];
 
-            process_f32_callback(&mut output, &mixer, &rx, 1, &mut profiler);
+            process_f32_callback(
+                &mut output,
+                &mixer,
+                &rx,
+                1,
+                instruments(&mut profiler, &health),
+            );
 
             assert!(rx.try_recv().is_err(), "both sources should be drained");
             // Two sources each contributing 0.5 should sum to ~1.0.

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -68,6 +68,15 @@ pub(super) struct CpalOutputStreamFactory {
     device: parking_lot::Mutex<cpal::Device>,
     /// The name the device was resolved by, so a rebuild can re-resolve it.
     device_name: String,
+    /// Whether this handle has ever produced a stream.
+    ///
+    /// Gates re-resolution: a handle that has worked and then stopped may have
+    /// gone stale, but one that has never worked is simply wrong, and
+    /// re-resolving it would just find the same device again. Without this, a
+    /// config the device rejects makes every attempt of the perpetual 500ms
+    /// retry enumerate twice — once in `Device::get` and once here — holding the
+    /// enumeration lock for a good fraction of every second.
+    has_built: std::sync::atomic::AtomicBool,
     target_format: TargetFormat,
     config: cpal::StreamConfig,
     max_samples: usize,
@@ -97,6 +106,7 @@ impl CpalOutputStreamFactory {
         Self {
             device: parking_lot::Mutex::new(device),
             device_name,
+            has_built: std::sync::atomic::AtomicBool::new(false),
             target_format,
             config,
             max_samples,
@@ -115,8 +125,10 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
     /// the handle is dead for good, and the recovery loop in `OutputManager`
     /// would retry it forever without this.
     ///
-    /// Re-resolution only happens after a build has already failed, so the
-    /// working path costs nothing and never enumerates.
+    /// Re-resolution only happens after a build has already failed *and* the
+    /// handle has worked at least once before, so the working path costs nothing
+    /// and a device that simply rejects the configuration is not enumerated for
+    /// twice a second forever.
     fn build_stream(
         &self,
         mixer: AudioMixer,
@@ -125,6 +137,8 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
         error_notify: CondvarNotify,
         health: Arc<OutputHealth>,
     ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
+        use std::sync::atomic::Ordering;
+
         let device = self.device.lock().clone();
         let first_err = match self.build_on(
             &device,
@@ -134,9 +148,18 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
             error_notify.clone(),
             health.clone(),
         ) {
-            Ok(stream) => return Ok(stream),
+            Ok(stream) => {
+                self.has_built.store(true, Ordering::Relaxed);
+                return Ok(stream);
+            }
             Err(e) => e,
         };
+
+        // A handle that has never worked is wrong, not stale — re-resolving it
+        // would find the same device and fail the same way.
+        if !self.has_built.load(Ordering::Relaxed) {
+            return Err(first_err);
+        }
 
         let resolved = match resolve_output_device(&self.device_name) {
             Ok(Some(resolved)) => resolved,
@@ -165,6 +188,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
             device = %self.device_name,
             "Audio device came back under a new handle; stream rebuilt"
         );
+        self.has_built.store(true, Ordering::Relaxed);
         *self.device.lock() = resolved.device;
         Ok(stream)
     }

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -15,7 +15,7 @@ use std::error::Error;
 use std::time::Instant;
 
 use cpal::traits::{DeviceTrait, StreamTrait};
-use tracing::error;
+use tracing::{error, info};
 
 use crate::audio::format::{SampleFormat, TargetFormat};
 use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
@@ -23,6 +23,7 @@ use crate::thread_priority::{
     callback_thread_priority, env_flag, promote_to_realtime, rt_audio_enabled,
 };
 
+use super::device::resolve_output_device;
 use super::profiler::CallbackProfiler;
 use super::CondvarNotify;
 
@@ -59,7 +60,11 @@ impl OutputStream for CpalOutputStream {}
 
 /// Builds CPAL output streams for a given device, format, and buffer config.
 pub(super) struct CpalOutputStreamFactory {
-    device: cpal::Device,
+    /// The handle streams are built from. Replaced when it goes stale — see
+    /// [`CpalOutputStreamFactory::build_stream`].
+    device: parking_lot::Mutex<cpal::Device>,
+    /// The name the device was resolved by, so a rebuild can re-resolve it.
+    device_name: String,
     target_format: TargetFormat,
     config: cpal::StreamConfig,
     max_samples: usize,
@@ -68,6 +73,7 @@ pub(super) struct CpalOutputStreamFactory {
 impl CpalOutputStreamFactory {
     pub(super) fn new(
         device: cpal::Device,
+        device_name: String,
         target_format: TargetFormat,
         output_buffer_size: Option<u32>,
     ) -> Self {
@@ -86,7 +92,8 @@ impl CpalOutputStreamFactory {
             .unwrap_or(4096 * 64);
 
         Self {
-            device,
+            device: parking_lot::Mutex::new(device),
+            device_name,
             target_format,
             config,
             max_samples,
@@ -95,8 +102,73 @@ impl CpalOutputStreamFactory {
 }
 
 impl OutputStreamFactory for CpalOutputStreamFactory {
+    /// Builds a stream, re-resolving the device by name if the handle we hold
+    /// turns out to be dead.
+    ///
+    /// A handle that worked once is not guaranteed to work again. ALSA keys a
+    /// device by name, so the original handle reopens the interface fine after a
+    /// power cycle — but CoreAudio keys it by `AudioDeviceID` and WASAPI by
+    /// endpoint, and a re-plugged interface comes back under a *new* one. There
+    /// the handle is dead for good, and the recovery loop above would retry it
+    /// forever without this.
+    ///
+    /// Re-resolution only happens after a build has already failed, so the
+    /// working path costs nothing and never enumerates.
     fn build_stream(
         &self,
+        mixer: AudioMixer,
+        source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+        num_channels: u16,
+        error_notify: CondvarNotify,
+    ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
+        let device = self.device.lock().clone();
+        let first_err = match self.build_on(
+            &device,
+            mixer.clone(),
+            source_rx.clone(),
+            num_channels,
+            error_notify.clone(),
+        ) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => e,
+        };
+
+        let resolved = match resolve_output_device(&self.device_name) {
+            Ok(Some(resolved)) => resolved,
+            // Genuinely absent, or we cannot tell. Either way the original error
+            // is the more useful one to report.
+            Ok(None) => return Err(first_err),
+            Err(e) => {
+                error!(
+                    device = %self.device_name,
+                    err = %e,
+                    "Failed to re-resolve audio device after a failed stream build"
+                );
+                return Err(first_err);
+            }
+        };
+
+        let stream = self.build_on(
+            &resolved.device,
+            mixer,
+            source_rx,
+            num_channels,
+            error_notify,
+        )?;
+        info!(
+            device = %self.device_name,
+            "Audio device came back under a new handle; stream rebuilt"
+        );
+        *self.device.lock() = resolved.device;
+        Ok(stream)
+    }
+}
+
+impl CpalOutputStreamFactory {
+    /// Builds a stream on one specific device handle.
+    fn build_on(
+        &self,
+        device: &cpal::Device,
         mixer: AudioMixer,
         source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
         num_channels: u16,
@@ -113,7 +185,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
         let stream = if self.target_format.sample_format == SampleFormat::Float {
             let mut callback = create_direct_f32_callback(mixer, source_rx, num_channels);
             let notify = error_notify;
-            self.device.build_output_stream(
+            device.build_output_stream(
                 &config,
                 move |data: &mut [f32], info: &cpal::OutputCallbackInfo| {
                     callback(data, info);
@@ -140,7 +212,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
                         max_samples,
                     );
                     let notify = error_notify;
-                    self.device.build_output_stream(
+                    device.build_output_stream(
                         &config,
                         move |data: &mut [i16], info: &cpal::OutputCallbackInfo| {
                             callback(data, info);
@@ -166,7 +238,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
                         max_samples,
                     );
                     let notify = error_notify;
-                    self.device.build_output_stream(
+                    device.build_output_stream(
                         &config,
                         move |data: &mut [i32], info: &cpal::OutputCallbackInfo| {
                             callback(data, info);
@@ -413,6 +485,9 @@ pub(super) mod test {
         alive: Arc<AtomicBool>,
         build_count: std::sync::atomic::AtomicU32,
         captured_error_notify: parking_lot::Mutex<Option<CondvarNotify>>,
+        /// Number of upcoming builds that should fail, simulating a device that is
+        /// mid-re-enumeration and not yet openable.
+        fail_next: std::sync::atomic::AtomicU32,
     }
 
     /// A factory that captures the error_notify so tests can trigger stream error recovery.
@@ -442,6 +517,12 @@ pub(super) mod test {
         pub(in crate::audio::cpal) fn is_alive(&self) -> bool {
             self.state.alive.load(Ordering::Relaxed)
         }
+
+        /// Make the next `n` build attempts fail, as a USB device would while it is
+        /// re-enumerating after a power cycle.
+        pub(in crate::audio::cpal) fn fail_next_builds(&self, n: u32) {
+            self.state.fail_next.store(n, Ordering::Relaxed);
+        }
     }
 
     impl ErrorCapturingFactory {
@@ -450,6 +531,7 @@ pub(super) mod test {
                 alive: Arc::new(AtomicBool::new(false)),
                 build_count: std::sync::atomic::AtomicU32::new(0),
                 captured_error_notify: parking_lot::Mutex::new(None),
+                fail_next: std::sync::atomic::AtomicU32::new(0),
             });
             let handle = ErrorCapturingHandle {
                 state: state.clone(),
@@ -467,6 +549,14 @@ pub(super) mod test {
             error_notify: CondvarNotify,
         ) -> Result<Box<dyn OutputStream>, Box<dyn Error>> {
             self.state.build_count.fetch_add(1, Ordering::Relaxed);
+            if self
+                .state
+                .fail_next
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
+                .is_ok()
+            {
+                return Err("device is not available".into());
+            }
             *self.state.captured_error_notify.lock() = Some(error_notify);
             self.state.alive.store(true, Ordering::Relaxed);
             Ok(Box::new(MockOutputStream {

--- a/src/audio/health.rs
+++ b/src/audio/health.rs
@@ -48,14 +48,61 @@ use std::time::{Duration, Instant};
 /// does.
 const SILENCE_FLOOR: f32 = 1.0e-4;
 
-/// How recently the callback must have run to count as alive.
+/// How long the callback may be silent before it counts as stopped.
 ///
-/// Generous next to a typical few-millisecond callback period, so a large buffer
-/// size or a scheduling hiccup doesn't read as a stall. It does assume a callback
-/// period well under a second: at 44.1kHz that holds until roughly a 32k-frame
-/// buffer, far past anything mtrack's buffer sizing produces. A rig configured
-/// past that would need this derived from the negotiated buffer instead.
+/// Not a jitter margin — a consequence threshold. Once a full second has passed
+/// with nothing handed to the device, the moment is gone whether or not the
+/// device was really dead, so a "false positive" here is not meaningfully false:
+/// the song it ends was already ruined by the second of silence that triggered
+/// it. That is what makes one second a principled number rather than an
+/// arbitrary one, and also why it should not be much larger — past this point
+/// waiting only extends the silence without learning anything.
+///
+/// The error bars are deliberately lopsided. Concluding too late costs a little
+/// more of an already-silent moment; concluding too early kills a healthy song
+/// in front of an audience. Given that asymmetry, this sits at the generous end.
 pub const LIVENESS_WINDOW: Duration = Duration::from_secs(1);
+
+/// How many consecutive callback periods must be missed before the floor is
+/// overridden. Only reachable when a single period approaches a second on its
+/// own — see [`liveness_window`].
+const MISSED_CALLBACKS: u32 = 4;
+
+/// The liveness window for a device whose callback period is known.
+///
+/// [`LIVENESS_WINDOW`] on every configuration anyone actually runs: at the
+/// default 1024 frames / 44.1kHz a period is 23ms, so four of them is 92ms and
+/// the floor wins by an order of magnitude.
+///
+/// The derived term exists only for absurd buffers. `buffer_size` has no upper
+/// bound, and at 65536 frames a period is ~1.5s — longer than the floor, so a
+/// perfectly healthy callback would look stopped between every buffer and every
+/// song would be ended a second after it started. Scaling to "four consecutive
+/// missed buffers" keeps the check meaningful there instead of making playback
+/// impossible.
+///
+/// `None` means the period is unknown, which is what `BufferSize::Default`
+/// leaves us with — the backend picked, and did not say. The floor is the only
+/// safe answer.
+pub fn liveness_window(callback_period: Option<Duration>) -> Duration {
+    match callback_period {
+        Some(period) => LIVENESS_WINDOW.max(period * MISSED_CALLBACKS),
+        None => LIVENESS_WINDOW,
+    }
+}
+
+/// The time one callback covers, for a buffer size in frames and a sample rate.
+///
+/// `None` when either is unknown or zero, rather than guessing.
+pub fn callback_period(buffer_frames: Option<u32>, sample_rate: u32) -> Option<Duration> {
+    let frames = buffer_frames?;
+    if frames == 0 || sample_rate == 0 {
+        return None;
+    }
+    Some(Duration::from_secs_f64(
+        f64::from(frames) / f64::from(sample_rate),
+    ))
+}
 
 /// How recently non-silent audio must have been written to count as signalling.
 ///
@@ -176,6 +223,39 @@ pub fn has_output_signal(data: &[f32]) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn default_buffer_uses_the_floor() {
+        // 1024 frames at 44.1kHz is a 23ms period; four of those is 92ms, so the
+        // floor wins. A 92ms window would read an ordinary scheduling hiccup on a
+        // loaded machine as a dead device and end the song for it.
+        let period = callback_period(Some(1024), 44_100).unwrap();
+        assert!(period < Duration::from_millis(25));
+        assert_eq!(liveness_window(Some(period)), LIVENESS_WINDOW);
+    }
+
+    #[test]
+    fn an_absurd_buffer_scales_past_the_floor() {
+        // 65536 frames at 44.1kHz is ~1.49s — longer than the floor on its own,
+        // so without scaling a healthy callback would look stopped between every
+        // buffer and no song could ever play.
+        let period = callback_period(Some(65_536), 44_100).unwrap();
+        assert!(period > LIVENESS_WINDOW);
+        assert!(liveness_window(Some(period)) > period * 2);
+    }
+
+    #[test]
+    fn unknown_period_uses_the_floor() {
+        // BufferSize::Default: the backend chose and didn't say.
+        assert_eq!(callback_period(None, 44_100), None);
+        assert_eq!(liveness_window(None), LIVENESS_WINDOW);
+    }
+
+    #[test]
+    fn nonsense_inputs_do_not_produce_a_period() {
+        assert_eq!(callback_period(Some(0), 44_100), None);
+        assert_eq!(callback_period(Some(1024), 0), None);
+    }
 
     #[test]
     fn empty_buffer_has_no_signal() {

--- a/src/audio/health.rs
+++ b/src/audio/health.rs
@@ -1,0 +1,262 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+//! Liveness facts recorded by the audio output callback.
+//!
+//! A stream that opened successfully tells you the device accepted the format. It
+//! does not tell you the callback is still running, and it certainly does not tell
+//! you sound is coming out. This records the two things mtrack can actually know:
+//!
+//! - the callback is being invoked, and
+//! - the samples being handed to the device are not silence.
+//!
+//! Neither proves audio reached the room — a device can accept every buffer and
+//! produce nothing, which no amount of host-side instrumentation can detect. What
+//! these facts buy is the other half of the diagnosis: they let mtrack be ruled out
+//! in seconds instead of guessed at.
+//!
+//! This is deliberately *not* metering. Nothing here reports a level, because a
+//! level sampled by a status poller is a bad meter (a poll sees one callback in
+//! several hundred) and a good meter is a different feature with a different
+//! reader. All that is asked of the audio here is a yes/no above the silence
+//! floor, which is cheaper than a peak and answers the health question exactly.
+//!
+//! Everything is written from the realtime audio callback, so it holds no locks,
+//! allocates nothing, and reads the clock at most once per callback.
+//!
+//! Nothing here is backend-specific: it lives beside the `Device` trait rather
+//! than inside the cpal implementation so a second backend — or a second
+//! interface, once multi-interface output lands — reports health the same way.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Absolute sample value at or below which a buffer counts as silence.
+///
+/// Chosen just above the quantisation floor of 16-bit audio (1/32768 ≈ 3.05e-5) so
+/// dither or a stray LSB doesn't read as signal, while anything genuinely audible
+/// does.
+const SILENCE_FLOOR: f32 = 1.0e-4;
+
+/// How recently the callback must have run to count as alive.
+///
+/// Generous next to a typical few-millisecond callback period, so a large buffer
+/// size or a scheduling hiccup doesn't read as a stall. It does assume a callback
+/// period well under a second: at 44.1kHz that holds until roughly a 32k-frame
+/// buffer, far past anything mtrack's buffer sizing produces. A rig configured
+/// past that would need this derived from the negotiated buffer instead.
+pub const LIVENESS_WINDOW: Duration = Duration::from_secs(1);
+
+/// How recently non-silent audio must have been written to count as signalling.
+///
+/// Wider than [`LIVENESS_WINDOW`] because real music has quiet passages: a fade,
+/// a break, or a soft intro should not read as "gone silent" the moment it dips
+/// below the floor.
+pub const SIGNAL_WINDOW: Duration = Duration::from_secs(2);
+
+/// Lock-free liveness signals written by the output callback.
+pub struct OutputHealth {
+    /// Reference point for the nanosecond timestamps below.
+    base: Instant,
+    /// Nanos since `base` at the last callback invocation. 0 means "never called".
+    last_callback_nanos: AtomicU64,
+    /// Nanos since `base` at the last callback whose output exceeded the silence
+    /// floor. 0 means "no signal has ever been written".
+    last_signal_nanos: AtomicU64,
+    /// Total callbacks served, for diagnostics.
+    callbacks: AtomicU64,
+}
+
+impl Default for OutputHealth {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutputHealth {
+    pub fn new() -> Self {
+        Self {
+            base: Instant::now(),
+            last_callback_nanos: AtomicU64::new(0),
+            last_signal_nanos: AtomicU64::new(0),
+            callbacks: AtomicU64::new(0),
+        }
+    }
+
+    /// Record that the callback ran, and whether it handed the device anything
+    /// above the silence floor. Called from the realtime thread.
+    pub fn record_callback(&self, has_signal: bool) {
+        // Saturates after ~584 years of uptime, which is not a scenario worth code.
+        let now = self.base.elapsed().as_nanos() as u64;
+        // Never store 0 for a real callback — 0 is the "never" sentinel, and it is
+        // reachable if a callback lands in the first nanosecond of the process.
+        let now = now.max(1);
+
+        self.callbacks.fetch_add(1, Ordering::Relaxed);
+        self.last_callback_nanos.store(now, Ordering::Relaxed);
+        if has_signal {
+            self.last_signal_nanos.store(now, Ordering::Relaxed);
+        }
+    }
+
+    /// Read the current facts.
+    pub fn snapshot(&self) -> OutputHealthSnapshot {
+        let now = self.base.elapsed().as_nanos() as u64;
+        let age = |stamp: u64| {
+            if stamp == 0 {
+                None
+            } else {
+                Some(Duration::from_nanos(now.saturating_sub(stamp)))
+            }
+        };
+
+        OutputHealthSnapshot {
+            since_last_callback: age(self.last_callback_nanos.load(Ordering::Relaxed)),
+            since_last_signal: age(self.last_signal_nanos.load(Ordering::Relaxed)),
+            callbacks: self.callbacks.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A point-in-time read of [`OutputHealth`].
+///
+/// Deliberately facts rather than a verdict. "Silent" is correct and expected when
+/// nothing is playing, so whether silence is a problem can only be decided where
+/// playback state is known — see the stall check in the playback monitor loop,
+/// which is the one place that knows audio is supposed to be coming out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutputHealthSnapshot {
+    /// Time since the callback last ran, or `None` if it never has.
+    pub since_last_callback: Option<Duration>,
+    /// Time since non-silent audio was last written, or `None` if it never was.
+    pub since_last_signal: Option<Duration>,
+    /// Total callbacks served since the device was opened.
+    pub callbacks: u64,
+}
+
+impl OutputHealthSnapshot {
+    /// Whether the callback has run within `threshold`.
+    pub fn callback_alive(&self, threshold: Duration) -> bool {
+        matches!(self.since_last_callback, Some(age) if age <= threshold)
+    }
+
+    /// Whether non-silent audio was written within `threshold`.
+    ///
+    /// False is normal whenever nothing is playing, and can also go false during
+    /// a genuinely quiet passage or with output gains at zero. Callers that treat
+    /// this as a fault must know playback state.
+    pub fn writing_signal(&self, threshold: Duration) -> bool {
+        matches!(self.since_last_signal, Some(age) if age <= threshold)
+    }
+}
+
+/// Whether a buffer contains anything above the silence floor.
+///
+/// Runs in the audio callback. `any` short-circuits, so a buffer with audio in it
+/// costs a few samples and only true silence costs a full pass — cheaper than
+/// computing a peak, which is the other reason not to report a level from here.
+///
+/// NaN compares false against every threshold, so a corrupt sample can never latch
+/// "signal" permanently on.
+#[inline]
+pub fn has_output_signal(data: &[f32]) -> bool {
+    data.iter().any(|sample| sample.abs() > SILENCE_FLOOR)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_buffer_has_no_signal() {
+        assert!(!has_output_signal(&[]));
+    }
+
+    #[test]
+    fn negative_extreme_counts_as_signal() {
+        assert!(has_output_signal(&[0.0, -0.8, 0.0]));
+    }
+
+    #[test]
+    fn nan_is_not_signal() {
+        // A corrupt sample must not latch the signal timestamp on forever.
+        assert!(!has_output_signal(&[f32::NAN, f32::NAN]));
+        assert!(has_output_signal(&[f32::NAN, 0.5]));
+    }
+
+    #[test]
+    fn dither_level_output_is_not_signal() {
+        // One LSB of 16-bit audio, below the floor.
+        assert!(!has_output_signal(&[1.0 / 32768.0; 8]));
+    }
+
+    #[test]
+    fn fresh_health_reports_nothing_seen() {
+        let snap = OutputHealth::new().snapshot();
+        assert_eq!(snap.since_last_callback, None);
+        assert_eq!(snap.since_last_signal, None);
+        assert_eq!(snap.callbacks, 0);
+        assert!(!snap.callback_alive(LIVENESS_WINDOW));
+        assert!(!snap.writing_signal(SIGNAL_WINDOW));
+    }
+
+    #[test]
+    fn silent_callback_is_alive_but_not_signalling() {
+        let health = OutputHealth::new();
+        health.record_callback(false);
+
+        let snap = health.snapshot();
+        assert_eq!(snap.callbacks, 1);
+        assert!(
+            snap.callback_alive(LIVENESS_WINDOW),
+            "a callback that ran is alive even when it wrote silence"
+        );
+        assert!(!snap.writing_signal(SIGNAL_WINDOW));
+    }
+
+    #[test]
+    fn signal_registers() {
+        let health = OutputHealth::new();
+        health.record_callback(true);
+
+        assert!(health.snapshot().writing_signal(SIGNAL_WINDOW));
+    }
+
+    #[test]
+    fn signal_age_persists_after_going_quiet() {
+        let health = OutputHealth::new();
+        health.record_callback(true);
+        health.record_callback(false);
+
+        let snap = health.snapshot();
+        assert!(
+            snap.writing_signal(SIGNAL_WINDOW),
+            "signal age should remember the earlier non-silent buffer"
+        );
+        assert_eq!(snap.callbacks, 2);
+    }
+
+    #[test]
+    fn a_stale_callback_reads_as_not_alive() {
+        let health = OutputHealth::new();
+        health.record_callback(true);
+        std::thread::sleep(Duration::from_millis(20));
+
+        let snap = health.snapshot();
+        assert!(
+            !snap.callback_alive(Duration::from_millis(1)),
+            "a callback 20ms old must not pass a 1ms liveness threshold"
+        );
+        assert!(snap.callback_alive(LIVENESS_WINDOW));
+    }
+}

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -325,7 +325,11 @@ impl McpServer {
         live state (`connected`/`not_connected`/...) and device name of each \
         subsystem (audio, MIDI, DMX, trigger). Use this to confirm which host \
         a configuration's `profiles` list selected and what hardware is \
-        actually wired up.")]
+        actually wired up. `audio_output` additionally reports whether the \
+        output callback is still running and whether non-silent audio is being \
+        written — check it when diagnosing 'no sound', since the audio \
+        subsystem reads `connected` from the moment the device opens, \
+        regardless of whether anything is flowing.")]
     async fn host_info(&self) -> Result<CallToolResult, McpError> {
         let snapshot = self.player.hardware_status();
         let json = serde_json::to_value(&snapshot).map_err(|e| {

--- a/src/player.rs
+++ b/src/player.rs
@@ -202,6 +202,36 @@ pub struct SubsystemStatus {
     pub name: Option<String>,
 }
 
+/// What the audio output callback is actually doing, as distinct from whether the
+/// device opened.
+///
+/// `connected` on the audio subsystem only ever meant "we constructed a device
+/// object at startup". These are the runtime facts on top of that.
+///
+/// Note what this cannot tell you: a device can accept every buffer and produce no
+/// sound, and nothing here will notice. `writing_signal` true with a silent room
+/// means the fault is downstream of mtrack — which is the question worth answering
+/// quickly when a rig goes quiet.
+///
+/// Not a meter. There is no level here on purpose: a level sampled by a status
+/// poller sees one callback in several hundred, which makes a poor meter and adds
+/// nothing to the health question that the two booleans don't already answer.
+#[derive(Clone, serde::Serialize)]
+pub struct AudioOutputHealth {
+    /// The callback has run recently. False means the stream is open but stalled.
+    pub callback_alive: bool,
+    /// Non-silent audio was handed to the device recently. False is normal and
+    /// expected whenever nothing is playing, and can also go false during a
+    /// genuinely quiet passage or with output gains at zero.
+    pub writing_signal: bool,
+    /// Milliseconds since the callback last ran, absent if it never has.
+    pub since_last_callback_ms: Option<u64>,
+    /// Milliseconds since non-silent audio was last written, absent if it never was.
+    pub since_last_signal_ms: Option<u64>,
+    /// Total callbacks served since the device was opened.
+    pub callbacks: u64,
+}
+
 /// Snapshot of all hardware subsystem statuses.
 #[derive(Clone, serde::Serialize)]
 pub struct HardwareStatusSnapshot {
@@ -209,6 +239,8 @@ pub struct HardwareStatusSnapshot {
     pub hostname: Option<String>,
     pub profile: Option<String>,
     pub audio: SubsystemStatus,
+    /// Runtime output health, when the audio device can report it.
+    pub audio_output: Option<AudioOutputHealth>,
     pub midi: SubsystemStatus,
     pub dmx: SubsystemStatus,
     pub trigger: SubsystemStatus,

--- a/src/player.rs
+++ b/src/player.rs
@@ -914,19 +914,32 @@ fn decide_cleanup_action(
     if loop_broken {
         return CleanupAction::LoopBreakAndPlay;
     }
+    // A failure is checked before cancellation because playback can cancel
+    // *itself*: when the audio callback stops mid-song, the audio thread cancels
+    // the handle so MIDI and DMX don't sit on a frozen clock, then reports the
+    // failure. `StopCancelled` would be wrong there — it skips the cleanup on
+    // the grounds that `stop()` already did it, and nothing called `stop()`, so
+    // `join` and `play_start_time` would stay set and the player would believe
+    // a song was still playing forever.
+    //
+    // A stop() cancellation does not reach here as a failure: play_from returns
+    // Ok once it sees the handle cancelled, so the two cases stay distinct.
+    if let PlaybackResult::Failed(e) = &result {
+        warn!(
+            err = %e,
+            "Advancing playlist despite playback failure so user is not stuck"
+        );
+        return CleanupAction::AdvancePlaylist;
+    }
     if cancelled {
         return CleanupAction::StopCancelled;
     }
     match &result {
-        PlaybackResult::Failed(e) => {
-            warn!(
-                err = %e,
-                "Advancing playlist despite playback failure so user is not stuck"
-            );
-        }
         PlaybackResult::SenderDropped => {
             error!("Error receiving playback signal (receiver dropped)");
         }
+        // Handled above, before the cancellation check.
+        PlaybackResult::Failed(_) => unreachable!("failures return early"),
         PlaybackResult::Success => {}
     }
     CleanupAction::AdvancePlaylist
@@ -2047,11 +2060,30 @@ mod test {
         );
     }
 
+    /// Playback that cancelled *itself* still needs the full cleanup.
+    ///
+    /// When the audio callback stops mid-song, the audio thread cancels the
+    /// shared handle so MIDI and DMX don't sit waiting on a frozen clock, then
+    /// reports the failure. Both flags are therefore set at once, which used to
+    /// read as `StopCancelled` — a path that skips clearing `join` and
+    /// `play_start_time` because it assumes `stop()` already did. Nothing called
+    /// `stop()` here, so taking it left the player believing a song was still
+    /// playing, with no way back short of a restart.
     #[test]
-    fn cleanup_failed_cancelled() {
+    fn cleanup_failed_and_self_cancelled_still_advances() {
         assert_eq!(
             decide_cleanup_action(PlaybackResult::Failed("err".into()), true, false),
-            CleanupAction::StopCancelled
+            CleanupAction::AdvancePlaylist
+        );
+    }
+
+    /// A loop break still wins over a failure: it cancels deliberately in order
+    /// to advance and keep playing, and that intent outranks the error.
+    #[test]
+    fn cleanup_loop_break_wins_over_failure() {
+        assert_eq!(
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, true),
+            CleanupAction::LoopBreakAndPlay
         );
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -907,6 +907,7 @@ fn decide_cleanup_action(
     result: PlaybackResult,
     cancelled: bool,
     loop_broken: bool,
+    self_cancelled: bool,
 ) -> CleanupAction {
     // Loop break takes priority over cancel — we intentionally cancel
     // playback to break out of a loop immediately, but the intent is
@@ -914,32 +915,36 @@ fn decide_cleanup_action(
     if loop_broken {
         return CleanupAction::LoopBreakAndPlay;
     }
-    // A failure is checked before cancellation because playback can cancel
-    // *itself*: when the audio callback stops mid-song, the audio thread cancels
-    // the handle so MIDI and DMX don't sit on a frozen clock, then reports the
-    // failure. `StopCancelled` would be wrong there — it skips the cleanup on
-    // the grounds that `stop()` already did it, and nothing called `stop()`, so
-    // `join` and `play_start_time` would stay set and the player would believe
-    // a song was still playing forever.
+    // Playback that cancelled *itself* — the audio callback stopped mid-song, so
+    // the audio thread cancelled the handle to bring MIDI and DMX down off a
+    // frozen clock. `StopCancelled` would be wrong: it skips the cleanup on the
+    // grounds that `stop()` already did it, and nothing called `stop()`, so
+    // `join` and `play_start_time` would stay set and the player would believe a
+    // song was playing forever.
     //
-    // A stop() cancellation does not reach here as a failure: play_from returns
-    // Ok once it sees the handle cancelled, so the two cases stay distinct.
-    if let PlaybackResult::Failed(e) = &result {
-        warn!(
-            err = %e,
-            "Advancing playlist despite playback failure so user is not stuck"
-        );
+    // Deliberately keyed on *who cancelled*, not on whether there was also an
+    // error. A seek or a stop cancels an in-flight playback that can report an
+    // error on its way out, and treating that as a self-cancellation lets this
+    // cleanup clear state belonging to the playback the seek has already
+    // started — which is precisely what the `StopCancelled` early return exists
+    // to prevent.
+    if self_cancelled {
+        warn!("Playback ended itself; advancing playlist so the player is not left wedged");
         return CleanupAction::AdvancePlaylist;
     }
     if cancelled {
         return CleanupAction::StopCancelled;
     }
     match &result {
+        PlaybackResult::Failed(e) => {
+            warn!(
+                err = %e,
+                "Advancing playlist despite playback failure so user is not stuck"
+            );
+        }
         PlaybackResult::SenderDropped => {
             error!("Error receiving playback signal (receiver dropped)");
         }
-        // Handled above, before the cancellation check.
-        PlaybackResult::Failed(_) => unreachable!("failures return early"),
         PlaybackResult::Success => {}
     }
     CleanupAction::AdvancePlaylist
@@ -2039,7 +2044,7 @@ mod test {
     #[test]
     fn cleanup_success_not_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Success, false, false),
+            decide_cleanup_action(PlaybackResult::Success, false, false, false),
             CleanupAction::AdvancePlaylist
         );
     }
@@ -2047,7 +2052,7 @@ mod test {
     #[test]
     fn cleanup_success_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Success, true, false),
+            decide_cleanup_action(PlaybackResult::Success, true, false, false),
             CleanupAction::StopCancelled
         );
     }
@@ -2055,7 +2060,7 @@ mod test {
     #[test]
     fn cleanup_failed_not_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Failed("err".into()), false, false),
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), false, false, false),
             CleanupAction::AdvancePlaylist
         );
     }
@@ -2064,25 +2069,42 @@ mod test {
     ///
     /// When the audio callback stops mid-song, the audio thread cancels the
     /// shared handle so MIDI and DMX don't sit waiting on a frozen clock, then
-    /// reports the failure. Both flags are therefore set at once, which used to
-    /// read as `StopCancelled` — a path that skips clearing `join` and
-    /// `play_start_time` because it assumes `stop()` already did. Nothing called
-    /// `stop()` here, so taking it left the player believing a song was still
-    /// playing, with no way back short of a restart.
+    /// reports the failure. `StopCancelled` would be wrong: it skips clearing
+    /// `join` and `play_start_time` because it assumes `stop()` already did.
+    /// Nothing called `stop()` here, so taking it left the player believing a
+    /// song was still playing, with no way back short of a restart.
     #[test]
-    fn cleanup_failed_and_self_cancelled_still_advances() {
+    fn cleanup_self_cancelled_advances() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, false),
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, false, true),
             CleanupAction::AdvancePlaylist
         );
     }
 
-    /// A loop break still wins over a failure: it cancels deliberately in order
-    /// to advance and keep playing, and that intent outranks the error.
+    /// The mirror of the case above, and the reason it is keyed on *who*
+    /// cancelled rather than on whether an error came with it.
+    ///
+    /// A seek cancels the in-flight playback and immediately starts a new one.
+    /// That cancelled playback can report an error on its way out, so "failed
+    /// and cancelled" is not enough to identify a self-cancellation — reading it
+    /// that way let this cleanup run and clear `join` and `play_start_time`
+    /// belonging to the playback the seek had already started, leaving
+    /// `is_playing()` false in the middle of a seek. Caught by
+    /// `test_seek_spam_stays_consistent` under CI load, not locally.
+    #[test]
+    fn cleanup_deliberate_cancel_with_an_error_still_stops() {
+        assert_eq!(
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, false, false),
+            CleanupAction::StopCancelled
+        );
+    }
+
+    /// A loop break outranks everything: it cancels deliberately in order to
+    /// advance and keep playing.
     #[test]
     fn cleanup_loop_break_wins_over_failure() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, true),
+            decide_cleanup_action(PlaybackResult::Failed("err".into()), true, true, true),
             CleanupAction::LoopBreakAndPlay
         );
     }
@@ -2090,7 +2112,7 @@ mod test {
     #[test]
     fn cleanup_sender_dropped_not_cancelled() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::SenderDropped, false, false),
+            decide_cleanup_action(PlaybackResult::SenderDropped, false, false, false),
             CleanupAction::AdvancePlaylist
         );
     }
@@ -2098,7 +2120,7 @@ mod test {
     #[test]
     fn cleanup_loop_broken() {
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Success, false, true),
+            decide_cleanup_action(PlaybackResult::Success, false, true, false),
             CleanupAction::LoopBreakAndPlay
         );
     }
@@ -2108,7 +2130,7 @@ mod test {
         // If both cancelled and loop_broken, loop_broken wins — we intentionally
         // cancel to break out of the loop immediately, but the intent is to advance.
         assert_eq!(
-            decide_cleanup_action(PlaybackResult::Success, true, true),
+            decide_cleanup_action(PlaybackResult::Success, true, true, false),
             CleanupAction::LoopBreakAndPlay
         );
     }

--- a/src/player/hardware.rs
+++ b/src/player/hardware.rs
@@ -399,10 +399,15 @@ impl Player {
             }
         };
 
+        let liveness_window = hw
+            .device
+            .as_ref()
+            .map(|d| d.liveness_window())
+            .unwrap_or(audio::health::LIVENESS_WINDOW);
         let audio_output = hw.device.as_ref().and_then(|d| d.output_health()).map(|h| {
             let as_ms = |d: Option<Duration>| d.map(|d| d.as_millis() as u64);
             AudioOutputHealth {
-                callback_alive: h.callback_alive(audio::health::LIVENESS_WINDOW),
+                callback_alive: h.callback_alive(liveness_window),
                 writing_signal: h.writing_signal(audio::health::SIGNAL_WINDOW),
                 since_last_callback_ms: as_ms(h.since_last_callback),
                 since_last_signal_ms: as_ms(h.since_last_signal),

--- a/src/player/hardware.rs
+++ b/src/player/hardware.rs
@@ -28,8 +28,8 @@ use crate::trigger::TriggerEngine;
 use crate::{audio, config, dmx, midi, samples};
 
 use super::{
-    ClockSource, HardwareState, HardwareStatusSnapshot, Player, SongChangeNotifier, StatusEvents,
-    SubsystemStatus,
+    AudioOutputHealth, ClockSource, HardwareState, HardwareStatusSnapshot, Player,
+    SongChangeNotifier, StatusEvents, SubsystemStatus,
 };
 
 impl Player {
@@ -399,6 +399,17 @@ impl Player {
             }
         };
 
+        let audio_output = hw.device.as_ref().and_then(|d| d.output_health()).map(|h| {
+            let as_ms = |d: Option<Duration>| d.map(|d| d.as_millis() as u64);
+            AudioOutputHealth {
+                callback_alive: h.callback_alive(audio::health::LIVENESS_WINDOW),
+                writing_signal: h.writing_signal(audio::health::SIGNAL_WINDOW),
+                since_last_callback_ms: as_ms(h.since_last_callback),
+                since_last_signal_ms: as_ms(h.since_last_signal),
+                callbacks: h.callbacks,
+            }
+        });
+
         HardwareStatusSnapshot {
             init_done,
             hostname: hw.hostname.clone(),
@@ -407,6 +418,7 @@ impl Player {
                 hw.device.is_some(),
                 hw.device.as_ref().map(|d| d.to_string()),
             ),
+            audio_output,
             midi: status_for(
                 hw.midi_device.is_some(),
                 hw.midi_device.as_ref().map(|d| d.to_string()),

--- a/src/player/playback.rs
+++ b/src/player/playback.rs
@@ -197,6 +197,10 @@ impl Player {
                 };
 
                 let cancelled = cancel_handle_for_cleanup.is_cancelled();
+                // Playback that ended itself, as distinct from one that stop()
+                // or a seek ended: only the former has nobody to clean up after
+                // it. See decide_cleanup_action.
+                let self_cancelled = cancel_handle_for_cleanup.cancelled_due_to_failure();
                 let loop_broken = player.loop_break.swap(false, Ordering::Relaxed);
 
                 info!(
@@ -206,7 +210,7 @@ impl Player {
                     "Song finished playing."
                 );
 
-                let action = decide_cleanup_action(result, cancelled, loop_broken);
+                let action = decide_cleanup_action(result, cancelled, loop_broken, self_cancelled);
                 if action == CleanupAction::StopCancelled {
                     // stop() already cleared join and play_start_time.
                     // Touching them here would clobber state from a new play() that

--- a/src/playsync.rs
+++ b/src/playsync.rs
@@ -95,7 +95,13 @@ impl Default for LoopControl {
 #[derive(PartialEq)]
 enum CancelState {
     Untouched,
+    /// Cancelled deliberately, by `stop()`, a seek, or a loop break. Whoever
+    /// asked for it is responsible for the player-side cleanup.
     Cancelled,
+    /// Cancelled by playback itself because it could not continue — the audio
+    /// device disappearing mid-song. Nobody is waiting to clean up after this
+    /// one, so the cleanup task has to do it.
+    CancelledByFailure,
 }
 
 /// A cancel handle is passed to the device during a play operation. It's the player's responsibility
@@ -125,9 +131,13 @@ impl Default for CancelHandle {
 }
 
 impl CancelHandle {
-    /// Returns true if the device process has been cancelled.
+    /// Returns true if the device process has been cancelled, for either reason.
+    ///
+    /// Every subsystem loop polls this to know it should wind up, and that is
+    /// true whichever way the cancellation came about — only the player-side
+    /// cleanup cares about the difference.
     pub fn is_cancelled(&self) -> bool {
-        *self.cancelled.lock() == CancelState::Cancelled
+        *self.cancelled.lock() != CancelState::Untouched
     }
 
     /// Waits for the cancel handle to be cancelled or for finished to be set to true.
@@ -172,6 +182,34 @@ impl CancelHandle {
             // Signal directly — we already hold the mutex.
             self.condvar.notify_all();
         }
+    }
+
+    /// Cancels because playback cannot continue, rather than because anyone
+    /// asked it to.
+    ///
+    /// Distinct from [`CancelHandle::cancel`] because the two want opposite
+    /// cleanup. A deliberate cancel is issued by `stop()`, which clears the
+    /// player's `join` and `play_start_time` itself and may already have started
+    /// a *new* playback — so the cleanup task must not touch that state. A
+    /// failure cancel has nobody behind it, so the cleanup task is the only
+    /// thing that will ever clear it.
+    ///
+    /// Telling them apart by "was there also an error?" is not enough: a
+    /// deliberately cancelled playback can report an error on its way out, and
+    /// treating that as a failure lets the cleanup clobber the playback a seek
+    /// has just started.
+    pub fn cancel_due_to_failure(&self) {
+        let mut cancel_state = self.cancelled.lock();
+        if *cancel_state == CancelState::Untouched {
+            *cancel_state = CancelState::CancelledByFailure;
+            self.condvar.notify_all();
+        }
+    }
+
+    /// Whether cancellation came from playback failing rather than from a
+    /// deliberate stop, seek, or loop break.
+    pub fn cancelled_due_to_failure(&self) -> bool {
+        *self.cancelled.lock() == CancelState::CancelledByFailure
     }
 }
 


### PR DESCRIPTION
Refs #350, #347, #349

Six commits, from working backwards from a real incident: mtrack running, room silent, logs clean, several mtrack restarts not helping, fixed only by restarting the interface *and then* mtrack.

Rebased onto current `main` (it sits on top of #362, which the device re-resolution depends on).

## What the evidence ruled out

The startup log showed `"Audio output stream started successfully (direct callback mode)"`, emitted **only** from the `Ok(stream)` branch — the failure path logs `"Failed to create audio stream"` at ERROR. So the first build succeeded and #350's swallowed-failure path did not occur.

More decisively: the silence survived repeated mtrack restarts. A fresh process re-enumerates the device and rebuilds everything, so no in-process mtrack state explains it. The interface held the bad state, and mtrack opened it successfully every time — through `plughw`, which silently converts rate and format — and wrote samples into something that produced no sound.

**None of this fixes that incident**, and nothing host-side could. What it fixes is the surrounding blindness, and one failure mode next door to it that strands a rig mid-set.

## 1. Keep the output thread alive across device loss

The `Err` arm of the build loop ended in an unconditional `return`, so *any* build failure killed the output thread. Two consequences:

- **First build**: the thread tripped the barrier from the `Err` branch exactly as from `Ok`, so `start_output_thread` returned `Ok(())` with a dead thread behind it. `get_device` reported success, so `retry_until_ready` — which exists precisely to wait out a not-ready device — never re-ran, since it only retries on `Err`. That's #350.
- **Rebuild after a backend error**: the single immediate attempt was the only one. Power-cycling a USB interface raises the error at once, but re-enumeration takes seconds, so that lone rebuild lands while the card is still absent, fails, and the thread exits. **This is why mtrack needed restarting after the interface came back** — nothing was left listening.

First-build failure now reaches the caller through a result channel replacing the `Barrier`, so the existing retry loop re-runs device discovery. Later failures retry in-thread with shutdown-aware backoff (250ms doubling to 5s). After a successful start the thread exits only on shutdown, so `connected` can no longer mean *connected to nothing*.

**Stale handles.** The loop retried the `cpal::Device` resolved at startup, forever. ALSA keys a device by name, so that handle reopens a power-cycled interface fine — but CoreAudio keys it by `AudioDeviceID` and WASAPI by endpoint, and a re-plugged interface returns under a *new* one. We ship macOS builds, so that's reachable. A failed build now re-resolves by name, but only once the handle has built successfully at least once: a handle that never worked is wrong rather than stale, and re-resolving it would just find the same device again — without that gate, a rejected config made every attempt of the perpetual 500ms retry enumerate twice.

That put enumeration on the output thread, which surfaced an existing hazard: enumeration silences ALSA by redirecting the process's file descriptors, and two threads doing that at once lose the real stdout for the life of the process — a failure that by construction prints nothing at all. Web UI enumeration could already race init. The three paths now serialise on one lock.

**Saying which failure it is.** The retry re-runs twice a second forever and logged the same line either way. Those want opposite responses: a device still enumerating gets picked up by the next retry, which is what the perpetual retry is *for*; one that is present and refuses to open will still be refusing in an hour. Locating and opening are now split, so any failure past the point where the device was found reports `'X' was found but could not be opened`, distinct from `no device found with name X`.

## 2. Record callback liveness

Nothing was recorded about the callback after startup. `process_f32_callback` called the mixer and returned; the only instrumentation was the profiler's timing, behind `MTRACK_PROFILE_AUDIO` at `debug!`.

`OutputHealth` records two facts — when the callback last ran, and when it last handed the device something above the silence floor — lock-free, no allocation, one clock read per callback. It is owned by `OutputManager` rather than the stream, so a rebuild doesn't reset the history. `hardware_status` gains an `audio_output` section, which reaches the web UI status endpoint and the MCP `host_info` tool for free.

**No level, deliberately.** An earlier revision reported a peak. Nothing in the health path read it — the silence-floor test uses the value computed inside the callback, before storage — so it was display-only, and a poor display: a status poller sees roughly one callback in several hundred. Reset-on-read metering semantics can't be retrofitted either, since `hardware_status` has two independent callers that would steal peaks from each other. Removing it made the callback *cheaper*: it now asks `has_output_signal`, which short-circuits on the first sample above the floor. Metering is a separate feature with a reader of its own.

The module lives at `audio::health`, beside the `Device` trait rather than inside the cpal implementation — nothing in it is backend-specific, and multi-interface output will want it per interface.

## 3. Harness: prove an unopenable device is told apart from a missing one

Covers the distinction above, and #350's regression from the other side — such a device used to report `connected`. The lever is `bits_per_sample: 24` with the default integer format, which `stream.rs` rejects outright, so the failure is independent of what the interface supports. An unsupported *sample rate* would not do: ALSA's plug layer converts silently and the stream opens.

## 4. End the song when the callback stops mid-playback

Reporting the stall and carrying on was wrong, and worse than the bug it replaced.

The transport is driven by the callback's sample counter, so an outage does not advance it — it **freezes** it. Audio, MIDI and cues stop together and, when the device returns, would resume from the bar they froze on rather than from where the room now is.

On stage that is the wrong end to recover. The band has just played through the gap with no click and no tracks, so they are not where the frozen transport thinks they are, and audio reappearing mid-song hands them a second, confidently wrong reference to follow. The one piece of state that would make resumption correct — where the band is — is not observable from the host at any level of cleverness. Fast-forwarding to a wall clock fails identically: it assumes the band held tempo through the one moment they had nothing to hold it to.

This makes commit 1 conditional on it. Before commit 1, a mid-set outage was permanent silence until restart: bad, but unambiguous — the track is gone and stays gone, and someone counts the song out. Audio returning at an arbitrary point is not obviously better and arguably worse. **The rebuild loop should not ship without this.**

So the split is by layer: `OutputManager` keeps rebuilding so the interface is ready for whatever the operator starts next, and `play_from` ends the song it was playing. The ERROR is for working out afterwards what happened; nobody reads a log mid-set.

The audio thread cancels the shared handle before returning the error, because the song's MIDI and DMX threads wait on the same frozen clock and would otherwise never be joined, then resume together when the device came back. That makes playback the first thing that can cancel *itself*, which `decide_cleanup_action` did not allow for: `cancelled` short-circuited ahead of `Failed` and returned `StopCancelled`, a path that deliberately skips clearing `join` and `play_start_time` because it assumes `stop()` already did. Nothing calls `stop()` here, so the player would have believed a song was still playing forever. Failures are now decided before cancellation; a `stop()` cancellation doesn't reach that branch because `play_from` returns `Ok` once it observes the handle.

## 5. Key self-cancellation on *who* cancelled, not on the error

Caught by CI, not by me. Making playback cancel itself meant the cleanup task had to recognise that case, and I identified it as "cancelled, and also failed" — which is wrong. A seek cancels the in-flight playback and immediately starts a new one, and the playback it cancelled can report an error on its way out, so that description fits an ordinary seek too. Reading it as a self-cancellation let the cleanup clear `join` and `play_start_time` belonging to the playback the seek had just started, leaving `is_playing()` false mid-seek. The `StopCancelled` comment warns about exactly this; I restated it in a commit message and then wrote the bug anyway.

Cancellation now carries its reason. `CancelHandle` grows `CancelledByFailure` alongside `Cancelled` — `is_cancelled()` is true for both, so every subsystem loop winds up identically, and only the player-side cleanup asks which it was.

Worth noting how thin the verification was: the seek test passes 60/60 locally both with and without the bug, because the race needs CI's contention. What distinguishes them is `cleanup_deliberate_cancel_with_an_error_still_stops`, which pins the seek case directly and fails against the old discriminator — confirmed by restoring it, watching that test fail, and reverting. The timing-dependent test found the bug; the deterministic one keeps it found.

## 6. Floor the liveness window rather than deriving it

The window is a consequence threshold, not a jitter margin. Once a second has passed with nothing handed to the device, the moment is gone whether or not the device was really dead — so a "false positive" there is not meaningfully false: the song it ends was already ruined by the silence that triggered it. That is what makes one second principled rather than arbitrary, and why it should not be much larger either.

Deriving it from the buffer, as #347 asked, would be worse. Jitter and death differ by orders of magnitude, so anything from a couple of hundred milliseconds to several seconds behaves identically on a real rig — and a purely derived window is dangerous at the small end. At the default 1024 frames / 44.1kHz, four periods is 92ms, and the test rig logs `Failed to set RT SCHED_FIFO ... error code 1` on every start, so its callback thread runs at normal priority where a 92ms scheduling gap under prewarming or page faults is ordinary. Each one would now kill a song. The error bars are lopsided: concluding late costs a little more of an already-silent moment, concluding early kills a healthy song in front of an audience.

It can't be dropped entirely either, because `buffer_size` is validated only as `> 0`. At 65536 frames a period is ~1.5s — longer than the floor, so a healthy callback would look stopped between every buffer and no song could ever play, from a config that passes validation today and worked before this branch.

So: `max(1s, 4 callback periods)`. Exactly 1s for every configuration anyone runs, self-correcting for absurd ones. `liveness_window` and `callback_period` are free functions, so those cases are unit tests rather than something only a strange rig could demonstrate, and the window is on the `Device` trait so the status snapshot and the playback monitor judge liveness by the same number.

## Verified on real hardware

Run on the Pi rig against a MAT 8x16 at the branch head (`24cf0dc`), by unbinding `snd-usb-audio` in sysfs mid-song — a real driver-level removal, which unlike `modprobe -r` works while the PCM is open.

| stage | observed |
|---|---|
| playing | `alive=true signal=true`, `Playing: true`, elapsed 0:02 |
| **yank** | MAT vanishes from `aplay -l` |
| +1s | `alive=false`, **`Playing: false`**, elapsed reset |
| callbacks | froze at 1477 and stayed frozen — the transport freeze, measured |
| rebind | callbacks resume 1488 → 1587 → 1685 → 1783 |
| replay | accepted; `Playing: true`, elapsed advancing |
| **loopback capture** | out1 → in3: peak `0.1949`, 440 Hz energy `0.00591` vs 997 Hz control `0.00002` |

That last row is the one that matters: real audio physically left the interface and came back down the cable, after the device died and returned, in the same process with no restart. `writing_signal` alone would not have justified the claim.

The journal during the yank:

```
ERROR Audio output callback stopped during playback; ending the song...
      since_last_callback_ms=1007 callbacks=1477
ERROR Error while playing song err=Audio stream error: ...
INFO  Song finished playing. cancelled=true loop_broken=false
WARN  Advancing playlist despite playback failure so user is not stuck
ERROR Failed to recreate audio stream: snd_pcm_open ... No such device (19) (retrying in 2s)
ERROR Failed to recreate audio stream: snd_pcm_open ... No such device (19) (retrying in 4s)
INFO  Audio output stream recovered after backend error
```

`cancelled=true` *and* a failure is exactly the combination that previously took `StopCancelled`; it took the failure path instead.

Full harness suite: **30/30**, so the 1s threshold does not misfire during normal playback, section looping, or beat clock. New harness check passes and its `--self-test` sabotage control fires.

Unit tests: 3103 passing (the 6 `webui::server::server_serves_*` failures need `src/webui/svelte/dist/`, gitignored build output absent from a fresh worktree). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

**Not verified**: the stale-handle re-resolution. ALSA reopens by name, so the rig recovers without ever exercising that branch — the log shows `recovered after backend error` and never `came back under a new handle`. It only matters on CoreAudio and WASAPI, and only a Mac with a hand on a cable can settle it.

## Left for you

- **#348** untouched, and I'd narrow rather than close it. "A startup self-test would have passed anyway" holds for a *silent* probe. It doesn't hold for #348's audible probe: a channel-ID sweep at load-in would have had the operator hear the silence before the set. And "nothing host-side can detect it" is overstated given mtrack has an input path and the rig runs a physical loopback — the capture above is that detector, working.
- **#349 is only half done.** During the yank, `audio` reported `connected` the entire time the card was absent from `aplay -l`, because that status is still `hw.device.is_some()`. `audio_output.callback_alive` was the only honest signal. Worth finishing.
- **No web UI surface yet.** A song that stops on its own needs a visible cause; the backend data is there for one to consume.
- **A permanently unbuildable device still wedges hardware init** — filed as #368. This PR only makes the situation legible; ending that retry is broader, since the same helper backs MIDI and DMX and whether init should come up degraded is a behaviour decision. It predates this branch: a zero sample rate already failed permanently and already spun there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
