### PR TITLE
Remove the release layer command (#342)

### DIFF
--- a/examples/lighting/shows/README.md
+++ b/examples/lighting/shows/README.md
@@ -49,18 +49,19 @@ The lighting system supports professional-grade crossfades for smooth transition
 
 ```light
 # Basic crossfade syntax
-effect_name: effect_type parameters..., fade_in: 2s, fade_out: 1s, duration: 5s
+effect_name: effect_type parameters..., up_time: 2s, down_time: 1s, duration: 5s
 
 # Examples
-front_wash: static color: "blue", dimmer: 100%, duration: 5s, fade_in: 2s
-back_wash: cycle color: "red", color: "green", speed: 1.0, fade_in: 1s, fade_out: 1s, duration: 8s
-strobe_lights: strobe frequency: 4, fade_in: 0.5s, fade_out: 0.5s, duration: 3s
+front_wash: static color: "blue", dimmer: 100%, duration: 5s, up_time: 2s
+back_wash: cycle color: "red", color: "green", speed: 1.0, up_time: 1s, down_time: 1s, duration: 8s
+strobe_lights: strobe frequency: 4, up_time: 0.5s, down_time: 0.5s, duration: 3s
 ```
 
 ### Crossfade Parameters
 
-- `fade_in: <duration>` - Time to fade in from 0% to 100% intensity
-- `fade_out: <duration>` - Time to fade out from 100% to 0% intensity
+- `up_time: <duration>` - Time to fade in from 0% to 100% intensity
+- `down_time: <duration>` - Time to fade out from 100% to 0% intensity
+- `hold_time: <duration>` - Time held at full intensity between the two fades
 - `duration: <duration>` - Total effect duration (**required** for all effect types except dimmer)
 - Fade parameters are optional; duration is required
 - Duration can be specified in seconds (s), milliseconds (ms), or as time values (e.g., 2.5s)
@@ -213,22 +214,23 @@ Effects are organized into three layers, processed from bottom to top:
 ### Commands
 
 #### `clear` - Immediate Stop
-Immediately stops all effects on a layer (like a panic button).
+Immediately stops all effects on a layer (like a panic button). This is a hard
+cut, not a fade, and it takes no time parameter.
 
 ```light
+# Hard cut on one layer
 clear(layer: foreground)
+
+# Hard cut on every layer
+clear()
 ```
 
-#### `release` - Graceful Fade Out
-Gracefully fades out all effects on a layer. Uses each effect's `fade_out` time, or a custom time.
+There is no command that fades a layer out. Every effect declares a finite
+duration, so a graceful exit is authored on the effect itself with `down_time`
+and happens when the effect ends:
 
 ```light
-# Use effects' own fade_out times (or 1s default)
-release(layer: foreground)
-
-# Custom fade time
-release(layer: foreground, time: 2s)
-release(layer: background, time: 500ms)
+front_wash: static color: "blue", duration: 8s, down_time: 2s
 ```
 
 #### `freeze` - Pause Effects
@@ -276,17 +278,13 @@ show "Layer Control Demo" {
     @00:05.000
         master(layer: background, intensity: 50%)
 
-    # Add a foreground strobe
+    # Add a foreground strobe that fades itself out over its last 2 seconds
     @00:10.000
-        strobes: strobe frequency: 8, layer: foreground, duration: 30s
+        strobes: strobe frequency: 8, layer: foreground, duration: 12s, down_time: 2s
 
     # Freeze the rainbow effect
     @00:15.000
         freeze(layer: midground)
-
-    # Release foreground with 2 second fade
-    @00:20.000
-        release(layer: foreground, time: 2s)
 
     # Resume the rainbow
     @00:25.000
@@ -311,7 +309,7 @@ show "Layer Control Demo" {
 | Scenario | Command |
 |----------|---------|
 | Panic/blackout on a layer | `clear(layer: foreground)` |
-| Smooth transition to next song section | `release(layer: midground, time: 4s)` |
+| Smooth transition to next song section | `down_time: 4s` on the outgoing effects |
 | Dramatic pause | `freeze(layer: background)` |
 | Build intensity gradually | `master(layer: background, intensity: 25%)` then increase |
 | Sync effects to tempo change | `master(layer: midground, speed: 150%)` |

--- a/examples/lighting/shows/layer_control_demo.light
+++ b/examples/lighting/shows/layer_control_demo.light
@@ -3,9 +3,12 @@
 //
 // This show demonstrates:
 // - clear() - instantly stop all effects on a layer
-// - release() - gracefully fade out a layer
 // - freeze() / unfreeze() - pause and resume effects
 // - master() - control intensity and speed per layer
+//
+// There is no release() command. Every effect declares a finite duration, so a
+// graceful fade-out is authored on the effect itself with down_time rather than
+// imposed on the layer afterwards.
 
 show "Layer Control Demo" {
     // Start with effects on multiple layers
@@ -30,16 +33,16 @@ show "Layer Control Demo" {
     @00:12.000
         unfreeze(layer: midground)
 
-    // Gracefully release the foreground with a 2 second fade
+    // A foreground effect that fades itself out over its last 2 seconds
     @00:15.000
-        release(layer: foreground, time: 2s)
+        accent: static color: "#ff8800", dimmer: 90%, layer: foreground, duration: 3s, down_time: 2s
 
-    // Add a new strobe effect on foreground (previous one is fading out)
-    @00:16.000
+    // Add a new strobe effect on foreground
+    @00:18.000
         strobe_fx: strobe frequency: 8, layer: foreground, duration: 5s
 
     // Slow down the midground rainbow to half speed
-    @00:18.000
+    @00:19.000
         master(layer: midground, speed: 50%)
 
     // Restore background to full intensity
@@ -58,17 +61,8 @@ show "Layer Control Demo" {
     @00:26.000
         master(layer: midground, speed: 100%)
 
-    // Release all layers gracefully at the end
-    @00:30.000
-        release(layer: foreground, time: 1s)
-        release(layer: midground, time: 2s)
-        release(layer: background, time: 3s)
+    // A closing wash that fades out under its own down_time
+    @00:28.000
+        front_wash: static color: "#0066ff", dimmer: 100%, layer: background, duration: 5s, down_time: 3s
+        back_wash: static color: "#0066ff", dimmer: 100%, layer: midground, duration: 5s, down_time: 2s
 }
-
-
-
-
-
-
-
-

--- a/examples/lighting_simulator.rs
+++ b/examples/lighting_simulator.rs
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Update timeline
         timeline_update = timeline.update(current_time);
 
-        // Process layer commands (clear, release, etc.) before starting new effects
+        // Process layer commands (clear, freeze, master) before starting new effects
         apply_layer_commands(&mut effect_engine, &timeline_update);
 
         // Start new effects (sequence effects first so show effects win conflicts)
@@ -249,15 +249,6 @@ fn apply_layer_commands(effect_engine: &mut EffectEngine, timeline_update: &Time
                     effect_engine.clear_layer(layer);
                 } else {
                     effect_engine.clear_all_layers();
-                }
-            }
-            LayerCommandType::Release => {
-                if let Some(layer) = cmd.layer {
-                    if let Some(fade_time) = cmd.fade_time {
-                        effect_engine.release_layer_with_time(layer, Some(fade_time));
-                    } else {
-                        effect_engine.release_layer(layer);
-                    }
                 }
             }
             LayerCommandType::Freeze => {

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -66,8 +66,8 @@ parameters: `layer:` is required, the others are optional.
 
 ```
 @01:00.000
-release(layer: foreground)                       # stop all effects on this layer
-clear(layer: midground, time: 250ms)             # fade everything off over 250ms
+clear(layer: midground)                          # hard cut — stop this layer now
+clear()                                          # hard cut on every layer
 freeze(layer: background)                        # pin current output, ignore new cues
 unfreeze(layer: background)                      # resume normal updates
 master(layer: foreground, intensity: 50%)        # scale the layer's output
@@ -75,6 +75,10 @@ master(layer: foreground, intensity: 50%)        # scale the layer's output
 
 `master(...)` also accepts `speed:` (scales effect rates) in addition to
 `intensity:`.
+
+`clear(...)` is an immediate stop, not a fade. There is no layer command that
+fades a layer out: every effect declares a finite duration, so author the
+fade on the effect itself with `down_time:` and let it end when it should.
 
 Layer masters and freezes last for the song that set them. They are reset when
 playback stops or a new song loads, and when the layer is cleared (`clear(layer:

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -3248,7 +3248,6 @@ mod test {
                 layer_commands: vec![LayerCommand {
                     command_type: LayerCommandType::Clear,
                     layer: None,
-                    fade_time: None,
                     intensity: None,
                     speed: None,
                 }],

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -166,8 +166,6 @@ pub struct EffectEngine {
     /// Optional tempo map for tempo-aware effects (measure/beat-based timing)
     tempo_map: Option<TempoMap>,
     layer_state: LayerState,
-    /// Effects being released — tracks (release_fade_time, release_start_time) per effect
-    releasing_effects: HashMap<String, (Duration, Instant)>,
     /// Last computed merged fixture states (for preview/debugging)
     last_merged_states: HashMap<String, FixtureState>,
     /// Last known song time (score-time) for tempo-aware speed lookups.
@@ -194,7 +192,6 @@ impl EffectEngine {
             engine_elapsed: Duration::ZERO,
             tempo_map: None,
             layer_state: LayerState::new(),
-            releasing_effects: HashMap::new(),
             last_merged_states: HashMap::new(),
             last_song_time: None,
             midi_dmx_store: None,
@@ -413,8 +410,7 @@ impl EffectEngine {
         // Fast path for MIDI-DMX-only frames: when no DSL effects are running,
         // generate DmxCommands directly from the store. This skips all HashMap
         // cloning, fixture state rebuilding, and the full pipeline.
-        if !self.cache.dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
-        {
+        if !self.cache.dirty && self.active_effects.is_empty() {
             let store_gen = self
                 .midi_dmx_store
                 .as_ref()
@@ -469,8 +465,7 @@ impl EffectEngine {
 
         // Cache-only fast path: effects existed previously but are now done,
         // permanent state exists, and nothing has changed.
-        if !self.cache.dirty && self.active_effects.is_empty() && self.releasing_effects.is_empty()
-        {
+        if !self.cache.dirty && self.active_effects.is_empty() {
             let store_gen = self
                 .midi_dmx_store
                 .as_ref()
@@ -586,9 +581,6 @@ impl EffectEngine {
                 // Get reference to effect to avoid unnecessary clone
                 let effect = self.active_effects.get(&effect_id).unwrap();
 
-                // Check if this effect is being released
-                let release_info = self.releasing_effects.get(&effect_id).cloned();
-
                 // Calculate base elapsed time
                 // If layer is frozen, use the frozen time instead of current time
                 let reference_time = frozen_at.unwrap_or(self.current_time);
@@ -625,19 +617,9 @@ impl EffectEngine {
                     false
                 };
 
-                // Check if a releasing effect has completed its fade
-                let release_completed = if let Some((fade_time, release_start)) = &release_info {
-                    let release_elapsed = self.current_time.duration_since(*release_start);
-                    release_elapsed >= *fade_time
-                } else {
-                    false
-                };
-
-                if is_expired || release_completed {
-                    // Effect has completed. For temporary effects, do not blend final state.
-                    // For permanent effects, preserve via the completion handler below.
-
-                    // Queue for removal after this frame
+                if is_expired {
+                    // Effect has completed — no state persists, so don't blend a final
+                    // frame. Queue for removal after this frame.
                     completed_effects.push(effect_id.clone());
                     continue;
                 }
@@ -650,29 +632,11 @@ impl EffectEngine {
                     absolute_time,
                     self.tempo_map.as_ref(),
                 )? {
-                    // Calculate release fade multiplier if this effect is being released
-                    let release_multiplier = if let Some((fade_time, release_start)) = release_info
-                    {
-                        let release_elapsed = self.current_time.duration_since(release_start);
-                        let progress = if fade_time.is_zero() {
-                            1.0
-                        } else {
-                            (release_elapsed.as_secs_f64() / fade_time.as_secs_f64())
-                                .clamp(0.0, 1.0)
-                        };
-                        1.0 - progress // Fade from 1.0 to 0.0
-                    } else {
-                        1.0
-                    };
-
-                    // Combined intensity multiplier (layer master * release fade)
-                    let intensity_multiplier = layer_intensity * release_multiplier;
-
-                    // Apply intensity multiplier to effect states if not 1.0
-                    if (intensity_multiplier - 1.0).abs() > f64::EPSILON {
+                    // Apply the layer intensity master to effect states if not 1.0
+                    if (layer_intensity - 1.0).abs() > f64::EPSILON {
                         for fixture_state in effect_states.values_mut() {
                             for channel_state in fixture_state.channels.values_mut() {
-                                channel_state.value *= intensity_multiplier;
+                                channel_state.value *= layer_intensity;
                             }
                         }
                     }
@@ -694,8 +658,6 @@ impl EffectEngine {
 
         // Handle completed effects — simply remove them. No state persists after completion.
         for effect_id in completed_effects {
-            self.releasing_effects.remove(&effect_id);
-
             if let Some(effect) = self.active_effects.remove(&effect_id) {
                 // Clean up per-layer multipliers for completed effects
                 let multiplier_keys: Vec<String> = MULTIPLIER_PREFIXES
@@ -742,7 +704,6 @@ impl EffectEngine {
     /// Stop all active effects and reset per-song layer state
     pub fn stop_all_effects(&mut self) {
         self.active_effects.clear();
-        self.releasing_effects.clear();
         self.last_merged_states.clear();
         // Layer masters and freezes belong to the song that set them. The engine is
         // reused across songs, so without this a show stopped mid-duck leaves the next
@@ -775,7 +736,6 @@ impl EffectEngine {
         // Remove the effects
         for effect_id in to_remove {
             self.active_effects.remove(&effect_id);
-            self.releasing_effects.remove(&effect_id);
         }
         self.cache.invalidate();
     }
@@ -787,7 +747,6 @@ impl EffectEngine {
     pub fn clear_layer(&mut self, layer: EffectLayer) {
         layers::clear_layer(
             &mut self.active_effects,
-            &mut self.releasing_effects,
             &mut self.layer_state.frozen,
             layer,
         );
@@ -801,35 +760,11 @@ impl EffectEngine {
     /// Clear all layers - immediately stops all effects on all layers
     /// This is equivalent to a "kill all" or panic button for everything
     pub fn clear_all_layers(&mut self) {
-        layers::clear_all_layers(
-            &mut self.active_effects,
-            &mut self.releasing_effects,
-            &mut self.layer_state.frozen,
-        );
+        layers::clear_all_layers(&mut self.active_effects, &mut self.layer_state.frozen);
         // Including the layer masters — a panic button that leaves the rig mastered
         // down is not a panic button.
         self.layer_state.reset();
         self.last_merged_states.clear();
-        self.cache.invalidate();
-    }
-
-    /// Release a layer - gracefully fades out all effects on the specified layer
-    /// Uses each effect's down_time, or a default of 1 second if not specified
-    pub fn release_layer(&mut self, layer: EffectLayer) {
-        self.release_layer_with_time(layer, None);
-    }
-
-    /// Release a layer with a custom fade time
-    /// If fade_time is None, uses each effect's down_time (or 1 second default)
-    pub fn release_layer_with_time(&mut self, layer: EffectLayer, fade_time: Option<Duration>) {
-        layers::release_layer_with_time(
-            &mut self.active_effects,
-            &mut self.releasing_effects,
-            &mut self.layer_state.frozen,
-            layer,
-            fade_time,
-            self.current_time,
-        );
         self.cache.invalidate();
     }
 
@@ -909,15 +844,6 @@ impl EffectEngine {
                     self.clear_layer(layer);
                 } else {
                     self.clear_all_layers();
-                }
-            }
-            LayerCommandType::Release => {
-                if let Some(layer) = cmd.layer {
-                    if let Some(fade_time) = cmd.fade_time {
-                        self.release_layer_with_time(layer, Some(fade_time));
-                    } else {
-                        self.release_layer(layer);
-                    }
                 }
             }
             LayerCommandType::Freeze => {
@@ -1038,27 +964,6 @@ impl EffectEngine {
                     effect.target_fixtures.len(),
                     elapsed.as_secs_f64(),
                     duration_str
-                )
-                .unwrap();
-            }
-        }
-
-        // Also show releasing effects if any
-        if !self.releasing_effects.is_empty() {
-            writeln!(
-                output,
-                "\nReleasing effects ({}):",
-                self.releasing_effects.len()
-            )
-            .unwrap();
-            for (effect_id, (fade_time, release_start)) in &self.releasing_effects {
-                let release_elapsed = self.current_time.duration_since(*release_start);
-                writeln!(
-                    output,
-                    "    - {} - fading out (elapsed: {:.2}s / {:.2}s)",
-                    effect_id,
-                    release_elapsed.as_secs_f64(),
-                    fade_time.as_secs_f64()
                 )
                 .unwrap();
             }

--- a/src/lighting/engine/layers.rs
+++ b/src/lighting/engine/layers.rs
@@ -13,24 +13,16 @@
 //
 
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use super::super::effects::{EffectInstance, EffectLayer};
 
 /// Clear a layer - immediately stops all effects on the specified layer
 pub(crate) fn clear_layer(
     active_effects: &mut HashMap<String, EffectInstance>,
-    releasing_effects: &mut HashMap<String, (Duration, Instant)>,
     frozen_layers: &mut HashMap<EffectLayer, Instant>,
     layer: EffectLayer,
 ) {
-    // Remove matching effects from releasing_effects before removing from active_effects,
-    // since we need active_effects to know which IDs are on this layer
-    releasing_effects.retain(|id, _| {
-        active_effects
-            .get(id)
-            .is_none_or(|effect| effect.layer != layer)
-    });
     active_effects.retain(|_, effect| effect.layer != layer);
     frozen_layers.remove(&layer);
 }
@@ -38,35 +30,10 @@ pub(crate) fn clear_layer(
 /// Clear all layers - immediately stops all effects on all layers
 pub(crate) fn clear_all_layers(
     active_effects: &mut HashMap<String, EffectInstance>,
-    releasing_effects: &mut HashMap<String, (Duration, Instant)>,
     frozen_layers: &mut HashMap<EffectLayer, Instant>,
 ) {
     active_effects.clear();
-    releasing_effects.clear();
     frozen_layers.clear();
-}
-
-/// Release a layer with a custom fade time
-pub(crate) fn release_layer_with_time(
-    active_effects: &mut HashMap<String, EffectInstance>,
-    releasing_effects: &mut HashMap<String, (Duration, Instant)>,
-    frozen_layers: &mut HashMap<EffectLayer, Instant>,
-    layer: EffectLayer,
-    fade_time: Option<Duration>,
-    current_time: Instant,
-) {
-    let default_fade = Duration::from_secs(1);
-
-    for (effect_id, effect) in active_effects.iter() {
-        if effect.layer == layer && !releasing_effects.contains_key(effect_id) {
-            let release_time =
-                fade_time.unwrap_or_else(|| effect.down_time.unwrap_or(default_fade));
-            releasing_effects.insert(effect_id.clone(), (release_time, current_time));
-        }
-    }
-    // Unfreeze the layer if it was frozen (properly adjusts effect start times
-    // to maintain smooth animation continuity during the fade-out)
-    unfreeze_layer(frozen_layers, active_effects, layer, current_time);
 }
 
 /// Freeze a layer - pauses all effects on the layer at their current state
@@ -192,14 +159,8 @@ mod tests {
             "b".to_string(),
             make_effect("b", vec!["f1"], EffectLayer::Foreground),
         );
-        let mut releasing = HashMap::new();
         let mut frozen = HashMap::new();
-        clear_layer(
-            &mut active,
-            &mut releasing,
-            &mut frozen,
-            EffectLayer::Background,
-        );
+        clear_layer(&mut active, &mut frozen, EffectLayer::Background);
         assert!(!active.contains_key("a"));
         assert!(active.contains_key("b"));
     }
@@ -213,13 +174,10 @@ mod tests {
             "a".to_string(),
             make_effect("a", vec!["f1"], EffectLayer::Background),
         );
-        let mut releasing = HashMap::new();
-        releasing.insert("a".to_string(), (Duration::from_secs(1), Instant::now()));
         let mut frozen = HashMap::new();
         frozen.insert(EffectLayer::Background, Instant::now());
-        clear_all_layers(&mut active, &mut releasing, &mut frozen);
+        clear_all_layers(&mut active, &mut frozen);
         assert!(active.is_empty());
-        assert!(releasing.is_empty());
         assert!(frozen.is_empty());
     }
 

--- a/src/lighting/engine/tests/layer_commands_tests.rs
+++ b/src/lighting/engine/tests/layer_commands_tests.rs
@@ -185,10 +185,11 @@ fn test_freeze_unfreeze_layer() {
 }
 
 #[test]
-fn test_release_frozen_layer_maintains_animation_continuity() {
-    // Regression test: releasing a frozen layer should not cause animation discontinuity.
-    // Before the fix, release_layer_with_time would call frozen_layers.remove() directly
-    // instead of unfreeze_layer(), causing effects to jump forward in their animation.
+fn test_unfreeze_layer_maintains_animation_continuity() {
+    // Regression test: unfreezing a layer must resume the animation where it stopped,
+    // not jump forward by the wall-clock time that elapsed while frozen. This requires
+    // pushing each effect's start_time forward by the frozen duration; dropping the
+    // layer out of `frozen` without that adjustment produces a visible snap.
     let mut engine = EffectEngine::new();
 
     // Create RGB fixture for rainbow test
@@ -245,26 +246,26 @@ fn test_release_frozen_layer_maintains_animation_continuity() {
     frozen_sorted.sort_by_key(|(ch, _)| *ch);
     let vals_frozen: Vec<u8> = frozen_sorted.iter().map(|(_, v)| *v).collect();
 
-    // Now release the frozen layer with a fade time
-    engine.release_layer_with_time(EffectLayer::Background, Some(Duration::from_secs(2)));
+    // Now unfreeze the layer
+    engine.unfreeze_layer(EffectLayer::Background);
 
-    // Immediately after release, the effect should continue from where it was frozen,
+    // Immediately after unfreezing, the effect should continue from where it was frozen,
     // NOT jump forward by the 1 second that passed while frozen.
-    let commands_after_release = engine.update(Duration::from_millis(10), None).unwrap();
+    let commands_after_unfreeze = engine.update(Duration::from_millis(10), None).unwrap();
     // Sort by channel for consistent comparison
-    let mut after_release_sorted: Vec<_> = commands_after_release
+    let mut after_unfreeze_sorted: Vec<_> = commands_after_unfreeze
         .iter()
         .map(|c| (c.channel, c.value))
         .collect();
-    after_release_sorted.sort_by_key(|(ch, _)| *ch);
-    let vals_after_release: Vec<u8> = after_release_sorted.iter().map(|(_, v)| *v).collect();
+    after_unfreeze_sorted.sort_by_key(|(ch, _)| *ch);
+    let vals_after_unfreeze: Vec<u8> = after_unfreeze_sorted.iter().map(|(_, v)| *v).collect();
 
-    // The values right after release should be very close to the frozen values
+    // The values right after unfreezing should be very close to the frozen values
     // (only 10ms of animation has passed, not 1+ second)
     // We allow small differences due to the 10ms update and fade starting
     let max_diff: i16 = vals_frozen
         .iter()
-        .zip(vals_after_release.iter())
+        .zip(vals_after_unfreeze.iter())
         .map(|(a, b)| (*a as i16 - *b as i16).abs())
         .max()
         .unwrap_or(0);
@@ -276,37 +277,12 @@ fn test_release_frozen_layer_maintains_animation_continuity() {
     // With the fix, we should see only tiny differences from the 10ms elapsed.
     assert!(
         max_diff < 30,
-        "Release of frozen layer caused animation discontinuity! \
-     Frozen: {:?}, After release: {:?}, Max diff: {}. \
+        "Unfreeze caused animation discontinuity! \
+     Frozen: {:?}, After unfreeze: {:?}, Max diff: {}. \
      Effect should continue from frozen state, not jump forward.",
         vals_frozen,
-        vals_after_release,
+        vals_after_unfreeze,
         max_diff
-    );
-
-    // Also verify the effect is actually fading out over time
-    engine.update(Duration::from_millis(1000), None).unwrap();
-    let commands_mid_fade = engine.update(Duration::from_millis(10), None).unwrap();
-    // Sort by channel for consistent comparison
-    let mut mid_fade_sorted: Vec<_> = commands_mid_fade
-        .iter()
-        .map(|c| (c.channel, c.value))
-        .collect();
-    mid_fade_sorted.sort_by_key(|(ch, _)| *ch);
-    let vals_mid_fade: Vec<u8> = mid_fade_sorted.iter().map(|(_, v)| *v).collect();
-
-    // At 1 second into a 2 second fade, values should be roughly half
-    let avg_mid: f64 =
-        vals_mid_fade.iter().map(|v| *v as f64).sum::<f64>() / vals_mid_fade.len() as f64;
-    let avg_frozen: f64 =
-        vals_frozen.iter().map(|v| *v as f64).sum::<f64>() / vals_frozen.len() as f64;
-
-    // Mid-fade average should be notably lower than frozen average
-    assert!(
-        avg_mid < avg_frozen * 0.8,
-        "Effect should be fading: frozen avg={:.1}, mid-fade avg={:.1}",
-        avg_frozen,
-        avg_mid
     );
 }
 
@@ -370,54 +346,6 @@ fn test_layer_speed_master() {
 }
 
 #[test]
-fn test_release_layer_fade_behavior() {
-    let mut engine = EffectEngine::new();
-    let fixture = create_test_fixture("test_fixture", 1, 1);
-    engine.register_fixture(fixture);
-
-    // Start an effect on background layer
-    let effect = EffectInstance::new(
-        "bg_effect".to_string(),
-        EffectType::Static {
-            parameters: {
-                let mut p = HashMap::new();
-                p.insert("dimmer".to_string(), 1.0);
-                p
-            },
-            duration: Duration::from_secs(5),
-        },
-        vec!["test_fixture".to_string()],
-        None,
-        None,
-        None,
-    );
-    engine.start_effect(effect).unwrap();
-
-    // Get initial commands at full brightness
-    let commands_before = engine.update(Duration::from_millis(16), None).unwrap();
-    assert_eq!(commands_before.len(), 1);
-    assert_eq!(commands_before[0].value, 255);
-
-    // Release the layer with a 1 second fade
-    engine.release_layer_with_time(EffectLayer::Background, Some(Duration::from_secs(1)));
-
-    // Immediately after release, should still be near full
-    let commands_start = engine.update(Duration::from_millis(16), None).unwrap();
-    assert!(!commands_start.is_empty());
-
-    // Halfway through fade (500ms), should be around half brightness
-    let commands_mid = engine.update(Duration::from_millis(500), None).unwrap();
-    if !commands_mid.is_empty() {
-        // Value should be less than full
-        assert!(
-            commands_mid[0].value < 200,
-            "Should be fading: {}",
-            commands_mid[0].value
-        );
-    }
-}
-
-#[test]
 fn test_layer_commands_edge_cases() {
     let mut engine = EffectEngine::new();
     let fixture = create_test_fixture("test_fixture", 1, 1);
@@ -426,9 +354,6 @@ fn test_layer_commands_edge_cases() {
     // Clear an empty layer - should not panic
     engine.clear_layer(EffectLayer::Foreground);
     assert_eq!(engine.active_effects_count(), 0);
-
-    // Release an empty layer - should not panic
-    engine.release_layer(EffectLayer::Midground);
 
     // Double freeze - should not panic
     engine.freeze_layer(EffectLayer::Background);

--- a/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
+++ b/src/lighting/engine/tests/sequence_and_layer_control_tests.rs
@@ -120,51 +120,6 @@ fn test_stop_sequence_stops_all_effects_from_sequence() {
 }
 
 #[test]
-fn test_stop_sequence_handles_releasing_effects() {
-    let mut engine = EffectEngine::new();
-    let fixture = create_test_fixture("test_fixture", 1, 1);
-    engine.register_fixture(fixture);
-
-    // Create an effect that will be releasing
-    let mut seq_effect = EffectInstance::new(
-        "seq_test_effect_1".to_string(),
-        EffectType::Static {
-            parameters: {
-                let mut p = HashMap::new();
-                p.insert("dimmer".to_string(), 1.0);
-                p
-            },
-            duration: Duration::from_secs(5),
-        },
-        vec!["test_fixture".to_string()],
-        None,
-        None,
-        None,
-    );
-    seq_effect.id = "seq_test_effect_1".to_string();
-    seq_effect.layer = EffectLayer::Foreground;
-
-    engine.start_effect(seq_effect).unwrap();
-    assert_eq!(engine.active_effects_count(), 1);
-
-    // Start releasing the layer (adds effect to releasing_effects, but keeps it in active_effects)
-    engine.release_layer(EffectLayer::Foreground);
-
-    // Effect should still be in active_effects (release doesn't remove it)
-    assert_eq!(engine.active_effects_count(), 1);
-    engine.update(Duration::from_millis(100), None).unwrap();
-
-    // Stop the sequence - should remove from both active_effects and releasing_effects
-    // The effect ID is "seq_test_effect_1", so sequence name "test" should match
-    engine.stop_sequence("test");
-
-    // Effect should be completely gone (both from active and releasing)
-    assert_eq!(engine.active_effects_count(), 0);
-    // Verify the effect is not in the engine at all
-    assert!(!engine.has_effect("seq_test_effect_1"));
-}
-
-#[test]
 fn test_stop_sequence_with_no_matching_effects() {
     let mut engine = EffectEngine::new();
     let fixture = create_test_fixture("test_fixture", 1, 1);
@@ -316,62 +271,6 @@ fn test_clear_all_layers_clears_frozen_layers() {
 
     // Layer should no longer be frozen and effect should be gone
     assert!(!engine.is_layer_frozen(EffectLayer::Background));
-    assert_eq!(engine.active_effects_count(), 0);
-}
-
-#[test]
-fn test_clear_all_layers_clears_releasing_effects() {
-    let mut engine = EffectEngine::new();
-    let fixture = create_test_fixture("test_fixture", 1, 1);
-    engine.register_fixture(fixture);
-
-    // Start effects on different layers
-    let mut bg_effect = EffectInstance::new(
-        "bg_effect".to_string(),
-        EffectType::Static {
-            parameters: {
-                let mut p = HashMap::new();
-                p.insert("dimmer".to_string(), 0.5);
-                p
-            },
-            duration: Duration::from_secs(5),
-        },
-        vec!["test_fixture".to_string()],
-        None,
-        None,
-        None,
-    );
-    bg_effect.layer = EffectLayer::Background;
-
-    let mut fg_effect = EffectInstance::new(
-        "fg_effect".to_string(),
-        EffectType::Static {
-            parameters: {
-                let mut p = HashMap::new();
-                p.insert("red".to_string(), 1.0);
-                p
-            },
-            duration: Duration::from_secs(5),
-        },
-        vec!["test_fixture".to_string()],
-        None,
-        None,
-        None,
-    );
-    fg_effect.layer = EffectLayer::Foreground;
-
-    engine.start_effect(bg_effect).unwrap();
-    engine.start_effect(fg_effect).unwrap();
-
-    // Start releasing one layer
-    engine.release_layer(EffectLayer::Foreground);
-
-    // Update to move effect to releasing state
-    engine.update(Duration::from_millis(100), None).unwrap();
-
-    // Clear all layers - should stop both active and releasing effects
-    engine.clear_all_layers();
-
     assert_eq!(engine.active_effects_count(), 0);
 }
 
@@ -630,43 +529,6 @@ fn test_freeze_unfreeze_different_layers_independently() {
 
     // Both effects should still be active
     assert_eq!(engine.active_effects_count(), 2);
-}
-
-#[test]
-fn test_freeze_unfreeze_with_releasing_effects() {
-    let mut engine = EffectEngine::new();
-    let fixture = create_test_fixture("test_fixture", 1, 1);
-    engine.register_fixture(fixture);
-
-    // Start an effect
-    let mut effect = EffectInstance::new(
-        "test_effect".to_string(),
-        EffectType::Static {
-            parameters: {
-                let mut p = HashMap::new();
-                p.insert("dimmer".to_string(), 1.0);
-                p
-            },
-            duration: Duration::from_secs(5),
-        },
-        vec!["test_fixture".to_string()],
-        None,
-        None,
-        None,
-    );
-    effect.layer = EffectLayer::Background;
-
-    engine.start_effect(effect).unwrap();
-
-    // Freeze the layer
-    engine.freeze_layer(EffectLayer::Background);
-    assert!(engine.is_layer_frozen(EffectLayer::Background));
-
-    // Start releasing - should unfreeze automatically
-    engine.release_layer(EffectLayer::Background);
-
-    // Layer should no longer be frozen (release clears freeze)
-    assert!(!engine.is_layer_frozen(EffectLayer::Background));
 }
 
 // ── Layer master lifetime (#343) ───────────────────────────────────

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -61,15 +61,15 @@ reset_measures_command = { "reset_measures" }
 // Layer control commands (grandMA-inspired)
 layer_command = { layer_command_type ~ "(" ~ layer_command_params? ~ ")" }
 
-layer_command_type = { "release" | "clear" | "freeze" | "unfreeze" | "master" }
+layer_command_type = { "clear" | "freeze" | "unfreeze" | "master" }
 
 layer_command_params = { layer_command_param ~ ("," ~ layer_command_param)* }
 
 layer_command_param = { layer_command_param_name ~ ":" ~ layer_command_param_value }
 
-layer_command_param_name = { "layer" | "time" | "intensity" | "speed" }
+layer_command_param_name = { "layer" | "intensity" | "speed" }
 
-layer_command_param_value = { layer_parameter | time_parameter | percentage | number_value }
+layer_command_param_value = { layer_parameter | percentage | number_value }
 
 time_string = @{ "@" ~ (time_mm_ss_mmm | time_ss_mmm) }
 

--- a/src/lighting/parser/show.rs
+++ b/src/lighting/parser/show.rs
@@ -597,7 +597,7 @@ fn parse_sequence_cue_structure(
     }
 
     for layer_command_pair in layer_command_pairs {
-        let layer_command = parse_layer_command(layer_command_pair, tempo_map, abs_time)?;
+        let layer_command = parse_layer_command(layer_command_pair)?;
         layer_commands.push(layer_command);
     }
 
@@ -1326,7 +1326,7 @@ fn parse_cue_definition(
         }
 
         for layer_command_pair in layer_command_pairs {
-            let layer_command = parse_layer_command(layer_command_pair, tempo_map, abs_time)?;
+            let layer_command = parse_layer_command(layer_command_pair)?;
             layer_commands.push(layer_command);
         }
 
@@ -1511,7 +1511,7 @@ fn parse_cue_definition(
 
     // Parse layer commands
     for layer_command_pair in layer_command_pairs {
-        let layer_command = parse_layer_command(layer_command_pair, tempo_map, abs_time)?;
+        let layer_command = parse_layer_command(layer_command_pair)?;
         layer_commands.push(layer_command);
     }
 
@@ -1529,14 +1529,9 @@ fn parse_cue_definition(
     ))
 }
 
-fn parse_layer_command(
-    pair: Pair<Rule>,
-    tempo_map: &Option<TempoMap>,
-    cue_time: Duration,
-) -> Result<LayerCommand, Box<dyn Error>> {
+fn parse_layer_command(pair: Pair<Rule>) -> Result<LayerCommand, Box<dyn Error>> {
     let mut command_type = LayerCommandType::Clear;
     let mut layer: Option<EffectLayer> = None;
-    let mut fade_time = None;
     let mut intensity = None;
     let mut speed = None;
 
@@ -1545,7 +1540,6 @@ fn parse_layer_command(
             Rule::layer_command_type => {
                 command_type = match inner_pair.as_str() {
                     "clear" => LayerCommandType::Clear,
-                    "release" => LayerCommandType::Release,
                     "freeze" => LayerCommandType::Freeze,
                     "unfreeze" => LayerCommandType::Unfreeze,
                     "master" => LayerCommandType::Master,
@@ -1578,14 +1572,6 @@ fn parse_layer_command(
                                     "foreground" => EffectLayer::Foreground,
                                     other => return Err(format!("Invalid layer: {}", other).into()),
                                 });
-                            }
-                            "time" => {
-                                fade_time = Some(super::utils::parse_duration_string(
-                                    &param_value,
-                                    tempo_map,
-                                    Some(cue_time),
-                                    0.0, // Layer commands don't use offsets for duration parsing
-                                )?);
                             }
                             "intensity" => {
                                 // Parse percentage (e.g., "50%") or number (e.g., "0.5")
@@ -1626,7 +1612,6 @@ fn parse_layer_command(
             "Layer command '{}' requires a layer parameter",
             match command_type {
                 LayerCommandType::Clear => "clear",
-                LayerCommandType::Release => "release",
                 LayerCommandType::Freeze => "freeze",
                 LayerCommandType::Unfreeze => "unfreeze",
                 LayerCommandType::Master => "master",
@@ -1638,7 +1623,6 @@ fn parse_layer_command(
     Ok(LayerCommand {
         command_type,
         layer,
-        fade_time,
         intensity,
         speed,
     })

--- a/src/lighting/parser/tests/layer_commands_tests.rs
+++ b/src/lighting/parser/tests/layer_commands_tests.rs
@@ -23,9 +23,6 @@ fn test_layer_command_parsing() {
     front_wash: static color: "blue", duration: 5s, layer: foreground
 
     @00:05.000
-    release(layer: foreground, time: 2s)
-
-    @00:10.000
     clear(layer: foreground)
 
     @00:15.000
@@ -48,40 +45,31 @@ fn test_layer_command_parsing() {
     let show = shows.get("Layer Control Test").expect("Show should exist");
 
     // Check that cues were parsed
-    assert_eq!(show.cues.len(), 6, "Should have 6 cues");
+    assert_eq!(show.cues.len(), 5, "Should have 5 cues");
 
     // First cue has an effect, no layer commands
     assert_eq!(show.cues[0].effects.len(), 1);
     assert_eq!(show.cues[0].layer_commands.len(), 0);
 
-    // Second cue: release command
+    // Second cue: clear command
     assert_eq!(show.cues[1].effects.len(), 0);
     assert_eq!(show.cues[1].layer_commands.len(), 1);
-    let release_cmd = &show.cues[1].layer_commands[0];
-    assert_eq!(release_cmd.command_type, LayerCommandType::Release);
-    assert_eq!(release_cmd.layer, Some(EffectLayer::Foreground));
-    assert_eq!(
-        release_cmd.fade_time,
-        Some(std::time::Duration::from_secs(2))
-    );
-
-    // Third cue: clear command
-    let clear_cmd = &show.cues[2].layer_commands[0];
+    let clear_cmd = &show.cues[1].layer_commands[0];
     assert_eq!(clear_cmd.command_type, LayerCommandType::Clear);
     assert_eq!(clear_cmd.layer, Some(EffectLayer::Foreground));
 
-    // Fourth cue: freeze command
-    let freeze_cmd = &show.cues[3].layer_commands[0];
+    // Third cue: freeze command
+    let freeze_cmd = &show.cues[2].layer_commands[0];
     assert_eq!(freeze_cmd.command_type, LayerCommandType::Freeze);
     assert_eq!(freeze_cmd.layer, Some(EffectLayer::Background));
 
-    // Fifth cue: unfreeze command
-    let unfreeze_cmd = &show.cues[4].layer_commands[0];
+    // Fourth cue: unfreeze command
+    let unfreeze_cmd = &show.cues[3].layer_commands[0];
     assert_eq!(unfreeze_cmd.command_type, LayerCommandType::Unfreeze);
     assert_eq!(unfreeze_cmd.layer, Some(EffectLayer::Background));
 
-    // Sixth cue: master command
-    let master_cmd = &show.cues[5].layer_commands[0];
+    // Fifth cue: master command
+    let master_cmd = &show.cues[4].layer_commands[0];
     assert_eq!(master_cmd.command_type, LayerCommandType::Master);
     assert_eq!(master_cmd.layer, Some(EffectLayer::Midground));
     assert!((master_cmd.intensity.unwrap() - 0.5).abs() < 0.01);

--- a/src/lighting/parser/tests/sequences_tests.rs
+++ b/src/lighting/parser/tests/sequences_tests.rs
@@ -307,7 +307,7 @@ show "Test" {
     # Some comment
     
     @1.000
-    release(layer: background, time: 2s)
+    freeze(layer: background)
     # Another comment
     
     @2.000
@@ -342,19 +342,18 @@ show "Test" {
         Some(crate::lighting::effects::EffectLayer::Foreground)
     );
 
-    // Second cue should have release command with time
+    // Second cue should have freeze command
     let second_cue = &show.cues[1];
     assert_eq!(second_cue.layer_commands.len(), 1);
-    let release_cmd = &second_cue.layer_commands[0];
+    let freeze_cmd = &second_cue.layer_commands[0];
     assert_eq!(
-        release_cmd.command_type,
-        crate::lighting::parser::LayerCommandType::Release
+        freeze_cmd.command_type,
+        crate::lighting::parser::LayerCommandType::Freeze
     );
     assert_eq!(
-        release_cmd.layer,
+        freeze_cmd.layer,
         Some(crate::lighting::effects::EffectLayer::Background)
     );
-    assert!(release_cmd.fade_time.is_some());
 
     // Third cue should have master command with intensity
     let third_cue = &show.cues[2];

--- a/src/lighting/parser/tests/show_edge_cases_tests.rs
+++ b/src/lighting/parser/tests/show_edge_cases_tests.rs
@@ -589,7 +589,7 @@ show "Test" {
     sequence "seq"
 
     @10.000
-    release(layer: background, time: 1s)
+    freeze(layer: background)
 }
 "#;
 
@@ -625,7 +625,7 @@ show "Test" {
         "Cue at 5.0s should have effects from sequence"
     );
 
-    // Find cue at 10.0s - should have release command
+    // Find cue at 10.0s - should have freeze command
     let cue_at_10 = show
         .cues
         .iter()
@@ -635,12 +635,8 @@ show "Test" {
     assert!(
         cue.layer_commands
             .iter()
-            .any(|lc| lc.command_type == LayerCommandType::Release),
-        "Cue at 10.0s should have release layer command"
-    );
-    assert!(
-        cue.layer_commands[0].fade_time.is_some(),
-        "Release command should have fade_time"
+            .any(|lc| lc.command_type == LayerCommandType::Freeze),
+        "Cue at 10.0s should have freeze layer command"
     );
 }
 
@@ -1291,7 +1287,9 @@ show "Test" {
 }
 
 #[test]
-fn test_layer_command_release_with_time() {
+fn test_release_command_is_rejected() {
+    // `release` was removed once every effect gained a mandatory finite duration
+    // (#342). A show still using it should fail loudly rather than silently no-op.
     let content = r#"
 show "Test" {
     @0.000
@@ -1302,37 +1300,29 @@ show "Test" {
 }
 "#;
 
-    let result = parse_light_shows(content);
     assert!(
-        result.is_ok(),
-        "Should parse release with time: {:?}",
-        result.err()
+        parse_light_shows(content).is_err(),
+        "release() should no longer parse"
     );
+}
 
-    let shows = result.unwrap();
-    let show = shows.get("Test").unwrap();
+#[test]
+fn test_clear_with_time_is_rejected() {
+    // `time:` only ever fed `release`. `clear(time: ...)` parsed but was silently
+    // ignored, so the parameter is gone rather than left lying about what it does.
+    let content = r#"
+show "Test" {
+    @0.000
+    front_wash: static, color: "red", layer: background, duration: 5s
 
-    let cue_at_5 = show
-        .cues
-        .iter()
-        .find(|c| (c.time.as_secs_f64() - 5.0).abs() < 0.01);
-    assert!(cue_at_5.is_some(), "Should have a cue at 5.0s");
-    let cue = cue_at_5.unwrap();
+    @5.000
+    clear(layer: background, time: 2s)
+}
+"#;
 
-    assert_eq!(cue.layer_commands.len(), 1);
-    assert_eq!(
-        cue.layer_commands[0].command_type,
-        LayerCommandType::Release
-    );
     assert!(
-        cue.layer_commands[0].fade_time.is_some(),
-        "Release should have fade_time"
-    );
-    let fade_time = cue.layer_commands[0].fade_time.unwrap();
-    assert!(
-        (fade_time.as_secs_f64() - 2.0).abs() < 0.01,
-        "Fade time should be 2.0s, got {:?}",
-        fade_time
+        parse_light_shows(content).is_err(),
+        "clear() should no longer accept a time parameter"
     );
 }
 

--- a/src/lighting/parser/types.rs
+++ b/src/lighting/parser/types.rs
@@ -137,8 +137,6 @@ impl Effect {
 pub enum LayerCommandType {
     /// Clear - immediately stop all effects on the layer
     Clear,
-    /// Release - gracefully fade out all effects on the layer
-    Release,
     /// Freeze - pause all effects on the layer at their current state
     Freeze,
     /// Unfreeze - resume paused effects on the layer
@@ -152,7 +150,6 @@ pub enum LayerCommandType {
 pub struct LayerCommand {
     pub command_type: LayerCommandType,
     pub layer: Option<EffectLayer>, // None means all layers (only valid for clear)
-    pub fade_time: Option<Duration>,
     pub intensity: Option<f64>,
     pub speed: Option<f64>,
 }
@@ -411,7 +408,6 @@ mod tests {
     #[test]
     fn layer_command_type_equality() {
         assert_eq!(LayerCommandType::Clear, LayerCommandType::Clear);
-        assert_ne!(LayerCommandType::Clear, LayerCommandType::Release);
         assert_ne!(LayerCommandType::Freeze, LayerCommandType::Unfreeze);
     }
 }

--- a/src/lighting/timeline.rs
+++ b/src/lighting/timeline.rs
@@ -645,7 +645,6 @@ mod tests {
                 layer_commands: vec![LayerCommand {
                     command_type: LayerCommandType::Clear,
                     layer: Some(EffectLayer::Foreground),
-                    fade_time: None,
                     intensity: None,
                     speed: None,
                 }],
@@ -656,9 +655,8 @@ mod tests {
                 time: Duration::from_secs(1),
                 effects: vec![],
                 layer_commands: vec![LayerCommand {
-                    command_type: LayerCommandType::Release,
+                    command_type: LayerCommandType::Freeze,
                     layer: Some(EffectLayer::Background),
-                    fade_time: Some(Duration::from_secs(2)),
                     intensity: None,
                     speed: None,
                 }],
@@ -671,7 +669,6 @@ mod tests {
                 layer_commands: vec![LayerCommand {
                     command_type: LayerCommandType::Master,
                     layer: Some(EffectLayer::Midground),
-                    fade_time: None,
                     intensity: Some(0.5),
                     speed: Some(2.0),
                 }],
@@ -696,16 +693,16 @@ mod tests {
             Some(EffectLayer::Foreground)
         );
 
-        // Second cue: release command with fade time
+        // Second cue: freeze command
         let result1 = timeline.update(Duration::from_secs(1));
         assert_eq!(result1.layer_commands.len(), 1);
         assert_eq!(
             result1.layer_commands[0].command_type,
-            LayerCommandType::Release
+            LayerCommandType::Freeze
         );
         assert_eq!(
-            result1.layer_commands[0].fade_time,
-            Some(Duration::from_secs(2))
+            result1.layer_commands[0].layer,
+            Some(EffectLayer::Background)
         );
 
         // Third cue: master command with intensity and speed
@@ -747,7 +744,6 @@ mod tests {
             layer_commands: vec![LayerCommand {
                 command_type: LayerCommandType::Master,
                 layer: Some(EffectLayer::Background),
-                fade_time: None,
                 intensity: Some(0.75),
                 speed: None,
             }],
@@ -992,7 +988,6 @@ mod tests {
                 layer_commands: vec![LayerCommand {
                     command_type: LayerCommandType::Clear,
                     layer: Some(EffectLayer::Foreground),
-                    fade_time: None,
                     intensity: None,
                     speed: None,
                 }],
@@ -1080,7 +1075,6 @@ mod tests {
                 layer_commands: vec![LayerCommand {
                     command_type: LayerCommandType::Clear,
                     layer: None,
-                    fade_time: None,
                     intensity: None,
                     speed: None,
                 }],

--- a/src/webui/svelte/src/components/lighting/LayerCommandForm.svelte
+++ b/src/webui/svelte/src/components/lighting/LayerCommandForm.svelte
@@ -17,13 +17,7 @@
   import type { LayerCommand } from "../../lib/lighting/types";
   import { LAYERS } from "../../lib/lighting/types";
 
-  const COMMANDS = [
-    "clear",
-    "release",
-    "freeze",
-    "unfreeze",
-    "master",
-  ] as const;
+  const COMMANDS = ["clear", "freeze", "unfreeze", "master"] as const;
 
   interface Props {
     command: LayerCommand;
@@ -69,22 +63,6 @@
         {/each}
       </select>
     </label>
-
-    {#if command.command === "release"}
-      <label class="field">
-        <span class="field-label">{$t("effect.command.time")}</span>
-        <input
-          type="text"
-          class="input"
-          placeholder="2s"
-          value={command.time ?? ""}
-          onchange={(e) => {
-            const v = (e.target as HTMLInputElement).value;
-            update("time", v || undefined);
-          }}
-        />
-      </label>
-    {/if}
 
     {#if command.command === "master"}
       <label class="field">

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -667,7 +667,6 @@
   "effect.removeEffect": "Remove effect",
   "effect.command.command": "Command",
   "effect.command.layer": "Layer",
-  "effect.command.time": "Time",
   "effect.command.intensity": "Intensity",
   "effect.command.speed": "Speed",
   "effect.command.removeCommand": "Remove command",

--- a/src/webui/svelte/src/lib/lighting/parser.ts
+++ b/src/webui/svelte/src/lib/lighting/parser.ts
@@ -251,10 +251,8 @@ function parseCueBlock(lines: string[], startIdx: number): [Cue[], number] {
       continue;
     }
 
-    // Layer command: clear(...) / release(...) / freeze(...) / unfreeze(...) / master(...)
-    const cmdMatch = line.match(
-      /^(clear|release|freeze|unfreeze|master)\(([^)]*)\)/,
-    );
+    // Layer command: clear(...) / freeze(...) / unfreeze(...) / master(...)
+    const cmdMatch = line.match(/^(clear|freeze|unfreeze|master)\(([^)]*)\)/);
     if (cmdMatch) {
       const cmd = parseLayerCommand(cmdMatch[1], cmdMatch[2]);
       currentCue.commands.push(cmd);
@@ -398,9 +396,6 @@ function parseLayerCommand(cmd: string, paramsStr: string): LayerCommand {
 
   const layerM = paramsStr.match(/layer:\s*(\w+)/);
   if (layerM) result.layer = layerM[1];
-
-  const timeM = paramsStr.match(/time:\s*(\S+)/);
-  if (timeM) result.time = timeM[1];
 
   const intensityM = paramsStr.match(/intensity:\s*(\S+)/);
   if (intensityM) result.intensity = intensityM[1].replace(/,/g, "");

--- a/src/webui/svelte/src/lib/lighting/serializer.ts
+++ b/src/webui/svelte/src/lib/lighting/serializer.ts
@@ -215,7 +215,6 @@ function serializeEffect(cueEffect: CueEffect): string {
 function serializeLayerCommand(cmd: LayerCommand): string {
   const params: string[] = [];
   if (cmd.layer) params.push(`layer: ${cmd.layer}`);
-  if (cmd.time) params.push(`time: ${cmd.time}`);
   if (cmd.intensity) params.push(`intensity: ${cmd.intensity}`);
   if (cmd.speed) params.push(`speed: ${cmd.speed}`);
   return `${cmd.command}(${params.join(", ")})`;

--- a/src/webui/svelte/src/lib/lighting/types.ts
+++ b/src/webui/svelte/src/lib/lighting/types.ts
@@ -141,11 +141,10 @@ export interface CueEffect {
   sequenceName?: string;
 }
 
-/** Layer command (clear/release/freeze/unfreeze/master) */
+/** Layer command (clear/freeze/unfreeze/master) */
 export interface LayerCommand {
-  command: "clear" | "release" | "freeze" | "unfreeze" | "master";
+  command: "clear" | "freeze" | "unfreeze" | "master";
   layer?: string;
-  time?: string;
   intensity?: string;
   speed?: string;
 }


### PR DESCRIPTION
Closes #342.

`release` was needed when effects could run untimed. They can't any more — every effect must declare a finite duration, and even `loop: loop` is expanded to a bounded count at parse time. That left `release` with no unique job in an authored show, and it was the sole owner of a subsystem that cost work on every frame.

## What this removes

- `release_layer` / `release_layer_with_time` on `EffectEngine`, and the `layers::release_layer_with_time` helper
- the `releasing_effects` map, its per-effect per-frame lookup in the render path, and the release fade multiplier that followed it
- the `Release` variant, its parser branch, and its grammar alternative
- `fade_time` on `LayerCommand` — `release` was its only consumer

`clear_layer` / `clear_all_layers` lose their `releasing_effects` parameter, and the intensity multiplier in the render path is now just the layer master.

## `time:` goes too

`time:` only ever fed `release`. `clear(time:)` parsed the parameter into `fade_time` and then never passed it to `clear_layer`, so an author following the reference's own documented example — `clear(layer: midground, time: 250ms)` — silently got a hard cut. Rather than leave a parameter that lies, `time:` is out of the layer-command grammar; a show using it now fails to parse. Two new parser tests lock both rejections in.

## Docs corrections

`lighting_dsl_reference` documented the two commands backwards:

| | reference said | actually did |
|---|---|---|
| `clear` | "fade everything off over 250ms" | hard immediate stop |
| `release` | "stop all effects on this layer" | fades, honouring each effect's `down_time` |

Both entries are now accurate, and the reference states plainly that no layer command fades a layer out — `down_time:` on the effect is how you author that.

While in the shipped show README I also found it documenting `fade_in:` / `fade_out:` effect parameters that **do not exist**. They parse (they land in the generic parameter map) and are silently ignored; the real names are `up_time:` / `down_time:`. Same class of bug as the `clear(time:)` lie, in a section adjacent to the one this PR had to touch, so it's corrected here. Flagging it because it's beyond the issue's stated scope.

`examples/lighting/shows/layer_control_demo.light` is rewritten to demonstrate `down_time` instead of `release`, and verified against the simulator.

## Tests

- `cargo test` — 3187 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
- `npm run check` (svelte-check) — 411 files, 0 errors
- every example `.light` show re-parsed through `lighting_simulator`

Three engine tests that existed only to exercise releasing state are deleted; their non-release coverage is already held by neighbouring tests. `test_release_frozen_layer_maintains_animation_continuity` is kept as `test_unfreeze_layer_maintains_animation_continuity` — the no-jump-forward regression it guards is real and `unfreeze_layer` is now the only path to it.

## Unrelated pre-existing issue noticed

`examples/lighting/shows/measure_timing_demo.light` fails to parse on `main` as well (`Invalid chase direction: 'forward'`). Not touched here.

## Breaking change

Shows using `release(...)` or `clear(..., time: ...)` no longer parse. Replace a `release` with a `down_time` on the effects that should fade, or a `clear` where a hard cut was intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)