### PR TITLE
Retire venue-defined groups, superseded by tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Venue-defined groups**: a `venue "..." { … }` block no longer accepts
+  `group "name" = Fixture1, Fixture2`. Tag the fixtures instead and declare a
+  logical group under `dmx.lighting.groups` that selects on the tag — that is
+  what every shipped example, and the documented three-layer model, has done
+  since tags were introduced one release after venue groups landed. Tags
+  survive a venue change; venue groups did not.
+
+  A venue still using one now fails to load with a message naming the group and
+  the migration. Nothing else changes: logical groups, constraints, and tags are
+  untouched.
+
+  This was not a live feature in practice. No shipped venue has ever declared a
+  group, they were absent from the documentation, they were a last-resort
+  fallback behind logical groups during resolution, and the web UI's venue
+  editor could neither create them nor preserve them — saving a venue there
+  silently dropped any it had. A venue could not hold more than one until it was
+  fixed days before this removal, which is how long the feature had gone
+  unexercised.
+
 ### Added
 
 - **Test a device from the config editor, before saving the profile**: a Test button beside the

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -173,35 +173,27 @@ reset_measures      # back to the original baseline
 
 ## Groups
 
-A cue targets one or more **groups**. Groups come from two places:
+A cue targets one or more **groups**. Groups are declared in `mtrack.yaml`
+under `dmx.lighting.groups` and select fixtures by the tags those fixtures
+carry in the venue, so the same show works against a different rig. They are
+defined in YAML, not the `.light` DSL:
 
-1. **Logical groups** — declared in `mtrack.yaml` under `dmx.lighting.groups`.
-   These match by tag/role and survive venue changes. Defined in YAML, not the
-   `.light` DSL:
+```yaml
+lighting:
+  groups:
+    all_lights:
+      name: "all_lights"
+      constraints:
+        - MinCount: 1
+    front_wash:
+      constraints:
+        - AllOf: ["wash", "front"]
+        - MinCount: 1
+```
 
-   ```yaml
-   lighting:
-     groups:
-       all_lights:
-         name: "all_lights"
-         constraints:
-           - MinCount: 1
-       front_wash:
-         constraints:
-           - AllOf: ["wash", "front"]
-           - MinCount: 1
-   ```
-
-2. **Venue groups** — declared inside a `venue "..." { … }` block. These are
-   explicit member lists tied to that venue:
-
-   ```
-   venue "main_stage" {
-       fixture "Wash1" RGBW_Par @ 1:1 tags ["wash", "front"]
-       fixture "Wash2" RGBW_Par @ 1:7 tags ["wash", "front"]
-       group "front_wash" = Wash1, Wash2
-   }
-   ```
+Venues do not define groups of their own — tag the fixtures instead. A cue
+cannot target a bare tag or a bare fixture name; it targets a group name from
+the config.
 
 `all_lights` is **not** auto-generated — define it explicitly as a logical
 group with `MinCount: 1` if you want a catch-all. Use `list_groups` from MCP
