### PR TITLE
analyze_show: dark windows, coverage, and per-group usage (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`analyze_show`: where the rig goes dark, and what the rig is actually doing**: reports dark
+  windows, per-group and per-layer coverage seconds, the show's span, and which targeted groups
+  resolve to no fixtures in the current venue. Dark windows are the headline — they are invisible
+  in the source and the most error-prone thing to compute by hand, because doing it correctly
+  means resolving every duration through the tempo map (`1measure` is 1.5s inside a 2/4 bar) and
+  honouring layer commands (a `clear` truncates effects the source says run far longer).
+
+  Darkness means "no effect is running", not "every channel is zero". A strobe is dark half its
+  life by design, and reporting its off-phase would bury the real gaps. The span likewise ends
+  where activity ends, not at the furthest authored duration, so it cannot contradict the gap
+  list beside it.
+
 - **Test a device from the config editor, before saving the profile**: a Test button beside the
   device picker opens the selected device with the settings currently in the form, confirms its
   output callback runs, and closes it — reporting streaming, opened-but-silent, or could-not-open

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -64,6 +64,10 @@ Roughly 50 tools are available. They fall into a few groups:
   detailed song metadata and beat-grid queries.
 - **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
   and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
+- **Show analysis** — `analyze_show` reports where the rig goes dark, how long each group and
+  layer is actually doing something, and which targeted groups resolve to no fixtures. Durations
+  resolve through the tempo map and layer commands are honoured, so a `clear` that truncates a
+  long effect shows up as the gap it creates rather than the duration the source claims.
 - **Lighting state** — `evaluate_show` reports what the fixtures *would* be doing at any set of
   times, and `get_fixture_state` reports what they *are* doing right now. Both return per-fixture
   DMX values (0–255, including virtual-dimmer RGB scaling) alongside the effects running at each

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1600,6 +1600,114 @@ async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Er
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-quater: show coverage analysis (#339)
+// ---------------------------------------------------------------------------
+
+/// `analyze_show` reports the gaps and coverage that are invisible in the
+/// source. This drives it over the wire with a show whose real dark window is
+/// created by a `clear`, not by the durations on the page.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_analyze_show_reports_gaps_and_coverage() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+    std::fs::create_dir_all(fixture.root.join("lighting/venues"))?;
+    std::fs::create_dir_all(fixture.root.join("lighting/fixture_types"))?;
+    copy_dir_recursive(
+        Path::new("examples/lighting/fixture_types"),
+        &fixture.root.join("lighting/fixture_types"),
+    )?;
+    std::fs::write(
+        fixture.root.join("lighting/venues/main_stage.light"),
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\", \"left\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n}\n",
+    )?;
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    // `all_lights` is a configured logical group; `movers` is not, so it
+    // resolves to nothing and should be warned about. The 30s bed is cut short
+    // by a clear at 5s, opening a gap the durations alone do not reveal.
+    let source = r#"show "Coverage" {
+    @00:00.000
+    all_lights: static color: "blue", duration: 30s
+
+    @00:05.000
+    clear(layer: background)
+
+    @00:08.000
+    all_lights: static color: "red", duration: 2s
+
+    @00:10.000
+    movers: strobe frequency: 8, duration: 2s
+}
+"#;
+
+    let body = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            970,
+            "analyze_show",
+            json!({"source": source}),
+        )
+        .await,
+    );
+
+    assert_eq!(body["cue_count"], 4, "{body}");
+    assert_eq!(
+        body["span_seconds"], 12.0,
+        "span ends with activity: {body}"
+    );
+
+    // The gap is 5s (the clear) to 8s (the next cue) — invisible in the source,
+    // which says the first effect runs for 30 seconds.
+    let windows = body["dark_windows"].as_array().expect("dark_windows");
+    assert_eq!(windows.len(), 1, "expected one gap: {body}");
+    assert_eq!(windows[0]["from"], 5.0);
+    assert_eq!(windows[0]["to"], 8.0);
+    assert_eq!(windows[0]["seconds"], 3.0);
+    assert_eq!(body["dark_seconds"], 3.0);
+
+    // Coverage is per authored group, unioned.
+    assert_eq!(body["per_group_seconds"]["all_lights"], 7.0, "{body}");
+    assert_eq!(body["per_group_seconds"]["movers"], 2.0, "{body}");
+
+    // The strobe runs on the foreground by default only if authored so; here
+    // everything is background, and its off-phase must not read as a gap.
+    assert_eq!(body["per_layer_seconds"]["background"], 9.0, "{body}");
+
+    // `movers` matches no configured group, so its cues would do nothing.
+    let warnings: Vec<&str> = body["warnings"]
+        .as_array()
+        .expect("warnings")
+        .iter()
+        .filter_map(|w| w.as_str())
+        .collect();
+    assert!(
+        warnings.iter().any(|w| w.contains("movers")),
+        "expected a warning about `movers`: {body}"
+    );
+    assert!(
+        !warnings.iter().any(|w| w.contains("all_lights")),
+        "`all_lights` resolves and should not be warned about: {body}"
+    );
+
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -238,6 +238,15 @@ fn default_true() -> bool {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct AnalyzeShowArgs {
+    /// Song name as listed by `list_songs`. Analyses the song's registered
+    /// lighting shows. Mutually exclusive with `source`.
+    pub song: Option<String>,
+    /// `.light` DSL source to analyse directly. Mutually exclusive with `song`.
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SongLightingArgs {
     /// Song name as listed by `list_songs`.
     pub song: String,
@@ -1161,6 +1170,97 @@ impl McpServer {
             .collect();
 
         Ok(ok_json(json!({ "evaluations": results })))
+    }
+
+    #[tool(description = "Analyse a light show's coverage: where the rig goes \
+        dark, how long each group and layer is actually doing something, and \
+        which targeted groups resolve to no fixtures in the current venue. \
+        Durations resolve through the tempo map, so `1measure` is correctly \
+        1.5s inside a 2/4 bar, and layer commands are honoured, so a `clear` \
+        that truncates a long effect shows up as the gap it creates. Darkness \
+        means no effect is running rather than every channel at zero, so a \
+        strobe's off-phase is not reported as a gap. Pass either `song` or \
+        `source`.")]
+    async fn analyze_show(
+        &self,
+        Parameters(args): Parameters<AnalyzeShowArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (shows, fallback_tempo) = self.resolve_shows_to_evaluate(&EvaluateShowArgs {
+            song: args.song.clone(),
+            source: args.source.clone(),
+            times: Vec::new(),
+            include_fixtures: false,
+        })?;
+
+        let lighting_system = self
+            .player
+            .dmx_engine()
+            .and_then(|dmx| dmx.broadcast_handles().lighting_system);
+        let targeted = group_names(&shows);
+
+        let (analysis, empty_groups, venue) = tokio::task::spawn_blocking(move || {
+            // Which targeted groups the current venue cannot fill. This is the
+            // warning the issue asks for, and it needs the venue — the analysis
+            // itself deliberately does not.
+            let (empty_groups, venue) = match &lighting_system {
+                Some(system) => {
+                    let mut guard = system.lock();
+                    let venue = guard.current_venue().map(str::to_owned);
+                    let empty: Vec<String> = targeted
+                        .iter()
+                        .filter(|name| guard.resolve_logical_group_graceful(name).is_empty())
+                        .cloned()
+                        .collect();
+                    (empty, venue)
+                }
+                None => (Vec::new(), None),
+            };
+            let analysis = crate::lighting::analyze::analyze_show(shows, fallback_tempo.as_ref());
+            (analysis, empty_groups, venue)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("analysis failed: {e}"), None))?;
+
+        let dark_windows: Vec<Value> = analysis
+            .dark_windows
+            .iter()
+            .map(|w| {
+                json!({
+                    "from": w.from.as_secs_f64(),
+                    "to": w.to.as_secs_f64(),
+                    "seconds": w.seconds(),
+                    "position": w.position,
+                })
+            })
+            .collect();
+
+        let warnings: Vec<String> = empty_groups
+            .iter()
+            .map(|name| match &venue {
+                Some(venue) => format!(
+                    "group `{name}` resolves to 0 fixtures in venue `{venue}` — \
+                     its cues will do nothing"
+                ),
+                None => format!(
+                    "group `{name}` resolves to 0 fixtures — no venue is loaded, \
+                     so this may be a false alarm"
+                ),
+            })
+            .collect();
+
+        Ok(ok_json(json!({
+            "cue_count": analysis.cue_count,
+            "span_seconds": analysis.span.as_secs_f64(),
+            "dark_seconds": analysis.dark_seconds(),
+            "dark_windows": dark_windows,
+            "per_group_seconds": analysis.per_group_seconds,
+            "per_layer_seconds": analysis
+                .per_layer_seconds
+                .iter()
+                .map(|(layer, secs)| (format!("{layer:?}").to_lowercase(), *secs))
+                .collect::<std::collections::BTreeMap<_, _>>(),
+            "warnings": warnings,
+        })))
     }
 
     #[tool(description = "List the venues known to the running DMX engine. Each \

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -12,6 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+pub mod analyze;
 #[cfg(test)]
 mod consistency_tests;
 pub mod effects;

--- a/src/lighting/analyze.rs
+++ b/src/lighting/analyze.rs
@@ -1,0 +1,529 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! Coverage analysis for a light show.
+//!
+//! Answers the questions that are invisible in the source and error-prone to
+//! compute by hand: where does the rig go dark, how long is each group actually
+//! doing something, and how is the work spread across layers.
+//!
+//! Getting this right needs every duration resolved through the tempo map —
+//! `1measure` is 1.5s inside a 2/4 bar and 3.0s inside a 4/4 one — and needs
+//! layer commands honoured, since a `clear` truncates effects that the source
+//! says run much longer. Both fall out of driving the real timeline and engine
+//! rather than reading the text.
+//!
+//! **Darkness here means "no effect is running", not "every channel is zero".**
+//! A strobe is dark half its life by design, and reporting its off-phase as a
+//! gap would bury the real ones. An effect that is running but black — a
+//! `static` at `dimmer: 0%` — is a deliberate authoring choice and counts as
+//! covered.
+
+use std::collections::{BTreeMap, HashSet};
+use std::time::Duration;
+
+use crate::lighting::effects::{EffectInstance, EffectLayer, FixtureInfo};
+use crate::lighting::evaluate::apply_timeline_update;
+use crate::lighting::parser::LightShow;
+use crate::lighting::tempo::TempoMap;
+use crate::lighting::timeline::LightingTimeline;
+use crate::lighting::EffectEngine;
+
+/// A span during which nothing is running.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DarkWindow {
+    pub from: Duration,
+    pub to: Duration,
+    /// Musical position of `from`, when the show has a tempo map.
+    pub position: Option<String>,
+}
+
+impl DarkWindow {
+    pub fn seconds(&self) -> f64 {
+        self.to.saturating_sub(self.from).as_secs_f64()
+    }
+}
+
+/// What a show does over its own span.
+#[derive(Clone, Debug, Default)]
+pub struct Analysis {
+    pub cue_count: usize,
+    /// First moment anything runs to the last moment anything runs.
+    ///
+    /// This is where activity actually stops, not the furthest authored
+    /// duration: an effect written as 60s but cut by a `clear` at 5s ends the
+    /// span at 5s, matching the gap analysis rather than contradicting it.
+    pub span: Duration,
+    pub dark_windows: Vec<DarkWindow>,
+    /// Seconds each authored group name is covered by at least one effect.
+    /// Union, not sum — two effects on one group at once is still one second.
+    pub per_group_seconds: BTreeMap<String, f64>,
+    /// Seconds each layer is covered by at least one effect, unioned the same way.
+    pub per_layer_seconds: BTreeMap<EffectLayer, f64>,
+}
+
+impl Analysis {
+    /// Total dark time across the span.
+    pub fn dark_seconds(&self) -> f64 {
+        self.dark_windows.iter().map(|w| w.seconds()).sum()
+    }
+}
+
+/// Analyses `shows` without audio, DMX, or the wall clock.
+///
+/// Group names are reported as authored, not resolved to fixtures: the author
+/// reasons in group names, and a group that resolves to nothing still shows the
+/// time it was *meant* to cover. Whether a group resolves is a separate
+/// question, answered where the venue is known.
+pub fn analyze_show(shows: Vec<LightShow>, fallback_tempo_map: Option<&TempoMap>) -> Analysis {
+    let cue_count: usize = shows.iter().map(|s| s.cues.len()).sum();
+
+    let mut timeline = LightingTimeline::new(shows);
+    let tempo_map = timeline
+        .tempo_map()
+        .cloned()
+        .or_else(|| fallback_tempo_map.cloned());
+
+    // The state can only change where a cue fires or an effect ends, so those
+    // are the only boundaries worth testing. Sampling on a fixed grid instead
+    // would quantise every window to the step size and still cost more.
+    let boundaries = boundaries(&timeline);
+    if boundaries.is_empty() {
+        return Analysis {
+            cue_count,
+            ..Default::default()
+        };
+    }
+
+    let mut engine = EffectEngine::new();
+    engine.set_tempo_map(tempo_map.clone());
+    // Register a stand-in fixture per authored group name. The engine rejects
+    // effects targeting names it does not know, and analysis is about the show,
+    // not the rig — a group that resolves to nothing in the current venue still
+    // occupies the time the author gave it.
+    for name in target_names(&timeline) {
+        engine.register_fixture(stand_in_fixture(&name));
+    }
+    timeline.start();
+
+    let mut analysis = Analysis {
+        cue_count,
+        ..Default::default()
+    };
+    let mut dark_from: Option<Duration> = None;
+    let mut first_active: Option<Duration> = None;
+    let mut last_active_end = Duration::ZERO;
+    let mut previous = Duration::ZERO;
+
+    for pair in boundaries.windows(2) {
+        let (start, end) = (pair[0], pair[1]);
+        // Probe the middle of the interval: the endpoints are exactly where
+        // effects start and stop, so they are the one place the answer is
+        // ambiguous.
+        let probe = start + (end - start) / 2;
+
+        for at in [start, probe] {
+            let update = timeline.update(at);
+            apply_timeline_update(&mut engine, update, &mut |e| e);
+            let _ = engine.update(at.saturating_sub(previous), Some(at));
+            previous = at;
+        }
+
+        let active: Vec<&EffectInstance> = engine.get_active_effects().values().collect();
+        let seconds = (end - start).as_secs_f64();
+
+        if active.is_empty() {
+            dark_from.get_or_insert(start);
+        } else {
+            if let Some(from) = dark_from.take() {
+                analysis.dark_windows.push(window(from, start, &tempo_map));
+            }
+            first_active.get_or_insert(start);
+            last_active_end = end;
+            // A group or layer covered by any running effect earns the whole
+            // interval once, however many effects are stacked on it.
+            let mut groups: HashSet<&str> = HashSet::new();
+            let mut layers: HashSet<EffectLayer> = HashSet::new();
+            for effect in active {
+                groups.extend(effect.target_fixtures.iter().map(String::as_str));
+                layers.insert(effect.layer);
+            }
+            for group in groups {
+                *analysis
+                    .per_group_seconds
+                    .entry(group.to_string())
+                    .or_default() += seconds;
+            }
+            for layer in layers {
+                *analysis.per_layer_seconds.entry(layer).or_default() += seconds;
+            }
+        }
+    }
+
+    // A run of dark intervals reaching the end of the show is not a gap in the
+    // show, it is the end of it.
+    dark_from.take();
+
+    analysis.span = last_active_end.saturating_sub(first_active.unwrap_or_default());
+    analysis
+}
+
+/// Every distinct name the show's cues target.
+fn target_names(timeline: &LightingTimeline) -> Vec<String> {
+    let mut names: Vec<String> = timeline
+        .cue_effects()
+        .flat_map(|(_, effects)| effects.iter().flat_map(|e| e.groups.iter().cloned()))
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// A minimal RGB+dimmer fixture, so effects targeting a group name validate.
+/// Never addressed and never rendered — only its presence matters.
+fn stand_in_fixture(name: &str) -> FixtureInfo {
+    let channels = [("red", 1), ("green", 2), ("blue", 3), ("dimmer", 4)]
+        .into_iter()
+        .map(|(c, offset)| (c.to_string(), offset))
+        .collect();
+    FixtureInfo::new(
+        name.to_string(),
+        1,
+        1,
+        "analysis-stand-in".to_string(),
+        channels,
+        None,
+    )
+}
+
+/// Every instant the running set can change: each cue time, and each effect's
+/// end. Sorted and deduplicated.
+fn boundaries(timeline: &LightingTimeline) -> Vec<Duration> {
+    let mut times: Vec<Duration> = Vec::new();
+    for (time, effects) in timeline.cue_effects() {
+        times.push(time);
+        for effect in effects {
+            times.push(time + effect.total_duration());
+        }
+    }
+    times.sort();
+    times.dedup();
+    times
+}
+
+fn window(from: Duration, to: Duration, tempo_map: &Option<TempoMap>) -> DarkWindow {
+    let position = tempo_map.as_ref().map(|map| {
+        let (measure, beat) = map.time_to_measure_beat(from);
+        format!("@{measure}/{beat:.2}")
+    });
+    DarkWindow { from, to, position }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lighting::parser::parse_light_shows;
+
+    fn shows(source: &str) -> Vec<LightShow> {
+        let mut parsed: Vec<_> = parse_light_shows(source)
+            .expect("test show should parse")
+            .into_values()
+            .collect();
+        parsed.sort_by(|a, b| a.name.cmp(&b.name));
+        parsed
+    }
+
+    fn analyze(source: &str) -> Analysis {
+        analyze_show(shows(source), None)
+    }
+
+    fn windows(analysis: &Analysis) -> Vec<(f64, f64)> {
+        analysis
+            .dark_windows
+            .iter()
+            .map(|w| (w.from.as_secs_f64(), w.to.as_secs_f64()))
+            .collect()
+    }
+
+    #[test]
+    fn a_gap_between_two_cues_is_a_dark_window() {
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:06.000
+    wash: static color: "red", duration: 4s
+}
+"#,
+        );
+        assert_eq!(analysis.cue_count, 2);
+        assert_eq!(windows(&analysis), [(4.0, 6.0)]);
+        assert_eq!(analysis.dark_seconds(), 2.0);
+        assert_eq!(analysis.span, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn a_show_with_no_gaps_reports_none() {
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 5s
+
+    @00:05.000
+    wash: static color: "red", duration: 5s
+}
+"#,
+        );
+        assert!(analysis.dark_windows.is_empty());
+        assert_eq!(analysis.dark_seconds(), 0.0);
+    }
+
+    #[test]
+    fn overlapping_effects_leave_no_gap() {
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+
+    @00:04.000
+    spot: static color: "red", duration: 2s
+}
+"#,
+        );
+        assert!(
+            analysis.dark_windows.is_empty(),
+            "the bed covers the whole span: {:?}",
+            analysis.dark_windows
+        );
+        // Union, not sum: the overlap is not counted twice for either group.
+        assert_eq!(analysis.per_group_seconds["wash"], 10.0);
+        assert_eq!(analysis.per_group_seconds["spot"], 2.0);
+    }
+
+    #[test]
+    fn trailing_silence_is_not_a_dark_window() {
+        // The show simply ends. Reporting the end as a gap would put a false
+        // finding on every show ever written.
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+}
+"#,
+        );
+        assert!(analysis.dark_windows.is_empty());
+        assert_eq!(analysis.span, Duration::from_secs(4));
+    }
+
+    #[test]
+    fn a_clear_opens_a_gap_the_source_does_not_show() {
+        // The source says 60s. The clear at 5s means the rig is dark from
+        // there until the next cue — the class of gap that is invisible when
+        // reading durations off the page.
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 60s
+
+    @00:05.000
+    clear(layer: background)
+
+    @00:08.000
+    wash: static color: "red", duration: 2s
+}
+"#,
+        );
+        assert_eq!(windows(&analysis), [(5.0, 8.0)]);
+        assert_eq!(
+            analysis.per_group_seconds["wash"], 7.0,
+            "5s before the clear plus the 2s cue, not the authored 60s"
+        );
+    }
+
+    #[test]
+    fn a_strobes_off_phase_is_not_a_gap() {
+        // Darkness is "nothing running", not "every channel zero". An 8Hz
+        // strobe is dark half its life by design.
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: strobe frequency: 8, duration: 5s
+}
+"#,
+        );
+        assert!(
+            analysis.dark_windows.is_empty(),
+            "strobe phase should not read as gaps: {:?}",
+            analysis.dark_windows
+        );
+        assert_eq!(analysis.per_group_seconds["wash"], 5.0);
+    }
+
+    #[test]
+    fn layer_seconds_are_unioned_per_layer() {
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s, layer: background
+    spot: static color: "red", duration: 4s, layer: background
+    beam: strobe frequency: 4, duration: 6s, layer: foreground
+}
+"#,
+        );
+        // Two background effects overlap; the layer still earns 10s, not 14.
+        assert_eq!(analysis.per_layer_seconds[&EffectLayer::Background], 10.0);
+        assert_eq!(analysis.per_layer_seconds[&EffectLayer::Foreground], 6.0);
+        assert!(!analysis
+            .per_layer_seconds
+            .contains_key(&EffectLayer::Midground));
+    }
+
+    #[test]
+    fn several_gaps_are_reported_separately() {
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 2s
+
+    @00:03.000
+    wash: static color: "red", duration: 2s
+
+    @00:07.000
+    wash: static color: "green", duration: 2s
+}
+"#,
+        );
+        assert_eq!(windows(&analysis), [(2.0, 3.0), (5.0, 7.0)]);
+        assert_eq!(analysis.dark_seconds(), 3.0);
+    }
+
+    #[test]
+    fn measure_durations_resolve_through_the_tempo_map() {
+        // The reason this cannot be done by reading the source: `1measure` is
+        // 1.5s in the 2/4 bar and 3.0s either side of it.
+        let analysis = analyze(
+            r#"
+tempo {
+    start: 0ms
+    bpm: 80
+    time_signature: 4/4
+    changes: [
+        @2/1 { time_signature: 2/4 },
+        @3/1 { time_signature: 4/4 }
+    ]
+}
+
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1measures
+
+    @3/1
+    wash: static color: "red", duration: 1measures
+}
+"#,
+        );
+        // 80bpm: a 4/4 bar is 3.0s, the 2/4 bar is 1.5s. Bar 1 covers 0.0-3.0,
+        // bar 2 is the short one (3.0-4.5), so bar 3 starts at 4.5.
+        let gaps = windows(&analysis);
+        assert_eq!(gaps.len(), 1, "one gap across the short bar: {gaps:?}");
+        let (from, to) = gaps[0];
+        assert!((from - 3.0).abs() < 0.01, "gap starts at bar 2: {from}");
+        assert!((to - 4.5).abs() < 0.01, "2/4 bar is 1.5s, not 3.0s: {to}");
+    }
+
+    #[test]
+    fn dark_windows_carry_a_musical_position_when_tempo_is_known() {
+        let analysis = analyze(
+            r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1s
+
+    @2/1
+    wash: static color: "red", duration: 2s
+}
+"#,
+        );
+        // At 120bpm a 4/4 bar is 2s, so bar 2 starts at 2.0 and the 1s effect
+        // leaves a second of nothing behind it.
+        assert_eq!(windows(&analysis), [(1.0, 2.0)]);
+        let position = analysis.dark_windows[0]
+            .position
+            .as_deref()
+            .expect("a tempo map should yield a position");
+        assert!(position.starts_with('@'), "{position}");
+    }
+
+    #[test]
+    fn a_show_without_tempo_omits_positions() {
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 2s
+
+    @00:04.000
+    wash: static color: "red", duration: 2s
+}
+"#,
+        );
+        assert_eq!(analysis.dark_windows.len(), 1);
+        assert!(analysis.dark_windows[0].position.is_none());
+    }
+
+    #[test]
+    fn span_ends_where_activity_ends_not_where_the_source_claims() {
+        // The bed is authored for 60s but cut at 5s. Reporting a 60s span
+        // would contradict the gap analysis sitting right next to it.
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 60s
+
+    @00:05.000
+    clear(layer: background)
+
+    @00:08.000
+    wash: static color: "red", duration: 2s
+}
+"#,
+        );
+        assert_eq!(analysis.span, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn an_empty_show_analyses_to_nothing() {
+        let analysis = analyze("show \"T\" {\n}\n");
+        assert_eq!(analysis.cue_count, 0);
+        assert_eq!(analysis.span, Duration::ZERO);
+        assert!(analysis.dark_windows.is_empty());
+        assert!(analysis.per_group_seconds.is_empty());
+    }
+}

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -123,9 +123,9 @@ where
             // on it. `start_at` stops short of `time` by design, so both halves
             // are needed for a cue at the requested instant to count.
             let history = timeline.start_at(time);
