### PR TITLE
feat(audio): expose audio health on gRPC and OSC

### DIFF
--- a/src/audio/health.rs
+++ b/src/audio/health.rs
@@ -266,6 +266,12 @@ impl OutputHealth {
     }
 }
 
+impl serde::Serialize for OutputStatus {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
 /// A point-in-time read of [`OutputHealth`].
 ///
 /// Deliberately facts rather than a verdict. "Silent" is correct and expected when
@@ -303,8 +309,7 @@ pub struct OutputHealthSnapshot {
 /// Deliberately says nothing about whether audio reached the room. `Healthy`
 /// means the callback is running and being handed buffers — a device can still
 /// accept every one and produce nothing, which is not observable from here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputStatus {
     /// The callback is running.
     Healthy,
@@ -319,6 +324,21 @@ pub enum OutputStatus {
 }
 
 impl OutputStatus {
+    /// The canonical name for this state.
+    ///
+    /// One vocabulary for every surface — the JSON status endpoint, the gRPC
+    /// status response, the OSC broadcast and the web UI all use these exact
+    /// strings, and the UI switches on them. Serialization goes through here so
+    /// they cannot drift apart.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OutputStatus::Healthy => "healthy",
+            OutputStatus::Recovering => "recovering",
+            OutputStatus::Stalled => "stalled",
+            OutputStatus::NeverStarted => "never_started",
+        }
+    }
+
     /// Whether this state should be shown to an operator as something wrong.
     ///
     /// `NeverStarted` is not a fault: it only survives for one liveness window
@@ -543,6 +563,22 @@ mod test {
                 "\"never_started\""
             ]
         );
+
+        // gRPC and OSC send `as_str` directly rather than serializing, so the
+        // two must agree — otherwise a remote monitor and the web UI would
+        // disagree about what the same device is doing.
+        for status in [
+            OutputStatus::Healthy,
+            OutputStatus::Recovering,
+            OutputStatus::Stalled,
+            OutputStatus::NeverStarted,
+        ] {
+            assert_eq!(
+                serde_json::to_string(&status).unwrap(),
+                format!("\"{}\"", status.as_str()),
+                "{status:?} serializes differently from as_str"
+            );
+        }
     }
 
     /// `is_fault` must agree with what the status page paints red.

