### PR TITLE
fix(trigger): stop rebuilding the input stream for faults cpal already fixed

### DIFF
--- a/src/trigger/engine.rs
+++ b/src/trigger/engine.rs
@@ -36,6 +36,23 @@ use crate::thread_priority::{callback_thread_priority, promote_to_realtime, rt_a
 /// to the recovery thread.
 type ErrorNotify = Arc<(Mutex<bool>, Condvar)>;
 
+/// Whether a backend error means this stream is finished and must be replaced.
+///
+/// An xrun is not. cpal's input worker reports every one through the error
+/// callback and then calls `prepare()` and `start()` and carries on, so the
+/// stream keeps delivering — and they arrive routinely, exactly when the machine
+/// is already under load. Rebuilding for one costs a device re-resolve, a
+/// detector rebuild, and a window with no trigger detection at all, to replace a
+/// glitch cpal had already fixed. The output path reached the same conclusion in
+/// #370 and measured the reopen at ~29ms against a glitch of about one.
+///
+/// Everything else does warrant a rebuild, including the case that makes this
+/// loop necessary: on `DeviceNotAvailable` cpal's worker returns outright, so
+/// nothing will ever be delivered again until the stream is replaced.
+fn warrants_rebuild(err: &cpal::Error) -> bool {
+    err.kind() != cpal::ErrorKind::Xrun
+}
+
 /// Shared shutdown signal so `Drop` can wake the recovery thread.
 type ShutdownNotify = Arc<(Mutex<bool>, Condvar)>;
 
@@ -184,7 +201,7 @@ impl TriggerEngine {
             std::thread::Builder::new()
                 .name("trigger-input-recovery".into())
                 .spawn(move || {
-                    Self::recovery_loop(stream, params, tx, error_notify, shutdown);
+                    Self::recovery_loop(stream, error_notify, params, tx, shutdown);
                 })?
         };
 
@@ -203,26 +220,30 @@ impl TriggerEngine {
     /// Runs the stream recovery loop. Blocks until shutdown.
     fn recovery_loop(
         mut stream: cpal::Stream,
+        mut error_notify: ErrorNotify,
         params: StreamParams,
         tx: Sender<TriggerAction>,
-        error_notify: ErrorNotify,
         shutdown: ShutdownNotify,
     ) {
         loop {
             // Wait for either a stream error or shutdown.
-            let (err_mutex, err_condvar) = &*error_notify;
-            let (shut_mutex, _) = &*shutdown;
-            loop {
-                if *shut_mutex.lock() {
-                    drop(stream);
-                    return;
+            //
+            // Scoped so the borrow of `error_notify` ends before the rebuild
+            // below replaces it.
+            {
+                let (err_mutex, err_condvar) = &*error_notify;
+                let (shut_mutex, _) = &*shutdown;
+                loop {
+                    if *shut_mutex.lock() {
+                        drop(stream);
+                        return;
+                    }
+                    let mut errored = err_mutex.lock();
+                    if *errored {
+                        break;
+                    }
+                    err_condvar.wait_for(&mut errored, std::time::Duration::from_millis(500));
                 }
-                let mut errored = err_mutex.lock();
-                if *errored {
-                    *errored = false;
-                    break;
-                }
-                err_condvar.wait_for(&mut errored, std::time::Duration::from_millis(500));
             }
 
             // Drop the old stream and attempt to rebuild.
@@ -257,6 +278,21 @@ impl TriggerEngine {
                     }
                 };
 
+                // A fresh signal per attempt, never the one the dead stream held.
+                //
+                // Sharing one meant an error latched by a stream that was already
+                // gone was still set when its replacement came up, and the wait
+                // above returned immediately and tore the new stream straight back
+                // down. cpal can raise the same fault twice — one USB unplug on the
+                // test rig produced two POLLERR callbacks 0.2ms apart — so the
+                // second outlived the rebuild it triggered. Clearing the flag
+                // before each build fixes that instance and not the class: the
+                // attempt below can build a stream, have `play()` fail, drop it,
+                // and go round again, and that discarded stream still holds the
+                // signal. A fresh one has nobody to inherit from. Same fix as the
+                // output path in #370.
+                let attempt_notify: ErrorNotify = Arc::new((Mutex::new(false), Condvar::new()));
+
                 match Self::build_input_stream(
                     &device,
                     &params.stream_config,
@@ -265,7 +301,7 @@ impl TriggerEngine {
                     tx.clone(),
                     params.sample_format,
                     params.crosstalk,
-                    error_notify.clone(),
+                    attempt_notify.clone(),
                 ) {
                     Ok(new_stream) => {
                         if let Err(e) = new_stream.play() {
@@ -275,6 +311,7 @@ impl TriggerEngine {
                         }
                         info!("Trigger input stream recovered after backend error");
                         stream = new_stream;
+                        error_notify = attempt_notify;
                         break;
                     }
                     Err(e) => {
@@ -361,7 +398,15 @@ impl TriggerEngine {
                     process_frame(&f32_frame, &mut detectors, &tx, crosstalk);
                 }
             },
-            move |err| {
+            move |err: cpal::Error| {
+                if !warrants_rebuild(&err) {
+                    // Runs on cpal's input worker. No formatting happens unless
+                    // the level is enabled, which matters because xruns arrive
+                    // in storms precisely when the machine is already struggling.
+                    debug!(error = %err, "Trigger input xrun; cpal recovered in place");
+                    return;
+                }
+
                 error!(
                     error = %err,
                     "Trigger input stream error (will attempt to recover)"
@@ -532,6 +577,54 @@ fn process_frame(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    mod warrants_rebuild_tests {
+        use super::*;
+
+        /// cpal recovers an input xrun itself, via `prepare()` + `start()`, so
+        /// the stream keeps delivering. Rebuilding costs a device re-resolve and
+        /// a window with no trigger detection, to replace a glitch already fixed.
+        #[test]
+        fn an_xrun_does_not_warrant_a_rebuild() {
+            assert!(!warrants_rebuild(&cpal::Error::new(cpal::ErrorKind::Xrun)));
+        }
+
+        /// The case this loop exists for: cpal's worker returns outright, so
+        /// nothing is ever delivered again until the stream is replaced.
+        #[test]
+        fn a_lost_device_warrants_a_rebuild() {
+            assert!(warrants_rebuild(&cpal::Error::new(
+                cpal::ErrorKind::DeviceNotAvailable
+            )));
+        }
+
+        /// Unknown faults rebuild. Guessing wrong that way costs one reopen;
+        /// guessing wrong the other way leaves triggers silently dead for a set.
+        #[test]
+        fn other_faults_warrant_a_rebuild() {
+            for kind in [
+                cpal::ErrorKind::StreamInvalidated,
+                cpal::ErrorKind::BackendError,
+                cpal::ErrorKind::DeviceBusy,
+                cpal::ErrorKind::Other,
+            ] {
+                assert!(
+                    warrants_rebuild(&cpal::Error::new(kind)),
+                    "{kind:?} should rebuild"
+                );
+            }
+        }
+
+        /// The message carried alongside the kind must not change the verdict —
+        /// an xrun that cpal annotated is still an xrun.
+        #[test]
+        fn the_verdict_comes_from_the_kind_not_the_message() {
+            assert!(!warrants_rebuild(&cpal::Error::with_message(
+                cpal::ErrorKind::Xrun,
+                "buffer underrun on capture"
+            )));
+        }
+    }
 
     mod resolve_stream_format_tests {
         use super::*;


### PR DESCRIPTION
Two problems in the trigger input recovery path. The output path already solved both; the trigger path inherited neither. Found while looking at cpal 0.18's error handling in #383 — neither is a regression from that upgrade, both predate it.

## An xrun tore the stream down

The error callback woke the recovery thread for *any* backend error, and recovery is not cheap: re-resolve the device, rebuild every detector, rebuild and restart the stream, with one-second sleeps between failed attempts. Triggers are dead for that whole window and detector state resets.

But cpal reports every xrun through that same callback and then calls `prepare()` and `start()` and carries on — the stream is still delivering. So the rebuild replaced a glitch cpal had already fixed, at exactly the moment the machine was under enough load to produce one. #370 reached this conclusion for the output path and measured the reopen at ~29ms against a glitch of about one.

`warrants_rebuild` makes that a rule rather than a coincidence of which errors happen to arrive. Everything that is not an xrun still rebuilds, including the case the loop exists for: on `DeviceNotAvailable` cpal's worker returns outright, and nothing is delivered again until the stream is replaced.

The asymmetry was chronological, not deliberate: this recovery loop landed in #259, and the output path only learned to filter xruns in #370.

## A dead stream could tear down its own replacement

One `ErrorNotify` was created at construction and cloned into every stream ever built. A fault latched by a stream that was already gone was still set when its replacement came up, so the recovery thread's wait returned immediately and rebuilt again.

Clearing the flag on wake does not fix the class, which is why #370 didn't stop there either: an attempt can build a stream, have `play()` fail, drop it, and go round again — and that discarded stream still holds the signal. Each attempt now gets a fresh one, which has nobody to inherit from.

## Verified on the hardware rig

Test rig, MAT 8x16 over USB, trigger on `alsa:hw:CARD=MAT,DEV=0` at 16ch/48k/I32. Device loss simulated by unbinding the USB interfaces from `snd-usb-audio` — the technique #370 used. I confirmed the unbind/rebind cycle was reversible before relying on it.

One run caught **a genuine xrun at stream startup**, so both paths appear in a single trace:

```
01:56:21.231 DEBUG Trigger input xrun; cpal recovered in place  error=A buffer underrun or overrun occurred.
01:56:23.805 ERROR Trigger input stream error (will attempt to recover)  error=Device disconnected
01:56:23.810 WARN  Trigger input stream error detected, attempting recovery
01:56:36.903 INFO  Trigger input stream recovered after backend error
```

The xrun filtered to debug with no rebuild; the device loss rebuilt and recovered exactly once, across ~13s of the device being absent.

**Control**, current `main` on the same rig and the same unbind cycle: one error, one rebuild, one recovery. The device-loss path is unchanged by this PR — that is the result I wanted from the control, since breaking recovery is the risk this change carries.

## What I could not demonstrate, and why

Being explicit about the limits of the above:

- **No controlled before/after for the xrun path.** Xruns are rare on this rig: 0 in 4 runs on each build, with the single observed event coming from a ~10th run. I could not provoke one on demand — CPU load to 3.59 produced none, because the SCHED_FIFO audio threads simply preempt normal-priority work. So the "before" is not demonstrated on hardware. It is not in doubt from the source, though: `main`'s error callback has no classification at all, so an `Xrun` sets the flag like anything else. There is no path by which it avoids the rebuild.
- **The double-rebuild did not reproduce.** cpal raised a single error for the unbind here, not the two POLLERR callbacks 0.2ms apart that #370 saw. So that fix is preventive: correct by construction and matching the established fix, but latent rather than observed.

## Tests

4 unit tests on `warrants_rebuild` — the xrun verdict, the lost-device verdict, unknown kinds defaulting to rebuild, and the verdict coming from the kind rather than an attached message. 3191 pass locally, fmt and clippy clean.

Also built and run against **released** cpal 0.18.1 on a machine with no local cpal checkout, so no `[patch]` could silently intervene. Six `webui::server` tests fail there for an unrelated reason — `src/webui/svelte/dist/` is a build artifact absent from a fresh worktree, and all six either fetch an asset, fetch `/`, or hit an unregistered path that falls through to the SPA. Confirmed by removing `dist/` locally to reproduce exactly those six, and restoring it to get 29/29.

Worth a separate look: `server_api_playlist` asserts 200 from `/api/playlist`, which is not a route — only `/api/playlists` is. It passes solely because the SPA fallback answers, and would keep passing if the real endpoint were deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
