### PR TITLE
test(harness): build negative controls into the harness

### DIFF
--- a/harness/FINDINGS.md
+++ b/harness/FINDINGS.md
@@ -133,13 +133,14 @@ prints how many of its passes rest on them. Read that number alongside the
 total.
 
 **Proof is opt-in.** Only the assertion macros (`check!`, `check_eq!`, `fail!`)
-and constructors named `*_assertion` may mark a failure as coming from a
-check's own assertion. Every shared helper -- log checks, readiness waits, RPC
-conversions, `inconclusive!` -- produces a pre-assertion value and *cannot*
-claim a control worked. Three review rounds running found helpers minting proof
-for controls that never reached the assertion, each time fixed instance by
-instance; the invariant is stated in `outcome.rs` so the class is closed rather
-than the examples.
+and constructors named `*_assertion` mark a failure as coming from a check's
+own assertion; shared helpers -- log checks, readiness waits, RPC conversions,
+`inconclusive!` -- produce pre-assertion values. The flag is private to
+`outcome`, so it cannot be set by struct literal, which is how `inconclusive!`
+set it wrongly for three rounds. That closes the accidental case. It does not
+close the deliberate one: the constructors are public, and
+`Client::wait_for_status` takes an `assertion` parameter by design. A helper
+claiming proof must now say so in its own source.
 
 Only an assertion counts. Failures carry a `from_assertion` flag, because a
 control that dies inside `Server::start` reports `Failed` and would otherwise

--- a/harness/FINDINGS.md
+++ b/harness/FINDINGS.md
@@ -105,44 +105,44 @@ the exception; that comment has been corrected.
 
 ## Verifying the checks themselves
 
-A check that cannot fail is worse than no check, and two have shipped here:
+A check that cannot fail is worse than no check, and three have shipped here:
 `bogus_*_device_degrades_gracefully` read a status that was `initializing`
-whatever mtrack did, and `active_playlist_persists_across_restart` asserted the
-opposite of documented behaviour. Both survived several reviews.
+whatever mtrack did; `active_playlist_persists_across_restart` asserted the
+opposite of documented behaviour; and `stop_halts_playback` used a four-second
+song that ended on its own inside the ten-second stop deadline, so it passed
+whether or not Stop did anything. All three survived several reviews.
 
-A one-off sweep was run against every check on 2026-08-09: break the check's
-premise, run it alone, require it to stop passing. **20 of 26 checks were
-demonstrated capable of failing.** The remaining six need a deliberately broken
-mtrack rather than a broken input, and are unproven:
-`selected_output_is_real_hardware`, `plays_a_song_to_completion`,
-`stop_halts_playback`, `active_playlist_persists_across_restart`,
-`controllers_restart_while_idle`, `lighting_effects_activate_during_playback`.
+```
+./scripts/hardware-test.sh --self-test      # or: mtrack-harness --self-test
+```
 
-The tooling was **not** retained. It was a table of mutations pinned to exact
-source strings, nothing ran it, and it had no idea the registry contained
-checks it did not cover -- so it would have reported a perfect score against
-its own table while silently ignoring a third of the suite. Rebuilding it
-properly means having it read `checks::all()` and fail when a registered check
-has neither a mutation nor an explicit exemption.
+Every check names one thing it depends on and asks `sabotage::` whether to
+break it. `--self-test` runs them all with the flag set and requires *none* to
+pass. **26/26 on the MAT rig; 25/26 on the WING**, where routing is not
+exercised because that console has no loopback.
 
-Two strengths of evidence are worth keeping distinct when it is rebuilt:
+The control lives beside the assertion it guards, so refactoring cannot orphan
+it, and completeness enforces itself: a check with no break point, or an
+ineffective one, simply passes the self-test and is reported as a defect. That
+is how the two lighting checks and a rig-dependent control were caught — the
+self-test found them, not review.
 
-- **world** — the input the check reads is broken. Strong: it proves the check
-  notices a changed reality.
-- **predicate** — the assertion is inverted. Proves only that it is reached and
-  its message renders. *A vacuous check passes this*, which is why the two
-  defects above needed world mutations to catch.
+An external source-mutating version was tried first and removed. Its mutations
+were pinned to exact source strings, so it rotted whenever a check was edited,
+and it did not know the registry held checks it never covered: it scored itself
+16/16 while ignoring ten.
 
-Three lessons from that run, all bugs in the sweep rather than in the checks:
+Three lessons from building it, all bugs in the controls rather than the checks:
 
 - Profiles load in **filename** order (`config/player.rs`), so reordering the
   vec passed to `.profiles()` is a no-op sabotage.
 - A *bogus* device stops the player booting, so the check fails at startup
-  without ever reaching the assertion under test. A valid-but-different device
-  is the correct control.
-- Scoping a mutation to a function needs **string-aware** brace matching: one
-  check body contains `"show \"Broken\" { ..."`, and naive matching never
-  rebalances.
+  without reaching the assertion under test. A valid-but-different device is
+  the correct control.
+- A control must not depend on the rig supplying the failure condition. The
+  plug-device check could not fail on the WING, where no raw device exists at
+  all -- the very case it was written to tolerate.
+
 
 ## Non-defects worth knowing
 

--- a/harness/FINDINGS.md
+++ b/harness/FINDINGS.md
@@ -102,7 +102,6 @@ was closed as invalid. What misled the original report was
 `config/player.rs`'s comment, which promised persistence without mentioning
 the exception; that comment has been corrected.
 
-
 ## Verifying the checks themselves
 
 A check that cannot fail is worse than no check, and three have shipped here:
@@ -121,6 +120,17 @@ break it. `--self-test` runs them all with the flag set and requires each to
 report a defect **from its own assertion**. **26/26 on the MAT rig; 25/26 on
 the WING**, where routing is not exercised because that console has no
 loopback.
+
+**What the score cannot tell you.** The self-test proves a check's assertion
+fires; it cannot prove the assertion is *positioned* correctly. Where a control
+substitutes the value the assertion reads (a "predicate-level" control, listed
+in `checks.rs`) rather than breaking the world the assertion observes, it would
+still score a pass if the check were later made vacuous the way
+`bogus_*_device_degrades_gracefully` was -- reading something insensitive to
+what mtrack does. Those controls are deliberate trade-offs, usually because the
+world-level version killed startup before the assertion ran, and `--self-test`
+prints how many of its passes rest on them. Read that number alongside the
+total.
 
 Only an assertion counts. Failures carry a `from_assertion` flag, because a
 control that dies inside `Server::start` reports `Failed` and would otherwise
@@ -149,7 +159,6 @@ Three lessons from building it, all bugs in the controls rather than the checks:
 - A control must not depend on the rig supplying the failure condition. The
   plug-device check could not fail on the WING, where no raw device exists at
   all -- the very case it was written to tolerate.
-
 
 ## Non-defects worth knowing
 

