### PR TITLE
deps(audio): upgrade to cpal 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It still cannot prove sound reached the room. A device can accept every buffer and produce
   nothing, and nothing host-side can see that.
 
+### Changed
+
+- **Upgraded to cpal 0.18.1**, which also required midir 0.11: cpal 0.18 moves ALSA onto
+  `alsa-sys` 0.4 and midir 0.10 links 0.3, and only one package in the graph may link a given
+  native library.
+
+  Device names persisted in existing configs keep working — cpal's `DeviceId` string form
+  (`"{host}:{pcm_id}"`, as in `alsa:plughw:CARD=WING,DEV=0`) is unchanged.
+
+  One audible difference: an ALSA POLLERR used to reach mtrack as a stream failure and force a
+  full device reopen, around 29ms, in place of a glitch of about one. cpal 0.18 classifies it as
+  an xrun and recovers in place, so it now costs the glitch alone.
+
 ### Fixed
+
+- **Software audio devices no longer advertise a channel count they cannot honour**: `alsa:default`
+  and `alsa:pulse` were listed as 32-channel devices. That number is what ALSA's plugin advertises,
+  not a width any hardware promised, and picking one of those for a 32-channel show would have
+  found that out during the set. Plug and software nodes are now labelled `virtual` unless their
+  real width can be read from the hardware node behind them, whatever count they happen to report.
 
 - **A device that will never open no longer holds the whole rig hostage**: hardware init retried
   any device error twice a second, forever, with no way to say "this will never succeed". Because

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,21 +19,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
-dependencies = [
- "alsa-sys",
- "bitflags 2.11.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "alsa"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.1",
@@ -43,12 +31,21 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "android-build"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fc9904ad2ad097c3c1cfe2eacaaf0fc24710936fa9ed941cb310b7c6ed2ab7"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -619,11 +616,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -654,14 +651,15 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.17.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
+checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
 dependencies = [
- "alsa 0.10.0",
+ "alsa",
+ "block2",
  "coreaudio-rs",
  "dasp_sample",
- "jni 0.21.1",
+ "jni 0.22.4",
  "js-sys",
  "libc",
  "mach2",
@@ -676,10 +674,9 @@ dependencies = [
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -932,6 +929,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60768c353d76ba6dd1b6332a5dbbdd3bc2dddadc2935f4cc6a9d0f17ca8ecb6a"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1258,6 +1265,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1739,6 +1752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,7 +1810,9 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
+ "java-locator",
  "jni-sys 0.3.1",
+ "libloading",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1823,6 +1847,21 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-min-helper"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913370a00ba1851b0f3369b49d0f3e745da2d20d3f15ecc296a64234ccda45f7"
+dependencies = [
+ "android-build",
+ "dlopen2",
+ "jni 0.21.1",
+ "libc",
+ "log",
+ "ndk-context",
+ "process_path",
 ]
 
 [[package]]
@@ -1937,9 +1976,19 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "line-clipping"
@@ -2016,12 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matchers"
@@ -2061,19 +2107,23 @@ dependencies = [
 
 [[package]]
 name = "midir"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56542e359bb7e4bd1a77cb79042be32d4af0713a9ce58160355eaf72df9db87c"
+checksum = "77c12e74a8604bc07f9a3fcf3d5889a81bc96ca6e07d6a114d63fc0371f3e5a4"
 dependencies = [
- "alsa 0.9.1",
- "bitflags 1.3.2",
+ "alsa",
+ "cc",
  "coremidi",
+ "jni 0.21.1",
+ "jni-min-helper",
  "js-sys",
  "libc",
+ "log",
+ "ndk-context",
  "parking_lot",
  "wasm-bindgen",
  "web-sys",
- "windows 0.56.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2439,6 +2489,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2856,6 +2907,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process_path"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f676f11eb0b3e2ea0fbaee218fa6b806689e2297b8c8adc5bf73df465c4f6171"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5356,16 +5417,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
-dependencies = [
- "windows-core 0.56.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5409,24 +5460,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
-dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5438,8 +5477,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5469,31 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5552,15 +5569,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ bin-dir = "{ name }-{ version }-{ target }/{ bin }{ binary-ext }"
 [dependencies]
 clap = { version = "4.5.60", features = ["cargo", "derive"] }
 config = "0.15.19"
-cpal = "0.17.1"
+cpal = "0.18.1"
 rayon = "1.11.0"
 num_cpus = "1.17.0"
 duration-string = "0.5.3"
 symphonia = { version = "0.6", features = ["all"] }
-midir = "0.10.1"
+midir = "0.11.0"
 midly = "0.5.3"
 ola = "0.1.0"
 prost = "0.14"

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -15,8 +15,8 @@ mtrack = { path = ".." }
 
 # Hardware access. These mirror mtrack's own versions so the harness talks to
 # the same driver stack the player does.
-cpal = "0.17.1"
-midir = "0.10.1"
+cpal = "0.18.1"
+midir = "0.11.0"
 shh = "1.0.1"
 hound = "3.5.1"
 midly = "0.5.3"

--- a/harness/src/capture.rs
+++ b/harness/src/capture.rs
@@ -337,7 +337,7 @@ where
 {
     let channels = channels.max(1) as usize;
     Ok(device.build_input_stream(
-        config,
+        *config,
         move |data: &[T], _: &cpal::InputCallbackInfo| {
             if !buffer.active.load(Ordering::Relaxed) {
                 return;
@@ -434,7 +434,7 @@ where
     T: cpal::SizedSample + cpal::FromSample<f32>,
 {
     Ok(device.build_output_stream(
-        config,
+        *config,
         move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
             let mut n = phase.lock();
             for frame in data.chunks_mut(channels) {

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -176,11 +176,18 @@ struct Silenced {
 /// The channel count cpal reports for a device whose real maximum it does not
 /// know.
 ///
-/// cpal clamps ALSA's reported maximum to this value -- `cmp::min(max_channels,
-/// 32)` in its `host/alsa/mod.rs` -- so a device advertising exactly this many
-/// channels may have this many or any number more. ALSA plug nodes accept an
-/// unbounded channel count and so always land here.
-const CPAL_CHANNEL_CLAMP: u16 = 32;
+/// cpal clamps ALSA's reported maximum to this value -- `CHANNEL_ENUM_CAP` in
+/// its `host/alsa/mod.rs` -- so a device advertising exactly this many channels
+/// may have this many or any number more. ALSA plug nodes accept an unbounded
+/// channel count and so always land here.
+///
+/// This must track cpal exactly, in both directions. Set too high and a real
+/// interface's honest count is read as a floor; set too low and a plug node's
+/// clamp is read as honest, which is worse -- `resolve_virtual_channel_counts`
+/// would stop correcting plug nodes and mtrack would validate track mappings
+/// against a number the hardware never promised. cpal 0.18 raised the cap from
+/// 32 to 64 (AES10/MADI's maximum), so 32 is now a genuine capability.
+const CPAL_CHANNEL_CLAMP: u16 = 64;
 
 /// The PCM id inside a device name, with cpal's host prefix removed.
 ///
@@ -488,7 +495,7 @@ fn resolve_virtual_channel_counts(infos: &mut [AudioDeviceInfo]) {
     // (card, subdevice) -> real channel count, because subdevices on one card
     // are not interchangeable. An Intel HDA card exposes `hw:CARD=PCH,DEV=0`
     // (analog, 2ch) beside `hw:CARD=PCH,DEV=3` (HDMI, 8ch), and every
-    // `plughw:CARD=PCH,DEV=n` in front of them reports the same clamped 32.
+    // `plughw:CARD=PCH,DEV=n` in front of them reports the same clamped maximum.
     let mut by_subdevice: HashMap<(String, u16), u16> = HashMap::new();
     // Card identity -> (subdevice index, channels) for the lowest subdevice,
     // which is where a plug node naming no `DEV=` routes.
@@ -1687,7 +1694,7 @@ mod test {
         /// The bug this keying exists to prevent, on the most ordinary hardware
         /// there is: an Intel HDA card exposes analog on `DEV=0` and HDMI on
         /// `DEV=3`, with different channel counts, and every plug node in front
-        /// of them reports the same clamped 32.
+        /// of them reports the same clamped maximum.
         ///
         /// Looking the sibling up by card alone handed `plughw:CARD=PCH,DEV=3`
         /// the analog node's 2 channels and marked it `channels_known` — a
@@ -1766,7 +1773,7 @@ mod test {
             assert_eq!(infos[2].channels_display(), "virtual");
         }
 
-        /// A genuine 32-or-more channel interface reports the clamp too, so its
+        /// An interface at or above the clamp reports the clamp too, so its
         /// count is a floor -- but it is hardware, not a plugin, and must not be
         /// labelled "virtual".
         #[test]
@@ -1774,7 +1781,19 @@ mod test {
             let device = info("alsa:hw:CARD=BIG,DEV=0", CPAL_CHANNEL_CLAMP);
             assert!(!device.virtual_node);
             assert!(!device.channels_known);
-            assert_eq!(device.channels_display(), "32+");
+            assert_eq!(device.channels_display(), format!("{CPAL_CHANNEL_CLAMP}+"));
+        }
+
+        /// Below the clamp is an honest count, and the boundary is the whole
+        /// point of the constant: cpal 0.18 raised the cap to 64, so a 32-channel
+        /// interface now reports its real width instead of a floor. Pinned so a
+        /// future cpal bump that moves the cap again fails here rather than
+        /// silently re-labelling real hardware as unknown.
+        #[test]
+        fn a_count_below_the_clamp_is_honest() {
+            let device = info("alsa:hw:CARD=BIG,DEV=0", 32);
+            assert!(device.channels_known);
+            assert_eq!(device.channels_display(), "32");
         }
 
         #[test]

--- a/src/audio/cpal/device.rs
+++ b/src/audio/cpal/device.rs
@@ -189,6 +189,25 @@ struct Silenced {
 /// 32 to 64 (AES10/MADI's maximum), so 32 is now a genuine capability.
 const CPAL_CHANNEL_CLAMP: u16 = 64;
 
+/// Whether a device's reported channel count is its real maximum.
+///
+/// Two separate reasons it might not be. Hardware reporting the clamp has that
+/// many channels *or more*, so the figure is a floor. A virtual node's figure is
+/// not about hardware at all -- it is whatever the plugin advertises, and ALSA's
+/// software nodes advertise a number of their own choosing -- so it is never
+/// known from the node's own report, whatever it happens to be. Only
+/// [`resolve_virtual_channel_counts`], borrowing from a hardware sibling, can
+/// make a plug node's count known.
+///
+/// Tying the virtual case to the clamp instead is what cpal 0.18 caught out:
+/// `default` and `pulse` report 32, which *was* the clamp and so came back
+/// unknown by coincidence. Once the clamp moved to 64 the same 32 read as an
+/// honest count and `mtrack devices` printed `alsa:default (Channels=32)`,
+/// offering ALSA's software mixer as if it were a 32-channel interface.
+fn channels_are_known(virtual_node: bool, max_channels: u16) -> bool {
+    !virtual_node && max_channels < CPAL_CHANNEL_CLAMP
+}
+
 /// The PCM id inside a device name, with cpal's host prefix removed.
 ///
 /// Device names here are `cpal::DeviceId` strings, which are `"{host}:{pcm_id}"`
@@ -466,7 +485,7 @@ pub fn list_device_info() -> Result<Vec<AudioDeviceInfo>, Box<dyn Error>> {
                             })
                             .collect(),
                         virtual_node,
-                        channels_known: max_channels < CPAL_CHANNEL_CLAMP,
+                        channels_known: channels_are_known(virtual_node, max_channels),
                     });
                 }
             }
@@ -1621,7 +1640,7 @@ mod test {
                 supported_sample_rates: vec![48000],
                 supported_formats: vec![],
                 virtual_node: is_virtual_node(name),
-                channels_known: max_channels < CPAL_CHANNEL_CLAMP,
+                channels_known: channels_are_known(is_virtual_node(name), max_channels),
             }
         }
 
@@ -1794,6 +1813,23 @@ mod test {
             let device = info("alsa:hw:CARD=BIG,DEV=0", 32);
             assert!(device.channels_known);
             assert_eq!(device.channels_display(), "32");
+        }
+
+        /// ...but only for hardware. A software node's count is the plugin's,
+        /// not the rig's, at any value.
+        ///
+        /// Observed on the rig under cpal 0.18: `default` and `pulse` report 32,
+        /// which is below the new clamp, and `mtrack devices` offered them as
+        /// `(Channels=32)`. Under 0.17 the same 32 *was* the clamp, so they read
+        /// as unknown for a reason that had nothing to do with being virtual.
+        #[test]
+        fn a_software_node_never_reports_an_honest_count() {
+            for name in &["alsa:default", "alsa:pulse"] {
+                let device = info(name, 32);
+                assert!(device.virtual_node, "{name} should be a virtual node");
+                assert!(!device.channels_known, "{name} reported 32 as a capability");
+                assert_eq!(device.channels_display(), "virtual");
+            }
         }
 
         #[test]

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -218,7 +218,7 @@ impl CpalOutputStreamFactory {
             let mut callback = create_direct_f32_callback(mixer, source_rx, num_channels, health);
             let notify = error_notify;
             device.build_output_stream(
-                &config,
+                config,
                 move |data: &mut [f32], info: &cpal::OutputCallbackInfo| {
                     callback(data, info);
                 },
@@ -238,7 +238,7 @@ impl CpalOutputStreamFactory {
                     );
                     let notify = error_notify;
                     device.build_output_stream(
-                        &config,
+                        config,
                         move |data: &mut [i16], info: &cpal::OutputCallbackInfo| {
                             callback(data, info);
                         },
@@ -257,7 +257,7 @@ impl CpalOutputStreamFactory {
                     );
                     let notify = error_notify;
                     device.build_output_stream(
-                        &config,
+                        config,
                         move |data: &mut [i32], info: &cpal::OutputCallbackInfo| {
                             callback(data, info);
                         },
@@ -286,8 +286,8 @@ impl CpalOutputStreamFactory {
 fn error_handler(
     notify: CondvarNotify,
     health: Arc<OutputHealth>,
-) -> impl FnMut(cpal::StreamError) + Send + 'static {
-    move |err: cpal::StreamError| {
+) -> impl FnMut(cpal::Error) + Send + 'static {
+    move |err: cpal::Error| {
         // Runs on cpal's audio worker, which ALSA has already promoted to
         // realtime priority (`boost_current_thread_priority` sits at the top of
         // the loop that calls this), so the common path has to stay cheap.
@@ -304,10 +304,13 @@ fn error_handler(
         // replaces a glitch of about a millisecond with a full reopen — measured
         // at ~29ms on the test rig. Same outcome, thirty times the interruption.
         //
-        // POLLERR is different and still rebuilds: cpal returns that as an error
-        // *before* it reaches the `avail()` call whose EPIPE would have taken the
-        // recovery path, so the PCM stays in XRUN and only a new stream clears it.
-        if matches!(err, cpal::StreamError::BufferUnderrun) {
+        // Under cpal 0.17 POLLERR was the exception and did still rebuild, because
+        // cpal returned it as an error *before* reaching the `avail()` call whose
+        // EPIPE would have taken the recovery path, leaving the PCM stuck in XRUN.
+        // 0.18 fixed that: POLLERR now falls through to `avail_delay()`, comes back
+        // as `Xrun`, and the worker's `prepare()` clears it. So POLLERR lands here
+        // too, and the reopen it used to force is no longer needed.
+        if err.kind() == cpal::ErrorKind::Xrun {
             health.record_underrun();
             return;
         }

--- a/src/calibrate/stream.rs
+++ b/src/calibrate/stream.rs
@@ -96,7 +96,7 @@ where
     f32: cpal::FromSample<T>,
 {
     let stream = device.build_input_stream(
-        config,
+        *config,
         move |data: &[T], _: &cpal::InputCallbackInfo| {
             if !buffer.active.load(Ordering::Relaxed) {
                 return;

--- a/src/trigger/engine.rs
+++ b/src/trigger/engine.rs
@@ -349,7 +349,7 @@ impl TriggerEngine {
         let mut priority_set = false;
 
         let stream = device.build_input_stream(
-            config,
+            *config,
             move |data: &[T], _: &cpal::InputCallbackInfo| {
                 promote_to_realtime(callback_priority, rt_audio, &mut priority_set);
                 // Data is interleaved: [ch0, ch1, ch2, ..., ch0, ch1, ...]

--- a/src/webui/svelte/e2e/mock-server/test-data.ts
+++ b/src/webui/svelte/e2e/mock-server/test-data.ts
@@ -171,11 +171,12 @@ export const AUDIO_DEVICES = [
     channels_known: true,
   },
   // An ALSA plug node whose channel count could not be resolved from hardware:
-  // it reports cpal's clamped 32, which says nothing about the rig behind it.
-  // Kept selectable, because on some interfaces it is the only thing that works.
+  // it reports cpal's clamped maximum, which says nothing about the rig behind
+  // it. Kept selectable, because on some interfaces it is the only thing that
+  // works.
   {
     name: "alsa:plughw:CARD=WING",
-    max_channels: 32,
+    max_channels: 64,
     host_name: "ALSA",
     supported_sample_rates: [44100, 48000],
     supported_formats: [{ sample_format: "S32LE", bits_per_sample: 32 }],

--- a/src/webui/svelte/e2e/tests/config-audio.spec.ts
+++ b/src/webui/svelte/e2e/tests/config-audio.spec.ts
@@ -56,7 +56,7 @@ test.describe("Profile Editor - Audio Section", () => {
     await expect(option).toHaveText("USB Interface (18ch, ALSA)");
   });
 
-  // An ALSA plug node reports cpal's clamped 32 channels regardless of the
+  // An ALSA plug node reports cpal's clamped maximum regardless of the
   // hardware behind it, so the picker must not present that as a capability.
   // It stays in the list: on some interfaces it is the only node that works.
   test("plug nodes are labelled rather than given a fictional channel count", async ({
@@ -66,7 +66,7 @@ test.describe("Profile Editor - Audio Section", () => {
       "#audio-device-list option[value='alsa:plughw:CARD=WING']",
     );
     await expect(option).toHaveText("alsa:plughw:CARD=WING (virtual, ALSA)");
-    await expect(option).not.toContainText("32");
+    await expect(option).not.toContainText("64");
   });
 
   // Setting a rig up happens in this editor, not in a terminal, so the check


### PR DESCRIPTION
Upgrades cpal 0.17.1 → 0.18.1, and midir 0.10 → 0.11 because it has to: cpal 0.18 moves ALSA onto `alsa-sys` 0.4, midir 0.10 links 0.3, and cargo allows one `links = "alsa"` per graph. The two bump together or neither does.

## The API changes that reach us

- **`build_{input,output}_stream` takes `StreamConfig` by value.** It's `Copy`; the call sites deref.
- **`StreamError` is gone**, folded into a unified `cpal::Error` / `ErrorKind`. `StreamError::BufferUnderrun` → `ErrorKind::Xrun`.
- **Streams no longer auto-start on ALSA.** Every build site here already called `play()`, so nothing had to change — but that call is now load-bearing rather than redundant, which is why the rig check below is the one that mattered.
- `DeviceId`'s fields are private now. We only ever `.to_string()` it, and `Display`/`FromStr` are byte-identical (`"{host}:{id}"`), so **device names persisted in existing configs keep resolving** — confirmed on the rig against `alsa:plughw:CARD=WING,DEV=0`.

Not affected: `StreamInstant` (the callbacks ignore `OutputCallbackInfo`), `DeviceDescription::extended()` (unused), the `audio_thread_priority` → `realtime` feature rename (never enabled — `src/thread_priority.rs` promotes from inside the callback, and `audio_thread_priority` was not in the lockfile before this change either). midir 0.11's only breaking change is `find_port_by_id`, which we don't call.

## One behaviour change worth knowing about

0.17 let POLLERR bypass the `avail()` EPIPE that would have classified it, so it arrived as a hard error and the output thread tore the stream down and reopened the device — measured at ~29ms on the test rig, to replace a ~1ms glitch. 0.18 routes it through `avail_delay()`, it comes back as `Xrun`, and cpal's own `prepare()` clears it. So POLLERR now lands in the underrun filter with every other xrun and the reopen it used to force is gone. The comment there is updated to say so rather than to keep describing 0.17.

## The channel clamp, which is the real substance here

cpal caps its ALSA channel-count walk so a plug node reporting `u32::MAX` doesn't spin forever, and mtrack reads that cap back as a sentinel: a device reporting exactly it has *at least* that many channels, so `channels_known` is false, the count displays as `N+`, and `resolve_virtual_channel_counts` goes looking for a hardware sibling to borrow an honest number from.

**0.18 moved the cap from 32 to 64.** Left at 32 the sentinel points at nothing. Plug nodes now report 64 and stay unknown by luck, but every genuine interface between 32 and 64 channels also fails the test and gets marked unknown, and a real 32-channel interface — whose width 0.18 now reports honestly — is still read as a floor.

The existing clamp test would not have caught a wrong constant: it took the value from `CPAL_CHANNEL_CLAMP` but hardcoded `"32+"` in the assertion. It now derives both, and there's a new test at the boundary.

### What the rig then caught

With the constant fixed, `mtrack devices` on the rig said:

```
- alsa:default (Channels=32) (ALSA)
- alsa:pulse  (Channels=32) (ALSA)
```

Both are ALSA software nodes. 32 is what the plugin advertises, not a width any hardware promised, and presenting it as a capability is how someone picks `default` for a 32-channel show. `channels_known` was `max_channels < CPAL_CHANNEL_CLAMP` for every device alike — virtual nodes came back unknown **only because the number they report happened to equal the clamp**. A coincidence, not a rule, and moving the clamp ended it.

So the rule is stated instead: a virtual node's count is never known from its own report, whatever the value; only `resolve_virtual_channel_counts` can make one known. Hardware is untouched — below the clamp is honest, at it is a floor. There's a test carrying the rig's actual output as its rationale.

This is the bug I'd have shipped without hardware. The unit suite was green across all three of the wrong states.

## Verified on the rig

Raspberry Pi 5, Behringer WING over USB, against the real production config (`profiles_dir`, 48kHz/int32/256-frame buffer, OSC + gRPC + MIDI controllers, DMX, `UM-ONE` hardware MIDI out).

```
$ mtrack devices
- alsa:default (Channels=virtual) (ALSA)
- alsa:plughw:CARD=WING,DEV=0 (Channels=virtual) (ALSA)
- alsa:pulse (Channels=virtual) (ALSA)          # ...and the rest

$ mtrack midi-devices
- UM-ONE:UM-ONE MIDI 1 28:0 (Input/Output)      # the exact name in the profile

$ mtrack test-audio /mnt/storage/backing-tracks/mtrack.yaml
Testing audio device "alsa:plughw:CARD=WING,DEV=0"...
INFO Audio output stream started successfully (direct callback mode)
INFO Enabled RT SCHED_FIFO for real-time thread
✅ Audio device is streaming (5 callbacks served).
```

That last one is the check that mattered: **callbacks served** is what distinguishes "the stream opened" from "the stream is running", and a missed `play()` under 0.18's no-auto-start would have opened fine and served zero.

Then the whole player, audible through the WING: hardware init complete (audio + MIDI + DMX), `Soundcheck` played end to end and auto-advanced, `Bored to Undeath` played with a seek to 2:00 that landed and continued correctly, through a 44.1→48k Sinc resample. Final tally across the session: **0 underruns, 0 xruns, 0 stream errors, 0 ERROR lines.**

Input streams are the other API I changed and the active profile has no triggers, so I drove that path directly with `calibrate-triggers` against the WING — it opened, the callback ran, and it measured **64 channels**, which is the clamp change confirmed on real hardware rather than inferred from cpal's source. All channels silent, as expected with nothing patched to the WING's inputs.

## Tests

3186 unit tests, Playwright 508/508. fmt and clippy clean on both crates. The e2e plug-node fixture moved to 64 — it sets `channels_known` itself so it passed either way, but it claimed cpal reports something it no longer reports, and the picker test's `not.toContainText("32")` was guarding the old clamp value rather than the current one.

MSRV is now 1.85 (cpal's). CI is on `dtolnay/rust-toolchain@stable` with no pin, and already installs `libasound2-dev`, which covers alsa-sys 0.4 the same as 0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
