### PR TITLE
fix(config): make stream_buffer_size accept the values it documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`stream_buffer_size: min` and `default` can now actually be set**: both were documented in the
+  config, described in the web UI's own tooltip, and impossible to load — the profile failed to
+  parse with `data did not match any variant of untagged enum StreamBufferSize`. The enum was
+  `#[serde(untagged)]`, which matches by shape and ignores variant renames, so the two keyword
+  forms matched nothing and only a bare frame count was reachable. `Min`, the device-minimum
+  buffer lookup behind it, and its log line were all dead code from a config file's point of view.
+  Saving was affected too: `Min` serialized as `null` and read back as `Default`, so editing any
+  audio setting in the web UI silently downgraded a minimum-latency buffer to the backend default.
+
+  All three forms now parse (case-insensitively), survive a save, and an unrecognised value names
+  what was expected instead of reporting an untagged-enum mismatch. The web UI can reach `default`
+  as well as `min`, and its tooltip no longer says that leaving the field empty gives you the
+  backend default — an empty field uses the decode buffer size, which is a different thing.
+
 ### Added
 
 - **The status page says when audio is open but not playing out**: the audio subsystem reports

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -553,9 +553,23 @@ impl Device {
             (config.stream_buffer_size(), output_buffer_size)
         {
             if min_size.is_some() {
+                // Report the period in milliseconds as well as frames. "12
+                // frames" is what the MAT's minimum resolves to on the test rig
+                // and it means nothing on its own; "0.2ms" is immediately legible
+                // as the callback deadline it actually is. `min` reads as a
+                // recommendation, so the number behind it should not need
+                // arithmetic to interpret.
+                let period_ms = crate::audio::health::callback_period(
+                    Some(s),
+                    device.target_format.sample_rate,
+                )
+                .map(|p| p.as_secs_f64() * 1000.0)
+                .unwrap_or(0.0);
                 info!(
                     stream_buffer_size = s,
-                    "Using minimum supported stream buffer size (low latency)"
+                    period_ms = format!("{period_ms:.2}"),
+                    "Using minimum supported stream buffer size — lowest latency, \
+                     and the least tolerance for scheduling jitter"
                 );
             }
         }

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -34,17 +34,72 @@ pub enum ResamplerType {
 }
 
 /// How to choose the CPAL stream buffer size (period size). Affects latency vs underrun tolerance.
-#[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(untagged)]
+///
+/// Accepts `min`, `default`, or a frame count:
+///
+/// ```yaml
+/// stream_buffer_size: min       # smallest period the device supports
+/// stream_buffer_size: default   # let the backend choose
+/// stream_buffer_size: 1024      # a fixed number of frames
+/// ```
+///
+/// Deserialized by hand rather than with `#[serde(untagged)]`. Untagged matches
+/// by shape and ignores variant renames, so `#[serde(rename = "min")]` on a unit
+/// variant did nothing — a unit variant matches only `null` — and both keywords
+/// failed to parse at all, while the web UI's own tooltip told people to type
+/// them. It also round-tripped `Min` through `null` back to `Default`.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StreamBufferSize {
     /// Use the backend's default (may be high latency on some systems).
-    #[serde(rename = "default")]
     Default,
     /// Use the device's minimum supported period size (lowest latency, most jitter-sensitive).
-    #[serde(rename = "min")]
     Min,
     /// Use a fixed size in frames (same as buffer_size when not set).
     Fixed(usize),
+}
+
+impl StreamBufferSize {
+    /// The keyword accepted for this variant, if it has one.
+    fn keyword(&self) -> Option<&'static str> {
+        match self {
+            StreamBufferSize::Default => Some("default"),
+            StreamBufferSize::Min => Some("min"),
+            StreamBufferSize::Fixed(_) => None,
+        }
+    }
+}
+
+impl Serialize for StreamBufferSize {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            StreamBufferSize::Fixed(frames) => serializer.serialize_u64(*frames as u64),
+            other => serializer.serialize_str(other.keyword().expect("non-Fixed has a keyword")),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StreamBufferSize {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        /// What a config file is allowed to contain here.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Keyword(String),
+            Frames(usize),
+        }
+
+        match Repr::deserialize(deserializer)? {
+            Repr::Frames(frames) => Ok(StreamBufferSize::Fixed(frames)),
+            Repr::Keyword(word) if word.eq_ignore_ascii_case("min") => Ok(StreamBufferSize::Min),
+            Repr::Keyword(word) if word.eq_ignore_ascii_case("default") => {
+                Ok(StreamBufferSize::Default)
+            }
+            Repr::Keyword(word) => Err(serde::de::Error::custom(format!(
+                "unknown stream_buffer_size {word:?}: expected \"min\", \"default\", \
+                 or a number of frames"
+            ))),
+        }
+    }
 }
 
 /// A YAML representation of the audio configuration.