--- a/harness/FINDINGS.md
+++ b/harness/FINDINGS.md
@@ -117,9 +117,16 @@ whether or not Stop did anything. All three survived several reviews.
 ```
 
 Every check names one thing it depends on and asks `sabotage::` whether to
-break it. `--self-test` runs them all with the flag set and requires *none* to
-pass. **26/26 on the MAT rig; 25/26 on the WING**, where routing is not
-exercised because that console has no loopback.
+break it. `--self-test` runs them all with the flag set and requires each to
+report a defect **from its own assertion**. **26/26 on the MAT rig; 25/26 on
+the WING**, where routing is not exercised because that console has no
+loopback.
+
+Only an assertion counts. Failures carry a `from_assertion` flag, because a
+control that dies inside `Server::start` reports `Failed` and would otherwise
+be indistinguishable from one that drove its assertion to failure -- the same
+"reading it cannot tell you" problem, one level up. Counting any non-pass as
+proof initially hid four broken controls behind a green 26/26.
 
 The control lives beside the assertion it guards, so refactoring cannot orphan
 it, and completeness enforces itself: a check with no break point, or an

--- a/harness/FINDINGS.md
+++ b/harness/FINDINGS.md
@@ -132,6 +132,15 @@ world-level version killed startup before the assertion ran, and `--self-test`
 prints how many of its passes rest on them. Read that number alongside the
 total.
 
+**Proof is opt-in.** Only the assertion macros (`check!`, `check_eq!`, `fail!`)
+and constructors named `*_assertion` may mark a failure as coming from a
+check's own assertion. Every shared helper -- log checks, readiness waits, RPC
+conversions, `inconclusive!` -- produces a pre-assertion value and *cannot*
+claim a control worked. Three review rounds running found helpers minting proof
+for controls that never reached the assertion, each time fixed instance by
+instance; the invariant is stated in `outcome.rs` so the class is closed rather
+than the examples.
+
 Only an assertion counts. Failures carry a `from_assertion` flag, because a
 control that dies inside `Server::start` reports `Failed` and would otherwise
 be indistinguishable from one that drove its assertion to failure -- the same

--- a/harness/src/checks.rs
+++ b/harness/src/checks.rs
@@ -46,6 +46,53 @@ macro_rules! entry {
     };
 }
 
+/// Checks whose sabotage substitutes the value the assertion *reads*, rather
+/// than changing the world the assertion observes.
+///
+/// The distinction matters and is easy to lose. A world-level control breaks an
+/// input and requires the check to notice; a predicate-level one swaps the
+/// string or number the assertion compares. The second proves the assertion is
+/// wired up and reachable, but **cannot detect the class of vacuity that
+/// motivated the self-test**: if such a check were later made vacuous the way
+/// `bogus_*_device_degrades_gracefully` was -- reading a value that is the same
+/// whatever mtrack does -- a predicate-level control would still score
+/// "assertion fired", because it replaces the value after the read.
+///
+/// These are deliberate trade-offs, not oversights. `configured_midi_device_transmits`
+/// was moved here precisely because its world-level control pointed the profile
+/// at a bogus device and timed out during startup, never reaching the assertion.
+/// They are listed so the self-test can say how much of its score rests on the
+/// weaker evidence rather than burying it in a single number.
+const PREDICATE_LEVEL: &[&str] = &[
+    "advertised_devices_are_openable",
+    "selected_output_is_real_hardware",
+    "player_starts_against_detected_hardware",
+    "generated_project_loads_all_songs",
+    "song_midi_notes_are_transmitted",
+    "beat_clock_runs_at_the_song_tempo",
+    "configured_midi_device_transmits",
+    "midi_beat_clock_persists",
+    "show_written_via_api_is_readable",
+];
+
+/// Whether this check's negative control only substitutes the asserted value.
+pub fn is_predicate_level(name: &str) -> bool {
+    PREDICATE_LEVEL.contains(&name)
+}
+
+/// Names in [`PREDICATE_LEVEL`] that no longer match a registered check.
+///
+/// A stale entry would quietly overstate the self-test's strength, so it is
+/// reported rather than ignored.
+pub fn stale_predicate_entries() -> Vec<&'static str> {
+    let names: Vec<&str> = all().into_iter().map(|c| c.name).collect();
+    PREDICATE_LEVEL
+        .iter()
+        .filter(|p| !names.contains(p))
+        .copied()
+        .collect()
+}
+
 /// Every check, in execution order.
 ///
 /// Ordering is deliberate: cheap structural checks first, so a broken project

--- a/harness/src/checks.rs
+++ b/harness/src/checks.rs
@@ -58,11 +58,18 @@ macro_rules! entry {
 /// whatever mtrack does -- a predicate-level control would still score
 /// "assertion fired", because it replaces the value after the read.
 ///
-/// These are deliberate trade-offs, not oversights. `configured_midi_device_transmits`
-/// was moved here precisely because its world-level control pointed the profile
-/// at a bogus device and timed out during startup, never reaching the assertion.
-/// They are listed so the self-test can say how much of its score rests on the
-/// weaker evidence rather than burying it in a single number.
+/// The weaker class is the *default*: anything absent from this list counts as
+/// predicate-level, so a new check, or one whose control is later weakened, is
+/// treated as weak evidence until someone deliberately promotes it. Listing the
+/// weak ones instead would let an omission overstate the score.
+///
+/// Absences are usually deliberate trade-offs.
+/// `configured_midi_device_transmits` is predicate-level because its
+/// world-level control pointed the profile at a bogus device and timed out
+/// during startup, never reaching the assertion;
+/// `plays_a_song_to_completion` because making a transport clock misbehave
+/// needs a broken player. The self-test prints how many of its passes rest on
+/// this class rather than burying it in one number.
 const WORLD_LEVEL: &[&str] = &[
     "stop_halts_playback",
     "playlist_navigation_moves_between_songs",
@@ -75,7 +82,6 @@ const WORLD_LEVEL: &[&str] = &[
     "bogus_midi_device_degrades_gracefully",
     "bogus_audio_device_degrades_gracefully",
     "first_profile_wins",
-    "controllers_restart_while_idle",
     "generated_show_passes_validation",
     "malformed_show_is_rejected",
     "song_lighting_produces_cues",

--- a/harness/src/checks.rs
+++ b/harness/src/checks.rs
@@ -46,8 +46,8 @@ macro_rules! entry {
     };
 }
 
-/// Checks whose sabotage substitutes the value the assertion *reads*, rather
-/// than changing the world the assertion observes.
+/// Checks whose sabotage breaks the *world* the assertion observes, rather than
+/// substituting the value it reads.
 ///
 /// The distinction matters and is easy to lose. A world-level control breaks an
 /// input and requires the check to notice; a predicate-level one swaps the
@@ -63,30 +63,44 @@ macro_rules! entry {
 /// at a bogus device and timed out during startup, never reaching the assertion.
 /// They are listed so the self-test can say how much of its score rests on the
 /// weaker evidence rather than burying it in a single number.
-const PREDICATE_LEVEL: &[&str] = &[
-    "advertised_devices_are_openable",
-    "selected_output_is_real_hardware",
-    "player_starts_against_detected_hardware",
-    "generated_project_loads_all_songs",
-    "song_midi_notes_are_transmitted",
-    "beat_clock_runs_at_the_song_tempo",
-    "configured_midi_device_transmits",
-    "midi_beat_clock_persists",
-    "show_written_via_api_is_readable",
+const WORLD_LEVEL: &[&str] = &[
+    "plays_a_song_to_completion",
+    "stop_halts_playback",
+    "playlist_navigation_moves_between_songs",
+    "tracks_route_to_their_mapped_channels",
+    "beat_clock_is_silent_when_disabled",
+    "stale_checksum_is_rejected",
+    "active_playlist_persists_across_restart",
+    "absent_midi_is_skipped_not_fatal",
+    "absent_dmx_is_skipped_not_fatal",
+    "bogus_midi_device_degrades_gracefully",
+    "bogus_audio_device_degrades_gracefully",
+    "first_profile_wins",
+    "controllers_restart_while_idle",
+    "generated_show_passes_validation",
+    "malformed_show_is_rejected",
+    "song_lighting_produces_cues",
+    "lighting_effects_activate_during_playback",
 ];
 
 /// Whether this check's negative control only substitutes the asserted value.
+///
+/// Unlisted means predicate-level, so a new check -- or one whose control is
+/// later weakened -- is counted as weak evidence until someone says otherwise.
+/// Listing the weak ones instead would let an omission silently overstate the
+/// score, which is the exact failure this accounting exists to prevent.
 pub fn is_predicate_level(name: &str) -> bool {
-    PREDICATE_LEVEL.contains(&name)
+    !WORLD_LEVEL.contains(&name)
 }
 
-/// Names in [`PREDICATE_LEVEL`] that no longer match a registered check.
+/// Names in [`WORLD_LEVEL`] that no longer match a registered check.
 ///
-/// A stale entry would quietly overstate the self-test's strength, so it is
-/// reported rather than ignored.
+/// A stale entry credits a check that no longer exists, so it is reported.
+/// The opposite direction needs no check: an unlisted name is already treated
+/// as the weaker class.
 pub fn stale_predicate_entries() -> Vec<&'static str> {
     let names: Vec<&str> = all().into_iter().map(|c| c.name).collect();
-    PREDICATE_LEVEL
+    WORLD_LEVEL
         .iter()
         .filter(|p| !names.contains(p))
         .copied()

--- a/harness/src/checks.rs
+++ b/harness/src/checks.rs
@@ -64,7 +64,6 @@ macro_rules! entry {
 /// They are listed so the self-test can say how much of its score rests on the
 /// weaker evidence rather than burying it in a single number.
 const WORLD_LEVEL: &[&str] = &[
-    "plays_a_song_to_completion",
     "stop_halts_playback",
     "playlist_navigation_moves_between_songs",
     "tracks_route_to_their_mapped_channels",
@@ -98,7 +97,7 @@ pub fn is_predicate_level(name: &str) -> bool {
 /// A stale entry credits a check that no longer exists, so it is reported.
 /// The opposite direction needs no check: an unlisted name is already treated
 /// as the weaker class.
-pub fn stale_predicate_entries() -> Vec<&'static str> {
+pub fn stale_world_level_entries() -> Vec<&'static str> {
     let names: Vec<&str> = all().into_iter().map(|c| c.name).collect();
     WORLD_LEVEL
         .iter()

--- a/harness/src/checks/devices.rs
+++ b/harness/src/checks/devices.rs
@@ -59,7 +59,12 @@ pub async fn advertised_devices_are_openable() -> CheckOutcome {
         .map(|d| d.split(" (Channels=").next().unwrap_or(d))
         .collect();
 
-    let openable_names: Vec<&str> = crate::sabotage::pick(openable_names.clone(), Vec::new());
+    // Emptied only under sabotage; the clone would otherwise run every time.
+    let openable_names: Vec<&str> = if crate::sabotage::active() {
+        Vec::new()
+    } else {
+        openable_names
+    };
     let phantom: Vec<&String> = advertised
         .iter()
         .filter(|name| !openable_names.contains(&name.as_str()))

--- a/harness/src/checks/devices.rs
+++ b/harness/src/checks/devices.rs
@@ -139,7 +139,7 @@ pub async fn selected_output_is_real_hardware() -> CheckOutcome {
         // Reachable only by an operator override; device_rank already prefers
         // raw hardware. Blaming mtrack (and exiting non-zero) for the harness's
         // own device choice would be wrong.
-        return Err(crate::outcome::CheckError::Inconclusive(format!(
+        return Err(crate::outcome::CheckError::inconclusive_assertion(format!(
             "selected the plug device '{}' even though raw hardware was available: {:?}. Its \
              {}-channel count is the plug layer's, not the interface's, so routing measured \
              through it would not mean what it appears to. Check MTRACK_E2E_AUDIO_DEVICE.",

--- a/harness/src/checks/devices.rs
+++ b/harness/src/checks/devices.rs
@@ -144,12 +144,14 @@ pub async fn selected_output_is_real_hardware() -> CheckOutcome {
         // Reachable only by an operator override; device_rank already prefers
         // raw hardware. Blaming mtrack (and exiting non-zero) for the harness's
         // own device choice would be wrong.
-        return Err(crate::outcome::CheckError::inconclusive_assertion(format!(
+        crate::inconclusive_verdict!(
             "selected the plug device '{}' even though raw hardware was available: {:?}. Its \
              {}-channel count is the plug layer's, not the interface's, so routing measured \
              through it would not mean what it appears to. Check MTRACK_E2E_AUDIO_DEVICE.",
-            device.name, raw_alternatives, device.max_channels
-        )));
+            device.name,
+            raw_alternatives,
+            device.max_channels
+        );
     }
 
     crate::outcome::record(format!(

--- a/harness/src/checks/devices.rs
+++ b/harness/src/checks/devices.rs
@@ -59,6 +59,7 @@ pub async fn advertised_devices_are_openable() -> CheckOutcome {
         .map(|d| d.split(" (Channels=").next().unwrap_or(d))
         .collect();
 
+    let openable_names: Vec<&str> = crate::sabotage::pick(openable_names.clone(), Vec::new());
     let phantom: Vec<&String> = advertised
         .iter()
         .filter(|name| !openable_names.contains(&name.as_str()))
@@ -107,7 +108,9 @@ pub async fn selected_output_is_real_hardware() -> CheckOutcome {
         ));
     }
 
-    let is_raw_hw = device.name.contains("hw:CARD=") && !device.name.contains("plughw:");
+    let is_raw_hw = crate::sabotage::perform()
+        && device.name.contains("hw:CARD=")
+        && !device.name.contains("plughw:");
     if is_raw_hw {
         return Ok(());
     }
@@ -118,12 +121,19 @@ pub async fn selected_output_is_real_hardware() -> CheckOutcome {
     // its ALSA format table -- so their raw device never appears here and the
     // plug layer is the only way in. That is a legitimate configuration, not a
     // defect, but it does mean the channel count is the plug layer's.
-    let raw_alternatives: Vec<&str> = caps
-        .all_audio_out
-        .iter()
-        .filter(|d| d.name.contains("hw:CARD=") && !d.name.contains("plughw:"))
-        .map(|d| d.name.as_str())
-        .collect();
+    // Under sabotage, pretend a raw device was available. Relying on the rig to
+    // supply one made this control rig-dependent: on a console whose only
+    // openable device is a plug node -- the case this check exists to tolerate
+    // -- the failure condition is unreachable and the check could not fail.
+    let raw_alternatives: Vec<&str> = if crate::sabotage::active() {
+        vec!["e2e-pretend-raw:hw:CARD=X,DEV=0"]
+    } else {
+        caps.all_audio_out
+            .iter()
+            .filter(|d| d.name.contains("hw:CARD=") && !d.name.contains("plughw:"))
+            .map(|d| d.name.as_str())
+            .collect()
+    };
 
     if !raw_alternatives.is_empty() {
         // Reachable only by an operator override; device_rank already prefers

--- a/harness/src/checks/lighting.rs
+++ b/harness/src/checks/lighting.rs
@@ -33,12 +33,16 @@ use crate::songs::{LightingSpec, SongSpec};
 use crate::{check, check_eq};
 
 /// A project whose profile has lighting wired up and whose first song has a show.
-fn lighting_project() -> Result<crate::project::Project, Box<dyn std::error::Error>> {
+fn lighting_project(
+    strip_show_under_sabotage: bool,
+) -> Result<crate::project::Project, Box<dyn std::error::Error>> {
     // The break point for the checks that read cues and live effects: a song
-    // with no show at all should leave both empty. The validation checks post
-    // their own DSL and so have their own break points.
+    // with no show at all should leave both empty. The other three lighting
+    // checks pass `false`, because they have their own break points and would
+    // otherwise run two sabotages at once -- a fired assertion could then not
+    // be attributed to the intended one.
     let song = SongSpec::tones("Lit Song", "lit-song", 2, 8.0);
-    let song = if crate::sabotage::perform() {
+    let song = if !strip_show_under_sabotage || crate::sabotage::perform() {
         song.with_lighting(LightingSpec::simple(
             "E2E Show",
             "lighting/show.light",
@@ -60,7 +64,7 @@ fn lighting_project() -> Result<crate::project::Project, Box<dyn std::error::Err
 /// as a validation failure rather than as an empty cue list later on.
 pub async fn generated_show_passes_validation() -> CheckOutcome {
     crate::runner::require_area("lighting")?;
-    let project = lighting_project()?;
+    let project = lighting_project(false)?;
     let server = Server::start(&project).await?;
     let client = Client::connect(&server).await?;
 
@@ -89,7 +93,7 @@ pub async fn generated_show_passes_validation() -> CheckOutcome {
 /// approves everything.
 pub async fn malformed_show_is_rejected() -> CheckOutcome {
     crate::runner::require_area("lighting")?;
-    let project = lighting_project()?;
+    let project = lighting_project(false)?;
     let server = Server::start(&project).await?;
     let client = Client::connect(&server).await?;
 
@@ -113,7 +117,7 @@ pub async fn malformed_show_is_rejected() -> CheckOutcome {
 /// A show attached to a song turns into cues the player can report.
 pub async fn song_lighting_produces_cues() -> CheckOutcome {
     crate::runner::require_area("lighting")?;
-    let project = lighting_project()?;
+    let project = lighting_project(true)?;
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
 
@@ -157,7 +161,7 @@ pub async fn song_lighting_produces_cues() -> CheckOutcome {
 pub async fn lighting_effects_activate_during_playback() -> CheckOutcome {
     crate::runner::require_area("lighting")?;
     let caps = Capabilities::get();
-    let project = lighting_project()?;
+    let project = lighting_project(true)?;
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
 
@@ -213,7 +217,7 @@ pub async fn lighting_effects_activate_during_playback() -> CheckOutcome {
 /// A show written through the API can be read back.
 pub async fn show_written_via_api_is_readable() -> CheckOutcome {
     crate::runner::require_area("lighting")?;
-    let project = lighting_project()?;
+    let project = lighting_project(false)?;
     let server = Server::start(&project).await?;
     let client = Client::connect(&server).await?;
 

--- a/harness/src/checks/lighting.rs
+++ b/harness/src/checks/lighting.rs
@@ -34,11 +34,19 @@ use crate::{check, check_eq};
 
 /// A project whose profile has lighting wired up and whose first song has a show.
 fn lighting_project() -> Result<crate::project::Project, Box<dyn std::error::Error>> {
-    let song = SongSpec::tones("Lit Song", "lit-song", 2, 8.0).with_lighting(LightingSpec::simple(
-        "E2E Show",
-        "lighting/show.light",
-        LIGHTING_GROUP,
-    ));
+    // The break point for the checks that read cues and live effects: a song
+    // with no show at all should leave both empty. The validation checks post
+    // their own DSL and so have their own break points.
+    let song = SongSpec::tones("Lit Song", "lit-song", 2, 8.0);
+    let song = if crate::sabotage::perform() {
+        song.with_lighting(LightingSpec::simple(
+            "E2E Show",
+            "lighting/show.light",
+            LIGHTING_GROUP,
+        ))
+    } else {
+        song
+    };
 
     ProjectBuilder::new()
         .profiles(vec![ProfileSpec::detected("01-e2e").with_lighting()])
@@ -61,7 +69,7 @@ pub async fn generated_show_passes_validation() -> CheckOutcome {
         .send_text(
             reqwest::Method::POST,
             "lighting/validate",
-            show.source.clone(),
+            crate::sabotage::pick(show.source.clone(), "not a show".to_string()),
         )
         .await?;
 
@@ -85,7 +93,10 @@ pub async fn malformed_show_is_rejected() -> CheckOutcome {
     let server = Server::start(&project).await?;
     let client = Client::connect(&server).await?;
 
-    let broken = "show \"Broken\" { @00:00.000 this is not a valid effect line ".to_string();
+    let broken = crate::sabotage::pick(
+        "show \"Broken\" { @00:00.000 this is not a valid effect line ".to_string(),
+        LightingSpec::simple("Valid", "v.light", LIGHTING_GROUP).source,
+    );
     let (status, body) = client
         .send_text(reqwest::Method::POST, "lighting/validate", broken)
         .await?;
@@ -225,7 +236,7 @@ pub async fn show_written_via_api_is_readable() -> CheckOutcome {
         "reading the show back failed: HTTP {status}\n{readback}"
     );
     check!(
-        readback.contains(LIGHTING_GROUP),
+        readback.contains(crate::sabotage::pick(LIGHTING_GROUP, "e2e-absent-marker")),
         "the show read back does not contain what was written:\n{readback}"
     );
 

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -142,7 +142,9 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
         .take(expected_notes)
         .filter_map(|n| n.note())
         .collect();
-    let expected: Vec<u8> = (0..expected_notes).map(|b| 60 + (b as u8 % 12)).collect();
+    let expected: Vec<u8> = (0..expected_notes)
+        .map(|b| crate::sabotage::pick(60, 90) + (b as u8 % 12))
+        .collect();
     check_eq!(
         received,
         expected,
@@ -189,7 +191,12 @@ pub async fn beat_clock_runs_at_the_song_tempo() -> CheckOutcome {
         server.log()
     );
 
-    let expected = MidiSpec::scale("song.mid", TEMPO_BPM, 8).expected_clock_hz();
+    let expected = MidiSpec::scale(
+        "song.mid",
+        crate::sabotage::pick(TEMPO_BPM, TEMPO_BPM * 2.0),
+        8,
+    )
+    .expected_clock_hz();
     // `clock_hz` also returns None when the span is zero, which a backend
     // without real port timestamping can produce. Panicking there would surface
     // as a harness error -- the one outcome a measurement should never yield.
@@ -229,7 +236,7 @@ pub async fn beat_clock_is_silent_when_disabled() -> CheckOutcome {
     let listen = path.listen.clone();
     crate::outcome::record(path.describe());
 
-    let project = midi_project(false)?;
+    let project = midi_project(crate::sabotage::pick(false, true))?;
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
 
@@ -273,7 +280,13 @@ pub async fn configured_midi_device_transmits() -> CheckOutcome {
     let song = SongSpec::tones("Midi Hw", "midi-hw", 1, 6.0)
         .with_midi(MidiSpec::scale("song.mid", TEMPO_BPM, 4));
     let project = ProjectBuilder::new()
-        .profiles(vec![ProfileSpec::detected("01-e2e")])
+        .profiles(vec![{
+            let mut p = ProfileSpec::detected("01-e2e");
+            if !crate::sabotage::perform() {
+                p.midi = Subsystem::Bogus("e2e-nope".to_string());
+            }
+            p
+        }])
         .songs(vec![song])
         .build()?;
 

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -280,20 +280,20 @@ pub async fn configured_midi_device_transmits() -> CheckOutcome {
     let song = SongSpec::tones("Midi Hw", "midi-hw", 1, 6.0)
         .with_midi(MidiSpec::scale("song.mid", TEMPO_BPM, 4));
     let project = ProjectBuilder::new()
-        .profiles(vec![{
-            let mut p = ProfileSpec::detected("01-e2e");
-            if !crate::sabotage::perform() {
-                p.midi = Subsystem::Bogus("e2e-nope".to_string());
-            }
-            p
-        }])
+        .profiles(vec![ProfileSpec::detected("01-e2e")])
         .songs(vec![song])
         .build()?;
 
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
 
-    let status = client.subsystem_status("midi").await?;
+    // Compare against a name the profile never used. Pointing the profile at a
+    // bogus device instead made startup time out, so the control died before
+    // this assertion ever ran.
+    let status = crate::sabotage::pick(
+        client.subsystem_status("midi").await?,
+        "not_connected".to_string(),
+    );
     check!(
         status == "connected",
         "the configured MIDI device '{}' was not claimed (reported '{status}').\n--- log ---\n{}",

--- a/harness/src/checks/persistence.rs
+++ b/harness/src/checks/persistence.rs
@@ -154,7 +154,7 @@ pub async fn midi_beat_clock_persists() -> CheckOutcome {
         client,
         "midi beat_clock",
         "01-e2e",
-        crate::sabotage::pick("beat_clock: true", "kind: hardware_profile"),
+        crate::sabotage::pick("beat_clock: true", "beat_clock: false"),
         move |mut client, checksum| async move {
             let midi_json = serde_json::json!({
                 "device": device,

--- a/harness/src/checks/persistence.rs
+++ b/harness/src/checks/persistence.rs
@@ -154,7 +154,7 @@ pub async fn midi_beat_clock_persists() -> CheckOutcome {
         client,
         "midi beat_clock",
         "01-e2e",
-        "beat_clock: true",
+        crate::sabotage::pick("beat_clock: true", "kind: hardware_profile"),
         move |mut client, checksum| async move {
             let midi_json = serde_json::json!({
                 "device": device,
@@ -204,12 +204,21 @@ pub async fn stale_checksum_is_rejected() -> CheckOutcome {
         })
         .await?;
 
+    // Under sabotage, use a *current* checksum, which the store should accept --
+    // proving the rejection above is really about staleness.
+    let second_checksum = client
+        .grpc()
+        .get_config(GetConfigRequest {})
+        .await?
+        .into_inner()
+        .checksum;
+
     // Replaying the original checksum must now fail.
     let stale = client
         .grpc()
         .update_midi(UpdateMidiRequest {
             midi_json: serde_json::json!({"device": midi.name, "beat_clock": false}).to_string(),
-            expected_checksum: first.checksum,
+            expected_checksum: crate::sabotage::pick(first.checksum.clone(), second_checksum),
         })
         .await;
 
@@ -255,7 +264,11 @@ pub async fn active_playlist_persists_across_restart() -> CheckOutcome {
     client
         .grpc()
         .switch_to_playlist(SwitchToPlaylistRequest {
-            playlist_name: crate::project::ProjectBuilder::ALTERNATE_PLAYLIST.to_string(),
+            playlist_name: crate::sabotage::pick(
+                crate::project::ProjectBuilder::ALTERNATE_PLAYLIST,
+                "playlist",
+            )
+            .to_string(),
         })
         .await?;
 

--- a/harness/src/checks/persistence.rs
+++ b/harness/src/checks/persistence.rs
@@ -206,12 +206,18 @@ pub async fn stale_checksum_is_rejected() -> CheckOutcome {
 
     // Under sabotage, use a *current* checksum, which the store should accept --
     // proving the rejection above is really about staleness.
-    let second_checksum = client
-        .grpc()
-        .get_config(GetConfigRequest {})
-        .await?
-        .into_inner()
-        .checksum;
+    // Fetched only when it will be used: an extra RPC on every normal run to
+    // serve the sabotage path is waste.
+    let second_checksum = if crate::sabotage::active() {
+        client
+            .grpc()
+            .get_config(GetConfigRequest {})
+            .await?
+            .into_inner()
+            .checksum
+    } else {
+        String::new()
+    };
 
     // Replaying the original checksum must now fail.
     let stale = client

--- a/harness/src/checks/playback.rs
+++ b/harness/src/checks/playback.rs
@@ -44,17 +44,8 @@ const MEASURE_TAKE: Duration = Duration::from_millis(1500);
 /// assertion alone would miss.
 pub async fn plays_a_song_to_completion() -> CheckOutcome {
     crate::runner::require_area("playback")?;
-    // 0.8s: comfortably seen as playing by the 100ms readiness poll, but over
-    // before the third 400ms status reading, so readings.len() >= 3 fails.
-    // 1.6s was wrong in the other direction -- it yielded four readings and the
-    // assertion passed.
     let project = ProjectBuilder::new()
-        .songs(vec![SongSpec::tones(
-            "Short Tone",
-            "short-tone",
-            2,
-            crate::sabotage::pick(4.0, 0.8),
-        )])
+        .songs(vec![SongSpec::tones("Short Tone", "short-tone", 2, 4.0)])
         .build()?;
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
@@ -63,7 +54,11 @@ pub async fn plays_a_song_to_completion() -> CheckOutcome {
     client.wait_until_playing(Duration::from_secs(10)).await?;
 
     let mut readings = Vec::new();
-    for _ in 0..6 {
+    // Sampling fewer times than the assertion requires is deterministic. Tuning
+    // the song duration instead was a coin flip -- 0.3s could end before the
+    // readiness poll saw it and 1.6s yielded enough readings to pass, so the
+    // control was wrong in both directions before this.
+    for _ in 0..crate::sabotage::pick(6, 2) {
         tokio::time::sleep(Duration::from_millis(400)).await;
         let status = client.status().await?;
         if !status.playing {
@@ -230,7 +225,9 @@ pub async fn tracks_route_to_their_mapped_channels() -> CheckOutcome {
     // Rotating a mapping needs at least two links; with one, the sabotaged
     // mapping equals the real one and the control is a no-op.
     if crate::sabotage::active() && outputs.len() < 2 {
-        skip!("only one loopback link, so the routing mapping cannot be permuted");
+        crate::no_control_here!(
+            "only one loopback link, so the routing mapping cannot be permuted"
+        );
     }
 
     let song = SongSpec::tones("Routing", "routing", outputs.len(), 12.0);

--- a/harness/src/checks/playback.rs
+++ b/harness/src/checks/playback.rs
@@ -45,7 +45,12 @@ const MEASURE_TAKE: Duration = Duration::from_millis(1500);
 pub async fn plays_a_song_to_completion() -> CheckOutcome {
     crate::runner::require_area("playback")?;
     let project = ProjectBuilder::new()
-        .songs(vec![SongSpec::tones("Short Tone", "short-tone", 2, 4.0)])
+        .songs(vec![SongSpec::tones(
+            "Short Tone",
+            "short-tone",
+            2,
+            crate::sabotage::pick(4.0, 0.3),
+        )])
         .build()?;
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
@@ -88,14 +93,27 @@ pub async fn plays_a_song_to_completion() -> CheckOutcome {
 /// Stop takes effect while a song is mid-flight.
 pub async fn stop_halts_playback() -> CheckOutcome {
     crate::runner::require_area("playback")?;
-    let project = crate::checks::standard_project()?;
+
+    // A song far longer than the stop deadline. With the standard 4-6 second
+    // songs this check was vacuous: the song ended on its own well inside the
+    // timeout, so it passed whether or not Stop did anything. Verified by
+    // deleting the stop call, which changed nothing.
+    let project = ProjectBuilder::new()
+        .songs(vec![SongSpec::tones("Long Tone", "long-tone", 1, 120.0)])
+        .build()?;
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
-    client.grpc().stop(StopRequest {}).await?;
-    client.wait_until_stopped(Duration::from_secs(10)).await?;
+    if crate::sabotage::perform() {
+        client.grpc().stop(StopRequest {}).await?;
+    }
+
+    // Five seconds against a two-minute song: natural completion cannot
+    // masquerade as a successful stop.
+    client.wait_until_stopped(Duration::from_secs(5)).await?;
+    crate::outcome::record("stopped a 120s song within 5s of the stop request");
 
     server.check_clean_log(&[])?;
     Ok(())
@@ -109,7 +127,9 @@ pub async fn playlist_navigation_moves_between_songs() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let first = client.status().await?.current_song.map(|s| s.name);
-    client.grpc().next(NextRequest {}).await?;
+    if crate::sabotage::perform() {
+        client.grpc().next(NextRequest {}).await?;
+    }
     let second = client.status().await?.current_song.map(|s| s.name);
     check!(
         first != second,
@@ -203,7 +223,10 @@ pub async fn tracks_route_to_their_mapped_channels() -> CheckOutcome {
     let song = SongSpec::tones("Routing", "routing", outputs.len(), 12.0);
     let mut mappings = BTreeMap::new();
     for (track, output) in song.tracks.iter().zip(outputs.iter()) {
-        mappings.insert(track.name.clone(), vec![*output]);
+        mappings.insert(
+            track.name.clone(),
+            vec![crate::sabotage::pick(*output, outputs[0])],
+        );
     }
 
     let mut profile = ProfileSpec::detected("01-e2e");

--- a/harness/src/checks/playback.rs
+++ b/harness/src/checks/playback.rs
@@ -49,7 +49,7 @@ pub async fn plays_a_song_to_completion() -> CheckOutcome {
             "Short Tone",
             "short-tone",
             2,
-            crate::sabotage::pick(4.0, 0.3),
+            crate::sabotage::pick(4.0, 1.0),
         )])
         .build()?;
     let server = Server::start(&project).await?;
@@ -225,7 +225,7 @@ pub async fn tracks_route_to_their_mapped_channels() -> CheckOutcome {
     for (track, output) in song.tracks.iter().zip(outputs.iter()) {
         mappings.insert(
             track.name.clone(),
-            vec![crate::sabotage::pick(*output, outputs[0])],
+            vec![crate::sabotage::pick(*output, outputs[outputs.len() - 1])],
         );
     }
 

--- a/harness/src/checks/playback.rs
+++ b/harness/src/checks/playback.rs
@@ -54,17 +54,23 @@ pub async fn plays_a_song_to_completion() -> CheckOutcome {
     client.wait_until_playing(Duration::from_secs(10)).await?;
 
     let mut readings = Vec::new();
-    // Sampling fewer times than the assertion requires is deterministic. Tuning
-    // the song duration instead was a coin flip -- 0.3s could end before the
-    // readiness poll saw it and 1.6s yielded enough readings to pass, so the
-    // control was wrong in both directions before this.
-    for _ in 0..crate::sabotage::pick(6, 2) {
+    for _ in 0..6 {
         tokio::time::sleep(Duration::from_millis(400)).await;
         let status = client.status().await?;
         if !status.playing {
             break;
         }
         readings.push(elapsed_of(&status));
+    }
+
+    // Reversed under sabotage, so the monotonicity and advancement assertions
+    // below are the ones that fire. Sampling fewer times instead only
+    // manufactured a `len() >= 3` failure and never reached them -- a control
+    // weaker than the predicate-level ones, in the strong-evidence bucket.
+    // This is predicate-level: it substitutes what the assertion reads, because
+    // making the transport clock misbehave needs a broken player.
+    if crate::sabotage::active() {
+        readings.reverse();
     }
 
     check!(

--- a/harness/src/checks/playback.rs
+++ b/harness/src/checks/playback.rs
@@ -44,12 +44,16 @@ const MEASURE_TAKE: Duration = Duration::from_millis(1500);
 /// assertion alone would miss.
 pub async fn plays_a_song_to_completion() -> CheckOutcome {
     crate::runner::require_area("playback")?;
+    // 0.8s: comfortably seen as playing by the 100ms readiness poll, but over
+    // before the third 400ms status reading, so readings.len() >= 3 fails.
+    // 1.6s was wrong in the other direction -- it yielded four readings and the
+    // assertion passed.
     let project = ProjectBuilder::new()
         .songs(vec![SongSpec::tones(
             "Short Tone",
             "short-tone",
             2,
-            crate::sabotage::pick(4.0, 1.0),
+            crate::sabotage::pick(4.0, 0.8),
         )])
         .build()?;
     let server = Server::start(&project).await?;
@@ -111,8 +115,11 @@ pub async fn stop_halts_playback() -> CheckOutcome {
     }
 
     // Five seconds against a two-minute song: natural completion cannot
-    // masquerade as a successful stop.
-    client.wait_until_stopped(Duration::from_secs(5)).await?;
+    // masquerade as a successful stop. This wait *is* the assertion, hence the
+    // asserting variant.
+    client
+        .wait_until_stopped_asserting(Duration::from_secs(5))
+        .await?;
     crate::outcome::record("stopped a 120s song within 5s of the stop request");
 
     server.check_clean_log(&[])?;
@@ -220,12 +227,23 @@ pub async fn tracks_route_to_their_mapped_channels() -> CheckOutcome {
 
     // One tone track per verifiable output, mapped one-to-one so a tone's
     // identity determines which channel it should have come out of.
+    // Rotating a mapping needs at least two links; with one, the sabotaged
+    // mapping equals the real one and the control is a no-op.
+    if crate::sabotage::active() && outputs.len() < 2 {
+        skip!("only one loopback link, so the routing mapping cannot be permuted");
+    }
+
     let song = SongSpec::tones("Routing", "routing", outputs.len(), 12.0);
     let mut mappings = BTreeMap::new();
-    for (track, output) in song.tracks.iter().zip(outputs.iter()) {
+    for (index, (track, output)) in song.tracks.iter().zip(outputs.iter()).enumerate() {
+        // Under sabotage every track is shifted one link along, so each tone
+        // arrives on a neighbour's input rather than its own.
         mappings.insert(
             track.name.clone(),
-            vec![crate::sabotage::pick(*output, outputs[outputs.len() - 1])],
+            vec![crate::sabotage::pick(
+                *output,
+                outputs[(index + 1) % outputs.len()],
+            )],
         );
     }
 

--- a/harness/src/checks/startup.rs
+++ b/harness/src/checks/startup.rs
@@ -44,6 +44,7 @@ pub async fn player_starts_against_detected_hardware() -> CheckOutcome {
         .as_ref()
         .map(|d| d.name.clone())
         .unwrap_or_default();
+    let configured = crate::sabotage::pick(configured, "e2e-never-configured".to_string());
     let claimed = client.subsystem_device("audio").await?.unwrap_or_default();
     check!(
         claimed.starts_with(&configured),
@@ -98,7 +99,8 @@ pub async fn generated_project_loads_all_songs() -> CheckOutcome {
                 .and_then(|s| s.as_array())
                 .map(|a| a.len())
         })
-        .unwrap_or(0);
+        .unwrap_or(0)
+        + crate::sabotage::pick(0, 1);
 
     check_eq!(
         listed,

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -130,6 +130,11 @@ pub async fn absent_dmx_is_skipped_not_fatal() -> CheckOutcome {
 pub async fn bogus_midi_device_degrades_gracefully() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
+    // Same no-op as its sibling above: where no MIDI device exists, render_midi
+    // returns early and the sabotaged profile is byte-identical.
+    if crate::sabotage::active() && Capabilities::get().midi_out.is_none() {
+        skip!("this machine has no MIDI device, so making the profile declare one is a no-op");
+    }
     profile.midi = crate::sabotage::pick(
         Subsystem::Bogus("e2e-nonexistent-midi-device".to_string()),
         Subsystem::Detected,
@@ -219,13 +224,19 @@ pub async fn first_profile_wins() -> CheckOutcome {
     // assertion could run.
     let mut second = ProfileSpec::detected(crate::sabotage::pick("02-decoy", "00-decoy"));
     second.audio = if crate::sabotage::active() {
-        match caps
-            .all_audio_out
-            .iter()
-            .find(|d| Some(&d.name) != caps.audio_out.as_ref().map(|s| &s.name))
-        {
+        // Must have at least as many channels as the real one: render_audio
+        // derives track mappings and the pinned rate from the *selected*
+        // device, so a narrower decoy maps tracks to channels that do not
+        // exist and the player fails to boot -- the control would then die
+        // before this check's assertion.
+        let wanted = caps.audio_out.as_ref().map(|d| d.max_channels).unwrap_or(0);
+        match caps.all_audio_out.iter().find(|d| {
+            Some(&d.name) != caps.audio_out.as_ref().map(|s| &s.name) && d.max_channels >= wanted
+        }) {
             Some(other) => Subsystem::Named(other.name.clone()),
-            None => skip!("only one openable output device, so no decoy is possible"),
+            None => skip!(
+                "no alternative output with at least {wanted} channels, so no usable decoy exists"
+            ),
         }
     } else {
         Subsystem::Bogus("e2e-decoy-device".to_string())

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -25,7 +25,8 @@ use crate::client::Client;
 use crate::outcome::CheckOutcome;
 use crate::project::{ProfileSpec, ProjectBuilder, Subsystem};
 use crate::server::Server;
-use crate::{check, check_eq};
+use crate::{check, check_eq, fail};
+use mtrack::proto::player::v1::PlayRequest;
 
 /// How long to watch a deliberately-broken subsystem before concluding it
 /// degraded rather than misbehaved.
@@ -65,7 +66,7 @@ async fn watch_subsystem(
 pub async fn absent_midi_is_skipped_not_fatal() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
-    profile.midi = Subsystem::Absent;
+    profile.midi = crate::sabotage::pick(Subsystem::Absent, Subsystem::Detected);
 
     let project = ProjectBuilder::new()
         .profiles(vec![profile])
@@ -94,7 +95,7 @@ pub async fn absent_midi_is_skipped_not_fatal() -> CheckOutcome {
 pub async fn absent_dmx_is_skipped_not_fatal() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
-    profile.dmx = Subsystem::Absent;
+    profile.dmx = crate::sabotage::pick(Subsystem::Absent, Subsystem::Detected);
 
     let project = ProjectBuilder::new()
         .profiles(vec![profile])
@@ -126,7 +127,10 @@ pub async fn absent_dmx_is_skipped_not_fatal() -> CheckOutcome {
 pub async fn bogus_midi_device_degrades_gracefully() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
-    profile.midi = Subsystem::Bogus("e2e-nonexistent-midi-device".to_string());
+    profile.midi = crate::sabotage::pick(
+        Subsystem::Bogus("e2e-nonexistent-midi-device".to_string()),
+        Subsystem::Detected,
+    );
 
     let project = ProjectBuilder::new()
         .profiles(vec![profile])
@@ -163,7 +167,10 @@ pub async fn bogus_midi_device_degrades_gracefully() -> CheckOutcome {
 pub async fn bogus_audio_device_degrades_gracefully() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
-    profile.audio = Subsystem::Bogus("e2e-nonexistent-audio-device".to_string());
+    profile.audio = crate::sabotage::pick(
+        Subsystem::Bogus("e2e-nonexistent-audio-device".to_string()),
+        Subsystem::Detected,
+    );
 
     let project = ProjectBuilder::new()
         .profiles(vec![profile])
@@ -204,7 +211,7 @@ pub async fn first_profile_wins() -> CheckOutcome {
         return Ok(());
     };
 
-    let mut second = ProfileSpec::detected("02-decoy");
+    let mut second = ProfileSpec::detected(crate::sabotage::pick("02-decoy", "00-decoy"));
     second.audio = Subsystem::Bogus("e2e-decoy-device".to_string());
 
     let project = ProjectBuilder::new()
@@ -229,8 +236,12 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let project = crate::checks::standard_project()?;
     let server = Server::start(&project).await?;
-    let client = Client::connect(&server).await?;
+    let mut client = Client::connect(&server).await?;
 
+    if !crate::sabotage::perform() {
+        client.grpc().play(PlayRequest {}).await?;
+        client.wait_until_playing(Duration::from_secs(10)).await?;
+    }
     let (status, body) = client
         .send_text(reqwest::Method::POST, "controllers/restart", String::new())
         .await?;
@@ -240,9 +251,21 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     );
 
     // The gRPC controller must come back, or the player has lost its control
-    // surface without saying so.
-    let mut reconnected = Client::connect(&server).await?;
-    reconnected.status().await?;
+    // surface without saying so. Reconnecting *is* this check's assertion, so a
+    // failure here is a defect in the player -- not, as it was previously
+    // reported, an error in the harness.
+    let mut reconnected = match Client::connect(&server).await {
+        Ok(client) => client,
+        Err(e) => fail!(
+            "the gRPC controller did not come back after a restart, so the player has \
+             silently lost its control surface: {e}\n--- log ---\n{}",
+            server.log()
+        ),
+    };
+    if let Err(e) = reconnected.status().await {
+        fail!("the restarted gRPC controller accepted a connection but not a request: {e}");
+    }
+    crate::outcome::record("gRPC controller answered again after restart");
 
     server.check_clean_log(&[])?;
     Ok(())

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -25,7 +25,7 @@ use crate::client::Client;
 use crate::outcome::CheckOutcome;
 use crate::project::{ProfileSpec, ProjectBuilder, Subsystem};
 use crate::server::Server;
-use crate::{check, check_eq, fail};
+use crate::{check, check_eq, fail, skip};
 use mtrack::proto::player::v1::PlayRequest;
 
 /// How long to watch a deliberately-broken subsystem before concluding it
@@ -66,6 +66,9 @@ async fn watch_subsystem(
 pub async fn absent_midi_is_skipped_not_fatal() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
+    if crate::sabotage::active() && Capabilities::get().midi_out.is_none() {
+        skip!("this machine has no MIDI device, so making the profile declare one is a no-op");
+    }
     profile.midi = crate::sabotage::pick(Subsystem::Absent, Subsystem::Detected);
 
     let project = ProjectBuilder::new()
@@ -211,8 +214,22 @@ pub async fn first_profile_wins() -> CheckOutcome {
         return Ok(());
     };
 
+    // Sorts first under sabotage, and names a *valid* other device: a bogus one
+    // stops the player booting, so the control died before this check's
+    // assertion could run.
     let mut second = ProfileSpec::detected(crate::sabotage::pick("02-decoy", "00-decoy"));
-    second.audio = Subsystem::Bogus("e2e-decoy-device".to_string());
+    second.audio = if crate::sabotage::active() {
+        match caps
+            .all_audio_out
+            .iter()
+            .find(|d| Some(&d.name) != caps.audio_out.as_ref().map(|s| &s.name))
+        {
+            Some(other) => Subsystem::Named(other.name.clone()),
+            None => skip!("only one openable output device, so no decoy is possible"),
+        }
+    } else {
+        Subsystem::Bogus("e2e-decoy-device".to_string())
+    };
 
     let project = ProjectBuilder::new()
         .profiles(vec![ProfileSpec::detected("01-e2e"), second])
@@ -238,7 +255,7 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     let server = Server::start(&project).await?;
     let mut client = Client::connect(&server).await?;
 
-    if !crate::sabotage::perform() {
+    if crate::sabotage::active() {
         client.grpc().play(PlayRequest {}).await?;
         client.wait_until_playing(Duration::from_secs(10)).await?;
     }

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -25,8 +25,7 @@ use crate::client::Client;
 use crate::outcome::CheckOutcome;
 use crate::project::{ProfileSpec, ProjectBuilder, Subsystem};
 use crate::server::Server;
-use crate::{check, check_eq, fail, skip};
-use mtrack::proto::player::v1::PlayRequest;
+use crate::{check, check_eq, fail};
 
 /// How long to watch a deliberately-broken subsystem before concluding it
 /// degraded rather than misbehaved.
@@ -67,7 +66,9 @@ pub async fn absent_midi_is_skipped_not_fatal() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let mut profile = ProfileSpec::detected("01-e2e");
     if crate::sabotage::active() && Capabilities::get().midi_out.is_none() {
-        skip!("this machine has no MIDI device, so making the profile declare one is a no-op");
+        crate::no_control_here!(
+            "this machine has no MIDI device, so making the profile declare one is a no-op"
+        );
     }
     profile.midi = crate::sabotage::pick(Subsystem::Absent, Subsystem::Detected);
 
@@ -133,7 +134,9 @@ pub async fn bogus_midi_device_degrades_gracefully() -> CheckOutcome {
     // Same no-op as its sibling above: where no MIDI device exists, render_midi
     // returns early and the sabotaged profile is byte-identical.
     if crate::sabotage::active() && Capabilities::get().midi_out.is_none() {
-        skip!("this machine has no MIDI device, so making the profile declare one is a no-op");
+        crate::no_control_here!(
+            "this machine has no MIDI device, so making the profile declare one is a no-op"
+        );
     }
     profile.midi = crate::sabotage::pick(
         Subsystem::Bogus("e2e-nonexistent-midi-device".to_string()),
@@ -230,12 +233,29 @@ pub async fn first_profile_wins() -> CheckOutcome {
         // exist and the player fails to boot -- the control would then die
         // before this check's assertion.
         let wanted = caps.audio_out.as_ref().map(|d| d.max_channels).unwrap_or(0);
+        // render_audio also pins the *selected* device's rate into every
+        // profile, so a decoy that cannot play it dies at startup for a reason
+        // unrelated to which profile won.
+        let pinned: Option<u32> = caps
+            .audio_out
+            .as_ref()
+            .filter(|d| !d.sample_rates.is_empty() && !d.sample_rates.contains(&44_100))
+            .and_then(|d| {
+                if d.sample_rates.contains(&48_000) {
+                    Some(48_000)
+                } else {
+                    d.sample_rates.iter().copied().max()
+                }
+            });
         match caps.all_audio_out.iter().find(|d| {
-            Some(&d.name) != caps.audio_out.as_ref().map(|s| &s.name) && d.max_channels >= wanted
+            Some(&d.name) != caps.audio_out.as_ref().map(|s| &s.name)
+                && d.max_channels >= wanted
+                && pinned.is_none_or(|rate| d.sample_rates.contains(&rate))
         }) {
             Some(other) => Subsystem::Named(other.name.clone()),
-            None => skip!(
-                "no alternative output with at least {wanted} channels, so no usable decoy exists"
+            None => crate::no_control_here!(
+                "no alternative output matching {wanted} channels and the pinned rate, so no \
+                 usable decoy exists"
             ),
         }
     } else {
@@ -264,14 +284,15 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let project = crate::checks::standard_project()?;
     let server = Server::start(&project).await?;
-    let mut client = Client::connect(&server).await?;
+    let client = Client::connect(&server).await?;
 
-    if crate::sabotage::active() {
-        client.grpc().play(PlayRequest {}).await?;
-        client.wait_until_playing(Duration::from_secs(10)).await?;
-    }
+    // Ask an endpoint that does not exist, so the restart request itself fails.
+    // The previous control started playback and bet that restart-while-playing
+    // is rejected -- which worked only because a live player defect made it so.
+    // A control that breaks when the subject is fixed points the wrong way.
+    let endpoint = crate::sabotage::pick("controllers/restart", "controllers/restart-nonexistent");
     let (status, body) = client
-        .send_text(reqwest::Method::POST, "controllers/restart", String::new())
+        .send_text(reqwest::Method::POST, endpoint, String::new())
         .await?;
     check!(
         status.is_success(),

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -236,13 +236,22 @@ pub async fn first_profile_wins() -> CheckOutcome {
         // device, so a narrower decoy maps tracks to channels that do not
         // exist and the player fails to boot -- the control would then die
         // before this check's assertion.
-        let wanted = caps.audio_out.as_ref().map(|d| d.max_channels).unwrap_or(0);
+        // Mirrors render_audio: it clamps the channel count to a minimum of two
+        // and pins a rate only for a *raw* device, so screening on anything else
+        // rejects usable decoys and admits unusable ones.
+        let wanted = caps
+            .audio_out
+            .as_ref()
+            .map(|d| d.max_channels)
+            .unwrap_or(2)
+            .max(2);
         // render_audio also pins the *selected* device's rate into every
         // profile, so a decoy that cannot play it dies at startup for a reason
         // unrelated to which profile won.
         let pinned: Option<u32> = caps
             .audio_out
             .as_ref()
+            .filter(|d| d.name.contains("hw:CARD=") && !d.name.contains("plughw:"))
             .filter(|d| !d.sample_rates.is_empty() && !d.sample_rates.contains(&44_100))
             .and_then(|d| {
                 if d.sample_rates.contains(&48_000) {
@@ -290,10 +299,6 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     let server = Server::start(&project).await?;
     let client = Client::connect(&server).await?;
 
-    // Ask an endpoint that does not exist, so the restart request itself fails.
-    // The previous control started playback and bet that restart-while-playing
-    // is rejected -- which worked only because a live player defect made it so.
-    // A control that breaks when the subject is fixed points the wrong way.
     let endpoint = "controllers/restart";
     let (status, body) = client
         .send_text(reqwest::Method::POST, endpoint, String::new())
@@ -308,9 +313,14 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     // failure here is a defect in the player -- not, as it was previously
     // reported, an error in the harness.
     // Sabotage the *reconnect*, which is the assertion this check exists for --
-    // "controllers must come back, or control is silently lost". Breaking the
-    // restart request instead only proved the status check above, leaving the
-    // interesting assertion unexercised.
+    // "controllers must come back, or control is silently lost".
+    //
+    // Weaker than a predicate-level substitution: the error is injected without
+    // calling `Client::connect` at all, so it proves the match arm and `fail!`
+    // render, not that a real failed reconnect is detected. Making a genuine
+    // reconnect fail needs a second server or a wrong address, which is the
+    // improvement to make here. Listed as predicate-level in the meantime, so
+    // the score does not credit it as strong evidence.
     let reconnect = if crate::sabotage::active() {
         Err("sabotage: reconnect not attempted".into())
     } else {

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -25,7 +25,7 @@ use crate::client::Client;
 use crate::outcome::CheckOutcome;
 use crate::project::{ProfileSpec, ProjectBuilder, Subsystem};
 use crate::server::Server;
-use crate::{check, check_eq, fail};
+use crate::{check, check_eq, fail, skip};
 
 /// How long to watch a deliberately-broken subsystem before concluding it
 /// degraded rather than misbehaved.
@@ -219,7 +219,11 @@ pub async fn first_profile_wins() -> CheckOutcome {
     crate::runner::require_area("subsystems")?;
     let caps = Capabilities::get();
     let Some(expected) = caps.audio_out.as_ref().map(|d| d.name.clone()) else {
-        return Ok(());
+        // Not a pass: with no audio device there is nothing to claim, and
+        // returning Ok here would report success having verified nothing --
+        // and then make --self-test call the check CANNOT FAIL for what is
+        // really "this should have skipped".
+        skip!("no audio output device, so there is no claimed device to compare");
     };
 
     // Sorts first under sabotage, and names a *valid* other device: a bogus one
@@ -290,7 +294,7 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     // The previous control started playback and bet that restart-while-playing
     // is rejected -- which worked only because a live player defect made it so.
     // A control that breaks when the subject is fixed points the wrong way.
-    let endpoint = crate::sabotage::pick("controllers/restart", "controllers/restart-nonexistent");
+    let endpoint = "controllers/restart";
     let (status, body) = client
         .send_text(reqwest::Method::POST, endpoint, String::new())
         .await?;
@@ -303,7 +307,16 @@ pub async fn controllers_restart_while_idle() -> CheckOutcome {
     // surface without saying so. Reconnecting *is* this check's assertion, so a
     // failure here is a defect in the player -- not, as it was previously
     // reported, an error in the harness.
-    let mut reconnected = match Client::connect(&server).await {
+    // Sabotage the *reconnect*, which is the assertion this check exists for --
+    // "controllers must come back, or control is silently lost". Breaking the
+    // restart request instead only proved the status check above, leaving the
+    // interesting assertion unexercised.
+    let reconnect = if crate::sabotage::active() {
+        Err("sabotage: reconnect not attempted".into())
+    } else {
+        Client::connect(&server).await
+    };
+    let mut reconnected = match reconnect {
         Ok(client) => client,
         Err(e) => fail!(
             "the gRPC controller did not come back after a restart, so the player has \

--- a/harness/src/client.rs
+++ b/harness/src/client.rs
@@ -202,7 +202,21 @@ impl Client {
         &mut self,
         timeout: Duration,
     ) -> Result<StatusResponse, crate::outcome::CheckError> {
-        self.wait_for_status(timeout, "playing", |s| s.playing)
+        self.wait_for_status(timeout, "playing", false, |s| s.playing)
+            .await
+    }
+
+    /// Waits until the player reports it has stopped, treating a timeout as
+    /// *this check's* assertion.
+    ///
+    /// For checks whose whole point is that something stops. Separate from
+    /// [`Self::wait_until_stopped`] so the self-test can tell a control that
+    /// drove the assertion from one that merely failed during setup.
+    pub async fn wait_until_stopped_asserting(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<StatusResponse, crate::outcome::CheckError> {
+        self.wait_for_status(timeout, "stopped", true, |s| !s.playing)
             .await
     }
 
@@ -211,7 +225,7 @@ impl Client {
         &mut self,
         timeout: Duration,
     ) -> Result<StatusResponse, crate::outcome::CheckError> {
-        self.wait_for_status(timeout, "stopped", |s| !s.playing)
+        self.wait_for_status(timeout, "stopped", false, |s| !s.playing)
             .await
     }
 
@@ -219,6 +233,7 @@ impl Client {
         &mut self,
         timeout: Duration,
         what: &str,
+        assertion: bool,
         predicate: impl Fn(&StatusResponse) -> bool,
     ) -> Result<StatusResponse, crate::outcome::CheckError> {
         let deadline = Instant::now() + timeout;
@@ -231,13 +246,18 @@ impl Client {
             last = Some(status);
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        // Explicitly Failed, not `.into()`. `From<String>` maps to Harness, so
-        // a player that accepts Play and never plays was reported as "our bug,
-        // not mtrack's". Round five raised this; the signature was changed and
-        // the body was not.
-        Err(crate::outcome::CheckError::assertion(format!(
-            "player never reported {what} within {timeout:?} (last status: {last:?})"
-        )))
+        // A real defect in a normal run -- a player that accepts Play and never
+        // plays is broken -- but by default *not* this check's assertion: most
+        // call sites wait as setup before asserting something else. Call sites
+        // where the wait is itself the assertion use the `_asserting` variants,
+        // so the flag is chosen where the meaning is known rather than here.
+        let message =
+            format!("player never reported {what} within {timeout:?} (last status: {last:?})");
+        Err(if assertion {
+            crate::outcome::CheckError::assertion(message)
+        } else {
+            crate::outcome::CheckError::before_assertion(message)
+        })
     }
 }
 

--- a/harness/src/client.rs
+++ b/harness/src/client.rs
@@ -231,10 +231,13 @@ impl Client {
             last = Some(status);
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        Err(
-            format!("player never reported {what} within {timeout:?} (last status: {last:?})")
-                .into(),
-        )
+        // Explicitly Failed, not `.into()`. `From<String>` maps to Harness, so
+        // a player that accepts Play and never plays was reported as "our bug,
+        // not mtrack's". Round five raised this; the signature was changed and
+        // the body was not.
+        Err(crate::outcome::CheckError::assertion(format!(
+            "player never reported {what} within {timeout:?} (last status: {last:?})"
+        )))
     }
 }
 

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -39,6 +39,7 @@ mod plan;
 mod project;
 mod report;
 mod runner;
+mod sabotage;
 mod server;
 mod songs;
 
@@ -49,6 +50,7 @@ use std::process::ExitCode;
 struct Options {
     filter: Option<String>,
     list_only: bool,
+    self_test: bool,
     repeat: usize,
     json: Option<PathBuf>,
 }
@@ -57,6 +59,7 @@ fn parse_args() -> Result<Options, String> {
     let mut options = Options {
         filter: None,
         list_only: false,
+        self_test: false,
         repeat: 1,
         json: None,
     };
@@ -78,6 +81,7 @@ fn parse_args() -> Result<Options, String> {
                 options.json = Some(PathBuf::from(args.next().ok_or("--json needs a path")?));
             }
             "--list" => options.list_only = true,
+            "--self-test" => options.self_test = true,
             "-h" | "--help" => {
                 print_help();
                 std::process::exit(0);
@@ -94,6 +98,7 @@ fn print_help() {
          OPTIONS:\n  \
            --only <substring>   run only areas or checks matching this\n  \
            --list               print the plan and exit without running\n  \
+           --self-test          prove every check can fail, and exit\n  \
            --repeat <n>         run n times; reports how often each check failed\n  \
            --json <path>        write machine-readable results alongside the report\n  \
            -h, --help           this message\n\n\
@@ -144,6 +149,12 @@ async fn main() -> ExitCode {
             "Neither an audio output nor a MIDI port was found, so there is nothing to verify."
         );
         return ExitCode::from(2);
+    }
+
+    // Verifying the verifier: every check must stop passing when its own
+    // premise is broken.
+    if options.self_test {
+        return runner::run_self_test(&options.filter).await;
     }
 
     if options.repeat > 1 {

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -154,6 +154,11 @@ async fn main() -> ExitCode {
     // Verifying the verifier: every check must stop passing when its own
     // premise is broken.
     if options.self_test {
+        // Neither applies: the self-test is one deterministic pass over the
+        // controls, and its output is a verdict rather than a report.
+        if options.repeat > 1 || options.json.is_some() {
+            eprintln!("--self-test ignores --repeat and --json.\n");
+        }
         return runner::run_self_test(&options.filter).await;
     }
 

--- a/harness/src/outcome.rs
+++ b/harness/src/outcome.rs
@@ -278,6 +278,18 @@ impl CheckResult {
     }
 }
 
+// INVARIANT: only the assertion macros below (`check!`, `check_eq!`, `fail!`)
+// and constructors named `*_assertion` may set `from_assertion`. Every shared
+// helper -- log checks, readiness waits, RPC conversions, `inconclusive!` --
+// must produce a `before_assertion` value.
+//
+// The reason is empirical. Three review rounds in a row found helpers minting
+// proof for controls that never reached the check's own assertion, and each
+// time the fix addressed the instances named rather than the class. Making
+// proof opt-in, and stating it here, turns a recurring finding into a rule: a
+// helper cannot accidentally claim a control worked, because it has no way to
+// say so.
+
 /// Reports a defect when `cond` is false.
 ///
 /// The counterpart to `assert!`, except it yields a value instead of
@@ -337,8 +349,28 @@ macro_rules! skip {
 }
 
 /// Ran, but the measurement cannot be trusted.
+///
+/// Does *not* count as proof in `--self-test`: most uses report that something
+/// went wrong before the assertion could be evaluated (an interface underrun,
+/// an unmet precondition), which says nothing about whether the check works.
+/// Where an inconclusive verdict genuinely *is* the check's conclusion, use
+/// [`inconclusive_verdict!`].
 #[macro_export]
 macro_rules! inconclusive {
+    ($($arg:tt)+) => {
+        return Err($crate::outcome::CheckError::Inconclusive {
+            message: format!($($arg)+),
+            from_assertion: false,
+        })
+    };
+}
+
+/// The check's own conclusion is that the measurement cannot be trusted.
+///
+/// For checks whose strongest possible verdict is "I cannot trust this" rather
+/// than "this is broken". Counts as proof in `--self-test`.
+#[macro_export]
+macro_rules! inconclusive_verdict {
     ($($arg:tt)+) => {
         return Err($crate::outcome::CheckError::inconclusive_assertion(format!($($arg)+)))
     };

--- a/harness/src/outcome.rs
+++ b/harness/src/outcome.rs
@@ -27,24 +27,46 @@ use std::fmt;
 use std::sync::Mutex;
 use std::time::Duration;
 
+/// A defect report, and whether the check's own assertion produced it.
+///
+/// The flag is private and settable only through the constructors below, so the
+/// invariant is held by the compiler rather than by a comment. Three review
+/// rounds running found shared helpers minting proof for controls that never
+/// reached the check's assertion; each was fixed instance by instance while the
+/// rule stayed advisory. Now a helper cannot claim a control worked, because it
+/// has no way to say so.
+#[derive(Debug)]
+pub struct Defect {
+    message: String,
+    from_assertion: bool,
+}
+
+impl Defect {
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn is_assertion(&self) -> bool {
+        self.from_assertion
+    }
+
+    pub fn into_message(self) -> String {
+        self.message
+    }
+}
+
 /// Why a check did not simply pass.
 #[derive(Debug)]
 pub enum CheckError {
     /// The behaviour under test is wrong. This is a defect in mtrack.
-    ///
-    /// `from_assertion` records whether the check's own assertion produced
-    /// this, as opposed to a helper failing before the assertion was reached.
-    /// Both are real defect reports in a normal run; only the former proves
-    /// anything in `--self-test`, where a control that dies inside
-    /// `Server::start` would otherwise look identical to one that drove its
-    /// assertion to failure.
-    Failed {
-        message: String,
-        from_assertion: bool,
-    },
+    Failed(Defect),
     /// The check cannot run on this machine, typically for missing hardware.
     /// This will never pass here no matter how often it is run.
     Skipped(String),
+    /// The check runs here, but this machine cannot supply the failure
+    /// condition its negative control needs. Distinct from `Skipped`: the check
+    /// itself passes normally, only its verification is missing.
+    NoControlHere(String),
     /// The check could have run, but an earlier failure made it moot. Unlike a
     /// skip this says nothing about the machine -- fix the earlier failure and
     /// it becomes runnable.
@@ -52,13 +74,10 @@ pub enum CheckError {
     /// The check ran but its measurement cannot be trusted, e.g. the audio
     /// interface underran mid-capture. Not a defect, but not evidence either.
     ///
-    /// Carries the same origin flag as `Failed`: for a check whose strongest
-    /// verdict is "I cannot trust this", an inconclusive raised by its own
-    /// logic *is* its assertion firing.
-    Inconclusive {
-        message: String,
-        from_assertion: bool,
-    },
+    /// Carries the same origin as `Failed`: for a check whose strongest verdict
+    /// is "I cannot trust this", an inconclusive raised by its own logic *is*
+    /// its assertion firing.
+    Inconclusive(Defect),
     /// The harness itself broke: a connection failed, a temp dir could not be
     /// written. This says nothing about mtrack.
     Harness(String),
@@ -67,11 +86,13 @@ pub enum CheckError {
 impl fmt::Display for CheckError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CheckError::Failed { message: m, .. } => write!(f, "{m}"),
-            CheckError::Skipped(m) | CheckError::Blocked(m) | CheckError::Harness(m) => {
+            CheckError::Failed(d) | CheckError::Inconclusive(d) => write!(f, "{}", d.message()),
+            CheckError::Skipped(m)
+            | CheckError::NoControlHere(m)
+            | CheckError::Blocked(m)
+            | CheckError::Harness(m) => {
                 write!(f, "{m}")
             }
-            CheckError::Inconclusive { message: m, .. } => write!(f, "{m}"),
         }
     }
 }
@@ -124,42 +145,50 @@ impl From<tonic::Status> for CheckError {
 impl CheckError {
     /// A defect reported by a check's own assertion.
     pub fn assertion(message: impl Into<String>) -> CheckError {
-        CheckError::Failed {
+        CheckError::Failed(Defect {
             message: message.into(),
             from_assertion: true,
-        }
+        })
     }
 
     /// A defect detected before the check's assertion was reached, e.g. the
     /// player never becoming ready. Real in a normal run; proves nothing as a
     /// negative control.
     pub fn before_assertion(message: impl Into<String>) -> CheckError {
-        CheckError::Failed {
+        CheckError::Failed(Defect {
             message: message.into(),
             from_assertion: false,
-        }
+        })
     }
 
     /// A verdict of "this measurement cannot be trusted", from the check itself.
     pub fn inconclusive_assertion(message: impl Into<String>) -> CheckError {
-        CheckError::Inconclusive {
+        CheckError::Inconclusive(Defect {
             message: message.into(),
             from_assertion: true,
-        }
+        })
+    }
+
+    /// An inconclusive result from a helper, which proves nothing about the
+    /// check. The only constructor available to `inconclusive!`.
+    pub fn inconclusive_before_assertion(message: impl Into<String>) -> CheckError {
+        CheckError::Inconclusive(Defect {
+            message: message.into(),
+            from_assertion: false,
+        })
+    }
+
+    /// This machine cannot supply the control's failure condition.
+    pub fn no_control_here(message: impl Into<String>) -> CheckError {
+        CheckError::NoControlHere(message.into())
     }
 
     /// Whether this came from a check's own assertion.
     pub fn is_assertion(&self) -> bool {
-        matches!(
-            self,
-            CheckError::Failed {
-                from_assertion: true,
-                ..
-            } | CheckError::Inconclusive {
-                from_assertion: true,
-                ..
-            }
-        )
+        match self {
+            CheckError::Failed(d) | CheckError::Inconclusive(d) => d.is_assertion(),
+            _ => false,
+        }
     }
 }
 
@@ -204,6 +233,8 @@ pub enum Outcome {
     Failed,
     /// Cannot be verified on this machine.
     Skipped,
+    /// Runs here, but this machine cannot supply its control's premise.
+    NoControlHere,
     /// Runnable in principle, but an earlier failure made it moot.
     Blocked,
     Inconclusive,
@@ -226,6 +257,7 @@ impl Outcome {
             Outcome::Passed => "PASS",
             Outcome::Failed => "FAIL",
             Outcome::Skipped => "SKIP",
+            Outcome::NoControlHere => "NO CONTROL",
             Outcome::Blocked => "BLOCKED",
             Outcome::Inconclusive => "INCONCLUSIVE",
             Outcome::HarnessError => "HARNESS-ERROR",
@@ -259,10 +291,11 @@ impl CheckResult {
         let evidence = take_evidence();
         let (outcome, detail) = match result {
             Ok(()) => (Outcome::Passed, None),
-            Err(CheckError::Failed { message, .. }) => (Outcome::Failed, Some(message)),
+            Err(CheckError::Failed(d)) => (Outcome::Failed, Some(d.into_message())),
             Err(CheckError::Skipped(m)) => (Outcome::Skipped, Some(m)),
+            Err(CheckError::NoControlHere(m)) => (Outcome::NoControlHere, Some(m)),
             Err(CheckError::Blocked(m)) => (Outcome::Blocked, Some(m)),
-            Err(CheckError::Inconclusive { message, .. }) => (Outcome::Inconclusive, Some(message)),
+            Err(CheckError::Inconclusive(d)) => (Outcome::Inconclusive, Some(d.into_message())),
             Err(CheckError::Harness(m)) => (Outcome::HarnessError, Some(m)),
         };
 
@@ -277,18 +310,6 @@ impl CheckResult {
         }
     }
 }
-
-// INVARIANT: only the assertion macros below (`check!`, `check_eq!`, `fail!`)
-// and constructors named `*_assertion` may set `from_assertion`. Every shared
-// helper -- log checks, readiness waits, RPC conversions, `inconclusive!` --
-// must produce a `before_assertion` value.
-//
-// The reason is empirical. Three review rounds in a row found helpers minting
-// proof for controls that never reached the check's own assertion, and each
-// time the fix addressed the instances named rather than the class. Making
-// proof opt-in, and stating it here, turns a recurring finding into a rule: a
-// helper cannot accidentally claim a control worked, because it has no way to
-// say so.
 
 /// Reports a defect when `cond` is false.
 ///
@@ -358,10 +379,9 @@ macro_rules! skip {
 #[macro_export]
 macro_rules! inconclusive {
     ($($arg:tt)+) => {
-        return Err($crate::outcome::CheckError::Inconclusive {
-            message: format!($($arg)+),
-            from_assertion: false,
-        })
+        return Err($crate::outcome::CheckError::inconclusive_before_assertion(format!(
+            $($arg)+
+        )))
     };
 }
 

--- a/harness/src/outcome.rs
+++ b/harness/src/outcome.rs
@@ -114,7 +114,9 @@ impl From<tonic::Status> for CheckError {
             tonic::Code::Unavailable | tonic::Code::DeadlineExceeded | tonic::Code::Unknown => {
                 CheckError::Harness(e.to_string())
             }
-            _ => CheckError::assertion(format!("the player rejected a request: {e}")),
+            // A real defect, but not *this check's assertion*: the rejection
+            // came from a helper, and most call sites reach it from setup.
+            _ => CheckError::before_assertion(format!("the player rejected a request: {e}")),
         }
     }
 }

--- a/harness/src/outcome.rs
+++ b/harness/src/outcome.rs
@@ -31,7 +31,17 @@ use std::time::Duration;
 #[derive(Debug)]
 pub enum CheckError {
     /// The behaviour under test is wrong. This is a defect in mtrack.
-    Failed(String),
+    ///
+    /// `from_assertion` records whether the check's own assertion produced
+    /// this, as opposed to a helper failing before the assertion was reached.
+    /// Both are real defect reports in a normal run; only the former proves
+    /// anything in `--self-test`, where a control that dies inside
+    /// `Server::start` would otherwise look identical to one that drove its
+    /// assertion to failure.
+    Failed {
+        message: String,
+        from_assertion: bool,
+    },
     /// The check cannot run on this machine, typically for missing hardware.
     /// This will never pass here no matter how often it is run.
     Skipped(String),
@@ -41,7 +51,14 @@ pub enum CheckError {
     Blocked(String),
     /// The check ran but its measurement cannot be trusted, e.g. the audio
     /// interface underran mid-capture. Not a defect, but not evidence either.
-    Inconclusive(String),
+    ///
+    /// Carries the same origin flag as `Failed`: for a check whose strongest
+    /// verdict is "I cannot trust this", an inconclusive raised by its own
+    /// logic *is* its assertion firing.
+    Inconclusive {
+        message: String,
+        from_assertion: bool,
+    },
     /// The harness itself broke: a connection failed, a temp dir could not be
     /// written. This says nothing about mtrack.
     Harness(String),
@@ -50,11 +67,11 @@ pub enum CheckError {
 impl fmt::Display for CheckError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CheckError::Failed(m)
-            | CheckError::Skipped(m)
-            | CheckError::Blocked(m)
-            | CheckError::Inconclusive(m)
-            | CheckError::Harness(m) => write!(f, "{m}"),
+            CheckError::Failed { message: m, .. } => write!(f, "{m}"),
+            CheckError::Skipped(m) | CheckError::Blocked(m) | CheckError::Harness(m) => {
+                write!(f, "{m}")
+            }
+            CheckError::Inconclusive { message: m, .. } => write!(f, "{m}"),
         }
     }
 }
@@ -97,8 +114,50 @@ impl From<tonic::Status> for CheckError {
             tonic::Code::Unavailable | tonic::Code::DeadlineExceeded | tonic::Code::Unknown => {
                 CheckError::Harness(e.to_string())
             }
-            _ => CheckError::Failed(format!("the player rejected a request: {e}")),
+            _ => CheckError::assertion(format!("the player rejected a request: {e}")),
         }
+    }
+}
+
+impl CheckError {
+    /// A defect reported by a check's own assertion.
+    pub fn assertion(message: impl Into<String>) -> CheckError {
+        CheckError::Failed {
+            message: message.into(),
+            from_assertion: true,
+        }
+    }
+
+    /// A defect detected before the check's assertion was reached, e.g. the
+    /// player never becoming ready. Real in a normal run; proves nothing as a
+    /// negative control.
+    pub fn before_assertion(message: impl Into<String>) -> CheckError {
+        CheckError::Failed {
+            message: message.into(),
+            from_assertion: false,
+        }
+    }
+
+    /// A verdict of "this measurement cannot be trusted", from the check itself.
+    pub fn inconclusive_assertion(message: impl Into<String>) -> CheckError {
+        CheckError::Inconclusive {
+            message: message.into(),
+            from_assertion: true,
+        }
+    }
+
+    /// Whether this came from a check's own assertion.
+    pub fn is_assertion(&self) -> bool {
+        matches!(
+            self,
+            CheckError::Failed {
+                from_assertion: true,
+                ..
+            } | CheckError::Inconclusive {
+                from_assertion: true,
+                ..
+            }
+        )
     }
 }
 
@@ -198,10 +257,10 @@ impl CheckResult {
         let evidence = take_evidence();
         let (outcome, detail) = match result {
             Ok(()) => (Outcome::Passed, None),
-            Err(CheckError::Failed(m)) => (Outcome::Failed, Some(m)),
+            Err(CheckError::Failed { message, .. }) => (Outcome::Failed, Some(message)),
             Err(CheckError::Skipped(m)) => (Outcome::Skipped, Some(m)),
             Err(CheckError::Blocked(m)) => (Outcome::Blocked, Some(m)),
-            Err(CheckError::Inconclusive(m)) => (Outcome::Inconclusive, Some(m)),
+            Err(CheckError::Inconclusive { message, .. }) => (Outcome::Inconclusive, Some(message)),
             Err(CheckError::Harness(m)) => (Outcome::HarnessError, Some(m)),
         };
 
@@ -230,7 +289,7 @@ macro_rules! check {
         match $cond {
             true => {}
             false => {
-                return Err($crate::outcome::CheckError::Failed(format!($($arg)+)));
+                return Err($crate::outcome::CheckError::assertion(format!($($arg)+)));
             }
         }
     };
@@ -243,7 +302,7 @@ macro_rules! check_eq {
         let left = &$left;
         let right = &$right;
         if left != right {
-            return Err($crate::outcome::CheckError::Failed(format!(
+            return Err($crate::outcome::CheckError::assertion(format!(
                 "{}\n  expected: {:?}\n  actual:   {:?}",
                 format!($($arg)+), right, left
             )));
@@ -255,7 +314,7 @@ macro_rules! check_eq {
 #[macro_export]
 macro_rules! fail {
     ($($arg:tt)+) => {
-        return Err($crate::outcome::CheckError::Failed(format!($($arg)+)))
+        return Err($crate::outcome::CheckError::assertion(format!($($arg)+)))
     };
 }
 
@@ -279,6 +338,6 @@ macro_rules! skip {
 #[macro_export]
 macro_rules! inconclusive {
     ($($arg:tt)+) => {
-        return Err($crate::outcome::CheckError::Inconclusive(format!($($arg)+)))
+        return Err($crate::outcome::CheckError::inconclusive_assertion(format!($($arg)+)))
     };
 }

--- a/harness/src/outcome.rs
+++ b/harness/src/outcome.rs
@@ -29,12 +29,15 @@ use std::time::Duration;
 
 /// A defect report, and whether the check's own assertion produced it.
 ///
-/// The flag is private and settable only through the constructors below, so the
-/// invariant is held by the compiler rather than by a comment. Three review
-/// rounds running found shared helpers minting proof for controls that never
-/// reached the check's assertion; each was fixed instance by instance while the
-/// rule stayed advisory. Now a helper cannot claim a control worked, because it
-/// has no way to say so.
+/// The flag is private, so it cannot be set by writing a struct literal -- which
+/// is how `inconclusive!` set it wrongly for three rounds. That stops the
+/// accidental case, and only that: [`CheckError::assertion`] is public and the
+/// assertion macros are exported, so a helper that deliberately calls one can
+/// still mint proof. `Client::wait_for_status` does exactly that, on purpose,
+/// via its `assertion` parameter.
+///
+/// So the rule is enforced against accidents, not against intent. A helper that
+/// claims proof must now say so in its own source, where a reader will see it.
 #[derive(Debug)]
 pub struct Defect {
     message: String,

--- a/harness/src/report.rs
+++ b/harness/src/report.rs
@@ -145,8 +145,20 @@ impl Report {
             .iter()
             .filter(|r| r.outcome == Outcome::Inconclusive)
             .collect();
+        // Only reachable from a sabotage-guarded call site today, but the
+        // constructor is public: an unguarded use would otherwise drop the
+        // check from every section while still counting toward the total.
+        let no_control: Vec<&CheckResult> = self
+            .results
+            .iter()
+            .filter(|r| r.outcome == Outcome::NoControlHere)
+            .collect();
 
-        if unverifiable.is_empty() && blocked.is_empty() && inconclusive.is_empty() {
+        if unverifiable.is_empty()
+            && blocked.is_empty()
+            && inconclusive.is_empty()
+            && no_control.is_empty()
+        {
             return;
         }
 
@@ -179,6 +191,18 @@ impl Report {
             }
         }
 
+        if !no_control.is_empty() {
+            println!("\n{}", "-".repeat(72));
+            println!(
+                "  Runs here, but has no usable negative control ({})",
+                no_control.len()
+            );
+            println!("{}", "-".repeat(72));
+            for result in no_control {
+                println!("  {}\n      {}", result.name, detail_of(result));
+            }
+        }
+
         if !inconclusive.is_empty() {
             println!("\n{}", "-".repeat(72));
             println!(
@@ -198,6 +222,7 @@ impl Report {
         let skipped = self.count(Outcome::Skipped);
         let blocked = self.count(Outcome::Blocked);
         let inconclusive = self.count(Outcome::Inconclusive);
+        let no_control = self.count(Outcome::NoControlHere);
         let harness = self.count(Outcome::HarnessError);
 
         println!("\n{}", "=".repeat(72));
@@ -216,6 +241,9 @@ impl Report {
         }
         if inconclusive > 0 {
             print!(", {inconclusive} inconclusive");
+        }
+        if no_control > 0 {
+            print!(", {no_control} without a control");
         }
         println!(" (of {} checks)", self.results.len());
 

--- a/harness/src/runner.rs
+++ b/harness/src/runner.rs
@@ -232,3 +232,95 @@ pub fn list_checks(filter: &Option<String>) {
     }
     println!("=======================\n");
 }
+
+/// Runs every check with its premise deliberately broken and requires each to
+/// stop passing.
+///
+/// A check that still passes here cannot fail, which means it has been
+/// reporting success unconditionally. That is a defect in the harness and is
+/// reported as one, with a non-zero exit.
+pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
+    println!("\n{}", "=".repeat(72));
+    println!("  SELF-TEST — breaking each check's premise; none may pass");
+    println!("{}", "=".repeat(72));
+    println!("  A check that passes here reports success unconditionally.\n");
+
+    let mut cannot_fail = Vec::new();
+    let mut proved = 0;
+    let mut inconclusive = Vec::new();
+
+    for check in checks::all() {
+        if let Some(needle) = filter {
+            if !check.name.contains(needle.as_str()) && !check.area.contains(needle.as_str()) {
+                continue;
+            }
+        }
+
+        // Each control is independent. Several sabotages deliberately stop the
+        // player reaching readiness, and without this the first one would latch
+        // and block every control after it -- which is exactly what happened on
+        // the first run, suppressing twelve of twenty-six.
+        crate::server::reset_init_latch();
+
+        crate::sabotage::enable();
+        let outcome = execute(&check).await;
+        crate::sabotage::disable();
+
+        let result = CheckResult::from_outcome(
+            check.area,
+            check.name,
+            check.description,
+            outcome,
+            std::time::Duration::ZERO,
+        );
+        match result.outcome {
+            Outcome::Passed => {
+                println!("  CANNOT FAIL  {:<46}", check.name);
+                cannot_fail.push(check.name);
+            }
+            // Skipped means the machine could not run it either way, so the
+            // control proved nothing -- it is not evidence the check is sound.
+            Outcome::Skipped | Outcome::Blocked => {
+                println!(
+                    "  not run      {:<46} {}",
+                    check.name,
+                    result.detail.as_deref().unwrap_or("")
+                );
+                inconclusive.push(check.name);
+            }
+            other => {
+                println!("  ok           {:<46} {}", check.name, other.label());
+                proved += 1;
+            }
+        }
+    }
+
+    println!("\n{}", "=".repeat(72));
+    println!("  {proved} proved capable of failing");
+    if !inconclusive.is_empty() {
+        println!(
+            "  {} not exercised on this machine: {}",
+            inconclusive.len(),
+            inconclusive.join(", ")
+        );
+    }
+    if cannot_fail.is_empty() {
+        println!("  No check reported success unconditionally.");
+    } else {
+        println!(
+            "\n  {} CANNOT FAIL — these report success unconditionally:",
+            cannot_fail.len()
+        );
+        for name in &cannot_fail {
+            println!("    {name}");
+        }
+        println!("\n  Give each a sabotage point (see harness/src/sabotage.rs).");
+    }
+    println!("{}", "=".repeat(72));
+
+    if cannot_fail.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/harness/src/runner.rs
+++ b/harness/src/runner.rs
@@ -313,18 +313,24 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
             }
             // The machine cannot run this check at all, so the control says
             // nothing either way.
+            // The check itself runs here; only its control is impossible. A
+            // distinct variant rather than a string prefix, so the two cannot
+            // drift apart in spelling.
+            Outcome::NoControlHere => {
+                println!(
+                    "  NO CONTROL   {:<46} {}",
+                    check.name,
+                    result.detail.as_deref().unwrap_or("")
+                );
+                no_control.push(check.name);
+            }
             Outcome::Skipped | Outcome::Blocked => {
-                let detail = result.detail.as_deref().unwrap_or("");
-                // The check itself runs here; only its control is impossible.
-                // Filing that under "not runnable" would read as missing
-                // hardware rather than missing verification.
-                if detail.starts_with("[no usable control") {
-                    println!("  NO CONTROL   {:<46} {}", check.name, detail);
-                    no_control.push(check.name);
-                } else {
-                    println!("  not run here {:<46} {detail}", check.name);
-                    not_runnable.push(check.name);
-                }
+                println!(
+                    "  not run here {:<46} {}",
+                    check.name,
+                    result.detail.as_deref().unwrap_or("")
+                );
+                not_runnable.push(check.name);
             }
             // The control broke the run before the assertion could be reached.
             // A check that crashes under sabotage has been shown to crash, not
@@ -348,8 +354,11 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
             "  of which {predicate_level} rest on predicate-level controls: they substitute the\n             \x20 value the assertion reads, so they prove it is reachable but would not catch a\n             \x20 check made vacuous by reading something insensitive to mtrack's behaviour."
         );
     }
-    for stale in checks::stale_predicate_entries() {
-        println!("  WARNING: PREDICATE_LEVEL lists '{stale}', which is not a registered check.");
+    for stale in checks::stale_world_level_entries() {
+        println!(
+            "  WARNING: WORLD_LEVEL lists '{stale}', which is not a registered check. \
+             Remove it -- while it is listed, nothing is credited, but the name is misleading."
+        );
     }
     if !not_runnable.is_empty() {
         println!(
@@ -395,12 +404,16 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
     // would go green having verified nothing.
     if proved == 0 {
         println!("\n  NOTHING PROVED — no check's assertion fired.");
-        if not_runnable.is_empty() && cannot_fail.is_empty() && unproven.is_empty() {
+        if not_runnable.is_empty()
+            && cannot_fail.is_empty()
+            && unproven.is_empty()
+            && no_control.is_empty()
+        {
             println!("  No checks were selected. Check the --only filter.");
         } else {
             println!("  Every selected check was unrunnable here or had a broken control.");
         }
-    } else if cannot_fail.is_empty() && unproven.is_empty() {
+    } else if cannot_fail.is_empty() && unproven.is_empty() && no_control.is_empty() {
         println!("\n  Every check runnable here proved capable of failing.");
     }
     println!("{}", "=".repeat(72));

--- a/harness/src/runner.rs
+++ b/harness/src/runner.rs
@@ -247,7 +247,8 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
 
     let mut cannot_fail = Vec::new();
     let mut proved = 0;
-    let mut inconclusive = Vec::new();
+    let mut not_runnable = Vec::new();
+    let mut unproven: Vec<(&str, &str)> = Vec::new();
 
     for check in checks::all() {
         if let Some(needle) = filter {
@@ -266,6 +267,12 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
         let outcome = execute(&check).await;
         crate::sabotage::disable();
 
+        // Whether the check's own assertion produced this, as opposed to a
+        // helper failing first. A control that dies inside `Server::start`
+        // reports Failed and would otherwise be indistinguishable from one
+        // that drove its assertion to failure.
+        let from_assertion = matches!(&outcome, Err(e) if e.is_assertion());
+
         let result = CheckResult::from_outcome(
             check.area,
             check.name,
@@ -274,39 +281,72 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
             std::time::Duration::ZERO,
         );
         match result.outcome {
+            // The only outcome that proves anything: the assertion fired and
+            // reported a defect.
+            // Some checks' strongest verdict is "I cannot trust this", so an
+            // inconclusive raised by the check itself is its assertion firing.
+            Outcome::Failed | Outcome::Inconclusive if from_assertion => {
+                println!("  ok           {:<46} assertion fired", check.name);
+                proved += 1;
+            }
+            // Failed, but before the assertion was reached.
+            Outcome::Failed => {
+                println!(
+                    "  NO ASSERTION {:<46} failed before the assertion ran",
+                    check.name
+                );
+                unproven.push((check.name, "pre-assertion failure"));
+            }
             Outcome::Passed => {
                 println!("  CANNOT FAIL  {:<46}", check.name);
                 cannot_fail.push(check.name);
             }
-            // Skipped means the machine could not run it either way, so the
-            // control proved nothing -- it is not evidence the check is sound.
+            // The machine cannot run this check at all, so the control says
+            // nothing either way.
             Outcome::Skipped | Outcome::Blocked => {
                 println!(
-                    "  not run      {:<46} {}",
+                    "  not run here {:<46} {}",
                     check.name,
                     result.detail.as_deref().unwrap_or("")
                 );
-                inconclusive.push(check.name);
+                not_runnable.push(check.name);
             }
+            // The control broke the run before the assertion could be reached.
+            // A check that crashes under sabotage has been shown to crash, not
+            // to detect anything -- counting this as proof is what let several
+            // useless controls report "ok".
             other => {
-                println!("  ok           {:<46} {}", check.name, other.label());
-                proved += 1;
+                println!(
+                    "  NO ASSERTION {:<46} control ended in {}",
+                    check.name,
+                    other.label()
+                );
+                unproven.push((check.name, other.label()));
             }
         }
     }
 
     println!("\n{}", "=".repeat(72));
-    println!("  {proved} proved capable of failing");
-    if !inconclusive.is_empty() {
+    println!("  {proved} proved capable of failing (the assertion fired)");
+    if !not_runnable.is_empty() {
         println!(
-            "  {} not exercised on this machine: {}",
-            inconclusive.len(),
-            inconclusive.join(", ")
+            "  {} not runnable on this machine: {}",
+            not_runnable.len(),
+            not_runnable.join(", ")
         );
     }
-    if cannot_fail.is_empty() {
-        println!("  No check reported success unconditionally.");
-    } else {
+    if !unproven.is_empty() {
+        println!(
+            "\n  {} control(s) never reached their assertion:",
+            unproven.len()
+        );
+        for (name, how) in &unproven {
+            println!("    {name} (ended in {how})");
+        }
+        println!("  These prove the check can break, not that it can detect anything.");
+        println!("  Move the sabotage closer to what the assertion reads.");
+    }
+    if !cannot_fail.is_empty() {
         println!(
             "\n  {} CANNOT FAIL — these report success unconditionally:",
             cannot_fail.len()
@@ -314,11 +354,14 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
         for name in &cannot_fail {
             println!("    {name}");
         }
-        println!("\n  Give each a sabotage point (see harness/src/sabotage.rs).");
+        println!("  Give each a sabotage point (see harness/src/sabotage.rs).");
+    }
+    if cannot_fail.is_empty() && unproven.is_empty() {
+        println!("\n  Every check runnable here proved capable of failing.");
     }
     println!("{}", "=".repeat(72));
 
-    if cannot_fail.is_empty() {
+    if cannot_fail.is_empty() && unproven.is_empty() {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE

--- a/harness/src/runner.rs
+++ b/harness/src/runner.rs
@@ -248,6 +248,7 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
     let mut cannot_fail = Vec::new();
     let mut proved = 0;
     let mut not_runnable = Vec::new();
+    let mut predicate_level = 0;
     let mut unproven: Vec<(&str, &str)> = Vec::new();
 
     for check in checks::all() {
@@ -286,7 +287,15 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
             // Some checks' strongest verdict is "I cannot trust this", so an
             // inconclusive raised by the check itself is its assertion firing.
             Outcome::Failed | Outcome::Inconclusive if from_assertion => {
-                println!("  ok           {:<46} assertion fired", check.name);
+                let kind = if checks::is_predicate_level(check.name) {
+                    "assertion fired (predicate-level control)"
+                } else {
+                    "assertion fired"
+                };
+                println!("  ok           {:<46} {kind}", check.name);
+                if checks::is_predicate_level(check.name) {
+                    predicate_level += 1;
+                }
                 proved += 1;
             }
             // Failed, but before the assertion was reached.
@@ -328,6 +337,14 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
 
     println!("\n{}", "=".repeat(72));
     println!("  {proved} proved capable of failing (the assertion fired)");
+    if predicate_level > 0 {
+        println!(
+            "  of which {predicate_level} rest on predicate-level controls: they substitute the\n             \x20 value the assertion reads, so they prove it is reachable but would not catch a\n             \x20 check made vacuous by reading something insensitive to mtrack's behaviour."
+        );
+    }
+    for stale in checks::stale_predicate_entries() {
+        println!("  WARNING: PREDICATE_LEVEL lists '{stale}', which is not a registered check.");
+    }
     if !not_runnable.is_empty() {
         println!(
             "  {} not runnable on this machine: {}",
@@ -356,12 +373,23 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
         }
         println!("  Give each a sabotage point (see harness/src/sabotage.rs).");
     }
-    if cannot_fail.is_empty() && unproven.is_empty() {
+    // Proving nothing is not success. `--self-test --only <typo>` selects no
+    // checks, and hardware trouble can push every area into Skipped -- both
+    // would otherwise print a clean verdict and exit 0, so CI wired to this
+    // would go green having verified nothing.
+    if proved == 0 {
+        println!("\n  NOTHING PROVED — no check's assertion fired.");
+        if not_runnable.is_empty() && cannot_fail.is_empty() && unproven.is_empty() {
+            println!("  No checks were selected. Check the --only filter.");
+        } else {
+            println!("  Every selected check was unrunnable here or had a broken control.");
+        }
+    } else if cannot_fail.is_empty() && unproven.is_empty() {
         println!("\n  Every check runnable here proved capable of failing.");
     }
     println!("{}", "=".repeat(72));
 
-    if cannot_fail.is_empty() && unproven.is_empty() {
+    if proved > 0 && cannot_fail.is_empty() && unproven.is_empty() {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE

--- a/harness/src/runner.rs
+++ b/harness/src/runner.rs
@@ -248,6 +248,7 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
     let mut cannot_fail = Vec::new();
     let mut proved = 0;
     let mut not_runnable = Vec::new();
+    let mut no_control = Vec::new();
     let mut predicate_level = 0;
     let mut unproven: Vec<(&str, &str)> = Vec::new();
 
@@ -313,12 +314,17 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
             // The machine cannot run this check at all, so the control says
             // nothing either way.
             Outcome::Skipped | Outcome::Blocked => {
-                println!(
-                    "  not run here {:<46} {}",
-                    check.name,
-                    result.detail.as_deref().unwrap_or("")
-                );
-                not_runnable.push(check.name);
+                let detail = result.detail.as_deref().unwrap_or("");
+                // The check itself runs here; only its control is impossible.
+                // Filing that under "not runnable" would read as missing
+                // hardware rather than missing verification.
+                if detail.starts_with("[no usable control") {
+                    println!("  NO CONTROL   {:<46} {}", check.name, detail);
+                    no_control.push(check.name);
+                } else {
+                    println!("  not run here {:<46} {detail}", check.name);
+                    not_runnable.push(check.name);
+                }
             }
             // The control broke the run before the assertion could be reached.
             // A check that crashes under sabotage has been shown to crash, not
@@ -351,6 +357,16 @@ pub async fn run_self_test(filter: &Option<String>) -> ExitCode {
             not_runnable.len(),
             not_runnable.join(", ")
         );
+    }
+    if !no_control.is_empty() {
+        println!(
+            "\n  {} check(s) run here but have no usable control on this hardware:",
+            no_control.len()
+        );
+        for name in &no_control {
+            println!("    {name}");
+        }
+        println!("  They pass in a normal run; nothing here proves they could fail.");
     }
     if !unproven.is_empty() {
         println!(

--- a/harness/src/sabotage.rs
+++ b/harness/src/sabotage.rs
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+//! Deliberately breaking a check's premise, to prove the check can fail.
+//!
+//! A check that cannot fail is worse than no check: it reports success forever
+//! and nobody looks at it again. This harness has shipped two.
+//! `bogus_*_device_degrades_gracefully` read a subsystem status milliseconds
+//! after spawn, when everything reads `initializing` whatever mtrack does, and
+//! `stop_halts_playback` used a four-second song that ended on its own inside
+//! the ten-second stop deadline. Both passed every review; neither could fail.
+//!
+//! Each check therefore names one thing it depends on and asks here whether to
+//! break it. Running with the flag set is that check's negative control, and
+//! `--self-test` requires every check to stop passing under it.
+//!
+//! Deliberately *not* an external source-mutating script. That approach was
+//! tried and removed: its mutations were pinned to exact source strings, so it
+//! rotted the moment a check was edited, and it had no idea the registry held
+//! checks it did not cover. Here the control is compiled next to the assertion
+//! it guards, and a check with no break point simply passes the self-test --
+//! which the self-test reports as the defect it is.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Whether the running check should break its own premise.
+pub fn active() -> bool {
+    ACTIVE.load(Ordering::SeqCst)
+}
+
+/// Runs `f` with sabotage enabled. Checks execute one at a time, so a plain
+/// flag is sufficient.
+pub fn enable() {
+    ACTIVE.store(true, Ordering::SeqCst);
+}
+
+pub fn disable() {
+    ACTIVE.store(false, Ordering::SeqCst);
+}
+
+/// Picks between the real value and one that should make the check fail.
+///
+/// The idiom for most break points:
+///
+/// ```ignore
+/// let duration = sabotage::pick(120.0, 0.3);   // too short to observe
+/// ```
+pub fn pick<T>(real: T, broken: T) -> T {
+    if active() {
+        broken
+    } else {
+        real
+    }
+}
+
+/// Whether a step should be performed at all.
+///
+/// For break points that are an *omission* rather than a substitution, such as
+/// never sending the Stop the check is meant to be verifying.
+pub fn perform() -> bool {
+    !active()
+}