-            apply(&mut engine, history, &mut resolve_groups);
+            apply_timeline_update(&mut engine, history, &mut resolve_groups);
             let now = timeline.update(time);
-            apply(&mut engine, now, &mut resolve_groups);
+            apply_timeline_update(&mut engine, now, &mut resolve_groups);
 
             // Render a single frame at `time`. A zero delta keeps the engine's
             // clock exactly where the elapsed offsets were computed against.
@@ -238,7 +238,7 @@ pub fn snapshot(engine: &EffectEngine, at: Duration) -> Evaluation {
 /// Applies one timeline update to the engine in the same order the live path
 /// uses: layer commands, then stopped sequences, then seek-started effects in
 /// cue order, then freshly-fired effects with sequence effects first.
-fn apply<F>(
+pub(crate) fn apply_timeline_update<F>(
     engine: &mut EffectEngine,
     update: crate::lighting::timeline::TimelineUpdate,
     resolve_groups: &mut F,
@@ -551,7 +551,7 @@ show "T" {
 
         loop {
             let update = timeline.update(now);
-            apply(&mut engine, update, &mut |e| e);
+            apply_timeline_update(&mut engine, update, &mut |e| e);
             let _ = engine.update(step, Some(now));
 
             if times.contains(&now) {

--- a/src/lighting/timeline.rs
+++ b/src/lighting/timeline.rs
@@ -273,6 +273,16 @@ impl LightingTimeline {
         result
     }
 
+    /// Each cue's time paired with the effects it starts.
+    ///
+    /// Coverage analysis needs both to know where the running set can change:
+    /// a cue time, and that time plus each effect's authored duration.
+    pub fn cue_effects(&self) -> impl Iterator<Item = (Duration, &[Effect])> {
+        self.cues
+            .iter()
+            .map(|cue| (cue.time, cue.effects.as_slice()))
+    }
+
     /// Get all cues with their times and indices
     pub fn cues(&self) -> Vec<(Duration, usize)> {
         self.cues

--- a/src/tempo.rs
+++ b/src/tempo.rs
@@ -493,7 +493,7 @@ impl TempoMap {
 
     /// Convert an absolute time to a (measure, beat) position by integrating through
     /// all tempo/time-signature changes that precede it.
-    fn time_to_measure_beat(&self, target_time: Duration) -> (u32, f64) {
+    pub(crate) fn time_to_measure_beat(&self, target_time: Duration) -> (u32, f64) {
         let mut m: u32 = 1;
         let mut b: f64 = 1.0;
         let mut temp_time = self.start_offset;


### PR DESCRIPTION
Closes #339. Builds on `evaluate_show` from #386.

Reviewing whether a show does what you intended meant writing your own analysis. Most of that is the author's problem — dark windows are not, because computing them correctly means resolving every duration through the tempo map (`1measure` is 1.5s inside a 2/4 bar, 3.0s either side) and honouring layer commands (a `clear` truncates effects the source says run far longer). The hand-rolled version in the issue got it wrong by matching only `s` durations, counting every `1000ms` effect as zero-length and reporting phantom gaps.

## What it reports

```json
{
  "cue_count": 4,
  "span_seconds": 12.0,
  "dark_seconds": 3.0,
  "dark_windows": [{"from": 5.0, "to": 8.0, "seconds": 3.0, "position": "@3/1.00"}],
  "per_group_seconds": {"all_lights": 7.0, "movers": 2.0},
  "per_layer_seconds": {"background": 9.0},
  "warnings": ["group `movers` resolves to 0 fixtures in venue `main_stage` — its cues will do nothing"]
}
```

## Two definitions carry the design

**Darkness is "no effect is running", not "every channel is zero."** An 8Hz strobe is dark half its life by design; reporting its off-phase would bury the real gaps. An effect running black — a `static` at `dimmer: 0%` — is a deliberate authoring choice and counts as covered. There's a test for the strobe case specifically.

**The span ends where activity ends, not at the furthest authored duration.** A bed written for 60s and cut by a `clear` at 5s ends the span at 5s. The first implementation reported 30s for exactly such a show — caught by the integration test — which would have contradicted the gap list printed beside it.

## Other choices

- **Coverage is a union, not a sum.** Two effects stacked on one group still earn one second, so a group's seconds can never exceed the span. A sum would make "all_wash: 231s of a 309s show" meaningless.
- **Group names are reported as authored.** The author reasons in group names, and a group resolving to nothing still shows the time it was *meant* to fill. Whether it resolves is the separate `warnings` entry, which needs the venue that the analysis deliberately does not.
- **The walk probes interval midpoints, not a fixed grid.** State can only change where a cue fires or an effect ends, so those are the only boundaries worth testing — exact window boundaries, and roughly two evaluations per cue instead of thousands. Sampling a 10ms grid over a 5-minute show would quantise every window to the step and cost 30,000 evaluations.

## Tests

13 unit tests covering gaps between cues, no-gap shows, overlapping effects, trailing silence (not a gap — that's the show ending), clear-created gaps, strobe off-phase, layer unioning, multiple gaps, measure durations across a 2/4 bar, musical positions, span truncation, and empty shows. Plus an MCP integration test driving it over the wire.

- `cargo test` — 3214 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

## Small supporting changes

- `LightingTimeline::cue_effects()` — cue times paired with their effects, for boundary discovery.
- `evaluate::apply` is now `pub(crate) apply_timeline_update`, shared with the analyzer so both drive the engine in the live path's order.
- `TempoMap::time_to_measure_beat` is `pub(crate)`, for the `position` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)