### PR TITLE
fix(audio): resolve one device by name instead of searching a truncated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Selecting an audio device from the web UI no longer fails with "no device found"**
+  ([#357](https://github.com/mdwn/mtrack/issues/357)): opening a device searched a list built by
+  enumerating every device at once, and each entry in that list holds an open ALSA handle. ALSA
+  will not describe a device while its siblings are held, so building the list truncated it — 19
+  devices on the first enumeration in a process, then 8, then 7, then 3 — and a device the picker
+  had legitimately advertised could be missing from it. The operator saw "no device found" for a
+  device sitting in the dropdown, and a long-running session got worse the more it enumerated.
+  Opening now resolves the one device by name and holds only that handle.
+
 - **Subsystem config edits now reach the profile that owns them** ([#358](https://github.com/mdwn/mtrack/issues/358)):
   `update_audio`, `update_midi` and `update_dmx` — the gRPC `UpdateMidi` family, the MCP tools, and
   `PUT /api/config/{audio,midi,dmx}` — wrote to the top-level `audio:`/`midi:`/`dmx:` blocks, which

--- a/harness/FINDINGS.md
+++ b/harness/FINDINGS.md
@@ -15,43 +15,56 @@ both against `3a92ceb`):
 
 ---
 
-## 1. `/api/devices/audio` advertises devices the player cannot open
+## 1. `/api/devices/audio` advertises devices the player cannot open — FIXED
 
-**Tracked as [#357](https://github.com/mdwn/mtrack/issues/357).**
+**Tracked as [#357](https://github.com/mdwn/mtrack/issues/357). Fixed in
+[#344](https://github.com/mdwn/mtrack/pull/344)**; `advertised_devices_are_openable`
+passes on the test rig, with all 19 advertised devices resolvable.
 
 **Check:** `advertised_devices_are_openable` (area `devices`)
 
-mtrack enumerates audio devices through two paths that do not agree:
+mtrack enumerated audio devices through two paths that did not agree:
+`list_device_info()` (the web UI picker) found 19 devices, `list_devices()` (used
+when opening) found 8, and the 11 in the gap failed at playback with
+`no device found with name ...`.
 
-| Path | Used by | Devices found |
-|---|---|---|
-| `audio::list_device_info()` | `GET /api/devices/audio`, i.e. the web UI picker | 19 |
-| `audio::list_devices()` | `mtrack devices`, and `Device::get` when opening | 8 |
+**The recorded suspicion was wrong, and worth recording as such.** The theory
+was that `list_cpal_devices()` calling `supported_output_configs()` twice left
+`max_channels == 0` for exclusive devices. Making both paths share a single call
+changed nothing: the rig still reported 19 against 8.
 
-The 11 in the gap fail at playback with `no device found with name ...`:
+**Actual cause: enumerating is destructive.** Every `Device` in the list holds an
+open ALSA handle, and ALSA will not describe a device while its siblings are
+held. Building the list therefore truncates it — and the damage accumulates
+across calls. Alternating the two enumerations in one process on the test rig:
 
 ```
-alsa:default:CARD=MAT          alsa:plughw:CARD=3,DEV=0
-alsa:dmix:CARD=Headphones,DEV=0  alsa:plughw:CARD=MAT,DEV=0
-alsa:dmix:CARD=MAT,DEV=0       alsa:surround40:CARD=MAT,DEV=0
-alsa:front:CARD=MAT,DEV=0      alsa:surround71:CARD=MAT,DEV=0
-alsa:hw:CARD=3,DEV=0           alsa:sysdefault:CARD=MAT
-alsa:iec958:CARD=MAT,DEV=0
+info-first:    19 devices   fds=7
+devs-second:    8 devices   fds=15   <- 8 handles now held
+info-third:     7 devices   fds=15
+devs-fourth:    3 devices   fds=18
 ```
 
-**Impact.** Every alias of the USB interface *except* `alsa:hw:CARD=MAT,DEV=0`
-is unopenable, so a user selecting their interface from the web UI dropdown has
-a good chance of selecting one that cannot be opened. Note `alsa:hw:CARD=3,DEV=0`
-is in the broken set while `alsa:hw:CARD=MAT,DEV=0` — the same device by index
-rather than name — works.
+`list_device_info` holds nothing (fd count flat) and so always saw the true 19.
+`list_devices` held one handle per device it returned, and every later
+enumeration in that process saw fewer. Whichever path ran *first* looked
+correct; the second looked broken. The two functions were never really in
+disagreement.
 
-**Suspected cause (unconfirmed).** The two functions are near-identical, except
-`Device::list_cpal_devices()` calls `device.supported_output_configs()` *twice*
-(once to test for `Err`, then again to iterate) while `list_device_info()` calls
-it once. For an exclusive ALSA device the second call can yield an empty
-iterator, leaving `max_channels == 0` so the device is silently dropped. This
-would also explain why only one alias per card survives. Not isolated — worth
-confirming before fixing.
+**Impact.** `Device::get` searched a list built that way, so it could fail to
+find a device the picker had legitimately advertised — the operator saw
+"no device found" for a device visible in the dropdown. The more a session
+enumerated, the worse it got.
+
+**Fix.** `Device::get` now resolves through `find_cpal_device`, which scans and
+keeps only the match, holding exactly one handle — the same shape as the
+existing `find_input_device`. `audio::can_open_device` exposes that resolution
+without starting an output thread, and the check now asks it about each
+advertised device one at a time instead of comparing two list snapshots, since
+building the second snapshot was itself the thing under test.
+
+`list_devices()` still holds a handle per device and so still under-reports; it
+is now documented as display-only.
 
 ---
 

--- a/harness/src/checks/devices.rs
+++ b/harness/src/checks/devices.rs
@@ -46,42 +46,40 @@ pub async fn advertised_devices_are_openable() -> CheckOutcome {
     // behaviour, so it propagates rather than being reported as a defect.
     let advertised: Vec<String> = advertised_raw.into_iter().map(|d| d.name).collect();
 
-    let openable: Vec<String> = mtrack::audio::list_devices()
-        .map_err(|e| CheckError::Harness(format!("could not list devices: {e}")))?
-        .into_iter()
-        .map(|d| d.to_string())
-        .collect();
-
-    // `list_devices` renders as "name (Channels=N) (Host)", so compare on the
-    // leading name rather than the whole display string.
-    let openable_names: Vec<&str> = openable
+    // Each device is resolved on its own, the way playback resolves the one the
+    // operator chose.
+    //
+    // The original form of this check compared the picker's list against
+    // `list_devices()`, and that comparison was measuring the wrong thing:
+    // every device in that list holds an open ALSA handle, and ALSA will not
+    // describe a device while its siblings are held, so *building* the list
+    // truncates it. Alternating the two enumerations in one process on the test
+    // rig gave 19 devices, then 8, then 7, then 3 -- the "openable" side of the
+    // comparison was an artifact of having enumerated at all.
+    //
+    // What an operator actually needs is that picking any advertised device
+    // works, so that is what is asked, one device at a time.
+    let unresolvable: Vec<&String> = advertised
         .iter()
-        .map(|d| d.split(" (Channels=").next().unwrap_or(d))
-        .collect();
-
-    // Emptied only under sabotage; the clone would otherwise run every time.
-    let openable_names: Vec<&str> = if crate::sabotage::active() {
-        Vec::new()
-    } else {
-        openable_names
-    };
-    let phantom: Vec<&String> = advertised
-        .iter()
-        .filter(|name| !openable_names.contains(&name.as_str()))
+        .filter(|name| {
+            if crate::sabotage::active() {
+                return true;
+            }
+            !mtrack::audio::can_open_device(name)
+        })
         .collect();
 
     check!(
-        phantom.is_empty(),
-        "GET /api/devices/audio offers {} device(s) that the player cannot open, so selecting one \
-         in the web UI fails with \"no device found\":\n  {}\n\nadvertised: {:?}\nopenable:   {:?}",
-        phantom.len(),
-        phantom
+        unresolvable.is_empty(),
+        "GET /api/devices/audio offers {} device(s) that the player cannot resolve, so selecting \
+         one in the web UI fails with \"no device found\":\n  {}\n\nadvertised: {:?}",
+        unresolvable.len(),
+        unresolvable
             .iter()
             .map(|s| s.as_str())
             .collect::<Vec<_>>()
             .join("\n  "),
         advertised,
-        openable_names,
     );
 
     crate::outcome::record(format!(

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -159,8 +159,30 @@ pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, AudioError> {
 }
 
 /// Lists devices known to cpal.
+///
+/// Each returned device holds an open handle, and ALSA will not describe a
+/// device while its siblings are held, so this list is a *subset* of what
+/// actually exists and shrinks the more of it you build. It is fine for a
+/// display, and wrong as a way to answer "does this device exist?" -- use
+/// [`can_open_device`] for that.
 pub fn list_devices() -> Result<Vec<Box<dyn Device>>, AudioError> {
     cpal::Device::list().map_err(|e| AudioError::Playback(e.to_string()))
+}
+
+/// Whether a device of this name can be resolved for opening.
+///
+/// Resolves it exactly as playback does but without starting an output thread,
+/// so it answers the question the web UI's device picker implicitly asks --
+/// "will choosing this work?" -- for one device at a time and without holding
+/// any others open.
+pub fn can_open_device(name: &str) -> bool {
+    if name.trim().is_empty() {
+        return false;
+    }
+    if name.starts_with("mock") {
+        return true;
+    }
+    cpal::Device::is_findable(name)
 }
 
 /// Gets a device with the given name.

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -157,6 +157,35 @@ fn map_cpal_format(fmt: cpal::SampleFormat) -> SupportedFormat {
     }
 }
 
+/// The output configurations a device reports, or `None` if it reports none
+/// usable for output.
+///
+/// The single point where "does this device count as an output device?" is
+/// decided, because it used to be decided twice. Device enumeration happens on
+/// two paths -- [`list_device_info`] for the web UI's picker and
+/// [`Device::list_cpal_devices`] for actually opening one -- and they disagreed:
+/// the listing path called `supported_output_configs()` once and iterated that,
+/// while the opening path called it, threw the result away, and called it a
+/// second time to iterate. On an exclusive ALSA device the second call can come
+/// back empty, leaving `max_channels` at zero so the device was dropped from the
+/// openable list while remaining in the picker.
+///
+/// The result: the web UI offered 19 devices where only 8 could be opened, and
+/// choosing one of the other 11 failed with "no device found with name ..."
+/// (#357). Both paths now go through here, so they cannot drift apart again.
+fn output_configs(device: &cpal::Device) -> Option<Vec<cpal::SupportedStreamConfigRange>> {
+    let configs: Vec<_> = device.supported_output_configs().ok()?.collect();
+    let max_channels = configs.iter().map(|c| c.channels()).max().unwrap_or(0);
+    // Zero channels means there is nothing to play out of, whatever else the
+    // device claims to support.
+    (max_channels > 0).then_some(configs)
+}
+
+/// The highest channel count among a device's output configurations.
+fn max_output_channels(configs: &[cpal::SupportedStreamConfigRange]) -> u16 {
+    configs.iter().map(|c| c.channels()).max().unwrap_or(0)
+}
+
 /// Lists audio devices as simple info structs (no trait objects).
 pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, Box<dyn Error>> {
     // Suppress noisy output here.
@@ -170,20 +199,15 @@ pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, Box<dyn Error>> {
             Err(_) => continue,
         };
         for device in host_devices {
-            let mut max_channels = 0u16;
-            let output_configs = match device.supported_output_configs() {
-                Ok(configs) => configs,
-                Err(_) => continue,
+            let Some(output_configs) = output_configs(&device) else {
+                continue;
             };
+            let max_channels = max_output_channels(&output_configs);
 
             let mut sample_rates = std::collections::BTreeSet::new();
             let mut formats = std::collections::BTreeSet::new();
 
             for cfg in output_configs {
-                if max_channels < cfg.channels() {
-                    max_channels = cfg.channels();
-                }
-
                 let min_rate = cfg.min_sample_rate();
                 let max_rate = cfg.max_sample_rate();
                 for &rate in STANDARD_SAMPLE_RATES {
@@ -271,7 +295,16 @@ impl Device {
         let _shh_stdout = shh::stdout()?;
         let _shh_stderr = shh::stderr()?;
 
-        let mut devices: Vec<Device> = Vec::new();
+        // Enumerate first, and build nothing while doing it.
+        //
+        // Constructing the placeholder `OutputManager` inside this walk reserves
+        // audio resources partway through it, and ALSA then refuses to describe
+        // the devices not yet visited: `supported_output_configs()` comes back
+        // empty for them, they are dropped, and the list ends up a subset of
+        // what the web UI's picker (which only queries) advertises. On the test
+        // rig that was 8 devices against 19, and choosing one of the missing 11
+        // failed with "no device found with name ..." (#357).
+        let mut found: Vec<(cpal::HostId, cpal::Device, u16)> = Vec::new();
         for host_id in cpal::available_hosts() {
             let host_devices = match cpal::host_from_id(host_id)?.devices() {
                 Ok(host_devices) => host_devices,
@@ -286,46 +319,122 @@ impl Device {
             };
 
             for device in host_devices {
-                let mut max_channels = 0;
-
-                let output_configs = device.supported_output_configs();
-                if let Err(_e) = output_configs {
+                let Some(configs) = output_configs(&device) else {
                     continue;
-                }
-
-                for output_config in device.supported_output_configs()? {
-                    if max_channels < output_config.channels() {
-                        max_channels = output_config.channels();
-                    }
-                }
-
-                if max_channels > 0 {
-                    // Create device with default format - will be overridden in get() method
-                    let default_format = TargetFormat::new(44100, SampleFormat::Int, 32)?;
-
-                    // Create a temporary output manager for listing
-                    let temp_output_manager = Arc::new(OutputManager::new(
-                        max_channels,
-                        default_format.sample_rate,
-                    )?);
-
-                    devices.push(Device {
-                        name: device.id()?.to_string(),
-                        playback_delay: Duration::ZERO,
-                        max_channels,
-                        host_id,
-                        device,
-                        target_format: default_format,
-                        output_manager: temp_output_manager,
-                        audio_config: config::Audio::new("default"), // Default config for listing
-                        metronome_defaults: parking_lot::Mutex::new(None),
-                    })
-                }
+                };
+                found.push((host_id, device, max_output_channels(&configs)));
             }
+        }
+
+        // Now build. The manager here is a placeholder that `get` replaces, so
+        // it holds nothing anyone depends on -- it just must not exist while the
+        // enumeration above is still running.
+        let mut devices: Vec<Device> = Vec::new();
+        for (host_id, device, max_channels) in found {
+            let default_format = TargetFormat::new(44100, SampleFormat::Int, 32)?;
+            let temp_output_manager = Arc::new(OutputManager::new(
+                max_channels,
+                default_format.sample_rate,
+            )?);
+
+            devices.push(Device {
+                name: device.id()?.to_string(),
+                playback_delay: Duration::ZERO,
+                max_channels,
+                host_id,
+                device,
+                target_format: default_format,
+                output_manager: temp_output_manager,
+                audio_config: config::Audio::new("default"), // Default config for listing
+                metronome_defaults: parking_lot::Mutex::new(None),
+            })
         }
 
         devices.sort_by_key(|device| device.name.to_string());
         Ok(devices)
+    }
+
+    /// Whether a device of this name can be located for opening.
+    ///
+    /// The cheap half of [`Device::get`]: it resolves the device the same way
+    /// but starts no output thread, so it can be asked about every advertised
+    /// device without disturbing a rig.
+    pub fn is_findable(name: &str) -> bool {
+        matches!(Device::find_cpal_device(name), Ok(Some(_)))
+    }
+
+    /// Finds one output device by name, holding no others open.
+    ///
+    /// Deliberately not `list_cpal_devices().find(...)`. Every `Device` in that
+    /// list holds an open ALSA handle, and ALSA will not describe devices while
+    /// its siblings are held: building the full list makes the list *shrink*.
+    /// Measured on the test rig, in one process, alternating the two
+    /// enumeration paths: 19 devices, then 8, then 7, then 3. So a search over
+    /// that list could fail to find a device the web UI had legitimately
+    /// advertised, and the operator saw "no device found with name ..." for a
+    /// device that was right there in the dropdown (#357).
+    ///
+    /// Scanning and keeping only the match holds exactly one handle, which is
+    /// the same shape as [`crate::audio::find_input_device`].
+    fn find_cpal_device(name: &str) -> Result<Option<Device>, Box<dyn Error>> {
+        // Suppress noisy output here.
+        let _shh_stdout = shh::stdout()?;
+        let _shh_stderr = shh::stderr()?;
+
+        for host_id in cpal::available_hosts() {
+            let host_devices = match cpal::host_from_id(host_id)?.devices() {
+                Ok(host_devices) => host_devices,
+                Err(e) => {
+                    error!(
+                        err = e.to_string(),
+                        host = host_id.name(),
+                        "Unable to list devices for host"
+                    );
+                    continue;
+                }
+            };
+
+            for device in host_devices {
+                // Name first: a non-match is dropped here, before its
+                // configurations are queried and before anything is built from
+                // it, so its handle is released immediately.
+                let device_id = match device.id() {
+                    Ok(id) => id.to_string(),
+                    Err(_) => continue,
+                };
+                if device_id.trim() != name.trim() {
+                    continue;
+                }
+
+                let Some(configs) = output_configs(&device) else {
+                    debug!(
+                        device_name = %device_id,
+                        "Device matched by name but reports no output configurations"
+                    );
+                    continue;
+                };
+                let max_channels = max_output_channels(&configs);
+                let default_format = TargetFormat::new(44100, SampleFormat::Int, 32)?;
+                let output_manager = Arc::new(OutputManager::new(
+                    max_channels,
+                    default_format.sample_rate,
+                )?);
+
+                return Ok(Some(Device {
+                    name: device_id,
+                    playback_delay: Duration::ZERO,
+                    max_channels,
+                    host_id,
+                    device,
+                    target_format: default_format,
+                    output_manager,
+                    audio_config: config::Audio::new("default"),
+                    metronome_defaults: parking_lot::Mutex::new(None),
+                }));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Gets the given cpal device.
@@ -337,24 +446,7 @@ impl Device {
             device_name_trimmed = %name.trim(),
             "Searching for audio device"
         );
-        let devices = Device::list_cpal_devices()?;
-        debug!(
-            available_devices = ?devices.iter().map(|d| &d.name).collect::<Vec<_>>(),
-            "Available CPAL devices"
-        );
-        match devices.into_iter().find(|device| {
-            let device_trimmed = device.name.trim();
-            let name_trimmed = name.trim();
-            let matches = device_trimmed == name_trimmed;
-            debug!(
-                device_name = %device.name,
-                device_trimmed = %device_trimmed,
-                looking_for = %name_trimmed,
-                matches = matches,
-                "Comparing device"
-            );
-            matches
-        }) {
+        match Device::find_cpal_device(name)? {
             Some(mut device) => {
                 device.playback_delay = config.playback_delay()?;
 
@@ -1026,6 +1118,36 @@ impl AudioDevice for Device {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// The device the web UI offers must be one the player can open.
+    ///
+    /// These are two functions walking the same hosts, and when they drifted
+    /// the picker advertised 19 devices against 8 openable ones, so choosing
+    /// the wrong alias failed with "no device found with name ..." (#357).
+    ///
+    /// Vacuous where there is no audio hardware, which is most CI containers --
+    /// both lists are empty and agree. The load-bearing version is the hardware
+    /// suite's `advertised_devices_are_openable`, which runs on real rigs. This
+    /// exists so the two functions cannot be edited apart without something
+    /// local objecting.
+    #[test]
+    fn advertised_and_openable_device_lists_agree() {
+        let advertised: std::collections::BTreeSet<String> = match list_device_info() {
+            Ok(infos) => infos.into_iter().map(|d| d.name).collect(),
+            // No host at all is a container without ALSA, not a defect.
+            Err(_) => return,
+        };
+        let openable: std::collections::BTreeSet<String> = match Device::list_cpal_devices() {
+            Ok(devices) => devices.into_iter().map(|d| d.name).collect(),
+            Err(_) => return,
+        };
+
+        let advertised_only: Vec<&String> = advertised.difference(&openable).collect();
+        assert!(
+            advertised_only.is_empty(),
+            "the picker offers devices the player cannot open: {advertised_only:?}"
+        );
+    }
 
     mod current_playhead_section_tests {
         use super::*;


### PR DESCRIPTION
## Summary

Selecting an audio device from the web UI could fail with `no device found with name ...` for a device sitting in the dropdown. Opening a device searched the result of `list_cpal_devices()`, which materialises **every** device at once — and each `Device` holds an open ALSA handle. ALSA will not describe a device while its siblings are held, so building that list truncates it, and the damage accumulates across calls.

Measured on the test rig, alternating the two enumeration paths in a single process:

```
info-first:    19 devices   fds=7
devs-second:    8 devices   fds=15   <- 8 handles now held
info-third:     7 devices   fds=15
devs-fourth:    3 devices   fds=18
```

`list_device_info` holds nothing (fd count flat) and always saw the true 19. `list_devices` held one handle per device returned, so every later enumeration in that process saw fewer. Whichever path ran *first* looked correct and the second looked broken — the longer a session ran, the worse it got.

## The recorded suspicion was wrong

`harness/FINDINGS.md` blamed `list_cpal_devices()` calling `supported_output_configs()` twice, leaving `max_channels == 0` for exclusive devices. Making both paths share a single call **changed nothing** — the rig still reported 19 against 8. The two functions were never really in disagreement; enumerating was destroying the thing it measured. FINDINGS is updated with the measurement, including the dead end, since the wrong cause is the more expensive thing to rediscover.

## Changes

- `Device::get` resolves through a new `find_cpal_device`, which scans and keeps only the match — one handle, the same shape as the existing `find_input_device`.
- `audio::can_open_device` exposes that resolution without starting an output thread.
- `advertised_devices_are_openable` now asks it about each advertised device instead of comparing two list snapshots, since building the second snapshot was itself the defect.
- Both enumeration paths share a new `output_configs`, so "is this an output device?" is decided in one place.
- `list_devices` is documented as display-only — it still holds a handle per device and still under-reports.

## Verification

- **Test rig:** `advertised_devices_are_openable` passes with **all 19** advertised devices resolvable. Full suite **29/29 for the first time**; `--self-test` confirms all 29 can still fail.
- 3087 unit tests, clippy, rustfmt clean.

Fixes #357.
