### PR TITLE
validate_lighting returns resolved cue times (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`validate_lighting` returns resolved cue times**: on success each show now carries its cue
+  timeline — every cue's index, the absolute time it resolves to, the number of effects on it,
+  and, when the show has a tempo map, the bar/beat that time corresponds to. "It parses" and
+  "the cues are where I think they are" are different claims, and for a show written in
+  `@bar/beat` against a `tempo` block with meter changes, the second is the one worth checking.
+
+  Confirming a measure-based rewrite lands on the same times as an absolute-time original
+  previously meant writing the candidate under a second basename, repointing the song's
+  `lighting:` block, reloading, reading `get_cues`, then reverting — six steps, two of them
+  mutating the user's song config, to answer a read-only question. It is now one call per
+  version, touching nothing.
+
+  Pass `include_timeline: false` for a parse-only check.
+
 - **`analyze_show`: where the rig goes dark, and what the rig is actually doing**: reports dark
   windows, per-group and per-layer coverage seconds, the show's span, and which targeted groups
   resolve to no fixtures in the current venue. Dark windows are the headline — they are invisible

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -64,6 +64,8 @@ Roughly 50 tools are available. They fall into a few groups:
   detailed song metadata and beat-grid queries.
 - **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
   and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
+  `validate_lighting` returns each show's resolved cue timeline alongside the parse result, so
+  "the cues land where I meant" can be checked without loading the show into the player.
 - **Show analysis** — `analyze_show` reports where the rig goes dark, how long each group and
   layer is actually doing something, and which targeted groups resolve to no fixtures. Durations
   resolve through the tempo map and layer commands are honoured, so a `clear` that truncates a

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1708,6 +1708,157 @@ async fn mcp_analyze_show_reports_gaps_and_coverage() -> Result<(), Box<dyn Erro
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-quinquies: validate_lighting returns resolved cue times (#333)
+// ---------------------------------------------------------------------------
+
+/// The job #333 describes: confirm a measure-based rewrite of a show lands on
+/// the same times as the absolute-time original. That used to take six steps,
+/// two of which mutated the user's song config, to answer a read-only question.
+/// Here it is two calls that touch nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_validate_lighting_returns_resolved_cue_times() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    // 120bpm 4/4: a bar is 2s. Bars 1, 3 and 5 are 0.0s, 4.0s and 8.0s.
+    let absolute = r#"show "S" {
+    @00:00.000
+    all: static color: "blue", duration: 1s
+
+    @00:04.000
+    all: static color: "red", duration: 1s
+
+    @00:08.000
+    all: static color: "green", duration: 1s
+}
+"#;
+    let measures = r#"tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "S" {
+    @1/1
+    all: static color: "blue", duration: 1s
+
+    @3/1
+    all: static color: "red", duration: 1s
+
+    @5/1
+    all: static color: "green", duration: 1s
+}
+"#;
+
+    let times = |body: &Value| -> Vec<f64> {
+        body["shows"][0]["timeline"]
+            .as_array()
+            .expect("timeline")
+            .iter()
+            .filter_map(|c| c["time"].as_f64())
+            .collect()
+    };
+
+    let a = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            980,
+            "validate_lighting",
+            json!({"source": absolute}),
+        )
+        .await,
+    );
+    assert_eq!(a["ok"], true, "{a}");
+    assert_eq!(a["shows"][0]["cues"], 3, "{a}");
+    assert_eq!(times(&a), vec![0.0, 4.0, 8.0], "{a}");
+
+    let b = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            981,
+            "validate_lighting",
+            json!({"source": measures}),
+        )
+        .await,
+    );
+    assert_eq!(b["ok"], true, "{b}");
+    assert_eq!(
+        times(&b),
+        times(&a),
+        "the measure rewrite should land on the same times"
+    );
+
+    // With a tempo map, each cue reports the bar/beat its time corresponds to —
+    // this is what makes a wrong tempo block obvious at a glance.
+    let positions: Vec<&str> = b["shows"][0]["timeline"]
+        .as_array()
+        .expect("timeline")
+        .iter()
+        .filter_map(|c| c["position"].as_str())
+        .collect();
+    assert_eq!(positions.len(), 3, "{b}");
+    assert!(positions[0].starts_with("@1/"), "{positions:?}");
+    assert!(positions[1].starts_with("@3/"), "{positions:?}");
+    assert!(positions[2].starts_with("@5/"), "{positions:?}");
+
+    // Without a tempo map there is no musical position to report, and saying so
+    // beats inventing one.
+    assert!(
+        a["shows"][0]["timeline"][0]["position"].is_null(),
+        "absolute-time show has no tempo map: {a}"
+    );
+
+    // The timeline can be turned off for a parse-only check.
+    let lean = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            982,
+            "validate_lighting",
+            json!({"source": absolute, "include_timeline": false}),
+        )
+        .await,
+    );
+    assert_eq!(lean["ok"], true, "{lean}");
+    assert!(lean["shows"][0].get("timeline").is_none(), "{lean}");
+
+    // A broken show still reports the parse error, not a timeline.
+    let bad = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            983,
+            "validate_lighting",
+            json!({"source": "show \"Broken\" { @00:00.000 cue without colon }"}),
+        )
+        .await,
+    );
+    assert_eq!(bad["ok"], false, "{bad}");
+    assert!(bad["error"].as_str().is_some(), "{bad}");
+
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -215,6 +215,10 @@ pub struct WritePlaylistArgs {
 pub struct ValidateLightingArgs {
     /// `.light` DSL source to validate.
     pub source: String,
+    /// Include each show's resolved cue timeline. Defaults to true; set false
+    /// for a parse-only check on a very large show.
+    #[serde(default = "default_true")]
+    pub include_timeline: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1010,23 +1014,35 @@ impl McpServer {
     }
 
     #[tool(description = "Parse a `.light` DSL source and report any syntax or \
-        semantic errors. Returns the parsed show names and a summary of cues if \
-        valid; an error message otherwise.")]
+        semantic errors. On success returns each show with its resolved cue \
+        timeline: every cue's index, the absolute time it lands on, and — when \
+        the show has a tempo map — the bar/beat that time corresponds to. \
+        \"It parses\" and \"the cues are where I think they are\" are different \
+        claims, especially with meter changes in play; the timeline answers the \
+        second without touching the player or the song config. Returns an error \
+        message otherwise.")]
     async fn validate_lighting(
         &self,
         Parameters(args): Parameters<ValidateLightingArgs>,
     ) -> Result<CallToolResult, McpError> {
         match crate::lighting::parser::parse_light_shows(&args.source) {
             Ok(shows) => {
-                let summary: Vec<Value> = shows
+                let mut summary: Vec<Value> = shows
                     .iter()
                     .map(|(name, show)| {
-                        json!({
+                        let mut entry = json!({
                             "name": name,
                             "cues": show.cues.len(),
-                        })
+                        });
+                        if args.include_timeline {
+                            entry["timeline"] = json!(cue_timeline(show));
+                        }
+                        entry
                     })
                     .collect();
+                // Shows come out of a HashMap; order them so two runs of the
+                // same source can be diffed against each other.
+                summary.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
                 Ok(ok_json(json!({
                     "ok": true,
                     "shows": summary,
@@ -1886,6 +1902,32 @@ fn evaluation_json(
     }
 
     entry
+}
+
+/// A show's cues as resolved times, in cue order.
+///
+/// `position` is derived from the show's tempo map rather than read back from
+/// the source text, which the parser does not retain. That is what makes it
+/// useful for the job this exists for: a tempo block that disagrees with what
+/// the author intended shows up as a position that is not where they put the
+/// cue.
+fn cue_timeline(show: &crate::lighting::parser::LightShow) -> Vec<Value> {
+    show.cues
+        .iter()
+        .enumerate()
+        .map(|(index, cue)| {
+            let position = show.tempo_map.as_ref().map(|map| {
+                let (measure, beat) = map.time_to_measure_beat(cue.time);
+                format!("@{measure}/{beat:.2}")
+            });
+            json!({
+                "index": index,
+                "time": cue.time.as_secs_f64(),
+                "position": position,
+                "effects": cue.effects.len(),
+            })
+        })
+        .collect()
 }
 
 /// Orders shows by name so evaluation is reproducible.


### PR DESCRIPTION
Closes #333.

`validate_lighting` confirmed a show parses and returned nothing about *when* the cues land:

```json
{"ok": true, "shows": [{"cues": 125, "name": "Legions of Decay"}]}
```

For a show written in `@bar/beat` against a `tempo` block, that's the one thing you actually want to check. "It parses" and "the cues are where I think they are" are very different claims, especially with meter changes in play.

## What it returns now

```json
{"ok": true,
 "shows": [{"name": "S", "cues": 3,
            "timeline": [{"index": 0, "time": 0.0, "position": "@1/1.00", "effects": 1},
                         {"index": 1, "time": 4.0, "position": "@3/1.00", "effects": 1}]}]}
```

## What it replaces

Confirming a measure-based rewrite resolved to the same times as the absolute-time original took six steps — write the candidate under a second basename, `patch_song` the `lighting:` block, reload by re-selecting the song, `get_cues`, `patch_song` back, `rm` the temp file — two of which mutate the user's song config, to answer a read-only question.

It's now one call per version, touching neither the player nor the config. The integration test does exactly that comparison: it validates an absolute-time show and its measure-based rewrite, and asserts the resolved times match.

## Design notes

**`position` is derived from the tempo map, not read back from the source.** The parser doesn't retain the source spelling. Deriving it is what makes the field useful for the job this exists for — a tempo block that disagrees with what the author intended shows up as a position that isn't where they put the cue. A show with no tempo map reports `null` rather than inventing one.

**Shows are sorted by name.** They come out of a `HashMap`, so without this two runs over the same source couldn't be diffed against each other — which is the entire use case.

**`include_timeline: false`** keeps the old parse-only answer for a very large show. Default is on, since returning nothing useful was the complaint.

## Tests

Integration test over the wire covering: resolved times for an absolute-time show, the same times from its measure-based rewrite, bar/beat positions present with a tempo map and null without, `include_timeline: false`, and a parse error still reporting the error rather than a timeline.

- `cargo test` — 3215 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

Builds on `TempoMap::time_to_measure_beat`, made `pub(crate)` in #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)