### PR TITLE
fix(audio): stop underruns rebuilding the stream, and warn when one flaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Buffer underruns no longer rebuild the output stream**: cpal reports every XRUN through the
+  same error callback as a genuine failure, and mtrack tore the stream down for each one —
+  replacing a glitch of about a millisecond with a full device reopen, measured at ~29ms on the
+  test rig. Same outcome, thirty times the interruption. cpal has already recovered by then: an
+  underrun is the one fault it handles itself, calling `prepare()` so the stream restarts once two
+  periods are written. Underruns are still counted and reported. Backend errors other than
+  underruns still rebuild, because cpal reports those *before* reaching its own recovery path, so
+  the stream cannot come back without one.
+
+- **A stream that fails as fast as it starts now says so**: an audio buffer too small for the
+  machine to service produces a stream that dies within milliseconds, is rebuilt, and dies again —
+  on the test rig, lifetimes of 7ms to 184ms, indefinitely. Nothing in the logs said why the audio
+  was broken. mtrack now warns, at most once every ten seconds, with the stream's lifetime and a
+  running count. It deliberately does not slow the rebuilds down: measurement showed the rebuild is
+  the only thing that clears the fault, so audio delivered is a duty cycle of stream lifetime over
+  rebuild interval, and backing off traded 77% choppy audio for 2% silence.
+
 - **`stream_buffer_size: min` and `default` can now actually be set**: both were documented in the
   config, described in the web UI's own tooltip, and impossible to load — the profile failed to
   parse with `data did not match any variant of untagged enum StreamBufferSize`. The enum was

--- a/src/audio/cpal/manager.rs
+++ b/src/audio/cpal/manager.rs
@@ -14,13 +14,24 @@
 use parking_lot::{Condvar, Mutex};
 use std::{error::Error, fmt, sync::Arc, thread, time::Duration};
 
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// First delay before retrying a stream rebuild after a backend error.
 const REBUILD_BACKOFF_START: Duration = Duration::from_millis(250);
 /// Ceiling for the rebuild retry backoff. Bounded so a device that comes back
 /// after a long absence is picked up promptly rather than after a doubling gap.
 const REBUILD_BACKOFF_MAX: Duration = Duration::from_secs(5);
+
+/// How long a stream must last before it counts as having run at all.
+///
+/// Shorter than this and it died about as fast as it started, which on the test
+/// rig means a buffer the machine cannot service: a 64-frame period under load
+/// gave stream lifetimes of 7ms to 184ms, over and over.
+const STREAM_FLAPPING_UNDER: Duration = Duration::from_secs(1);
+
+/// Minimum gap between flap warnings. A flapping stream rebuilds tens of times a
+/// second, and the point is to tell the operator once, not to fill the journal.
+const FLAP_WARN_INTERVAL: Duration = Duration::from_secs(10);
 
 use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
 