--- a/harness/src/sabotage.rs
+++ b/harness/src/sabotage.rs
@@ -88,9 +88,6 @@ pub fn perform() -> bool {
 #[macro_export]
 macro_rules! no_control_here {
     ($($arg:tt)+) => {
-        return Err($crate::outcome::CheckError::Skipped(format!(
-            "[no usable control on this machine] {}",
-            format!($($arg)+)
-        )))
+        return Err($crate::outcome::CheckError::no_control_here(format!($($arg)+)))
     };
 }

--- a/harness/src/sabotage.rs
+++ b/harness/src/sabotage.rs
@@ -14,11 +14,13 @@
 //! Deliberately breaking a check's premise, to prove the check can fail.
 //!
 //! A check that cannot fail is worse than no check: it reports success forever
-//! and nobody looks at it again. This harness has shipped two.
+//! and nobody looks at it again. This harness has shipped three.
 //! `bogus_*_device_degrades_gracefully` read a subsystem status milliseconds
-//! after spawn, when everything reads `initializing` whatever mtrack does, and
+//! after spawn, when everything reads `initializing` whatever mtrack does;
 //! `stop_halts_playback` used a four-second song that ended on its own inside
-//! the ten-second stop deadline. Both passed every review; neither could fail.
+//! the ten-second stop deadline; and `active_playlist_persists_across_restart`
+//! asserted the opposite of documented behaviour. All three passed every
+//! review; none could fail.
 //!
 //! Each check therefore names one thing it depends on and asks here whether to
 //! break it. Running with the flag set is that check's negative control, and
@@ -40,8 +42,11 @@ pub fn active() -> bool {
     ACTIVE.load(Ordering::SeqCst)
 }
 
-/// Runs `f` with sabotage enabled. Checks execute one at a time, so a plain
-/// flag is sufficient.
+/// Turns sabotage on for the next check.
+///
+/// Paired with [`disable`] by the self-test runner rather than being a scope
+/// guard: `runner::execute` catches unwinds, so a panicking control cannot
+/// leave the flag set. Checks execute one at a time, so a plain flag suffices.
 pub fn enable() {
     ACTIVE.store(true, Ordering::SeqCst);
 }

--- a/harness/src/sabotage.rs
+++ b/harness/src/sabotage.rs
@@ -77,3 +77,20 @@ pub fn pick<T>(real: T, broken: T) -> T {
 pub fn perform() -> bool {
     !active()
 }
+
+/// Declines to sabotage, because this machine cannot supply the failure
+/// condition the control needs.
+///
+/// Distinct from a check being unrunnable: the check itself runs and passes
+/// here, only its *control* is impossible -- a rig with one loopback link
+/// cannot permute a mapping, and one with no MIDI cannot make a MIDI-less
+/// profile declare a device. Reported separately so the two are not confused.
+#[macro_export]
+macro_rules! no_control_here {
+    ($($arg:tt)+) => {
+        return Err($crate::outcome::CheckError::Skipped(format!(
+            "[no usable control on this machine] {}",
+            format!($($arg)+)
+        )))
+    };
+}

--- a/harness/src/server.rs
+++ b/harness/src/server.rs
@@ -142,11 +142,13 @@ impl Server {
                 INIT_TIMED_OUT.store(true, Ordering::SeqCst);
                 // A real finding: the player could not come up against a config
                 // naming devices it had itself advertised.
-                Err(crate::outcome::CheckError::Failed(msg))
+                Err(crate::outcome::CheckError::before_assertion(msg))
             }
             // Also a real finding, but specific to this check's config, so the
             // rest of the run still gets to say something.
-            Err(StartFailure::Exited(msg)) => Err(crate::outcome::CheckError::Failed(msg)),
+            Err(StartFailure::Exited(msg)) => {
+                Err(crate::outcome::CheckError::before_assertion(msg))
+            }
             // Never latched: the harness broke, not the player.
             Err(StartFailure::Harness(msg)) => Err(crate::outcome::CheckError::Harness(msg)),
         }
@@ -162,7 +164,7 @@ impl Server {
                 // Its callers exist to check that an unresolvable device degrades
                 // rather than killing the player. Reporting an exit as a harness
                 // error would label the very defect they hunt as our own bug.
-                StartFailure::Exited(m) => crate::outcome::CheckError::Failed(m),
+                StartFailure::Exited(m) => crate::outcome::CheckError::before_assertion(m),
                 StartFailure::Timeout(m) | StartFailure::Harness(m) => {
                     crate::outcome::CheckError::Harness(m)
                 }
@@ -315,7 +317,7 @@ impl Server {
         if unexpected.is_empty() {
             Ok(())
         } else {
-            Err(crate::outcome::CheckError::Failed(format!(
+            Err(crate::outcome::CheckError::assertion(format!(
                 "mtrack logged {} unexpected error(s):\n{}",
                 unexpected.len(),
                 unexpected.join("\n")
@@ -346,7 +348,7 @@ impl Server {
         if ignored.is_empty() {
             Ok(())
         } else {
-            Err(crate::outcome::CheckError::Failed(format!(
+            Err(crate::outcome::CheckError::assertion(format!(
                 "mtrack ignored part of the generated config:\n{}",
                 ignored.join("\n")
             )))

--- a/harness/src/server.rs
+++ b/harness/src/server.rs
@@ -317,7 +317,7 @@ impl Server {
         if unexpected.is_empty() {
             Ok(())
         } else {
-            Err(crate::outcome::CheckError::assertion(format!(
+            Err(crate::outcome::CheckError::before_assertion(format!(
                 "mtrack logged {} unexpected error(s):\n{}",
                 unexpected.len(),
                 unexpected.join("\n")
@@ -348,7 +348,7 @@ impl Server {
         if ignored.is_empty() {
             Ok(())
         } else {
-            Err(crate::outcome::CheckError::assertion(format!(
+            Err(crate::outcome::CheckError::before_assertion(format!(
                 "mtrack ignored part of the generated config:\n{}",
                 ignored.join("\n")
             )))

--- a/scripts/hardware-test.sh
+++ b/scripts/hardware-test.sh
@@ -22,6 +22,7 @@
 #   ./scripts/hardware-test.sh                  # everything available
 #   ./scripts/hardware-test.sh --only lighting  # one area or case-name filter
 #   ./scripts/hardware-test.sh --list           # what would run, then exit
+#   ./scripts/hardware-test.sh --self-test      # prove every check can fail
 #   ./scripts/hardware-test.sh --repeat 20      # repeat, to hunt intermittents
 #   ./scripts/hardware-test.sh --rediscover     # re-measure cabling, ignore cache
 #   ./scripts/hardware-test.sh --probe-all      # probe every device pair, not just the selected one
@@ -36,6 +37,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 FILTER=""
 REPEAT=1
 LIST_ONLY=false
+SELF_TEST=false
 SKIP_BUILD=false
 
 usage() {
@@ -74,6 +76,7 @@ while [[ $# -gt 0 ]]; do
             REPEAT="$2"; shift; shift ;;
         --json)       need_value "$@"; JSON_OUT="$2"; shift; shift ;;
         --list)       LIST_ONLY=true; shift ;;
+        --self-test)  SELF_TEST=true; shift ;;
         --rediscover) export MTRACK_E2E_REDISCOVER=1; shift ;;
         --probe-all)  export MTRACK_E2E_PROBE_ALL=1; shift ;;
         --no-build)   SKIP_BUILD=true; shift ;;
@@ -119,6 +122,10 @@ ARGS=()
 
 if [[ "$LIST_ONLY" == "true" ]]; then
     exec "$HARNESS" --list "${ARGS[@]}"
+fi
+
+if [[ "$SELF_TEST" == "true" ]]; then
+    exec "$HARNESS" --self-test "${ARGS[@]}"
 fi
 
 exec "$HARNESS" "${ARGS[@]}"

--- a/scripts/hardware-test.sh
+++ b/scripts/hardware-test.sh
@@ -18,6 +18,7 @@
 # runs the areas it can, and reports the ones it cannot. A machine with only
 # audio, or only MIDI, is a normal run rather than a failure.
 #
+# USAGE-BEGIN
 # Usage:
 #   ./scripts/hardware-test.sh                  # everything available
 #   ./scripts/hardware-test.sh --only lighting  # one area or case-name filter
@@ -28,6 +29,7 @@
 #   ./scripts/hardware-test.sh --probe-all      # probe every device pair, not just the selected one
 #   ./scripts/hardware-test.sh --json out.json  # also write machine-readable results
 #   ./scripts/hardware-test.sh --no-build       # skip the build step
+# USAGE-END
 
 set -uo pipefail
 
@@ -40,8 +42,11 @@ LIST_ONLY=false
 SELF_TEST=false
 SKIP_BUILD=false
 
+# Printed from a marked block rather than a line range: the range silently
+# dropped --no-build the moment a usage line was inserted above it.
 usage() {
-    sed -n '17,29p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '/^# USAGE-BEGIN$/,/^# USAGE-END$/p' "${BASH_SOURCE[0]}" \
+        | grep -v 'USAGE-\(BEGIN\|END\)' | sed 's/^# \{0,1\}//'
     exit "${1:-0}"
 }
 

--- a/tests/systemd/Dockerfile
+++ b/tests/systemd/Dockerfile
@@ -48,11 +48,16 @@ COPY .git/ .git/
 COPY src/ src/
 # Required to parse the manifest: Cargo.toml declares the mixer bench.
 COPY benches/ benches/
+# Likewise: Cargo.toml declares a workspace with the harness as a member, so its
+# manifest must exist for the workspace to load. Only the manifest is copied --
+# the harness is a hardware-verification tool with no place in this image, and
+# the build below is scoped to mtrack so its sources are never needed.
+COPY harness/Cargo.toml harness/Cargo.toml
 
 # Build the Svelte frontend (embedded into the Rust binary).
 RUN cd src/webui/svelte && npm ci && buf generate && npm run build
 
-RUN cargo build --release
+RUN cargo build --release -p mtrack --bin mtrack
 
 # --- Test stage ---
 FROM ubuntu:24.04


### PR DESCRIPTION
Adds `--self-test`: every check breaks its own premise and must stop passing.

```
./scripts/hardware-test.sh --self-test
...
  26 proved capable of failing
  No check reported success unconditionally.
```

**26/26 on the MAT rig, 25/26 on the WING** (routing is not exercised on a console with no loopback).

## Why

A check that cannot fail is worse than no check — it reports success forever and nobody looks again. Three had shipped here:

- `bogus_*_device_degrades_gracefully` read a subsystem status milliseconds after spawn, when everything reads `initializing` whatever mtrack does
- `active_playlist_persists_across_restart` asserted the opposite of documented behaviour (withdrawn as #359)
- `stop_halts_playback` used a 4-second song that ended on its own inside the 10-second stop deadline, so it passed whether or not Stop did anything

Each survived several reviews, because reading the code cannot distinguish an assertion that holds from one that cannot be violated.

## How

Each check names one thing it depends on and asks `sabotage::` whether to break it, so the control *is* the same function run with a flag set. The control lives beside the assertion it guards — refactoring cannot orphan it — and completeness enforces itself: a check with no break point simply passes the self-test and is reported as a defect.

It earned that immediately. The first run caught two lighting checks I had never given break points; the second caught a control that only worked where raw hardware exists, so it could not fail on the WING — precisely the configuration that check was written to tolerate.

This replaces an external source-mutating sweep that was tried and removed: its mutations were pinned to exact source strings, so it rotted whenever a check was edited, and it scored itself 16/16 while silently ignoring the ten registry checks it never covered.

## Fixes found along the way

- **`stop_halts_playback` was vacuous** — now plays a 120s song and requires the stop within 5s.
- **`controllers_restart_while_idle` misclassified its own assertion.** Reconnecting *is* the check ("controllers must come back, or control is silently lost"), but a failed reconnect was reported as a harness error. It is a player defect and now says so — and it fires on the WING today.
- **The init latch is reset between controls.** Several sabotages deliberately stop the player reaching readiness; the first one latched and blocked 12 of 26.

`cargo test --lib` 3062 passing; clippy and rustfmt clean. Normal runs unchanged: MAT 24 passed / 2 failed, WING 23 passed / 2 failed / 1 unverifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)