@@ -222,9 +214,12 @@ fixture_type "RGBW_Par" {
 venue "main_stage" {
     fixture "Wash1" RGBW_Par @ 1:1 tags ["wash", "front"]
     fixture "Wash2" RGBW_Par @ 1:7 tags ["wash", "front"]
-    group "front_wash" = Wash1, Wash2
 }
 ```
+
+Tags are the whole vocabulary a venue offers. Anything a show wants to address
+— `front`, `left`, an odd/even split — is a tag on the fixtures, selected by a
+logical group in the config.
 
 ## Authoring tips
 

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -437,6 +437,10 @@ dmx:
         name: "all_lights"
         constraints:
           - MinCount: 1
+      left:
+        name: "left"
+        constraints:
+          - AllOf: ["left"]
     directories:
       fixture_types: "lighting/fixture_types"
       venues: "lighting/venues"
@@ -754,7 +758,8 @@ async fn mcp_config_store_round_trip() -> Result<(), Box<dyn Error>> {
             .to_string(),
         "venues dir resolved unexpectedly: {initial_venues}",
     );
-    let venue_dsl = "venue \"test_stage\" {\n  fixture \"Wash1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  group \"front_wash\" = Wash1\n}\n";
+    let venue_dsl =
+        "venue \"test_stage\" {\n  fixture \"Wash1\" RGBW_Par @ 1:1 tags [\"wash\"]\n}\n";
     let _ = call_tool(
         &client,
         &url,
@@ -1113,7 +1118,7 @@ async fn mcp_cues_and_effects_against_live_timeline() -> Result<(), Box<dyn Erro
     )?;
     std::fs::write(
         fixture.root.join("lighting/venues/main_stage.light"),
-        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n}\n",
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n}\n",
     )?;
 
     // The bundled `main_show.light` references groups (front_wash, back_wash,
@@ -1252,7 +1257,7 @@ async fn mcp_evaluate_show_runs_offline() -> Result<(), Box<dyn Error>> {
     )?;
     std::fs::write(
         fixture.root.join("lighting/venues/main_stage.light"),
-        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n}\n",
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n}\n",
     )?;
 
     let player = build_standalone_player(&fixture).await?;
@@ -1409,7 +1414,7 @@ async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Er
     // a fixture *count* cannot stand in for knowing which ones are lit.
     std::fs::write(
         fixture.root.join("lighting/venues/main_stage.light"),
-        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"all_lights\" = Par1, Par2\n  group \"left\" = Par1\n}\n",
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\", \"left\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n}\n",
     )?;
 
     // A long green bed, so the reading is stable however far playback has got.
@@ -2519,9 +2524,9 @@ async fn mcp_host_info_returns_runtime_identity() -> Result<(), Box<dyn Error>> 
 #[tokio::test(flavor = "multi_thread")]
 async fn mcp_list_groups_surfaces_logical_groups() -> Result<(), Box<dyn Error>> {
     let fixture = setup_standalone_fixture()?;
-    // The standalone fixture already declares a logical group named
-    // `all_lights` (see write_config). Build a minimal venue with one
-    // explicit group too, so we can assert both flavors come back.
+    // The standalone fixture declares two logical groups (see write_config):
+    // `all_lights`, which selects on count alone, and `left`, which selects on
+    // a tag. The venue supplies the tags they resolve against.
     std::fs::create_dir_all(fixture.root.join("lighting/venues"))?;
     std::fs::create_dir_all(fixture.root.join("lighting/fixture_types"))?;
     copy_dir_recursive(
@@ -2530,7 +2535,7 @@ async fn mcp_list_groups_surfaces_logical_groups() -> Result<(), Box<dyn Error>>
     )?;
     std::fs::write(
         fixture.root.join("lighting/venues/main_stage.light"),
-        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n  group \"my_venue_group\" = Par1, Par2\n}\n",
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\", \"left\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n}\n",
     )?;
 
     let player = build_standalone_player(&fixture).await?;
@@ -2558,15 +2563,9 @@ async fn mcp_list_groups_surfaces_logical_groups() -> Result<(), Box<dyn Error>>
         .filter_map(|g| g["name"].as_str().map(|n| (n, g)))
         .collect();
     assert!(
-        by_name.contains_key("my_venue_group"),
-        "venue group missing from list_groups: {resp}",
-    );
-    assert_eq!(by_name["my_venue_group"]["source"].as_str(), Some("venue"));
-    assert!(
         by_name.contains_key("all_lights"),
         "logical group missing from list_groups: {resp}",
     );
-    assert_eq!(by_name["all_lights"]["source"].as_str(), Some("logical"));
     assert!(
         by_name["all_lights"]["constraints"]
             .as_array()
@@ -2574,6 +2573,20 @@ async fn mcp_list_groups_surfaces_logical_groups() -> Result<(), Box<dyn Error>>
             .unwrap_or(false),
         "logical group missing constraints: {resp}",
     );
+
+    // A tag-selecting group resolves to only the fixtures carrying that tag —
+    // the discrimination venue groups used to provide, now done with tags.
+    assert!(
+        by_name.contains_key("left"),
+        "tag-based group missing from list_groups: {resp}",
+    );
+    let left: Vec<&str> = by_name["left"]["fixtures"]
+        .as_array()
+        .expect("fixtures")
+        .iter()
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert_eq!(left, vec!["Par1"], "`left` should select only Par1: {resp}");
 
     controller.shutdown();
     Ok(())

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1178,11 +1178,9 @@ impl McpServer {
         let venues: Vec<Value> = guard
             .venues_iter()
             .map(|(name, venue)| {
-                let groups: Vec<&String> = venue.groups().keys().collect();
                 json!({
                     "name": name,
                     "fixtures": venue.fixtures().len(),
-                    "groups": groups,
                 })
             })
             .collect();
@@ -1192,12 +1190,10 @@ impl McpServer {
         })))
     }
 
-    #[tool(description = "List every group name valid as a cue target. Returns \
-        both venue-defined groups (explicit member lists from `venue \"...\" { … }` \
-        blocks) and logical groups (tag/constraint-based, declared under \
-        `dmx.lighting.groups` in the player config), each tagged with its \
-        `source`. Logical groups include their constraints and, when a venue \
-        is loaded, the fixtures they currently resolve to.")]
+    #[tool(description = "List every group name valid as a cue target. Groups \
+        are tag/constraint-based and declared under `dmx.lighting.groups` in the \
+        player config; each is returned with its constraints and, when a venue \
+        is loaded, the fixtures it currently resolves to.")]
     async fn list_groups(&self) -> Result<CallToolResult, McpError> {
         let dmx = match self.player.dmx_engine() {
             Some(d) => d,
@@ -1208,28 +1204,13 @@ impl McpServer {
             None => return Ok(ok_json(json!({ "groups": [] }))),
         };
 
-        // First pass: snapshot venue groups + logical group definitions while
-        // holding the guard immutably. `resolve_logical_group_graceful` takes
-        // `&mut self`, so we drop and re-acquire for the resolution pass to
-        // avoid borrow-checker contortions.
+        // First pass: snapshot the group definitions while holding the guard
+        // immutably. `resolve_logical_group_graceful` takes `&mut self`, so we
+        // drop and re-acquire for the resolution pass to avoid borrow-checker
+        // contortions.
         let snapshot: GroupSnapshot = {
             let guard = system.lock();
             let venue = guard.current_venue().map(str::to_owned);
-            let venue_groups = guard
-                .get_current_venue()
-                .map(|v| {
-                    v.groups()
-                        .iter()
-                        .map(|(name, group)| {
-                            json!({
-                                "name": name,
-                                "source": "venue",
-                                "fixtures": group.fixtures(),
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
             let logical_defs = guard
                 .logical_groups_iter()
                 .map(|(name, group)| {
@@ -1243,7 +1224,6 @@ impl McpServer {
                 .collect();
             GroupSnapshot {
                 venue,
-                venue_groups,
                 logical_defs,
             }
         };
@@ -1251,14 +1231,13 @@ impl McpServer {
         // Second pass: resolve each logical group against the current venue
         // so callers see what fixtures the group would actually target right
         // now. Resolution mutates the cache, hence the mutable lock.
-        let mut groups = snapshot.venue_groups;
+        let mut groups = Vec::new();
         {
             let mut guard = system.lock();
             for (name, constraints) in snapshot.logical_defs {
                 let fixtures = guard.resolve_logical_group_graceful(&name);
                 groups.push(json!({
                     "name": name,
-                    "source": "logical",
                     "constraints": constraints,
                     "fixtures": fixtures,
                 }));
@@ -2491,7 +2470,6 @@ pub(crate) fn validate_lighting_filename(name: &str) -> Result<(), McpError> {
 /// for logical-group resolution.
 struct GroupSnapshot {
     venue: Option<String>,
-    venue_groups: Vec<Value>,
     logical_defs: Vec<(String, Vec<String>)>,
 }
 

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::error::Error;
 
-use super::super::types::{Fixture, FixtureType, Group, Venue};
+use super::super::types::{Fixture, FixtureType, Venue};
 use super::error::get_error_context;
 use super::grammar::{LightingParser, Rule};
 use pest::iterators::Pair;
@@ -229,7 +229,6 @@ fn extract_string(pair: Pair<Rule>) -> String {
 fn parse_venue_definition(pair: Pair<Rule>) -> Result<Venue, Box<dyn Error>> {
     let mut name = String::new();
     let mut fixtures = HashMap::new();
-    let mut groups = HashMap::new();
 
     for pair in pair.into_inner() {
         match pair.as_rule() {
@@ -237,7 +236,7 @@ fn parse_venue_definition(pair: Pair<Rule>) -> Result<Venue, Box<dyn Error>> {
                 name = extract_string(pair);
             }
             Rule::venue_content => {
-                parse_venue_content(pair, &mut fixtures, &mut groups)?;
+                parse_venue_content(pair, &mut fixtures)?;
             }
             _ => {}
         }
@@ -247,13 +246,12 @@ fn parse_venue_definition(pair: Pair<Rule>) -> Result<Venue, Box<dyn Error>> {
         return Err("Venue name is required".into());
     }
 
-    Ok(Venue::new(name, fixtures, groups))
+    Ok(Venue::new(name, fixtures))
 }
 
 fn parse_venue_content(
     pair: Pair<Rule>,
     fixtures: &mut HashMap<String, Fixture>,
-    groups: &mut HashMap<String, Group>,
 ) -> Result<(), Box<dyn Error>> {
     for content_pair in pair.into_inner() {
         match content_pair.as_rule() {
@@ -261,9 +259,24 @@ fn parse_venue_content(
                 let fixture = parse_fixture_definition(content_pair)?;
                 fixtures.insert(fixture.name().to_string(), fixture);
             }
+            // `group` still parses so this can say what to do about it. Venue
+            // groups were superseded by fixture tags one release after they
+            // landed; a bare pest failure here would only say "expected
+            // fixture", which is no help to someone holding a rig file.
             Rule::group => {
-                let group = parse_group_definition(content_pair)?;
-                groups.insert(group.name().to_string(), group);
+                let name = content_pair
+                    .into_inner()
+                    .find(|p| p.as_rule() == Rule::string)
+                    .map(extract_string)
+                    .unwrap_or_default();
+                return Err(format!(
+                    "venue group `{name}` is no longer supported. Tag the fixtures \
+                     instead — add a tag to each member, e.g. `tags [\"{name}\"]`, \
+                     and declare a logical group under `dmx.lighting.groups` in the \
+                     player config with `constraints: [AllOf: [\"{name}\"]]`. Tags \
+                     survive a venue change; venue groups did not."
+                )
+                .into());
             }
             _ => {}
         }
@@ -317,32 +330,6 @@ fn parse_tags(pair: Pair<Rule>) -> Vec<String> {
                 .filter(|p| p.as_rule() == Rule::string)
                 .map(|tag| extract_string(tag))
         })
-        .collect()
-}
-
-fn parse_group_definition(pair: Pair<Rule>) -> Result<Group, Box<dyn Error>> {
-    let mut name = String::new();
-    let mut fixtures = Vec::new();
-
-    for pair in pair.into_inner() {
-        match pair.as_rule() {
-            Rule::string => {
-                name = extract_string(pair);
-            }
-            Rule::identifier_list => {
-                fixtures = parse_identifier_list(pair);
-            }
-            _ => {}
-        }
-    }
-
-    Ok(Group::new(name, fixtures))
-}
-
-fn parse_identifier_list(pair: Pair<Rule>) -> Vec<String> {
-    pair.into_inner()
-        .filter(|p| p.as_rule() == Rule::identifier)
-        .map(|id| id.as_str().trim().to_string())
         .collect()
 }
 
@@ -474,7 +461,6 @@ fixture_type "TypeB" {
         let v = result.get("Empty Hall").unwrap();
         assert_eq!(v.name(), "Empty Hall");
         assert!(v.fixtures().is_empty());
-        assert!(v.groups().is_empty());
     }
 
     #[test]
@@ -516,21 +502,25 @@ fixture_type "TypeB" {
     }
 
     #[test]
-    fn venue_with_groups() {
+    fn venue_group_is_rejected_with_migration_advice() {
+        // Venue groups were superseded by fixture tags (#104, one release after
+        // they landed) and are gone. The error has to be actionable: this is a
+        // rig file someone may be reading at soundcheck.
         let content = r#"venue "Stage" {
     fixture "L1" Par @ 1:1
     fixture "L2" Par @ 1:5
-    fixture "L3" Par @ 1:9
-    group "front" = L1, L2, L3
+    group "front" = L1, L2
 }"#;
-        let result = parse_venues(content).unwrap();
-        let v = result.get("Stage").unwrap();
-        assert_eq!(v.fixtures().len(), 3);
-        assert_eq!(v.groups().len(), 1);
-
-        let front = v.groups().get("front").unwrap();
-        assert_eq!(front.name(), "front");
-        assert_eq!(front.fixtures(), &["L1", "L2", "L3"]);
+        let msg = match parse_venues(content) {
+            Ok(_) => panic!("venue groups should be rejected"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("front"), "should name the group: {msg}");
+        assert!(msg.contains("tags"), "should point at tags: {msg}");
+        assert!(
+            msg.contains("dmx.lighting.groups"),
+            "should point at logical groups: {msg}"
+        );
     }
 
     #[test]

--- a/src/lighting/parser/tests/fixture_venue_tests.rs
+++ b/src/lighting/parser/tests/fixture_venue_tests.rs
@@ -75,7 +75,6 @@ fn test_t_parse_venue() {
     let venue = result.get("Club Venue").unwrap();
     assert_eq!(venue.name(), "Club Venue");
     assert_eq!(venue.fixtures().len(), 0);
-    assert_eq!(venue.groups().len(), 0);
 }
 
 #[test]
@@ -163,72 +162,53 @@ venue "built-in" {
     assert_eq!(block6.start_channel(), 21, "Block6 should be at address 21");
 }
 
-// ── Items following a `group` (#387) ───────────────────────────────────
+// ── Venue groups are gone (superseded by tags) ─────────────────────────
 //
-// `identifier` used to be non-atomic, so pest inserted implicit whitespace
-// inside its trailing repetition and a group's member list ran past the end
-// of the line — swallowing the next `group` or `fixture` keyword. The effect
-// was that a venue could declare at most one group, and only as its final
-// item. The diagnostic blamed the *following* line, so it read as a malformed
-// name rather than an over-running member list.
+// Venue groups were removed in favour of fixture tags plus logical groups.
+// The grammar still matches the old syntax so the parser can say what to do
+// about it — a bare pest failure would only report "expected fixture".
 
 #[test]
-fn venue_accepts_multiple_groups() {
+fn multiple_venue_groups_are_rejected() {
+    // This shape used to fail for an unrelated reason: `identifier` was not
+    // atomic, so a member list ran past the end of its line and swallowed the
+    // next keyword (#387). It now fails deliberately, and says why.
     let content = r#"venue "v" {
     fixture "P1" RGBW_Par @ 1:1
     fixture "P2" RGBW_Par @ 1:7
     group "all" = P1, P2
     group "left" = P1
-    group "right" = P2
 }
 "#;
-    let venues = parse_venues(content).expect("a venue may declare more than one group");
-    let venue = venues.get("v").expect("venue `v` not found");
-
-    assert_eq!(venue.groups().len(), 3);
-    assert_eq!(
-        venue.groups().get("all").expect("all").fixtures(),
-        ["P1", "P2"]
-    );
-    assert_eq!(venue.groups().get("left").expect("left").fixtures(), ["P1"]);
-    assert_eq!(
-        venue.groups().get("right").expect("right").fixtures(),
-        ["P2"]
-    );
+    let msg = match parse_venues(content) {
+        Ok(_) => panic!("venue groups should be rejected"),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("no longer supported"), "{msg}");
+    assert!(msg.contains("tags"), "should point at the migration: {msg}");
 }
 
 #[test]
-fn venue_accepts_a_fixture_after_a_group() {
-    // Not specific to groups following groups — anything after a group used to
-    // fail, because the member list ate the next keyword whatever it was.
+fn a_venue_of_only_fixtures_still_parses() {
+    // The shape every real venue uses. This also covers the `identifier`
+    // atomicity fix from #387: without it a fixture's type name could run past
+    // the end of its line and swallow the next `fixture` keyword.
     let content = r#"venue "v" {
-    fixture "P1" RGBW_Par @ 1:1
-    group "left" = P1
-    fixture "P2" RGBW_Par @ 1:7
+    fixture "P1" RGBW_Par @ 1:1 tags ["wash", "left"]
+    fixture "P2" RGBW_Par @ 1:7 tags ["wash", "right"]
+    fixture "P3" RGBW_Par @ 1:13
 }
 "#;
-    let venues = parse_venues(content).expect("a fixture may follow a group");
+    let venues = parse_venues(content).expect("a fixtures-only venue parses");
     let venue = venues.get("v").expect("venue `v` not found");
 
-    assert_eq!(venue.fixtures().len(), 2);
-    assert_eq!(venue.groups().len(), 1);
-    // The group's member list must stop at P1 rather than absorbing `fixture`.
-    assert_eq!(venue.groups().get("left").expect("left").fixtures(), ["P1"]);
-}
-
-#[test]
-fn venue_group_members_do_not_run_past_the_line() {
-    // Two groups on one line: the space-separated case, so this pins the
-    // whitespace handling rather than just newline handling.
-    let content = r#"venue "v" {
-    fixture "P1" RGBW_Par @ 1:1
-    group "a" = P1 group "b" = P1
-}
-"#;
-    let venues = parse_venues(content).expect("groups may share a line");
-    let venue = venues.get("v").expect("venue `v` not found");
-
-    assert_eq!(venue.groups().len(), 2);
-    assert_eq!(venue.groups().get("a").expect("a").fixtures(), ["P1"]);
-    assert_eq!(venue.groups().get("b").expect("b").fixtures(), ["P1"]);
+    assert_eq!(venue.fixtures().len(), 3);
+    assert_eq!(
+        venue.fixtures().get("P1").expect("P1").tags(),
+        ["wash", "left"]
+    );
+    assert_eq!(
+        venue.fixtures().get("P3").expect("P3").fixture_type(),
+        "RGBW_Par"
+    );
 }

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use tracing::info;
 
 use super::parser::{parse_fixture_types, parse_venues};
-use super::types::{Fixture, FixtureType, Group, Venue};
+use super::types::{Fixture, FixtureType, Venue};
 use crate::config::lighting::{GroupConstraint, LogicalGroup};
 use crate::config::Lighting;
 
@@ -206,17 +206,6 @@ impl LightingSystem {
     }
 
     /// Gets a group by name from the current venue.
-    pub fn get_group(&self, group_name: &str) -> Result<&Group, Box<dyn Error>> {
-        if let Some(venue_name) = self.current_venue() {
-            if let Some(venue) = self.venues.get(venue_name) {
-                if let Some(group) = venue.groups().get(group_name) {
-                    return Ok(group);
-                }
-            }
-        }
-        Err(format!("Group '{}' not found in current venue", group_name).into())
-    }
-
     /// Resolves a logical group to concrete fixture names for the current venue.
     /// Returns an empty vector if the group cannot be resolved (graceful fallback).
     pub fn resolve_logical_group(
@@ -282,10 +271,6 @@ impl LightingSystem {
                     return self.resolve_logical_group_graceful(&fallback_group);
                 }
 
-                // Try venue group system as final fallback
-                if let Ok(venue_group) = self.get_group(group_name) {
-                    return venue_group.fixtures().to_vec();
-                }
                 Vec::new()
             }
         }
@@ -483,7 +468,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -539,7 +524,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -611,7 +596,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -659,7 +644,7 @@ mod tests {
             );
         }
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -718,7 +703,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -802,7 +787,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -868,7 +853,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -918,7 +903,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -965,7 +950,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -991,7 +976,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -1030,7 +1015,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -1068,7 +1053,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -1122,7 +1107,7 @@ mod tests {
             ),
         );
 
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
+        let venue = Venue::new("Test Venue".to_string(), fixtures);
         system.venues.insert("Test Venue".to_string(), venue);
         system.current_venue = Some("Test Venue".to_string());
 
@@ -1168,39 +1153,6 @@ mod tests {
     // ── get_group ────────────────────────────────────────────────────
 
     #[test]
-    fn test_get_group_not_found() {
-        let mut system = LightingSystem::new();
-
-        let fixtures = HashMap::new();
-        let venue = Venue::new("Test Venue".to_string(), fixtures, HashMap::new());
-        system.venues.insert("Test Venue".to_string(), venue);
-        system.current_venue = Some("Test Venue".to_string());
-
-        let result = system.get_group("nonexistent");
-        assert!(result.is_err(), "Should error for missing group");
-        match result {
-            Err(error) => {
-                assert!(
-                    error.to_string().contains("not found"),
-                    "Error should mention 'not found': {}",
-                    error
-                );
-            }
-            Ok(_) => panic!("Expected error for missing group"),
-        }
-    }
-
-    #[test]
-    fn test_get_group_no_venue() {
-        let system = LightingSystem::new();
-
-        let result = system.get_group("some_group");
-        assert!(result.is_err(), "Should error when no venue selected");
-    }
-
-    // ── get_current_venue_fixtures ────────────────────────────
-
-    #[test]
     fn test_get_current_venue_fixtures_no_venue() {
         let system = LightingSystem::new();
         let result = system.get_current_venue_fixtures();
@@ -1231,8 +1183,7 @@ mod tests {
                 vec!["front".to_string()],
             ),
         );
-        let venue =
-            super::super::types::Venue::new("TestVenue".to_string(), fixtures, HashMap::new());
+        let venue = super::super::types::Venue::new("TestVenue".to_string(), fixtures);
         system.venues.insert("TestVenue".to_string(), venue);
         system.current_venue = Some("TestVenue".to_string());
 
@@ -1259,8 +1210,7 @@ mod tests {
                 vec![],
             ),
         );
-        let venue =
-            super::super::types::Venue::new("TestVenue".to_string(), fixtures, HashMap::new());
+        let venue = super::super::types::Venue::new("TestVenue".to_string(), fixtures);
         system.venues.insert("TestVenue".to_string(), venue);
         system.current_venue = Some("TestVenue".to_string());
 
@@ -1270,45 +1220,5 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Fixture type 'UnknownType' not found"));
-    }
-
-    #[test]
-    fn test_graceful_with_venue_group_fallback() {
-        let mut system = LightingSystem::new();
-
-        let mut fixtures = HashMap::new();
-        fixtures.insert(
-            "Wash1".to_string(),
-            Fixture::new(
-                "Wash1".to_string(),
-                "RGBW_Par".to_string(),
-                1,
-                1,
-                vec!["wash".to_string()],
-            ),
-        );
-
-        // Create venue with a venue group definition
-        let mut groups = HashMap::new();
-        groups.insert(
-            "venue_wash".to_string(),
-            Group::new("venue_wash".to_string(), vec!["Wash1".to_string()]),
-        );
-
-        let venue = Venue::new("Test Venue".to_string(), fixtures, groups);
-        system.venues.insert("Test Venue".to_string(), venue);
-        system.current_venue = Some("Test Venue".to_string());
-
-        // Don't define venue_wash as a logical group - it should fall through to venue groups
-        let results = system.resolve_logical_group_graceful("venue_wash");
-        assert_eq!(
-            results.len(),
-            1,
-            "Venue group fallback should return 1 fixture"
-        );
-        assert!(
-            results.contains(&"Wash1".to_string()),
-            "Venue group fallback should contain Wash1"
-        );
     }
 }

--- a/src/lighting/types.rs
+++ b/src/lighting/types.rs
@@ -162,33 +162,6 @@ impl Fixture {
     }
 }
 
-/// A group definition.
-#[derive(Clone, Serialize)]
-pub struct Group {
-    /// The name of the group.
-    name: String,
-
-    /// The fixtures in the group.
-    fixtures: Vec<String>,
-}
-
-impl Group {
-    /// Creates a new group.
-    pub fn new(name: String, fixtures: Vec<String>) -> Group {
-        Group { name, fixtures }
-    }
-
-    /// Gets the name.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Gets the fixtures.
-    pub fn fixtures(&self) -> &[String] {
-        &self.fixtures
-    }
-}
-
 /// A venue definition.
 #[derive(Clone, Serialize)]
 pub struct Venue {
@@ -197,23 +170,12 @@ pub struct Venue {
 
     /// The fixtures in the venue.
     fixtures: HashMap<String, Fixture>,
-
-    /// The groups in the venue.
-    groups: HashMap<String, Group>,
 }
 
 impl Venue {
     /// Creates a new venue.
-    pub fn new(
-        name: String,
-        fixtures: HashMap<String, Fixture>,
-        groups: HashMap<String, Group>,
-    ) -> Venue {
-        Venue {
-            name,
-            fixtures,
-            groups,
-        }
+    pub fn new(name: String, fixtures: HashMap<String, Fixture>) -> Venue {
+        Venue { name, fixtures }
     }
 
     /// Gets the name.
@@ -224,11 +186,6 @@ impl Venue {
     /// Gets the fixtures.
     pub fn fixtures(&self) -> &HashMap<String, Fixture> {
         &self.fixtures
-    }
-
-    /// Gets the groups.
-    pub fn groups(&self) -> &HashMap<String, Group> {
-        &self.groups
     }
 }
 
@@ -248,16 +205,6 @@ impl fmt::Display for Venue {
                 write!(f, " tags [{}]", tags.join(", "))?;
             }
             writeln!(f)?;
-        }
-        let mut groups: Vec<_> = self.groups.values().collect();
-        groups.sort_by_key(|g| g.name());
-        for group in &groups {
-            writeln!(
-                f,
-                "  group \"{}\" = {}",
-                group.name,
-                group.fixtures.join(", ")
-            )?;
         }
         write!(f, "}}")
     }
@@ -318,25 +265,6 @@ mod tests {
         assert!(f.tags().is_empty());
     }
 
-    // ── Group ──────────────────────────────────────────────────────
-
-    #[test]
-    fn group_new() {
-        let g = Group::new(
-            "front_wash".to_string(),
-            vec!["par1".to_string(), "par2".to_string()],
-        );
-        assert_eq!(g.name(), "front_wash");
-        assert_eq!(g.fixtures().len(), 2);
-        assert_eq!(g.fixtures()[0], "par1");
-    }
-
-    #[test]
-    fn group_empty_fixtures() {
-        let g = Group::new("empty".to_string(), vec![]);
-        assert!(g.fixtures().is_empty());
-    }
-
     // ── Venue ──────────────────────────────────────────────────────
 
     #[test]
@@ -347,17 +275,9 @@ mod tests {
             Fixture::new("par1".to_string(), "RGB".to_string(), 1, 1, vec![]),
         );
 
-        let mut groups = HashMap::new();
-        groups.insert(
-            "all".to_string(),
-            Group::new("all".to_string(), vec!["par1".to_string()]),
-        );
-
-        let v = Venue::new("Club".to_string(), fixtures, groups);
+        let v = Venue::new("Club".to_string(), fixtures);
         assert_eq!(v.name(), "Club");
         assert_eq!(v.fixtures().len(), 1);
         assert!(v.fixtures().contains_key("par1"));
-        assert_eq!(v.groups().len(), 1);
-        assert!(v.groups().contains_key("all"));
     }
 }

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -177,6 +177,7 @@ pub fn router() -> Router<WebUiState> {
                 .put(lighting_api::put_fixture_type)
                 .delete(lighting_api::delete_fixture_type),
         )
+        .route("/lighting/groups", get(lighting_api::get_lighting_groups))
         .route("/lighting/venues", get(lighting_api::get_venues))
         .route(
             "/lighting/venues/{name}",

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -477,6 +477,45 @@ pub(super) async fn delete_fixture_type(
 }
 
 /// GET /api/lighting/venues — lists all venues from the directory.
+/// Returns the group names valid as cue targets, with the fixtures each
+/// currently resolves to in the loaded venue.
+///
+/// These are the logical groups declared under `dmx.lighting.groups`. Venues no
+/// longer define groups of their own — fixtures carry tags, and logical groups
+/// select on them — so this is the only list a show can target.
+pub(super) async fn get_lighting_groups(State(state): State<WebUiState>) -> impl IntoResponse {
+    let Some(system) = state
+        .player
+        .dmx_engine()
+        .and_then(|dmx| dmx.broadcast_handles().lighting_system)
+    else {
+        return Json(json!({"groups": []})).into_response();
+    };
+
+    // The lighting system's mutex is shared with the effects loop thread, and
+    // resolution mutates its cache, so this belongs on the blocking pool.
+    let groups = tokio::task::spawn_blocking(move || {
+        let mut guard = system.lock();
+        let names: Vec<String> = guard
+            .logical_groups_iter()
+            .map(|(n, _)| n.clone())
+            .collect();
+        let mut out: Vec<serde_json::Value> = names
+            .into_iter()
+            .map(|name| {
+                let fixtures = guard.resolve_logical_group_graceful(&name);
+                json!({"name": name, "fixtures": fixtures})
+            })
+            .collect();
+        out.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+        out
+    })
+    .await
+    .unwrap_or_default();
+
+    Json(json!({"groups": groups})).into_response()
+}
+
 pub(super) async fn get_venues(
     State(state): State<WebUiState>,
     Query(query): Query<LightingDirQuery>,
@@ -753,18 +792,6 @@ fn venue_json_to_dsl(name: &str, json: &serde_json::Value) -> Result<String, Str
             }
         }
         dsl.push('\n');
-    }
-
-    if let Some(groups) = json.get("groups").and_then(|v| v.as_object()) {
-        for (group_name, group_fixtures) in groups {
-            if let Some(fixture_list) = group_fixtures.as_array() {
-                let names: Vec<&str> = fixture_list.iter().filter_map(|v| v.as_str()).collect();
-                dsl.push_str(&format!(
-                    "  group \"{group_name}\" = {}\n",
-                    names.join(", ")
-                ));
-            }
-        }
     }
 
     dsl.push_str("}\n");
@@ -1542,7 +1569,9 @@ show "test" {
     }
 
     #[test]
-    fn venue_json_to_dsl_with_groups() {
+    fn venue_json_to_dsl_ignores_groups() {
+        // Venue groups are gone. A stale client still sending them must not
+        // produce a file the parser then rejects.
         let json = serde_json::json!({
             "fixtures": [
                 {
@@ -1550,24 +1579,18 @@ show "test" {
                     "fixture_type": "Par",
                     "universe": 1,
                     "start_channel": 1
-                },
-                {
-                    "name": "L2",
-                    "fixture_type": "Par",
-                    "universe": 1,
-                    "start_channel": 5
                 }
             ],
             "groups": {
-                "front": ["L1", "L2"]
+                "front": ["L1"]
             }
         });
         let dsl = venue_json_to_dsl("Grouped", &json).unwrap();
-        assert!(dsl.contains("group \"front\" = L1, L2"));
-        // Verify the DSL actually parses.
-        let venues = lighting::parser::parse_venues(&dsl).unwrap();
-        let v = venues.get("Grouped").unwrap();
-        assert!(v.groups().contains_key("front"));
+        assert!(
+            !dsl.contains("group"),
+            "groups should not be emitted: {dsl}"
+        );
+        lighting::parser::parse_venues(&dsl).expect("emitted DSL must parse");
     }
 
     #[test]

--- a/src/webui/svelte/src/components/config/LightingSection.svelte
+++ b/src/webui/svelte/src/components/config/LightingSection.svelte
@@ -935,11 +935,6 @@
                   {$t("lighting.fixtureCount", {
                     values: { count: Object.keys(v.fixtures).length },
                   })}
-                  {#if Object.keys(v.groups).length > 0}
-                    &middot; {$t("lighting.groupCount", {
-                      values: { count: Object.keys(v.groups).length },
-                    })}
-                  {/if}
                 </div>
                 <div class="item-meta">
                   {Object.values(v.fixtures)

--- a/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
@@ -19,7 +19,7 @@
     saveLightingFile,
     deleteLightingFile,
     validateLighting,
-    fetchVenues,
+    fetchLightingGroups,
   } from "../../lib/api/config";
   import {
     fetchWaveform,
@@ -199,16 +199,8 @@
 
   async function loadVenueGroups() {
     try {
-      const venues = await fetchVenues();
-      const groupNames: string[] = [];
-      for (const v of Object.values(venues)) {
-        if (v.groups) {
-          for (const g of Object.keys(v.groups)) {
-            if (!groupNames.includes(g)) groupNames.push(g);
-          }
-        }
-      }
-      venueGroups = groupNames.sort();
+      const groups = await fetchLightingGroups();
+      venueGroups = groups.map((g) => g.name).sort();
     } catch {
       // Non-critical
     }

--- a/src/webui/svelte/src/lib/api/config.ts
+++ b/src/webui/svelte/src/lib/api/config.ts
@@ -337,7 +337,6 @@ export interface FixtureData {
 export interface VenueData {
   name: string;
   fixtures: Record<string, FixtureData>;
-  groups: Record<string, { name: string; fixtures: string[] }>;
 }
 
 export async function fetchFixtureTypes(
@@ -391,6 +390,18 @@ export async function deleteFixtureType(
   if (!res.ok) throw await apiError(res, "Failed to delete fixture type");
 }
 
+/// Group names a cue can target, with the fixtures each currently resolves to.
+/// These are the logical groups from `dmx.lighting.groups`; venues no longer
+/// define groups of their own.
+export async function fetchLightingGroups(): Promise<
+  { name: string; fixtures: string[] }[]
+> {
+  const res = await get("/lighting/groups");
+  if (!res.ok) throw await apiError(res, "Failed to fetch lighting groups");
+  const data = await res.json();
+  return data.groups ?? [];
+}
+
 export async function fetchVenues(
   dir?: string,
 ): Promise<Record<string, VenueData>> {
@@ -423,7 +434,6 @@ export async function saveVenue(
       start_channel: number;
       tags: string[];
     }[];
-    groups?: Record<string, string[]>;
   },
   dir?: string,
 ): Promise<void> {

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -358,7 +358,6 @@
   "lighting.noVenues": "No venues defined.",
   "lighting.venueHint": "Create one to define the physical fixture layout at a performance location.",
   "lighting.fixtureCount": "{count} fixture(s)",
-  "lighting.groupCount": "{count} group(s)",
   "lighting.deleteVenue": "Delete venue \"{name}\"?",
   "lighting.directories": "Directories",
   "lighting.directoriesHint": "Override where fixture types and venues are loaded from. Leave empty to use the defaults (lighting/fixture_types, lighting/venues).",

--- a/src/webui/svelte/src/pages/LightingEditor.svelte
+++ b/src/webui/svelte/src/pages/LightingEditor.svelte
@@ -18,7 +18,7 @@
     fetchLightingFile,
     saveLightingFile,
     validateLighting,
-    fetchVenues,
+    fetchLightingGroups,
   } from "../lib/api/config";
   import {
     fetchSongs,
@@ -129,16 +129,8 @@
 
   async function loadVenueGroups() {
     try {
-      const venues = await fetchVenues();
-      const groupNames: string[] = [];
-      for (const v of Object.values(venues)) {
-        if (v.groups) {
-          for (const g of Object.keys(v.groups)) {
-            if (!groupNames.includes(g)) groupNames.push(g);
-          }
-        }
-      }
-      venueGroups = groupNames.sort();
+      const groups = await fetchLightingGroups();
+      venueGroups = groups.map((g) => g.name).sort();
     } catch {
       // Non-critical
     }


### PR DESCRIPTION
Follow-up to #386. Venue groups are removed in favour of fixture tags plus logical groups.

## Why: the intent is recorded in the history

Venue groups landed in #103. Tags and logical groups landed in **#104, the very next PR**, whose commit message states the purpose directly:

> The lighting configuration has been updated to be **less coupled to the venue configuration**. A new tagging system has been introduced that allows optional lights, fallbacks, etc. This should allow more flexible configuration.

Venue groups *are* that coupling, and nothing has used them since:

- **The example venues created by #104** — `main_stage` and `small_club`, the pair that demonstrates "same logical groups work!" across rigs — have never contained a single `group` line in their entire history (`git log -S 'group "'` over that directory returns nothing).
- They appear in **no documentation**, in `docs/` or the README.
- They **resolve last**, behind logical groups, in `resolve_logical_group_graceful`.
- The web UI could **neither create nor preserve them**: the venue editor's save payload carries only `fixtures`, and `put_venue` regenerates the file wholesale with no merge — so editing a venue there silently deleted any groups it had.
- A venue could not hold **more than one** of them until #386 fixed the grammar days ago, which is how long the feature had gone unexercised.

## What changes

Removed: the `Group` type, `Venue::groups`, `LightingSystem::get_group` and the venue-group arm of `resolve_logical_group_graceful`, the venue-group branch of the MCP `list_groups` surface, and the web UI's group emission.

`group` still *parses*, purely so the error can name the group and give the migration. A bare grammar failure would report `expected fixture`, which is no help to someone reading a rig file at soundcheck:

```
venue group `front_wash` is no longer supported. Tag the fixtures instead —
add a tag to each member, e.g. `tags ["front_wash"]`, and declare a logical
group under `dmx.lighting.groups` with `constraints: [AllOf: ["front_wash"]]`.
Tags survive a venue change; venue groups did not.
```

Tags, logical groups, and the entire constraint system (`AllOf`, `AnyOf`, `Prefer`, `MinCount`, `MaxCount`, `FallbackTo`, `AllowEmpty`) are untouched.

## A dead feature this exposed

The show editors' group-name suggestions were sourced from venue groups — so that dropdown has been **empty for every tag-based rig**, including the only real one in evidence. It now reads from a new `GET /api/lighting/groups`, which returns the logical groups with the fixtures each currently resolves to. That is the list a cue can actually target, so the removal fixes a feature that was silently doing nothing.

**BREAKING CHANGE**: a venue declaring `group "name" = A, B` no longer loads. Tag the member fixtures and add a logical group under `dmx.lighting.groups` with `constraints: [AllOf: ["name"]]`.

## Tests

- `cargo test` — 3200 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
- `npm run check` — 411 files, 0 errors
- the real rig's venue re-parsed after the removal (1 venue, 8 fixtures)

Existing MCP integration tests that built venues with `group` lines are converted to the tag model, including a `left` logical group selecting on a tag — which demonstrates the same per-fixture discrimination venue groups used to provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)