@@ -151,6 +162,10 @@ impl OutputManager {
         let output_thread = thread::spawn(move || {
             let mut first_run = true;
             let mut backoff = REBUILD_BACKOFF_START;
+            // Flap accounting. Diagnosis only — see the warning below for why
+            // this does not also slow the rebuild down.
+            let mut flaps: u64 = 0;
+            let mut last_flap_warn: Option<std::time::Instant> = None;
 
             loop {
                 if *shutdown.0.lock() {
@@ -186,6 +201,7 @@ impl OutputManager {
                 match stream_result {
                     Ok(stream) => {
                         backoff = REBUILD_BACKOFF_START;
+                        let built_at = std::time::Instant::now();
                         if first_run {
                             info!(
                                 "Audio output stream started successfully (direct callback mode)"
@@ -221,7 +237,37 @@ impl OutputManager {
                         }
 
                         // Drop the stream so we can create a new one.
+                        let lifetime = built_at.elapsed();
                         drop(stream);
+
+                        // A stream that dies as fast as it starts says the buffer
+                        // is too small for what this machine can schedule. Worth
+                        // saying, because nothing else in the logs does — and an
+                        // operator staring at broken audio has no other way to
+                        // learn it.
+                        //
+                        // Deliberately does not throttle the rebuild. Measured on
+                        // the rig: cpal reports POLLERR without ever calling
+                        // `prepare()`, so the PCM stays in XRUN and rebuilding is
+                        // the *only* thing that recovers it. Audio delivered is
+                        // then a duty cycle of stream lifetime over rebuild
+                        // interval — backing off traded 77% choppy audio for 2%
+                        // silence. The storm is ugly, and it is also the recovery.
+                        if lifetime < STREAM_FLAPPING_UNDER {
+                            flaps += 1;
+                            let due =
+                                last_flap_warn.is_none_or(|at| at.elapsed() >= FLAP_WARN_INTERVAL);
+                            if due {
+                                warn!(
+                                    lifetime_ms = lifetime.as_millis() as u64,
+                                    flaps,
+                                    "Audio output stream is failing as fast as it starts; \
+                                     the buffer is likely too small for this machine to \
+                                     service reliably"
+                                );
+                                last_flap_warn = Some(std::time::Instant::now());
+                            }
+                        }
                     }
                     Err(e) => {
                         if first_run {
@@ -429,6 +475,40 @@ mod test {
             assert!(
                 handle.build_count() >= 4,
                 "expected the initial build plus retries, got {}",
+                handle.build_count()
+            );
+
+            drop(manager);
+        }
+
+        /// A flapping stream must still be rebuilt at full speed.
+        ///
+        /// This is the behaviour guarantee behind the warning: the rebuild is
+        /// the only thing that clears an XRUN once cpal has reported it as
+        /// POLLERR, so audio delivered is a duty cycle of stream lifetime over
+        /// rebuild interval. Throttling was tried and measured — it turned 77%
+        /// choppy audio into 2% silence.
+        #[test]
+        fn a_flapping_stream_is_still_rebuilt_promptly() {
+            let (factory, handle) = ErrorCapturingFactory::new();
+            let mut manager = OutputManager::new(2, 44100).unwrap();
+            manager
+                .start_output_thread(Box::new(factory))
+                .expect("should start");
+            assert_eq!(handle.build_count(), 1);
+
+            for _ in 0..5 {
+                handle.trigger_error();
+                let deadline = std::time::Instant::now() + Duration::from_secs(2);
+                let want = handle.build_count() + 1;
+                while std::time::Instant::now() < deadline && handle.build_count() < want {
+                    thread::sleep(Duration::from_millis(5));
+                }
+            }
+
+            assert!(
+                handle.build_count() >= 6,
+                "each fault should still produce a rebuild, got {}",
                 handle.build_count()
             );
 

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -299,20 +299,25 @@ fn error_handler(
         // actually failed under a pile of glitches, overwrite its message, and
         // cost an allocation and a lock on the audio thread each time.
         //
-        // Note it still falls through to the notify below, so an underrun
-        // continues to trigger a full stream rebuild. That is almost certainly
-        // wrong — cpal has already called `prepare()` and the stream restarts on
-        // its own — but it is a playback behaviour change rather than a
-        // reporting one, and predates this. See #369.
+        // It also does not wake the rebuild. `prepare()` is cpal's own recovery
+        // and it works, so tearing the stream down and opening the device again
+        // replaces a glitch of about a millisecond with a full reopen — measured
+        // at ~29ms on the test rig. Same outcome, thirty times the interruption.
+        //
+        // POLLERR is different and still rebuilds: cpal returns that as an error
+        // *before* it reaches the `avail()` call whose EPIPE would have taken the
+        // recovery path, so the PCM stays in XRUN and only a new stream clears it.
         if matches!(err, cpal::StreamError::BufferUnderrun) {
             health.record_underrun();
-        } else {
-            error!(
-                "CPAL output stream error: {} (will attempt to recover)",
-                err
-            );
-            health.record_stream_error(&err.to_string());
+            return;
         }
+
+        error!(
+            "CPAL output stream error: {} (will attempt to recover)",
+            err
+        );
+        health.record_stream_error(&err.to_string());
+
         let (mutex, condvar) = &*notify;
         let mut guard = mutex.lock();
         *guard = true;


### PR DESCRIPTION
Refs #369. Much smaller than that issue proposed, because measuring it on the rig disproved the premise — including the fix I had already written.

## What this does

**Underruns no longer wake the rebuild.** cpal reports every XRUN through the same error callback as a genuine failure, and mtrack tore the stream down for each one. It is also the one fault cpal recovers from itself — `prepare()`, and the stream restarts once two periods are written — so the rebuild replaced a glitch of about a millisecond with a full device reopen, measured at ~29ms. Same outcome, thirty times the interruption. They are still counted and reported.

POLLERR still rebuilds, and that distinction is the point: cpal returns POLLERR as an error *before* reaching the `avail()` call whose `EPIPE` takes it into that recovery, so the PCM stays in XRUN and only a new stream clears it.

**A flapping stream now says so.** A buffer too small for the machine gives stream lifetimes of milliseconds, rebuilt and dying again indefinitely, with nothing in the logs to explain why the audio is broken:

```
Audio output stream is failing as fast as it starts; the buffer is likely too
small for this machine to service reliably   lifetime_ms=12 flaps=1
```

Rate-limited to one every ten seconds. On the rig that was **2 warnings across 439 flaps**.

## What this deliberately does not do

Throttle the rebuild. I wrote that first, on the theory that the storm was competing for CPU with the callback it was trying to restore. Measured with a 64-frame buffer under load, it did exactly what it was told and made things worse:

| | rebuilds | dropout |
|---|---|---|
| unthrottled | 420 | 23% |
| unthrottled (repeat) | 300 | 17% |
| **throttled** | **7** | **98%** |

Because the rebuild is not the aggressor — it is the recovery. cpal never calls `prepare()` on the POLLERR path, so the PCM stays in XRUN and a new stream is the only thing that clears it. Audio delivered is then a duty cycle of stream lifetime over rebuild interval, and the throttle's stream lifetimes (`7ms`, `33ms`, `138ms`) against its own backoff (`250ms` … `5s`) predict the 2% exactly.

A test pins the prompt rebuild so this cannot be reintroduced by someone reasoning the way I did.

## Verified

On the rig, 48kHz, 64-frame buffer, all cores loaded: 563 rebuilds at full speed, underruns counted and no longer rebuilding, 2 warnings across 439 flaps. Harness suite **30/30**. Unit tests 3135 passing (the 6 `webui::server::*` failures need gitignored `dist/`). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

## Left on #369

The real fix is upstream: `prepare()` on the POLLERR path would cost microseconds and restore audio without any rebuild, fixing the whole class. mtrack cannot reach it — cpal owns the `alsa::pcm::PCM` handle and exposes no recovery call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)