@@ -332,6 +387,85 @@ mod test {
     fn builder_resampler_fft() {
         let audio = Audio::new("dev").with_resampler(ResamplerType::Fft);
         assert_eq!(audio.resampler(), ResamplerType::Fft);
+    }
+
+    /// Every form the tooltip and the doc comments promise must actually load.
+    ///
+    /// The enum was `#[serde(untagged)]` with renames on unit variants, which
+    /// serde ignores — untagged matches by shape, and a unit variant matches only
+    /// `null`. So `min` and `default` failed to parse at all while the web UI's
+    /// tooltip told people to type them, and the existing tests missed it by only
+    /// ever constructing the enum in Rust.
+    #[test]
+    fn stream_buffer_size_accepts_every_documented_form() {
+        let cases = [
+            ("min", StreamBufferSize::Min),
+            ("default", StreamBufferSize::Default),
+            ("1024", StreamBufferSize::Fixed(1024)),
+        ];
+        for (form, want) in cases {
+            let audio = from_yaml(&format!("device: dev\nstream_buffer_size: {form}\n"));
+            assert_eq!(
+                audio.stream_buffer_size(),
+                Some(want.clone()),
+                "stream_buffer_size: {form} should parse as {want:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn stream_buffer_size_keywords_are_case_insensitive() {
+        for form in ["MIN", "Min", "Default", "DEFAULT"] {
+            let audio = from_yaml(&format!("device: dev\nstream_buffer_size: {form}\n"));
+            assert!(
+                audio.stream_buffer_size().is_some(),
+                "hand-edited YAML should not care about case: {form}"
+            );
+        }
+    }
+
+    /// A typo must say what was expected rather than "did not match any variant".
+    #[test]
+    fn stream_buffer_size_rejects_unknown_keywords_helpfully() {
+        let err = config::Config::builder()
+            .add_source(config::File::from_str(
+                "device: dev\nstream_buffer_size: smallest\n",
+                config::FileFormat::Yaml,
+            ))
+            .build()
+            .expect("build config")
+            .try_deserialize::<Audio>()
+            .err()
+            .expect("smallest is not a valid setting");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("min"),
+            "error should name the valid forms: {msg}"
+        );
+        assert!(msg.contains("number of frames"), "{msg}");
+    }
+
+    /// Round-trip, because saving a config rewrites it.
+    ///
+    /// Under `untagged`, `Min` serialized as `null` and read back as `Default` —
+    /// so editing any audio setting in the web UI silently downgraded a `min`
+    /// buffer to the backend default.
+    #[test]
+    fn stream_buffer_size_survives_a_save() {
+        for want in [
+            StreamBufferSize::Min,
+            StreamBufferSize::Default,
+            StreamBufferSize::Fixed(256),
+        ] {
+            let audio = Audio::new("dev").with_stream_buffer_size(want.clone());
+            let yaml = crate::util::to_yaml_string(&audio).expect("serialize");
+            let back = from_yaml(&yaml);
+            assert_eq!(
+                back.stream_buffer_size(),
+                Some(want.clone()),
+                "{want:?} did not survive a save; wrote:\n{yaml}"
+            );
+        }
     }
 
     #[test]

--- a/src/webui/svelte/src/components/config/AudioSection.svelte
+++ b/src/webui/svelte/src/components/config/AudioSection.svelte
@@ -282,16 +282,18 @@
         id="audio-stream-buffer"
         type="text"
         class="input"
-        placeholder="default"
+        placeholder="auto"
         value={typeof audio.stream_buffer_size === "number"
           ? audio.stream_buffer_size
           : (audio.stream_buffer_size ?? "")}
         onchange={(e) => {
-          const v = (e.target as HTMLInputElement).value.trim();
-          if (!v || v === "default") {
+          const v = (e.target as HTMLInputElement).value.trim().toLowerCase();
+          // Empty and "default" are not the same thing. Unset falls back to the
+          // decode buffer size; "default" hands the choice to the backend.
+          if (!v) {
             setOrDelete("stream_buffer_size", undefined, undefined);
-          } else if (v === "min") {
-            set("stream_buffer_size", "min");
+          } else if (v === "min" || v === "default") {
+            set("stream_buffer_size", v);
           } else {
             const n = parseInt(v);
             setOrDelete(

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -799,7 +799,7 @@
   "tooltips.statusEvents.playingEvents": "MIDI events sent when the player is actively playing a song. Can drive a different LED color or blinking state.",
   "tooltips.profile.hostname": "System hostname this profile applies to. When mtrack starts, it matches the machine's hostname to select the correct profile. Leave empty for a default profile that matches any host.",
   "tooltips.audio.bufferSize": "Number of audio frames per hardware callback. Lower values reduce latency but increase CPU load. Leave empty to use the device default.",
-  "tooltips.audio.streamBufferSize": "Size of the internal stream buffer between the decoder and audio callback. Enter a number of frames, 'min' for minimum size, or leave empty for the default.",
+  "tooltips.audio.streamBufferSize": "Period size handed to the audio backend. Enter a number of frames, 'min' for the smallest period the device supports (lowest latency, most sensitive to jitter), or 'default' to let the backend choose. Leave empty to use the decode buffer size.",
   "tooltips.audio.bufferThreads": "Number of threads used to decode and buffer audio tracks in parallel. Default is 2.",
   "tooltips.audio.resampler": "Algorithm used when the source sample rate differs from the device. Sinc is higher quality; FFT may be faster for some configurations.",
   "tooltips.audio.playbackDelay": "Delay before audio playback starts, e.g. '500ms'. Used to synchronize audio with other subsystems like DMX or MIDI.",


### PR DESCRIPTION
Fixes #371.

`stream_buffer_size: min` did not load. The profile failed outright:

```
data did not match any variant of untagged enum StreamBufferSize for key `audio`
```

So did `default`. The enum was `#[serde(untagged)]` with `#[serde(rename)]` on its unit variants — untagged matches by shape rather than by name, so serde ignores those renames and a unit variant matches only `null`. Only the bare-integer `Fixed` form was reachable.

The web UI's tooltip has been telling people to type `min` the whole time, and its input already sends the string correctly. Only the backend couldn't accept it.

## What was dead as a result

`Min`, the `min_supported_buffer_size()` lookup that only the `Min` path consults, and the `"Using minimum supported stream buffer size (low latency)"` log line — all unreachable from a config file.

That log firing is the proof the fix works, on the rig against a MAT 8x16:

```
INFO Using minimum supported stream buffer size (low latency) stream_buffer_size=12
```

## Saving was affected too

`Min` serialized as `null`, and `null` reads back as the first unit variant. So a minimum-latency buffer became the backend default the next time anything in the audio section was edited — silently, with no error to notice.

## The fix

Deserialization written by hand: `min`, `default`, or a frame count, case-insensitive because these get hand-edited, with an error that names the accepted forms:

```
unknown stream_buffer_size "smallest": expected "min", "default", or a number of frames
```

Serialization emits the same three shapes, so a save round-trips.

On the UI side `default` is now sent rather than deleting the key, because those are not equivalent: an unset value falls back to the decode buffer size, while `default` hands the choice to the backend. The tooltip claimed otherwise and now describes all three forms.

## Tests

The existing tests missed this by only ever constructing the enum in Rust via `with_stream_buffer_size`, never through YAML. The new ones go through the config loader and through a save, and were confirmed to fail against the old representation — all four of them — before passing against the fix.

Verified on the rig with the real binary:

| value | result |
|---|---|
| `min` | loads, resolves to the device minimum (12 frames) |
| `default` | loads |
| `512` | loads |
| `MIN` | loads |
| `smallest` | rejected, naming the valid forms |

Full suite 3134 passing (the 6 `webui::server::*` failures need gitignored `dist/`). `cargo fmt --check`, clippy, svelte-check, eslint and prettier all clean.

## On the sharpness of `min`

An earlier version of this description said this "makes a footgun reachable that previously wasn't". That was wrong, and worth correcting rather than quietly editing: `Fixed(usize)` has always parsed, and the measurement on #369 that produced 785 POLLERRs, 420 stream rebuilds and 23% dropout ran on **unmodified `main`** with `stream_buffer_size: 64`. The hazard is already live and independent of this change.

What this does add is a friendly one-word name for the sharpest setting — and on the test rig `min` resolves to 12 frames, smaller than the 64 that collapsed. `min` reads as a recommendation, so the log now reports the period in milliseconds as well as frames (`stream_buffer_size=12 period_ms=0.25`) and says the setting carries the least tolerance for scheduling jitter, rather than only advertising low latency.

Deliberately no threshold or refusal. What determines whether a small period works is the period against the scheduling the machine can actually offer — mtrack already logs when it cannot get `SCHED_FIFO` — so a fixed cutoff would be false precision, nagging rigs that are fine and staying quiet on ones that are not.

The systemic fix is the rebuild throttling in #369: the backoff resets on every successful build, so a stream that comes up and fails immediately rebuilds unthrottled. That protects against any cause of flapping rather than this one setting, which is why it belongs there rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