--- a/src/config/controller.rs
+++ b/src/config/controller.rs
@@ -65,6 +65,9 @@ fn default_osc_track_gain() -> String {
 fn default_osc_status() -> String {
     "/mtrack/status".to_string()
 }
+fn default_osc_audio_health() -> String {
+    "/mtrack/audio/health".to_string()
+}
 fn default_osc_playlist_current() -> String {
     "/mtrack/playlist/current".to_string()
 }
@@ -364,6 +367,14 @@ pub struct OscController {
     /// The OSC address to broadcast to display the current player status.
     #[serde(default = "default_osc_status")]
     status: String,
+    /// The OSC address to broadcast the audio output's health verdict:
+    /// "healthy", "recovering", "stalled" or "never_started".
+    ///
+    /// Separate from `status`, which reports what the *player* is doing. A
+    /// control surface wants both: the player can be playing while the audio
+    /// output is stalled, and that combination is the one worth a red light.
+    #[serde(default = "default_osc_audio_health")]
+    audio_health: String,
     /// The OSC address to broadcast the current playlist songs.
     #[serde(default = "default_osc_playlist_current")]
     playlist_current: String,
@@ -398,6 +409,7 @@ impl Default for OscController {
             seek_section: default_osc_seek_section(),
             track_gain: default_osc_track_gain(),
             status: default_osc_status(),
+            audio_health: default_osc_audio_health(),
             playlist_current: default_osc_playlist_current(),
             playlist_current_song: default_osc_playlist_current_song(),
             playlist_current_song_elapsed: default_osc_playlist_current_song_elapsed(),
@@ -489,6 +501,11 @@ impl OscController {
     /// Gets the player status.
     pub fn status(&self) -> &str {
         &self.status
+    }
+
+    /// The address the audio health verdict is broadcast to.
+    pub fn audio_health(&self) -> &str {
+        &self.audio_health
     }
 
     /// Gets the playlist current OSC address.

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -22,7 +22,7 @@ use crate::{
     player::Player,
     proto::player::v1::{
         player_service_server::{PlayerService, PlayerServiceServer},
-        AddProfileRequest, Cue, GetActiveEffectsRequest, GetActiveEffectsResponse,
+        AddProfileRequest, AudioHealth, Cue, GetActiveEffectsRequest, GetActiveEffectsResponse,
         GetConfigRequest, GetConfigResponse, GetCuesRequest, GetCuesResponse, GetTrackGainsRequest,
         GetTrackGainsResponse, LoopSectionRequest, LoopSectionResponse, NextRequest, NextResponse,
         PlayFromRequest, PlayRequest, PlayResponse, PlaySongFromRequest, PreviousRequest,
@@ -327,11 +327,28 @@ impl PlayerService for PlayerServer {
 
         let playing = self.player.is_playing().await;
 
+        // Hardware health travels with playback state so a remote monitor can
+        // tell "silent because nothing is playing" from "silent and it should
+        // not be" without a second call.
+        let audio_health = self
+            .player
+            .hardware_status()
+            .audio_output
+            .map(|h| AudioHealth {
+                status: h.status.as_str().to_string(),
+                callback_alive: h.callback_alive,
+                writing_signal: h.writing_signal,
+                recoveries: h.recoveries,
+                underruns: h.underruns,
+                last_error: h.last_error,
+            });
+
         Ok(Response::new(StatusResponse {
             playlist_name: playlist_name.to_string(),
             current_song,
             playing,
             elapsed,
+            audio_health,
         }))
     }
 

--- a/src/controller/osc.rs
+++ b/src/controller/osc.rs
@@ -108,6 +108,8 @@ pub(super) struct OscEvents {
     track_gain_pattern: String,
     /// The OSC address to use to broadcast the player status.
     status: String,
+    /// The OSC address to use to broadcast the audio output's health verdict.
+    audio_health: String,
     /// The OSC address to use to broadcast the current playlist.
     playlist_current: String,
     /// The OSC address to use to broadcast the currently playing song.
@@ -149,6 +151,7 @@ impl Driver {
                 track_gain: Matcher::new(config.track_gain())?,
                 track_gain_pattern: config.track_gain().to_string(),
                 status: config.status().to_string(),
+                audio_health: config.audio_health().to_string(),
                 playlist_current: config.playlist_current().to_string(),
                 playlist_current_song: config.playlist_current_song().to_string(),
                 playlist_current_song_elapsed: config.playlist_current_song_elapsed().to_string(),
@@ -321,12 +324,21 @@ impl Driver {
         );
         let playlist_songs: Vec<String> = playlist.songs().to_vec();
 
+        // The player's status says what the transport is doing; this says
+        // whether audio is actually leaving the machine. A surface wants both —
+        // "playing" next to "stalled" is the combination worth a red light.
+        let audio_health = player
+            .hardware_status()
+            .audio_output
+            .map(|h| h.status.as_str());
+
         let mut packets = build_broadcast_packets(
             osc_events,
             song.name(),
             status_string,
             &duration_string,
             &playlist_songs,
+            audio_health,
         );
 
         // Per-track gain feedback (motorized faders / TouchOSC). Tracks whose
@@ -581,8 +593,9 @@ fn build_broadcast_packets(
     status: &str,
     duration_string: &str,
     playlist_songs: &[String],
+    audio_health: Option<&str>,
 ) -> Vec<OscPacket> {
-    vec![
+    let mut packets = vec![
         OscPacket::Message(OscMessage {
             addr: osc_events.playlist_current_song.clone(),
             args: vec![OscType::String(song_name.to_string())],
@@ -599,7 +612,18 @@ fn build_broadcast_packets(
             addr: osc_events.playlist_current.clone(),
             args: vec![OscType::String(format_playlist_content(playlist_songs))],
         }),
-    ]
+    ];
+
+    // Only when a device can report. A surface that shows nothing is clearer
+    // than one showing a health verdict invented for a rig with no audio.
+    if let Some(health) = audio_health {
+        packets.push(OscPacket::Message(OscMessage {
+            addr: osc_events.audio_health.clone(),
+            args: vec![OscType::String(health.to_string())],
+        }));
+    }
+
+    packets
 }
 
 #[cfg(test)]
@@ -1085,6 +1109,7 @@ mod test {
             track_gain: Matcher::new(config.track_gain()).unwrap(),
             track_gain_pattern: config.track_gain().to_string(),
             status: config.status().to_string(),
+            audio_health: config.audio_health().to_string(),
             playlist_current: config.playlist_current().to_string(),
             playlist_current_song: config.playlist_current_song().to_string(),
             playlist_current_song_elapsed: config.playlist_current_song_elapsed().to_string(),
@@ -1618,8 +1643,14 @@ mod test {
         fn returns_four_packets() {
             let events = make_default_osc_events();
             let songs = vec!["Song 1".to_string(), "Song 2".to_string()];
-            let packets =
-                build_broadcast_packets(&events, "Song 1", STATUS_STOPPED, "0:00/3:30", &songs);
+            let packets = build_broadcast_packets(
+                &events,
+                "Song 1",
+                STATUS_STOPPED,
+                "0:00/3:30",
+                &songs,
+                None,
+            );
             assert_eq!(packets.len(), 4);
         }
 
@@ -1627,7 +1658,7 @@ mod test {
         fn first_packet_is_current_song() {
             let events = make_default_osc_events();
             let packets =
-                build_broadcast_packets(&events, "My Song", STATUS_PLAYING, "1:00/3:00", &[]);
+                build_broadcast_packets(&events, "My Song", STATUS_PLAYING, "1:00/3:00", &[], None);
             assert_eq!(
                 packets[0],
                 OscPacket::Message(OscMessage {
@@ -1641,7 +1672,7 @@ mod test {
         fn second_packet_is_status() {
             let events = make_default_osc_events();
             let packets =
-                build_broadcast_packets(&events, "Song", STATUS_PLAYING, "0:00/0:00", &[]);
+                build_broadcast_packets(&events, "Song", STATUS_PLAYING, "0:00/0:00", &[], None);
             assert_eq!(
                 packets[1],
                 OscPacket::Message(OscMessage {
@@ -1651,11 +1682,50 @@ mod test {
             );
         }
 
+        /// A control surface needs the audio verdict next to the transport
+        /// state, because "playing" and "stalled" together is the combination
+        /// worth a red light — and `/mtrack/status` alone will happily say
+        /// "playing" while nothing is leaving the interface.
+        #[test]
+        fn audio_health_is_broadcast_when_the_device_can_report() {
+            let events = make_default_osc_events();
+            let packets = build_broadcast_packets(
+                &events,
+                "Song",
+                STATUS_PLAYING,
+                "0:10/3:00",
+                &[],
+                Some("stalled"),
+            );
+            assert!(
+                packets.contains(&OscPacket::Message(OscMessage {
+                    addr: events.audio_health.clone(),
+                    args: vec![OscType::String("stalled".to_string())],
+                })),
+                "the health verdict should be broadcast, got {packets:?}"
+            );
+        }
+
+        /// No device, no verdict. A surface showing nothing is clearer than one
+        /// showing a health state invented for a rig with no audio configured.
+        #[test]
+        fn audio_health_is_omitted_when_there_is_no_device() {
+            let events = make_default_osc_events();
+            let packets =
+                build_broadcast_packets(&events, "Song", STATUS_STOPPED, "0:00/1:00", &[], None);
+            assert!(
+                !packets
+                    .iter()
+                    .any(|p| matches!(p, OscPacket::Message(m) if m.addr == events.audio_health)),
+                "no audio device means no health packet"
+            );
+        }
+
         #[test]
         fn third_packet_is_elapsed() {
             let events = make_default_osc_events();
             let packets =
-                build_broadcast_packets(&events, "Song", STATUS_STOPPED, "1:23/4:56", &[]);
+                build_broadcast_packets(&events, "Song", STATUS_STOPPED, "1:23/4:56", &[], None);
             assert_eq!(
                 packets[2],
                 OscPacket::Message(OscMessage {
@@ -1670,7 +1740,7 @@ mod test {
             let events = make_default_osc_events();
             let songs = vec!["A".to_string(), "B".to_string()];
             let packets =
-                build_broadcast_packets(&events, "A", STATUS_STOPPED, "0:00/1:00", &songs);
+                build_broadcast_packets(&events, "A", STATUS_STOPPED, "0:00/1:00", &songs, None);
             assert_eq!(
                 packets[3],
                 OscPacket::Message(OscMessage {
@@ -1684,7 +1754,7 @@ mod test {
         fn stopped_status() {
             let events = make_default_osc_events();
             let packets =
-                build_broadcast_packets(&events, "Song", STATUS_STOPPED, "0:00/0:00", &[]);
+                build_broadcast_packets(&events, "Song", STATUS_STOPPED, "0:00/0:00", &[], None);
             if let OscPacket::Message(msg) = &packets[1] {
                 assert_eq!(msg.args[0], OscType::String(STATUS_STOPPED.to_string()));
             } else {

--- a/src/proto/player/v1/player.proto
+++ b/src/proto/player/v1/player.proto
@@ -123,6 +123,47 @@ message StatusResponse {
 
     // Elapsed is the amount of time that has elapsed while playing the song.
     google.protobuf.Duration elapsed = 4;
+
+    // AudioHealth is what the audio output is actually doing. Absent when no
+    // audio device is open, or when the device cannot report.
+    //
+    // Carried alongside playback state rather than in its own RPC because the
+    // two are only interpretable together: silence is correct when nothing is
+    // playing, so "playing = true, writing_signal = false" is the diagnostic,
+    // and splitting them would make a remote monitor correlate two calls.
+    optional AudioHealth audio_health = 5;
+}
+
+// AudioHealth reports what the audio output callback is doing, as distinct from
+// whether a device was opened. A device handle exists from the moment one is
+// found, and keeps existing while the interface is physically unplugged.
+message AudioHealth {
+    // Status is one of "healthy", "recovering", "stalled" or "never_started".
+    //
+    // A string rather than an enum so there is one vocabulary across gRPC, the
+    // JSON status endpoint and the web UI, which switches on these exact names.
+    string status = 1;
+
+    // CallbackAlive is true when the output callback has run recently. False
+    // means the stream is open but not producing.
+    bool callback_alive = 2;
+
+    // WritingSignal is true when non-silent audio was handed to the device
+    // recently. False is normal and expected whenever nothing is playing.
+    bool writing_signal = 3;
+
+    // Recoveries counts output streams rebuilt after a backend error. A rig
+    // recovering from a flaky cable several times a set looks healthy at any
+    // single instant; this is the only thing that shows it.
+    uint64 recoveries = 4;
+
+    // Underruns counts buffer underruns reported by the backend. Routine and
+    // self-healing; a rising count means the buffer is too small for the
+    // machine, not that anything has failed.
+    uint64 underruns = 5;
+
+    // LastError is the most recent backend error, retained after recovery.
+    optional string last_error = 6;
 }
 
 // PlayFromRequest is the message for requesting the player to play from a specific time.


### PR DESCRIPTION
Closes the remaining half of #349.

#370 added the health verdict but wired it only to the web UI and MCP. A remote monitor polling gRPC, or a control surface listening on OSC, still had nothing but the subsystem status — which reads `connected` from the moment a device handle exists and keeps reading it while the interface is physically unplugged. That was the original complaint, and it was left half-answered.

## What this adds

**gRPC** — `StatusResponse` gains an optional `AudioHealth`:

```proto
message AudioHealth {
    string status = 1;            // healthy | recovering | stalled | never_started
    bool callback_alive = 2;
    bool writing_signal = 3;
    uint64 recoveries = 4;
    uint64 underruns = 5;
    optional string last_error = 6;
}
```

**OSC** — a `/mtrack/audio/health` broadcast carrying the verdict, configurable like the other addresses, alongside the existing player status.

## Two decisions worth stating

**Carried with playback state, not in a separate call.** Neither means anything alone: silence is correct when nothing is playing, so the diagnostic is `playing` sitting next to `writing_signal`. Splitting them would make a monitor correlate two responses to answer one question, and a control surface deciding whether to light something red needs both anyway.

**The OSC address is omitted when no device can report**, rather than broadcasting a default. A surface showing nothing is clearer than one showing a verdict invented for a rig with no audio configured — tested both ways.

## One cleanup

The status is a string on the wire rather than a proto enum, so gRPC, the JSON endpoint, OSC and the web UI share one vocabulary — the UI switches on these exact names, pinned by an existing test. `OutputStatus::as_str` is now the single source for them and `Serialize` goes through it, with a test asserting the two agree. They were previously derived separately, which is exactly how they would have drifted apart.

## Verified

3137 unit tests passing (the 6 `webui::server::*` failures need gitignored `dist/`), including new coverage that OSC broadcasts the verdict when a device can report and omits the address entirely when it cannot. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

No hardware run: this is a plumbing change over data whose production was already verified on the rig in #370 and #373 — the verdict transitions through `recovering` and back to `healthy` under a real device yank were measured there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)