### PR TITLE
Offline show evaluation, live fixture state, and multi-group venues (#330, #331, #387)

### DIFF
--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -64,10 +64,13 @@ Roughly 50 tools are available. They fall into a few groups:
   detailed song metadata and beat-grid queries.
 - **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
   and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
-- **Offline show evaluation** — `evaluate_show` reports what the fixtures would be doing at any
-  set of times, as per-fixture DMX values plus the effects running at each instant. It needs no
-  audio, no DMX output, and no real-time waiting, so a show can be verified without playing the
-  song through the PA and the rig — and without perturbing playback if a song *is* running.
+- **Lighting state** — `evaluate_show` reports what the fixtures *would* be doing at any set of
+  times, and `get_fixture_state` reports what they *are* doing right now. Both return per-fixture
+  DMX values (0–255, including virtual-dimmer RGB scaling) alongside the effects running at each
+  instant and the fixtures each one resolved to, in the same shape, so predicted and actual state
+  can be compared directly. `evaluate_show` needs no audio, no DMX output, and no real-time
+  waiting, so a show can be verified without playing the song through the PA and the rig — and
+  without perturbing playback if a song *is* running.
 
 Every write and patch tool validates its input (YAML schema or `.light` DSL parse) **before** it
 writes to disk, so a malformed edit is rejected rather than corrupting a project file.

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -50,7 +50,7 @@ client's MCP server settings.
 
 ### Tools
 
-Roughly 45 tools are available. They fall into a few groups:
+Roughly 50 tools are available. They fall into a few groups:
 
 - **Status & discovery** — current playback status, host/runtime info, and listings of songs,
   playlists, groups, venues, and fixture types.
@@ -64,6 +64,10 @@ Roughly 45 tools are available. They fall into a few groups:
   detailed song metadata and beat-grid queries.
 - **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
   and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
+- **Offline show evaluation** — `evaluate_show` reports what the fixtures would be doing at any
+  set of times, as per-fixture DMX values plus the effects running at each instant. It needs no
+  audio, no DMX output, and no real-time waiting, so a show can be verified without playing the
+  song through the PA and the rig — and without perturbing playback if a song *is* running.
 
 Every write and patch tool validates its input (YAML schema or `.light` DSL parse) **before** it
 writes to disk, so a malformed edit is rejected rather than corrupting a project file.

--- a/examples/lighting/shows/measure_timing_demo.light
+++ b/examples/lighting/shows/measure_timing_demo.light
@@ -75,7 +75,7 @@ show "Measure Timing Demo" {
     front_wash: static color: "purple", dimmer: 100%, layer: background, blend_mode: replace, duration: 5s
     
     @18/1
-    front_wash: chase color: "purple", color: "magenta", color: "blue", duration: 1s, direction: forward, loop: loop
+    front_wash: chase color: "purple", color: "magenta", color: "blue", duration: 1s, direction: left_to_right, loop: loop
     
     # Section 4 - gradual tempo increase to 180 BPM (over 2 measures starting at measure 24)
     @24/1

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -55,7 +55,12 @@ Every effect must specify a finite `duration`. Effects can crossfade — set
   string (`#FF8800` or `"#FF8800"`), or `rgb(255, 128, 0)`.
 - `intensity`, `dimmer`, `red`, `green`, `blue`: floats `0.0`–`1.0`, or a
   percentage like `60%`.
-- `direction`: `forward | backward | random | pingpong | left_to_right | right_to_left | top_to_bottom | bottom_to_top | clockwise | counter_clockwise`.
+- `direction`: the accepted values depend on the effect — they are two
+  separate sets, not one list.
+  - `cycle`: `forward | backward | pingpong` (the order colours are stepped).
+  - `chase`: `left_to_right | right_to_left | top_to_bottom | bottom_to_top |
+    clockwise | counter_clockwise` (where the mask travels).
+  - No other effect reads `direction`; on `rainbow` it is accepted and ignored.
 - `layer`: `background | midground | foreground` (grandMA-inspired layers).
 - `blend_mode`: `replace | multiply | add | overlay | screen`.
 
@@ -97,7 +102,7 @@ sequence "Verse" {
     front_wash: static color: "blue", duration: 4s
 
     @00:02.000
-    movers: chase speed: 2.0, direction: forward, duration: 4s
+    movers: chase speed: 2.0, direction: left_to_right, duration: 4s
 }
 
 show "Song" {

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1389,6 +1389,155 @@ async fn mcp_evaluate_show_runs_offline() -> Result<(), Box<dyn Error>> {
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-ter: live fixture-level state (#331)
+// ---------------------------------------------------------------------------
+
+/// `get_fixture_state` reports which fixtures are lit, what they are outputting,
+/// and what is driving them — not just how many. It returns the same shape as
+/// `evaluate_show`, so this also checks the predicted and live answers agree.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+
+    std::fs::create_dir_all(fixture.root.join("lighting/venues"))?;
+    std::fs::create_dir_all(fixture.root.join("lighting/fixture_types"))?;
+    copy_dir_recursive(
+        Path::new("examples/lighting/fixture_types"),
+        &fixture.root.join("lighting/fixture_types"),
+    )?;
+    // Two fixtures in one group, so "how many" cannot stand in for "which".
+    // Exactly one `group` line: a venue declaring two does not parse today.
+    std::fs::write(
+        fixture.root.join("lighting/venues/main_stage.light"),
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n}\n",
+    )?;
+
+    // A long green bed, so the reading is stable however far playback has got.
+    let show = "show \"Which\" {\n    @00:00.000\n    all_lights: static color: \"green\", duration: 120s\n}\n";
+    let song_lighting_dir = fixture.root.join("songs/dsl-light-show-song/lighting");
+    std::fs::write(song_lighting_dir.join("main_show.light"), show)?;
+    // The song registers this show too. Keep its cue clear of the window under
+    // test so exactly one effect is running when we look.
+    std::fs::write(
+        song_lighting_dir.join("outro.light"),
+        "show \"Outro\" {\n    @01:00.000\n    all_lights: static color: \"white\", duration: 1s\n}\n",
+    )?;
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    // With nothing playing there is an engine, and nothing lit.
+    let idle =
+        tool_json(&call_tool(&client, &url, &session, 950, "get_fixture_state", json!({})).await);
+    assert_eq!(idle["available"], true, "expected a live engine: {idle}");
+    assert_eq!(
+        idle["dark"], true,
+        "nothing should be lit before play: {idle}"
+    );
+
+    let play_resp = tool_json(&call_tool(&client, &url, &session, 951, "play", json!({})).await);
+    assert!(
+        play_resp["now_playing"].is_object(),
+        "play did not start the song: {play_resp}"
+    );
+
+    // Poll until the timeline has armed and the bed is driving the rig.
+    let live = {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let body = tool_json(
+                &call_tool(&client, &url, &session, 952, "get_fixture_state", json!({})).await,
+            );
+            let lit = body["fixtures"]
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false);
+            if lit || std::time::Instant::now() > deadline {
+                break body;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
+
+    let effects = live["active_effects"].as_array().expect("effects");
+    assert_eq!(effects.len(), 1, "expected only the green bed: {live}");
+    let bed = &effects[0];
+    assert_eq!(bed["type"], "Static");
+
+    // The heart of #331: the effect names the fixtures it covers. A count of
+    // "2 fixture(s)" could not distinguish this from any other pair.
+    let driving: Vec<&str> = bed["fixtures"]
+        .as_array()
+        .expect("fixtures")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert_eq!(
+        driving,
+        vec!["Par1", "Par2"],
+        "the effect should name its fixtures: {live}"
+    );
+
+    // Per-fixture values, each naming what drives it.
+    let fixtures = live["fixtures"].as_array().expect("fixture states");
+    assert_eq!(fixtures.len(), 2, "both fixtures reported: {live}");
+    let par1 = fixtures
+        .iter()
+        .find(|f| f["name"] == "Par1")
+        .unwrap_or_else(|| panic!("Par1 missing: {live}"));
+    assert_eq!(par1["channels"]["green"], 255);
+    assert_eq!(par1["channels"]["red"], 0);
+    let driven_by: Vec<&str> = par1["driven_by"]
+        .as_array()
+        .expect("driven_by")
+        .iter()
+        .filter_map(|d| d.as_str())
+        .collect();
+    assert_eq!(driven_by.len(), 1, "Par1 should name its driver: {par1}");
+    assert_eq!(driven_by[0], bed["id"].as_str().unwrap_or_default());
+
+    // The offline evaluator, given the same show and venue, must agree.
+    let predicted = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            953,
+            "evaluate_show",
+            json!({"source": show, "times": ["1.0"]}),
+        )
+        .await,
+    );
+    let predicted_par1 = predicted["evaluations"][0]["fixtures"]
+        .as_array()
+        .expect("predicted fixtures")
+        .iter()
+        .find(|f| f["name"] == "Par1")
+        .cloned()
+        .unwrap_or_else(|| panic!("Par1 missing from prediction: {predicted}"));
+    assert_eq!(
+        predicted_par1["channels"], par1["channels"],
+        "offline evaluation disagrees with the live rig"
+    );
+
+    let _ = call_tool(&client, &url, &session, 954, "stop", json!({})).await;
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1454,19 +1454,23 @@ async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Er
     );
 
     // Poll until the timeline has armed and the bed is driving the rig.
+    //
+    // The condition is `dark == false`, not "some fixtures are reported": every
+    // known fixture is always reported, dark ones as zeros, so a non-empty
+    // fixture list says nothing about whether the show has started.
     let live = {
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         loop {
             let body = tool_json(
                 &call_tool(&client, &url, &session, 952, "get_fixture_state", json!({})).await,
             );
-            let lit = body["fixtures"]
-                .as_array()
-                .map(|a| !a.is_empty())
-                .unwrap_or(false);
-            if lit || std::time::Instant::now() > deadline {
+            if body["dark"] == false {
                 break body;
             }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timeline never armed within 15s: {body}"
+            );
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
     };

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1405,11 +1405,11 @@ async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Er
         Path::new("examples/lighting/fixture_types"),
         &fixture.root.join("lighting/fixture_types"),
     )?;
-    // Two fixtures in one group, so "how many" cannot stand in for "which".
-    // Exactly one `group` line: a venue declaring two does not parse today.
+    // Two fixtures, and two groups that resolve to different fixture sets — so
+    // a fixture *count* cannot stand in for knowing which ones are lit.
     std::fs::write(
         fixture.root.join("lighting/venues/main_stage.light"),
-        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n}\n",
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n  group \"left\" = Par1\n}\n",
     )?;
 
     // A long green bed, so the reading is stable however far playback has got.
@@ -1530,6 +1530,59 @@ async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Er
     assert_eq!(
         predicted_par1["channels"], par1["channels"],
         "offline evaluation disagrees with the live rig"
+    );
+
+    // The discrimination #331 asks for. `all_lights` and `left` both resolve
+    // to fixture lists, and they differ — two effects reporting "1 fixture"
+    // and "2 fixtures" could not tell you *which*. The song's own show must
+    // target a config-declared logical group, so `left` is exercised through
+    // `source`, which does not go through song validation.
+    let half = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            955,
+            "evaluate_show",
+            json!({
+                "source": "show \"Half\" {\n    @00:00.000\n    left: static color: \"red\", duration: 30s\n}\n",
+                "times": ["1.0"]
+            }),
+        )
+        .await,
+    );
+    let half_effects = half["evaluations"][0]["active_effects"]
+        .as_array()
+        .expect("effects");
+    let half_driving: Vec<&str> = half_effects[0]["fixtures"]
+        .as_array()
+        .expect("fixtures")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert_eq!(
+        half_driving,
+        vec!["Par1"],
+        "`left` covers Par1 only: {half}"
+    );
+
+    let half_fixtures = half["evaluations"][0]["fixtures"]
+        .as_array()
+        .expect("fixture states");
+    let half_par2 = half_fixtures
+        .iter()
+        .find(|f| f["name"] == "Par2")
+        .unwrap_or_else(|| panic!("Par2 missing: {half}"));
+    assert_eq!(
+        half_par2["channels"]["red"], 0,
+        "Par2 is not in `left` and must stay dark: {half_par2}"
+    );
+    assert!(
+        half_par2["driven_by"]
+            .as_array()
+            .expect("driven_by")
+            .is_empty(),
+        "nothing should be driving Par2: {half_par2}"
     );
 
     let _ = call_tool(&client, &url, &session, 954, "stop", json!({})).await;

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1234,6 +1234,161 @@ async fn mcp_cues_and_effects_against_live_timeline() -> Result<(), Box<dyn Erro
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-bis: offline show evaluation (#330)
+// ---------------------------------------------------------------------------
+
+/// `evaluate_show` answers "what would the rig be doing at time T" without
+/// audio, DMX, or the wall clock. This test never calls `play` — that is the
+/// whole point of the tool, so the absence of playback is the assertion.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_evaluate_show_runs_offline() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+
+    std::fs::create_dir_all(fixture.root.join("lighting/venues"))?;
+    std::fs::create_dir_all(fixture.root.join("lighting/fixture_types"))?;
+    copy_dir_recursive(
+        Path::new("examples/lighting/fixture_types"),
+        &fixture.root.join("lighting/fixture_types"),
+    )?;
+    std::fs::write(
+        fixture.root.join("lighting/venues/main_stage.light"),
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n}\n",
+    )?;
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    let source = r#"show "Offline" {
+    @00:00.000
+    all_lights: static color: "blue", duration: 4s
+
+    @00:10.000
+    all_lights: static color: "red", duration: 4s
+}
+"#;
+
+    let body = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            900,
+            "evaluate_show",
+            json!({"source": source, "times": ["1.0", "6.0", "0:11.000"]}),
+        )
+        .await,
+    );
+
+    let evaluations = body["evaluations"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected evaluations array: {body}"));
+    assert_eq!(evaluations.len(), 3, "one entry per requested time: {body}");
+
+    // 1.0s — inside the blue cue.
+    let at_1s = &evaluations[0];
+    assert_eq!(at_1s["dark"], false, "should be lit at 1s: {at_1s}");
+    let effects = at_1s["active_effects"].as_array().expect("effects");
+    assert_eq!(effects.len(), 1, "one effect at 1s: {at_1s}");
+    assert_eq!(effects[0]["type"], "Static");
+    assert_eq!(effects[0]["layer"], "background");
+    // The group resolved to real fixtures rather than staying a group name.
+    let resolved: Vec<&str> = effects[0]["fixtures"]
+        .as_array()
+        .expect("fixtures")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert_eq!(
+        resolved,
+        vec!["Par1", "Par2"],
+        "group `all_lights` should resolve to the venue's fixtures: {at_1s}"
+    );
+
+    let fixtures = at_1s["fixtures"].as_array().expect("fixture states");
+    assert_eq!(fixtures.len(), 2, "both fixtures reported: {at_1s}");
+    assert_eq!(fixtures[0]["name"], "Par1");
+    assert_eq!(fixtures[0]["channels"]["blue"], 255);
+    assert_eq!(fixtures[0]["channels"]["red"], 0);
+
+    // 6.0s — the blue cue has expired and the red one has not fired.
+    assert_eq!(
+        evaluations[1]["dark"], true,
+        "the gap between cues should be dark: {}",
+        evaluations[1]
+    );
+    assert!(evaluations[1]["active_effects"]
+        .as_array()
+        .expect("effects")
+        .is_empty());
+
+    // 0:11.000 — inside the red cue, and proof mm:ss.mmm times parse.
+    let at_11s = &evaluations[2];
+    assert_eq!(at_11s["dark"], false);
+    assert_eq!(at_11s["position"], "0:11.000");
+    let fixtures = at_11s["fixtures"].as_array().expect("fixture states");
+    assert_eq!(fixtures[0]["channels"]["red"], 255);
+    assert_eq!(fixtures[0]["channels"]["blue"], 0);
+
+    // `include_fixtures: false` drops the per-fixture block but keeps effects.
+    let lean = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            901,
+            "evaluate_show",
+            json!({"source": source, "times": ["1.0"], "include_fixtures": false}),
+        )
+        .await,
+    );
+    let lean_entry = &lean["evaluations"][0];
+    assert!(lean_entry.get("fixtures").is_none(), "{lean_entry}");
+    assert_eq!(
+        lean_entry["active_effects"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0),
+        1
+    );
+
+    // Passing both `song` and `source` is a caller error, not a silent choice.
+    let both = call_tool(
+        &client,
+        &url,
+        &session,
+        902,
+        "evaluate_show",
+        json!({"song": "song", "source": source, "times": ["1.0"]}),
+    )
+    .await;
+    assert!(
+        both["error"].is_object() || tool_text(&both).contains("not both"),
+        "expected a rejection when both song and source are given: {both}"
+    );
+
+    // Playback was never started, and evaluating must not have started it.
+    assert!(
+        !player.is_playing().await,
+        "evaluate_show must not touch the transport"
+    );
+
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -402,7 +402,8 @@ impl McpServer {
 
     #[tool(
         description = "Return a human-readable summary of all lighting effects \
-        currently active on the player."
+        currently active on the player. For a structured answer — and for what \
+        each fixture is actually outputting — use `get_fixture_state`."
     )]
     async fn get_active_effects(&self) -> Result<CallToolResult, McpError> {
         let summary = self
@@ -410,6 +411,47 @@ impl McpServer {
             .format_active_effects()
             .unwrap_or_else(|| "(no effect engine configured)".to_string());
         Ok(CallToolResult::success(vec![Content::text(summary)]))
+    }
+
+    #[tool(
+        description = "Return what the rig is doing right now: per-fixture DMX \
+        channel values (0-255, including virtual-dimmer RGB scaling), which \
+        effects are driving each fixture, and the active effects with the \
+        fixtures each resolved to. This is the live twin of `evaluate_show` and \
+        returns the same shape, so predicted and actual state can be compared \
+        directly. Unlike `get_active_effects` it distinguishes fixtures rather \
+        than only counting them."
+    )]
+    async fn get_fixture_state(&self) -> Result<CallToolResult, McpError> {
+        let engine = match self.player.effect_engine() {
+            Some(engine) => engine,
+            None => {
+                return Ok(ok_json(json!({
+                    "available": false,
+                    "reason": "no effect engine configured",
+                })))
+            }
+        };
+
+        let elapsed = self
+            .player
+            .elapsed()
+            .await
+            .map_err(internal_err)?
+            .unwrap_or_default();
+
+        // The effect engine's mutex is shared with the effects loop thread, so
+        // never block a tokio worker on it.
+        let snapshot = tokio::task::spawn_blocking(move || {
+            let guard = engine.lock();
+            crate::lighting::evaluate::snapshot(&guard, elapsed)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("snapshot failed: {e}"), None))?;
+
+        let mut value = evaluation_json(&snapshot, true);
+        value["available"] = json!(true);
+        Ok(ok_json(value))
     }
 
     // ---- Playback control ----
@@ -1115,43 +1157,7 @@ impl McpServer {
 
         let results: Vec<Value> = evaluations
             .iter()
-            .map(|evaluation| {
-                let effects: Vec<Value> = evaluation
-                    .active_effects
-                    .iter()
-                    .map(|effect| {
-                        json!({
-                            "id": effect.id,
-                            "type": effect.effect_type,
-                            "layer": format!("{:?}", effect.layer).to_lowercase(),
-                            "elapsed": effect.elapsed.as_secs_f64(),
-                            "duration": effect.duration.as_secs_f64(),
-                            "fixtures": effect.fixtures,
-                        })
-                    })
-                    .collect();
-
-                let mut entry = json!({
-                    "time": evaluation.time.as_secs_f64(),
-                    "position": format_duration(evaluation.time),
-                    "dark": evaluation.is_dark(),
-                    "active_effects": effects,
-                });
-                if include_fixtures {
-                    let fixtures: Vec<Value> = evaluation
-                        .fixtures
-                        .iter()
-                        .map(|fixture| {
-                            json!({
-                                "name": fixture.name,
-                                "channels": fixture.channels,
-                            })
-                        })
-                        .collect();
-                    entry["fixtures"] = json!(fixtures);
-                }
-                entry
-            })
+            .map(|evaluation| evaluation_json(evaluation, include_fixtures))
             .collect();
 
         Ok(ok_json(json!({ "evaluations": results })))
@@ -1746,6 +1752,63 @@ impl ServerHandler for McpServer {
 }
 
 /// Returns a successful tool result wrapping a JSON value as pretty-printed text.
+/// Renders one evaluation — predicted or live — as JSON.
+///
+/// `evaluate_show` and `get_fixture_state` share this so the two surfaces
+/// cannot drift into different shapes for the same data.
+fn evaluation_json(
+    evaluation: &crate::lighting::evaluate::Evaluation,
+    include_fixtures: bool,
+) -> Value {
+    let effects: Vec<Value> = evaluation
+        .active_effects
+        .iter()
+        .map(|effect| {
+            json!({
+                "id": effect.id,
+                "type": effect.effect_type,
+                "layer": format!("{:?}", effect.layer).to_lowercase(),
+                "elapsed": effect.elapsed.as_secs_f64(),
+                "duration": effect.duration.as_secs_f64(),
+                "fixtures": effect.fixtures,
+            })
+        })
+        .collect();
+
+    let mut entry = json!({
+        "time": evaluation.time.as_secs_f64(),
+        "position": format_duration(evaluation.time),
+        "dark": evaluation.is_dark(),
+        "active_effects": effects,
+    });
+
+    if include_fixtures {
+        let fixtures: Vec<Value> = evaluation
+            .fixtures
+            .iter()
+            .map(|fixture| {
+                // Which effects are driving this fixture. Inverting the per-effect
+                // lists here is what makes "4 fixture(s)" answerable as "these
+                // four, driven by that effect".
+                let driven_by: Vec<&str> = evaluation
+                    .active_effects
+                    .iter()
+                    .filter(|effect| effect.fixtures.iter().any(|f| f == &fixture.name))
+                    .map(|effect| effect.id.as_str())
+                    .collect();
+                json!({
+                    "name": fixture.name,
+                    "channels": fixture.channels,
+                    "driven_by": driven_by,
+                })
+            })
+            .collect();
+        entry["fixtures"] = json!(fixtures);
+    }
+
+    entry
+}
+
 /// Orders shows by name so evaluation is reproducible.
 ///
 /// Shows arrive from a `HashMap`, so without this both the cue order for

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -218,6 +218,26 @@ pub struct ValidateLightingArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct EvaluateShowArgs {
+    /// Song name as listed by `list_songs`. Evaluates the song's registered
+    /// lighting shows. Mutually exclusive with `source`.
+    pub song: Option<String>,
+    /// `.light` DSL source to evaluate directly, without registering it against
+    /// a song. Mutually exclusive with `song`.
+    pub source: Option<String>,
+    /// Times to evaluate, each `mm:ss.mmm`, `Ns`, or a bare number of seconds.
+    pub times: Vec<String>,
+    /// Include per-fixture channel values. Set false for a cheaper reply when
+    /// only the active-effect list is wanted. Defaults to true.
+    #[serde(default = "default_true")]
+    pub include_fixtures: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SongLightingArgs {
     /// Song name as listed by `list_songs`.
     pub song: String,
@@ -968,6 +988,175 @@ impl McpServer {
         }
     }
 
+    /// Resolves `evaluate_show`'s `song`/`source` choice into the shows to
+    /// evaluate plus the song's tempo map, if any.
+    fn resolve_shows_to_evaluate(
+        &self,
+        args: &EvaluateShowArgs,
+    ) -> Result<
+        (
+            Vec<crate::lighting::parser::LightShow>,
+            Option<crate::lighting::tempo::TempoMap>,
+        ),
+        McpError,
+    > {
+        match (&args.song, &args.source) {
+            (Some(_), Some(_)) => Err(McpError::invalid_params(
+                "pass either `song` or `source`, not both",
+                None,
+            )),
+            (None, None) => Err(McpError::invalid_params(
+                "pass either `song` (a loaded song's registered shows) or \
+                 `source` (raw `.light` DSL)",
+                None,
+            )),
+            (Some(name), None) => {
+                let song = self
+                    .player
+                    .songs()
+                    .get(name)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                let mut shows: Vec<_> = song
+                    .dsl_lighting_shows()
+                    .iter()
+                    .flat_map(|dsl| dsl.shows().values().cloned())
+                    .collect();
+                sort_shows(&mut shows);
+                if shows.is_empty() {
+                    return Err(McpError::invalid_params(
+                        format!(
+                            "song `{name}` has no DSL light shows loaded — check its \
+                             `lighting:` block actually references a `.light` file"
+                        ),
+                        None,
+                    ));
+                }
+                Ok((shows, song.tempo_map().cloned()))
+            }
+            (None, Some(source)) => {
+                let shows = crate::lighting::parser::parse_light_shows(source)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                let mut shows: Vec<_> = shows.into_values().collect();
+                sort_shows(&mut shows);
+                Ok((shows, None))
+            }
+        }
+    }
+
+    #[tool(description = "Evaluate a light show offline and report what the \
+        fixtures would be doing at each requested time. No audio, no DMX output, \
+        and no real-time waiting — this is a pure function of the show, the \
+        current venue, and the tempo map, so it neither needs nor disturbs \
+        playback. Pass either `song` (evaluates that song's registered shows) or \
+        `source` (evaluates DSL directly). Returns per-fixture DMX channel values \
+        (0-255, including virtual-dimmer RGB scaling) plus the effects running at \
+        each instant, with the fixtures each one resolved to.")]
+    async fn evaluate_show(
+        &self,
+        Parameters(args): Parameters<EvaluateShowArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (shows, fallback_tempo) = self.resolve_shows_to_evaluate(&args)?;
+
+        let times = args
+            .times
+            .iter()
+            .map(|t| parse_duration(t))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let lighting_system = self
+            .player
+            .dmx_engine()
+            .and_then(|dmx| dmx.broadcast_handles().lighting_system);
+
+        let include_fixtures = args.include_fixtures;
+        // The lighting system and effect engine are `parking_lot` mutexes shared
+        // with the effects loop thread, and evaluation is pure CPU besides — both
+        // belong off the async worker.
+        let evaluations = tokio::task::spawn_blocking(move || {
+            // Resolve every group the show mentions once, up front, so the lock
+            // is held for a short bounded step rather than across evaluation.
+            let (fixtures, group_map) = match &lighting_system {
+                Some(system) => {
+                    let mut guard = system.lock();
+                    let fixtures = guard.get_current_venue_fixtures().unwrap_or_default();
+                    let mut group_map: HashMap<String, Vec<String>> = HashMap::new();
+                    for name in group_names(&shows) {
+                        let resolved = guard.resolve_logical_group_graceful(&name);
+                        group_map.insert(name, resolved);
+                    }
+                    (fixtures, group_map)
+                }
+                None => (Vec::new(), HashMap::new()),
+            };
+
+            crate::lighting::evaluate::evaluate_show(
+                shows,
+                &fixtures,
+                fallback_tempo.as_ref(),
+                &times,
+                |mut effect| {
+                    effect.target_fixtures = effect
+                        .target_fixtures
+                        .iter()
+                        .flat_map(|target| match group_map.get(target) {
+                            Some(resolved) => resolved.clone(),
+                            // Not a known group — already a fixture name, or a
+                            // name that resolves to nothing. Either way, leave it
+                            // for the engine to accept or reject.
+                            None => vec![target.clone()],
+                        })
+                        .collect();
+                    effect
+                },
+            )
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("evaluation failed: {e}"), None))?;
+
+        let results: Vec<Value> = evaluations
+            .iter()
+            .map(|evaluation| {
+                let effects: Vec<Value> = evaluation
+                    .active_effects
+                    .iter()
+                    .map(|effect| {
+                        json!({
+                            "id": effect.id,
+                            "type": effect.effect_type,
+                            "layer": format!("{:?}", effect.layer).to_lowercase(),
+                            "elapsed": effect.elapsed.as_secs_f64(),
+                            "duration": effect.duration.as_secs_f64(),
+                            "fixtures": effect.fixtures,
+                        })
+                    })
+                    .collect();
+
+                let mut entry = json!({
+                    "time": evaluation.time.as_secs_f64(),
+                    "position": format_duration(evaluation.time),
+                    "dark": evaluation.is_dark(),
+                    "active_effects": effects,
+                });
+                if include_fixtures {
+                    let fixtures: Vec<Value> = evaluation
+                        .fixtures
+                        .iter()
+                        .map(|fixture| {
+                            json!({
+                                "name": fixture.name,
+                                "channels": fixture.channels,
+                            })
+                        })
+                        .collect();
+                    entry["fixtures"] = json!(fixtures);
+                }
+                entry
+            })
+            .collect();
+
+        Ok(ok_json(json!({ "evaluations": results })))
+    }
+
     #[tool(description = "List the venues known to the running DMX engine. Each \
         venue lists its groups and fixture count.")]
     async fn list_venues(&self) -> Result<CallToolResult, McpError> {
@@ -1557,6 +1746,28 @@ impl ServerHandler for McpServer {
 }
 
 /// Returns a successful tool result wrapping a JSON value as pretty-printed text.
+/// Orders shows by name so evaluation is reproducible.
+///
+/// Shows arrive from a `HashMap`, so without this both the cue order for
+/// identically-timed cues and — because `LightingTimeline` takes the first
+/// show's tempo map — which tempo block wins would vary between runs.
+fn sort_shows(shows: &mut [crate::lighting::parser::LightShow]) {
+    shows.sort_by(|a, b| a.name.cmp(&b.name));
+}
+
+/// Every distinct group name a set of shows targets, deduplicated.
+fn group_names(shows: &[crate::lighting::parser::LightShow]) -> Vec<String> {
+    let mut names: Vec<String> = shows
+        .iter()
+        .flat_map(|show| show.cues.iter())
+        .flat_map(|cue| cue.effects.iter())
+        .flat_map(|effect| effect.groups.iter().cloned())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
 pub(crate) fn ok_json(value: Value) -> CallToolResult {
     let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
     CallToolResult::success(vec![Content::text(text)])

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -16,6 +16,7 @@
 mod consistency_tests;
 pub mod effects;
 pub mod engine;
+pub mod evaluate;
 #[cfg(test)]
 mod layering_tests;
 pub mod parser;

--- a/src/lighting/effects/types.rs
+++ b/src/lighting/effects/types.rs
@@ -90,6 +90,20 @@ impl EffectType {
             | EffectType::Rainbow { duration, .. } => *duration,
         }
     }
+
+    /// The effect's name as reported to users — status output, MCP responses,
+    /// and offline evaluation all use this spelling.
+    pub fn name(&self) -> &'static str {
+        match self {
+            EffectType::Static { .. } => "Static",
+            EffectType::ColorCycle { .. } => "ColorCycle",
+            EffectType::Strobe { .. } => "Strobe",
+            EffectType::Dimmer { .. } => "Dimmer",
+            EffectType::Chase { .. } => "Chase",
+            EffectType::Rainbow { .. } => "Rainbow",
+            EffectType::Pulse { .. } => "Pulse",
+        }
+    }
 }
 
 /// Cycle direction for color cycling effects

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -943,15 +943,7 @@ impl EffectEngine {
                     Duration::ZERO
                 };
 
-                let effect_type_str = match &effect.effect_type {
-                    EffectType::Static { .. } => "Static",
-                    EffectType::ColorCycle { .. } => "ColorCycle",
-                    EffectType::Strobe { .. } => "Strobe",
-                    EffectType::Dimmer { .. } => "Dimmer",
-                    EffectType::Chase { .. } => "Chase",
-                    EffectType::Rainbow { .. } => "Rainbow",
-                    EffectType::Pulse { .. } => "Pulse",
-                };
+                let effect_type_str = effect.effect_type.name();
 
                 let total = effect.total_duration();
                 let duration_str = format!(" (duration: {:.2}s)", total.as_secs_f64());

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -901,6 +901,15 @@ impl EffectEngine {
         self.fixtures.as_map()
     }
 
+    /// How long an effect has been running, by the engine's own clock.
+    /// Zero for an effect that has not started.
+    pub fn effect_elapsed(&self, effect: &EffectInstance) -> Duration {
+        effect
+            .start_time
+            .map(|start| self.current_time.duration_since(start))
+            .unwrap_or(Duration::ZERO)
+    }
+
     /// Get a formatted string listing all active effects
     pub fn format_active_effects(&self) -> String {
         use std::fmt::Write;
@@ -937,12 +946,7 @@ impl EffectEngine {
             };
             writeln!(output, "  {}:", layer_name).unwrap();
             for effect in effects {
-                let elapsed = if let Some(start_time) = effect.start_time {
-                    self.current_time.duration_since(start_time)
-                } else {
-                    Duration::ZERO
-                };
-
+                let elapsed = self.effect_elapsed(effect);
                 let effect_type_str = effect.effect_type.name();
 
                 let total = effect.total_duration();

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -27,7 +27,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::lighting::effects::{EffectInstance, EffectLayer, FixtureInfo};
+use crate::lighting::effects::{is_multiplier_channel, EffectInstance, EffectLayer, FixtureInfo};
 use crate::lighting::parser::LightShow;
 use crate::lighting::tempo::TempoMap;
 use crate::lighting::timeline::LightingTimeline;
@@ -53,7 +53,9 @@ pub struct EvaluatedEffect {
 #[derive(Clone, Debug)]
 pub struct Evaluation {
     pub time: Duration,
-    /// Per-fixture DMX channel values (0–255), sorted by fixture name.
+    /// Per-fixture DMX channel values (0–255), sorted by fixture name. Every
+    /// known fixture appears, including ones no effect is touching, so a dark
+    /// fixture is reported as zeros rather than by being absent.
     pub fixtures: Vec<FixtureSnapshot>,
     /// Effects running at this instant, sorted by id.
     pub active_effects: Vec<EvaluatedEffect>,
@@ -61,9 +63,6 @@ pub struct Evaluation {
 
 impl Evaluation {
     /// True when every channel of every fixture is at zero — the rig is dark.
-    ///
-    /// A fixture absent from the snapshot is dark too: the engine only emits
-    /// state for fixtures some effect is driving.
     pub fn is_dark(&self) -> bool {
         self.fixtures
             .iter()
@@ -109,6 +108,8 @@ where
         .map(|f| (f.name.clone(), f.channels.contains_key("dimmer")))
         .collect();
 
+    // Held under a second name because `fixtures` is shadowed inside the closure.
+    let venue_fixtures = fixtures;
     times
         .iter()
         .map(|&time| {
@@ -130,7 +131,8 @@ where
             // clock exactly where the elapsed offsets were computed against.
             let _ = engine.update(Duration::ZERO, Some(time));
 
-            let fixtures = compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer);
+            let mut fixtures = compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer);
+            fill_dark_fixtures(&mut fixtures, venue_fixtures.iter());
             let mut active_effects: Vec<EvaluatedEffect> = engine
                 .get_active_effects()
                 .values()
@@ -159,6 +161,34 @@ where
             }
         })
         .collect()
+}
+
+/// Adds every known fixture that no effect is driving, with all its channels at
+/// zero.
+///
+/// The engine only holds state for fixtures something is currently touching, so
+/// without this a dark fixture is simply missing — indistinguishable from one
+/// that is not in the venue at all. "Par2 is dark" and "Par2 does not exist"
+/// are very different answers when you are checking a show's coverage.
+fn fill_dark_fixtures<'a>(
+    snapshots: &mut Vec<FixtureSnapshot>,
+    known: impl Iterator<Item = &'a FixtureInfo>,
+) {
+    for info in known {
+        if snapshots.iter().any(|s| s.name == info.name) {
+            continue;
+        }
+        snapshots.push(FixtureSnapshot {
+            name: info.name.clone(),
+            channels: info
+                .channels
+                .keys()
+                .filter(|name| !is_multiplier_channel(name))
+                .map(|name| (name.clone(), 0u8))
+                .collect(),
+        });
+    }
+    snapshots.sort_by(|a, b| a.name.cmp(&b.name));
 }
 
 /// Snapshots a running engine into the same shape [`evaluate_show`] produces.
@@ -195,9 +225,12 @@ pub fn snapshot(engine: &EffectEngine, at: Duration) -> Evaluation {
         .collect();
     active_effects.sort_by(|a, b| a.id.cmp(&b.id));
 
+    let mut fixtures = compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer);
+    fill_dark_fixtures(&mut fixtures, engine.get_fixture_registry().values());
+
     Evaluation {
         time: at,
-        fixtures: compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer),
+        fixtures,
         active_effects,
     }
 }
@@ -522,10 +555,9 @@ show "T" {
             let _ = engine.update(step, Some(now));
 
             if times.contains(&now) {
-                sampled.push((
-                    now,
-                    compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer),
-                ));
+                let mut snap = compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer);
+                fill_dark_fixtures(&mut snap, fixtures.iter());
+                sampled.push((now, snap));
             }
             if now >= last {
                 break;
@@ -594,6 +626,42 @@ show "T" {
                 );
             }
         }
+    }
+
+    #[test]
+    fn untouched_fixtures_are_reported_dark_not_omitted() {
+        // "Par2 is dark" and "Par2 is not in this venue" are different answers.
+        // The engine only holds state for fixtures an effect is driving, so
+        // without zero-filling the second fixture would simply be missing.
+        let fixtures = vec![rgb_fixture("lit", 1), rgb_fixture("unlit", 4)];
+        let source = r#"
+show "T" {
+    @00:00.000
+    lit: static color: "blue", duration: 5s
+}
+"#;
+        let results = eval(source, &fixtures, &[1.0]);
+
+        let names: Vec<&str> = results[0]
+            .fixtures
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(names, ["lit", "unlit"], "both fixtures should be reported");
+        assert_eq!(channel(&results[0], "lit", "blue"), 255);
+        assert_eq!(channel(&results[0], "unlit", "blue"), 0);
+
+        let unlit = results[0]
+            .fixtures
+            .iter()
+            .find(|f| f.name == "unlit")
+            .expect("unlit reported");
+        assert!(
+            !unlit.channels.is_empty(),
+            "a dark fixture still names its channels"
+        );
+        assert!(unlit.channels.values().all(|&v| v == 0));
+        assert!(!results[0].is_dark(), "one fixture is lit");
     }
 
     #[test]

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -161,6 +161,47 @@ where
         .collect()
 }
 
+/// Snapshots a running engine into the same shape [`evaluate_show`] produces.
+///
+/// This is the live twin of offline evaluation: predicted and actual state come
+/// out in one format, so they can be compared directly rather than by eye.
+///
+/// `at` is the time to label the snapshot with — normally the song's elapsed
+/// time. It does not drive the reading; effect elapsed values come from the
+/// engine's own clock, which is what makes this a measurement rather than a
+/// prediction.
+pub fn snapshot(engine: &EffectEngine, at: Duration) -> Evaluation {
+    let has_dimmer: HashMap<String, bool> = engine
+        .get_fixture_registry()
+        .iter()
+        .map(|(name, info)| (name.clone(), info.channels.contains_key("dimmer")))
+        .collect();
+
+    let mut active_effects: Vec<EvaluatedEffect> = engine
+        .get_active_effects()
+        .values()
+        .map(|effect| {
+            let mut fixtures = effect.target_fixtures.clone();
+            fixtures.sort();
+            EvaluatedEffect {
+                id: effect.id.clone(),
+                effect_type: effect.effect_type.name(),
+                layer: effect.layer,
+                elapsed: engine.effect_elapsed(effect),
+                duration: effect.total_duration(),
+                fixtures,
+            }
+        })
+        .collect();
+    active_effects.sort_by(|a, b| a.id.cmp(&b.id));
+
+    Evaluation {
+        time: at,
+        fixtures: compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer),
+        active_effects,
+    }
+}
+
 /// Applies one timeline update to the engine in the same order the live path
 /// uses: layer commands, then stopped sequences, then seek-started effects in
 /// cue order, then freshly-fired effects with sequence effects first.

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -1,0 +1,563 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Offline evaluation of a light show.
+//!
+//! Answers "what would the fixtures be doing at time T" without audio, DMX
+//! output, or wall-clock waiting. Verifying a show otherwise means playing the
+//! song in real time through the PA and the rig, once per check.
+//!
+//! Each requested time is evaluated independently against a fresh engine, by
+//! the same reconstruction the seek path uses: replay the cue history up to T,
+//! start each surviving effect at its elapsed offset, then render one frame.
+//! Nothing accumulates between samples, so evaluating `[10.0, 200.0]` costs the
+//! same as `[200.0, 10.0]` and neither perturbs the other.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::lighting::effects::{EffectInstance, EffectLayer, FixtureInfo};
+use crate::lighting::parser::LightShow;
+use crate::lighting::tempo::TempoMap;
+use crate::lighting::timeline::LightingTimeline;
+use crate::lighting::EffectEngine;
+use crate::state::{compute_fixture_snapshots, FixtureSnapshot};
+
+/// An effect running at the evaluated instant.
+#[derive(Clone, Debug)]
+pub struct EvaluatedEffect {
+    pub id: String,
+    /// Effect kind, e.g. `Static` or `Strobe`.
+    pub effect_type: &'static str,
+    pub layer: EffectLayer,
+    /// How far into the effect this instant is.
+    pub elapsed: Duration,
+    /// The effect's total authored duration (up + hold + down).
+    pub duration: Duration,
+    /// Fixtures the effect resolved to, sorted.
+    pub fixtures: Vec<String>,
+}
+
+/// Rendered show state at one instant.
+#[derive(Clone, Debug)]
+pub struct Evaluation {
+    pub time: Duration,
+    /// Per-fixture DMX channel values (0–255), sorted by fixture name.
+    pub fixtures: Vec<FixtureSnapshot>,
+    /// Effects running at this instant, sorted by id.
+    pub active_effects: Vec<EvaluatedEffect>,
+}
+
+impl Evaluation {
+    /// True when every channel of every fixture is at zero — the rig is dark.
+    ///
+    /// A fixture absent from the snapshot is dark too: the engine only emits
+    /// state for fixtures some effect is driving.
+    pub fn is_dark(&self) -> bool {
+        self.fixtures
+            .iter()
+            .all(|f| f.channels.values().all(|&v| v == 0))
+    }
+}
+
+/// Evaluates `shows` at each requested time.
+///
+/// `resolve_groups` maps an effect's group targets onto concrete fixture names
+/// — the same step the live path performs via the lighting system. Passing a
+/// pass-through closure evaluates against literal fixture names.
+///
+/// `fallback_tempo_map` is used only when no show carries its own `tempo` block,
+/// mirroring the live precedence in `dmx::engine::playback` (show tempo > song
+/// tempo). Note that today it can never fire: the parser rejects every musical
+/// construct — `@bar/beat` cues, `Nbeats` durations, `Nbeat` frequencies — when
+/// the `.light` file has no `tempo` block of its own, so a show that would need
+/// the fallback fails before it can be evaluated (see #337). The parameter is
+/// here so this evaluator keeps matching the live path when that changes.
+///
+/// Returned evaluations are in the order requested, including duplicates.
+pub fn evaluate_show<F>(
+    shows: Vec<LightShow>,
+    fixtures: &[FixtureInfo],
+    fallback_tempo_map: Option<&TempoMap>,
+    times: &[Duration],
+    mut resolve_groups: F,
+) -> Vec<Evaluation>
+where
+    F: FnMut(EffectInstance) -> EffectInstance,
+{
+    let mut timeline = LightingTimeline::new(shows);
+    let tempo_map = timeline
+        .tempo_map()
+        .cloned()
+        .or_else(|| fallback_tempo_map.cloned());
+
+    // Which fixtures own a dedicated dimmer channel decides whether their RGB
+    // values get scaled by the virtual dimmer. Same input the live sampler uses.
+    let has_dimmer: HashMap<String, bool> = fixtures
+        .iter()
+        .map(|f| (f.name.clone(), f.channels.contains_key("dimmer")))
+        .collect();
+
+    times
+        .iter()
+        .map(|&time| {
+            let mut engine = EffectEngine::new();
+            engine.set_tempo_map(tempo_map.clone());
+            for fixture in fixtures {
+                engine.register_fixture(fixture.clone());
+            }
+
+            // Replay everything before `time`, then fire the cues landing exactly
+            // on it. `start_at` stops short of `time` by design, so both halves
+            // are needed for a cue at the requested instant to count.
+            let history = timeline.start_at(time);
+            apply(&mut engine, history, &mut resolve_groups);
+            let now = timeline.update(time);
+            apply(&mut engine, now, &mut resolve_groups);
+
+            // Render a single frame at `time`. A zero delta keeps the engine's
+            // clock exactly where the elapsed offsets were computed against.
+            let _ = engine.update(Duration::ZERO, Some(time));
+
+            let fixtures = compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer);
+            let mut active_effects: Vec<EvaluatedEffect> = engine
+                .get_active_effects()
+                .values()
+                .map(|effect| {
+                    let mut fixtures = effect.target_fixtures.clone();
+                    fixtures.sort();
+                    EvaluatedEffect {
+                        id: effect.id.clone(),
+                        effect_type: effect.effect_type.name(),
+                        layer: effect.layer,
+                        elapsed: effect
+                            .cue_time
+                            .map(|cue| time.saturating_sub(cue))
+                            .unwrap_or(Duration::ZERO),
+                        duration: effect.total_duration(),
+                        fixtures,
+                    }
+                })
+                .collect();
+            active_effects.sort_by(|a, b| a.id.cmp(&b.id));
+
+            Evaluation {
+                time,
+                fixtures,
+                active_effects,
+            }
+        })
+        .collect()
+}
+
+/// Applies one timeline update to the engine in the same order the live path
+/// uses: layer commands, then stopped sequences, then seek-started effects in
+/// cue order, then freshly-fired effects with sequence effects first.
+fn apply<F>(
+    engine: &mut EffectEngine,
+    update: crate::lighting::timeline::TimelineUpdate,
+    resolve_groups: &mut F,
+) where
+    F: FnMut(EffectInstance) -> EffectInstance,
+{
+    for cmd in &update.layer_commands {
+        engine.apply_layer_command(cmd);
+    }
+
+    for sequence_name in &update.stop_sequences {
+        engine.stop_sequence(sequence_name);
+    }
+
+    let mut with_elapsed: Vec<_> = update.effects_with_elapsed.into_values().collect();
+    with_elapsed.sort_by_key(|(effect, _)| effect.cue_time.unwrap_or(Duration::ZERO));
+    for (effect, elapsed) in with_elapsed {
+        let resolved = resolve_groups(effect);
+        // A cue targeting a group with no fixtures in this venue fails validation.
+        // That is a fact about the show worth surfacing elsewhere (#340), not a
+        // reason to abandon the sample.
+        let _ = engine.start_effect_with_elapsed(resolved, elapsed);
+    }
+
+    let mut effects = update.effects;
+    effects.sort_by_key(|e| if e.id.starts_with("seq_") { 0 } else { 1 });
+    for effect in effects {
+        let resolved = resolve_groups(effect);
+        let _ = engine.start_effect(resolved);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lighting::parser::parse_light_shows;
+
+    fn rgb_fixture(name: &str, address: u16) -> FixtureInfo {
+        let mut channels = HashMap::new();
+        channels.insert("red".to_string(), 1);
+        channels.insert("green".to_string(), 2);
+        channels.insert("blue".to_string(), 3);
+        FixtureInfo::new(
+            name.to_string(),
+            1,
+            address,
+            "RGB".to_string(),
+            channels,
+            None,
+        )
+    }
+
+    /// Parses a source into shows, ordered so evaluation is deterministic.
+    fn shows(source: &str) -> Vec<LightShow> {
+        let mut parsed: Vec<_> = parse_light_shows(source)
+            .expect("test show should parse")
+            .into_values()
+            .collect();
+        parsed.sort_by(|a, b| a.name.cmp(&b.name));
+        parsed
+    }
+
+    fn eval(source: &str, fixtures: &[FixtureInfo], times: &[f64]) -> Vec<Evaluation> {
+        let times: Vec<Duration> = times.iter().map(|&t| Duration::from_secs_f64(t)).collect();
+        evaluate_show(shows(source), fixtures, None, &times, |e| e)
+    }
+
+    fn channel(evaluation: &Evaluation, fixture: &str, channel: &str) -> u8 {
+        evaluation
+            .fixtures
+            .iter()
+            .find(|f| f.name == fixture)
+            .and_then(|f| f.channels.get(channel).copied())
+            .unwrap_or(0)
+    }
+
+    const BLUE_5S: &str = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 5s
+}
+"#;
+
+    #[test]
+    fn effect_is_live_inside_its_duration_and_gone_after() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let results = eval(BLUE_5S, &fixtures, &[1.0, 4.9, 5.1, 30.0]);
+
+        assert_eq!(channel(&results[0], "wash", "blue"), 255);
+        assert_eq!(channel(&results[1], "wash", "blue"), 255);
+        assert!(results[2].is_dark(), "past its duration the effect is gone");
+        assert!(results[3].is_dark());
+
+        assert_eq!(results[0].active_effects.len(), 1);
+        assert_eq!(results[0].active_effects[0].effect_type, "Static");
+        assert_eq!(
+            results[0].active_effects[0].duration,
+            Duration::from_secs(5)
+        );
+        assert!(results[2].active_effects.is_empty());
+    }
+
+    #[test]
+    fn elapsed_is_measured_from_the_cue() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let results = eval(BLUE_5S, &fixtures, &[0.0, 2.0, 4.0]);
+        assert_eq!(results[0].active_effects[0].elapsed, Duration::ZERO);
+        assert_eq!(results[1].active_effects[0].elapsed, Duration::from_secs(2));
+        assert_eq!(results[2].active_effects[0].elapsed, Duration::from_secs(4));
+    }
+
+    #[test]
+    fn a_cue_landing_exactly_on_the_requested_time_counts() {
+        // `start_at` deliberately stops short of the requested instant, so a cue
+        // at exactly T only appears if the evaluator also pumps the timeline.
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let source = r#"
+show "T" {
+    @00:10.000
+    wash: static color: "red", duration: 5s
+}
+"#;
+        let results = eval(source, &fixtures, &[9.999, 10.0]);
+        assert!(results[0].is_dark(), "not yet fired just before the cue");
+        assert_eq!(channel(&results[1], "wash", "red"), 255);
+    }
+
+    #[test]
+    fn times_are_independent_of_request_order() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "red", duration: 4s
+
+    @00:10.000
+    wash: static color: "blue", duration: 4s
+}
+"#;
+        let ascending = eval(source, &fixtures, &[1.0, 11.0]);
+        let descending = eval(source, &fixtures, &[11.0, 1.0]);
+
+        assert_eq!(channel(&ascending[0], "wash", "red"), 255);
+        assert_eq!(channel(&ascending[1], "wash", "blue"), 255);
+        // Same instants, reversed request order, same answers.
+        assert_eq!(channel(&descending[1], "wash", "red"), 255);
+        assert_eq!(channel(&descending[0], "wash", "blue"), 255);
+    }
+
+    #[test]
+    fn repeated_times_evaluate_identically() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let results = eval(BLUE_5S, &fixtures, &[2.0, 2.0, 2.0]);
+        assert_eq!(results.len(), 3);
+        assert_eq!(channel(&results[0], "wash", "blue"), 255);
+        assert_eq!(channel(&results[1], "wash", "blue"), 255);
+        assert_eq!(channel(&results[2], "wash", "blue"), 255);
+    }
+
+    #[test]
+    fn a_clear_in_the_history_kills_the_effect() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 60s
+
+    @00:05.000
+    clear(layer: background)
+}
+"#;
+        let results = eval(source, &fixtures, &[4.0, 6.0]);
+        assert_eq!(channel(&results[0], "wash", "blue"), 255);
+        assert!(
+            results[1].is_dark(),
+            "the clear at 5s should have killed a 60s effect"
+        );
+    }
+
+    #[test]
+    fn group_resolution_closure_maps_targets_to_fixtures() {
+        // The show targets `all_wash`, which is not a fixture name. Without
+        // resolution the effect fails validation and nothing lights.
+        let fixtures = vec![rgb_fixture("brick1", 1), rgb_fixture("brick2", 4)];
+        let source = r#"
+show "T" {
+    @00:00.000
+    all_wash: static color: "green", duration: 5s
+}
+"#;
+        let times = [Duration::from_secs(1)];
+
+        let unresolved = evaluate_show(shows(source), &fixtures, None, &times, |e| e);
+        assert!(
+            unresolved[0].is_dark(),
+            "an unresolved group name matches no fixture"
+        );
+
+        let resolved = evaluate_show(shows(source), &fixtures, None, &times, |mut e| {
+            if e.target_fixtures == ["all_wash"] {
+                e.target_fixtures = vec!["brick1".to_string(), "brick2".to_string()];
+            }
+            e
+        });
+        assert_eq!(channel(&resolved[0], "brick1", "green"), 255);
+        assert_eq!(channel(&resolved[0], "brick2", "green"), 255);
+        assert_eq!(resolved[0].active_effects[0].fixtures, ["brick1", "brick2"]);
+    }
+
+    #[test]
+    fn musical_timing_requires_the_shows_own_tempo_block() {
+        // Pins today's behaviour, and explains why `fallback_tempo_map` cannot
+        // rescue a bar/beat show: the parser rejects musical timing outright
+        // when the `.light` file carries no `tempo` block, long before any
+        // fallback map is consulted. #337 is the issue that would change this.
+        let bar_beat_cue = r#"
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 5s
+}
+"#;
+        let beat_duration = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4beats
+}
+"#;
+        assert!(parse_light_shows(bar_beat_cue).is_err());
+        assert!(parse_light_shows(beat_duration).is_err());
+    }
+
+    #[test]
+    fn the_shows_own_tempo_wins_over_the_fallback() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let source = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 4beats
+}
+"#;
+        // Half the show's tempo. If the fallback were winning, bar 3 beat 1
+        // would land at 8.0s instead of 4.0s and 4 beats would last 4s not 2s.
+        let slow = TempoMap::new(
+            Duration::ZERO,
+            60.0,
+            crate::tempo::TimeSignature::new(4, 4),
+            vec![],
+        );
+        let times = [
+            Duration::from_secs_f64(4.5),
+            Duration::from_secs_f64(6.5),
+            Duration::from_secs_f64(8.5),
+        ];
+        let results = evaluate_show(shows(source), &fixtures, Some(&slow), &times, |e| e);
+
+        assert_eq!(channel(&results[0], "wash", "blue"), 255);
+        assert!(results[1].is_dark(), "4 beats at 120bpm ends by 6.0s");
+        assert!(results[2].is_dark(), "the 60bpm fallback was not used");
+    }
+
+    #[test]
+    fn no_fixtures_yields_no_state_but_still_reports_effects() {
+        let results = eval(BLUE_5S, &[], &[1.0]);
+        assert!(results[0].fixtures.is_empty());
+        assert!(results[0].is_dark());
+        // With nothing to validate against the effect never starts, so an empty
+        // venue reads as a dark rig rather than a crash.
+        assert!(results[0].active_effects.is_empty());
+    }
+
+    #[test]
+    fn an_empty_show_is_dark_everywhere() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        let results = eval("show \"T\" {\n}\n", &fixtures, &[0.0, 5.0, 100.0]);
+        assert!(results.iter().all(|r| r.is_dark()));
+        assert!(results.iter().all(|r| r.active_effects.is_empty()));
+    }
+
+    /// Drives the show forward from zero in small steps, the way a playback loop
+    /// does, sampling the fixture state at each requested time. This is the
+    /// thing `evaluate_show` claims to be a shortcut for.
+    fn play_through(
+        source: &str,
+        fixtures: &[FixtureInfo],
+        times: &[Duration],
+    ) -> Vec<Vec<FixtureSnapshot>> {
+        let step = Duration::from_millis(5);
+        let mut timeline = LightingTimeline::new(shows(source));
+        let tempo_map = timeline.tempo_map().cloned();
+        let mut engine = EffectEngine::new();
+        engine.set_tempo_map(tempo_map);
+        for fixture in fixtures {
+            engine.register_fixture(fixture.clone());
+        }
+        let has_dimmer: HashMap<String, bool> = fixtures
+            .iter()
+            .map(|f| (f.name.clone(), f.channels.contains_key("dimmer")))
+            .collect();
+
+        timeline.start();
+        let last = times.iter().copied().max().unwrap_or(Duration::ZERO);
+        let mut sampled = Vec::new();
+        let mut now = Duration::ZERO;
+
+        loop {
+            let update = timeline.update(now);
+            apply(&mut engine, update, &mut |e| e);
+            let _ = engine.update(step, Some(now));
+
+            if times.contains(&now) {
+                sampled.push((
+                    now,
+                    compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer),
+                ));
+            }
+            if now >= last {
+                break;
+            }
+            now += step;
+        }
+
+        times
+            .iter()
+            .map(|t| {
+                sampled
+                    .iter()
+                    .find(|(at, _)| at == t)
+                    .map(|(_, snap)| snap.clone())
+                    .unwrap_or_default()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn reconstruction_agrees_with_playing_the_show_through() {
+        // If these ever disagree, offline evaluation is lying about the rig.
+        let fixtures = vec![rgb_fixture("brick1", 1), rgb_fixture("brick2", 4)];
+        let source = r#"
+show "T" {
+    @00:00.000
+    brick1: static color: "red", duration: 8s
+    brick2: static color: "blue", duration: 3s
+
+    @00:03.000
+    brick2: static color: "green", duration: 2s
+
+    @00:06.000
+    clear(layer: background)
+
+    @00:07.000
+    brick1: static color: "white", duration: 4s
+    brick2: static color: "white", duration: 4s
+}
+"#;
+        let times: Vec<Duration> = [
+            0.0, 0.5, 2.5, 3.0, 3.5, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 10.0, 11.0, 12.0,
+        ]
+        .iter()
+        .map(|&t| Duration::from_secs_f64(t))
+        .collect();
+
+        let stepped = play_through(source, &fixtures, &times);
+        let reconstructed = evaluate_show(shows(source), &fixtures, None, &times, |e| e);
+
+        for (i, time) in times.iter().enumerate() {
+            let expected = &stepped[i];
+            let actual = &reconstructed[i].fixtures;
+            assert_eq!(
+                expected.len(),
+                actual.len(),
+                "fixture count differs at {:?}",
+                time
+            );
+            for (want, got) in expected.iter().zip(actual.iter()) {
+                assert_eq!(want.name, got.name, "fixture order differs at {:?}", time);
+                assert_eq!(
+                    want.channels, got.channels,
+                    "at {:?}, fixture `{}`: played-through {:?} but evaluated {:?}",
+                    time, want.name, want.channels, got.channels
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_times_requested_returns_no_evaluations() {
+        let fixtures = vec![rgb_fixture("wash", 1)];
+        assert!(eval(BLUE_5S, &fixtures, &[]).is_empty());
+    }
+}

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -138,8 +138,11 @@ quoted_rgb_color = @{ "\"" ~ "rgb(" ~ ASCII_DIGIT+ ~ "," ~ " "? ~ ASCII_DIGIT+ ~
 // Supports absolute time (ms, s) and musical time (beats, measures)
 time_parameter = @{ time_value ~ time_unit }
 
+// `cycle` accepts the first three, `chase` the last six. No effect accepts
+// both sets, and nothing accepts `random` — that value belongs to
+// chase_pattern_parameter and loop_parameter, not here.
 direction_parameter = {
-    "forward" | "backward" | "random" | "pingpong" |
+    "forward" | "backward" | "pingpong" |
     "left_to_right" | "right_to_left" |
     "top_to_bottom" | "bottom_to_top" |
     "clockwise" | "counter_clockwise"

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -179,7 +179,11 @@ time_unit = @{ "measures" | "measure" | "beats" | "beat" | "ms" | "s" }
 
 string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
-identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+// Atomic for the same reason bare_identifier is: without it pest inserts
+// implicit WHITESPACE inside the trailing repetition, so a venue's
+// `group "a" = P1` swallows the newline and the next line's `group` keyword
+// as further identifier characters.
+identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 
 // Tempo section rules
 tempo = { "tempo" ~ "{" ~ tempo_content ~ "}" }

--- a/src/lighting/layering_tests/integration_tests.rs
+++ b/src/lighting/layering_tests/integration_tests.rs
@@ -1802,36 +1802,44 @@ fn test_complex_multi_layer_multi_effect_scenarios() {
     assert!(engine.has_effect("high_priority_effect"));
     assert!(engine.has_effect("conflicting_strobe"));
 }
+/// Every shipped example show must parse.
+///
+/// This walks the directory rather than naming files. An earlier hardcoded list
+/// covered four of the six shows, and `measure_timing_demo.light` sat broken in
+/// the gap — it used `direction: forward` on a `chase`, which only `cycle`
+/// accepts. Adding an example is now enough to get it covered.
 #[test]
 fn test_example_files_parse() {
     use crate::lighting::parser::parse_light_shows;
     use std::fs;
 
-    let example_files = [
-        "examples/lighting/shows/crossfade_show.light",
-        "examples/lighting/shows/layering_show.light",
-        "examples/lighting/shows/comprehensive_show.light",
-        "examples/lighting/shows/layer_control_demo.light",
-    ];
+    let dir = "examples/lighting/shows";
+    let mut example_files: Vec<_> = fs::read_dir(dir)
+        .expect("Failed to read example show directory")
+        .map(|entry| entry.expect("Failed to read directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "light"))
+        .collect();
+    example_files.sort();
 
-    for file_path in example_files {
+    assert!(
+        !example_files.is_empty(),
+        "No .light files found in {} — the glob is wrong, not the examples",
+        dir
+    );
+
+    for file_path in &example_files {
+        let display = file_path.display();
         let content = fs::read_to_string(file_path).expect("Failed to read example file");
         let result = parse_light_shows(&content);
         assert!(
             result.is_ok(),
             "Failed to parse {}: {:?}",
-            file_path,
+            display,
             result.err()
         );
 
         let shows = result.unwrap();
-        assert!(!shows.is_empty(), "No shows found in {}", file_path);
-
-        println!(
-            "✅ {} parsed successfully with {} shows",
-            file_path,
-            shows.len()
-        );
+        assert!(!shows.is_empty(), "No shows found in {}", display);
     }
 }
 

--- a/src/lighting/parser/tests/fixture_venue_tests.rs
+++ b/src/lighting/parser/tests/fixture_venue_tests.rs
@@ -162,3 +162,73 @@ venue "built-in" {
     assert_eq!(block6.universe(), 1, "Block6 should be on universe 1");
     assert_eq!(block6.start_channel(), 21, "Block6 should be at address 21");
 }
+
+// ── Items following a `group` (#387) ───────────────────────────────────
+//
+// `identifier` used to be non-atomic, so pest inserted implicit whitespace
+// inside its trailing repetition and a group's member list ran past the end
+// of the line — swallowing the next `group` or `fixture` keyword. The effect
+// was that a venue could declare at most one group, and only as its final
+// item. The diagnostic blamed the *following* line, so it read as a malformed
+// name rather than an over-running member list.
+
+#[test]
+fn venue_accepts_multiple_groups() {
+    let content = r#"venue "v" {
+    fixture "P1" RGBW_Par @ 1:1
+    fixture "P2" RGBW_Par @ 1:7
+    group "all" = P1, P2
+    group "left" = P1
+    group "right" = P2
+}
+"#;
+    let venues = parse_venues(content).expect("a venue may declare more than one group");
+    let venue = venues.get("v").expect("venue `v` not found");
+
+    assert_eq!(venue.groups().len(), 3);
+    assert_eq!(
+        venue.groups().get("all").expect("all").fixtures(),
+        ["P1", "P2"]
+    );
+    assert_eq!(venue.groups().get("left").expect("left").fixtures(), ["P1"]);
+    assert_eq!(
+        venue.groups().get("right").expect("right").fixtures(),
+        ["P2"]
+    );
+}
+
+#[test]
+fn venue_accepts_a_fixture_after_a_group() {
+    // Not specific to groups following groups — anything after a group used to
+    // fail, because the member list ate the next keyword whatever it was.
+    let content = r#"venue "v" {
+    fixture "P1" RGBW_Par @ 1:1
+    group "left" = P1
+    fixture "P2" RGBW_Par @ 1:7
+}
+"#;
+    let venues = parse_venues(content).expect("a fixture may follow a group");
+    let venue = venues.get("v").expect("venue `v` not found");
+
+    assert_eq!(venue.fixtures().len(), 2);
+    assert_eq!(venue.groups().len(), 1);
+    // The group's member list must stop at P1 rather than absorbing `fixture`.
+    assert_eq!(venue.groups().get("left").expect("left").fixtures(), ["P1"]);
+}
+
+#[test]
+fn venue_group_members_do_not_run_past_the_line() {
+    // Two groups on one line: the space-separated case, so this pins the
+    // whitespace handling rather than just newline handling.
+    let content = r#"venue "v" {
+    fixture "P1" RGBW_Par @ 1:1
+    group "a" = P1 group "b" = P1
+}
+"#;
+    let venues = parse_venues(content).expect("groups may share a line");
+    let venue = venues.get("v").expect("venue `v` not found");
+
+    assert_eq!(venue.groups().len(), 2);
+    assert_eq!(venue.groups().get("a").expect("a").fixtures(), ["P1"]);
+    assert_eq!(venue.groups().get("b").expect("b").fixtures(), ["P1"]);
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -871,7 +871,6 @@ impl Player {
     }
 
     /// Returns the effect engine, if a DMX engine is configured.
-    #[cfg(test)]
     pub fn effect_engine(&self) -> Option<Arc<parking_lot::Mutex<crate::lighting::EffectEngine>>> {
         self.hardware
             .read()

--- a/src/state.rs
+++ b/src/state.rs
@@ -144,7 +144,7 @@ async fn sampler_loop_cancellable(
 }
 
 /// Converts fixture states into sorted `FixtureSnapshot` values with DMX 0-255 channel values.
-fn compute_fixture_snapshots(
+pub(crate) fn compute_fixture_snapshots(
     states: &HashMap<String, FixtureState>,
     has_dimmer_map: &HashMap<String, bool>,
 ) -> Vec<FixtureSnapshot> {

--- a/src/webui/svelte/src/components/lighting/EffectForm.svelte
+++ b/src/webui/svelte/src/components/lighting/EffectForm.svelte
@@ -21,6 +21,7 @@
     BLEND_MODES,
     CURVES,
     DIRECTIONS,
+    CYCLE_DIRECTIONS,
     CHASE_DIRECTIONS,
     CHASE_PATTERNS,
   } from "../../lib/lighting/types";
@@ -288,7 +289,8 @@
                 )}
             >
               <option value="">--</option>
-              {#each DIRECTIONS as d (d)}<option value={d}>{d}</option>{/each}
+              {#each CYCLE_DIRECTIONS as d (d)}<option value={d}>{d}</option
+                >{/each}
             </select>
           </label>
           <label class="param"

--- a/src/webui/svelte/src/lib/lighting/types.ts
+++ b/src/webui/svelte/src/lib/lighting/types.ts
@@ -82,10 +82,13 @@ export const CURVES = [
   "sine",
   "cosine",
 ];
+// `direction` is two disjoint sets, not one list: `cycle` takes the ordering
+// values below, `chase` takes the spatial ones. Offering the union lets the
+// editor write a show the parser rejects.
+export const CYCLE_DIRECTIONS = ["forward", "backward", "pingpong"];
 export const DIRECTIONS = [
   "forward",
   "backward",
-  "random",
   "pingpong",
   "left_to_right",
   "right_to_left",


### PR DESCRIPTION
Closes #330. Closes #331. Closes #387. Also fixes a shipped example that never parsed.

Verifying a light show meant playing the song in real time through the PA and the rig. Authoring a 125-cue show cost ~20 playback runs and ~25 minutes of real-time playback, and put every check through the live path — the same path #332 intermittently fails on.

## `evaluate_show` (#330)

Answers "what would the fixtures be doing at time T" as a pure function of the show, the venue, and the tempo map. No audio, no DMX, no wall clock, nothing that touches the transport.

Takes either `song` (that song's registered shows) or `source` (raw DSL) plus a list of times; returns per-fixture DMX values — including virtual-dimmer RGB scaling — alongside the effects running at each instant and the fixtures each resolved to.

Each time is evaluated independently against a fresh engine, using the reconstruction the seek path already performs: replay the cue history up to T, start each surviving effect at its elapsed offset, render one frame. Nothing accumulates between samples, so `[10.0, 200.0]` and `[200.0, 10.0]` give the same answers.

**The load-bearing test asserts reconstruction agrees with stepping the show through continuously.** If those ever diverge, offline evaluation is lying about the rig.

Group targets resolve through the lighting system exactly as the live path resolves them, resolved once up front so the lighting-system lock is held for a short bounded step, on the blocking pool because that lock and the effect engine's are shared with the effects loop thread.

## `get_fixture_state` (#331)

The live twin, through one shared serializer so the two cannot drift into different shapes. Reports per-fixture values, which effects are driving each fixture, and the fixtures each effect covers — the discrimination `"4 fixture(s)"` could not provide. An integration test asserts live and predicted agree on a running song.

Both tools report untouched fixtures as zeros rather than omitting them. The engine only holds state for fixtures an effect is driving, so a dark fixture was simply absent — indistinguishable from one not in the venue.

## Multi-group venues (#387)

A venue could declare at most one `group`, and only as its final item. Anything after a group line failed with `expected fixture or group`, blaming the *following* token so it read as a malformed name rather than an over-running member list.

`identifier` was not atomic, so pest inserted implicit `WHITESPACE` inside its trailing repetition: a member list ran past the end of the line and swallowed the next keyword. `bare_identifier` already had the `@` and a comment saying why; `identifier` now matches it.

## Also fixed: an example show that never parsed

`measure_timing_demo.light` used `direction: forward` on a `chase`, which only `cycle` accepts. `direction` is two disjoint sets, not one list, and three places advertised the union: the DSL reference documented one flat list *and used `chase ... direction: forward` in its own example*, the grammar accepted `random` (which neither parser takes), and the visual editor offered all ten values on a `cycle`. All three now match the parser. `test_example_files_parse` walked a hardcoded list of four of the seven shows — the broken one sat in the gap — and now reads the directory.

## Finding worth flagging

**The `song.tempo_map()` fallback at `dmx/engine/playback.rs:115` appears unreachable.** The parser rejects *every* musical construct — `@bar/beat` cues, `Nbeats` durations, `Nbeat` frequencies — when a `.light` file has no `tempo` block of its own. So a show needing the fallback fails at parse time, before any map is consulted; and a show with its own block satisfies `timeline.tempo_map()` first. This makes #337 a bigger change than filed: the fix is not a third fallback in the `set_tempo_map` chain, it is teaching the parser to accept a tempo map as input.

## Tests

- `cargo test` — 3206 passed, 0 failed
- `cargo clippy --all-targets`, `cargo fmt --check`, `npm run check` — clean
- all seven example `.light` shows re-parsed through the simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)