### PR TITLE
Inherit the song's tempo for @bar/beat cueing (#337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A light show inherits the song's tempo, so `@bar/beat` works without hand-writing one**:
+  musical timing — `@bar/beat` cues, `Nbeats` durations, `Nbeat` frequencies — is resolved when
+  the `.light` file is parsed, so a file with no `tempo` block could not use any of it. The song's
+  timing now reaches the parser: its `tempo:` config if it has one, otherwise a tempo map derived
+  from the click track's beat grid. A `tempo` block in the file still wins, keeping precedence
+  author-first.
+
+  The derived map takes the grid as ground truth. It does not round to a "nice" BPM, which would
+  drift a cue by half a second across a long song; instead it keeps the measured per-measure
+  tempo and emits a change only when the tempo moves more than 0.5% or the bar length changes.
+  A steady song therefore produces no tempo changes at all, and a song with two 2/4 bars produces
+  exactly the two meter changes around them.
+
+  Bar 1 beat 1 is placed at the first detected beat rather than at zero. `song_details` now
+  reports that as `lead_in_seconds`, so an author writing a `tempo` block by hand can see what
+  `start: 0ms` would get wrong.
+
+  `validate_lighting` takes an optional `song` so a bar/beat show can be checked against the
+  tempo it will actually load with, and `write_song_lighting` validates against its own song's
+  tempo rather than rejecting a show that would load fine.
+
 - **`validate_lighting` returns resolved cue times**: on success each show now carries its cue
   timeline — every cue's index, the absolute time it resolves to, the number of effects on it,
   and, when the show has a tempo map, the bar/beat that time corresponds to. "It parses" and

--- a/src/audio/click_analysis.rs
+++ b/src/audio/click_analysis.rs
@@ -135,6 +135,276 @@ impl BeatGrid {
             measure_starts,
         }
     }
+
+    /// The detected lead-in: how long before the first beat the song starts.
+    ///
+    /// A song with silence or a count-in ahead of bar 1 does not begin on beat
+    /// one at zero, and an author writing `start: 0ms` is wrong by exactly this
+    /// much with nothing to warn them.
+    pub fn lead_in(&self) -> Duration {
+        self.beats
+            .first()
+            .map(|secs| Duration::from_secs_f64(secs.max(0.0)))
+            .unwrap_or(Duration::ZERO)
+    }
+
+    /// Derives a tempo map from this grid, so a show can use `@bar/beat` cueing
+    /// against a song whose timing came from the click track rather than a
+    /// hand-written `tempo:` block.
+    ///
+    /// The grid is ground truth from the audio, so nothing here rounds to a
+    /// "nice" BPM — that would drift a cue by half a second across a long song.
+    /// Instead the measured per-measure tempo is kept, and a change is emitted
+    /// only when the tempo moves more than [`TEMPO_CHANGE_TOLERANCE`] or the
+    /// bar length changes. A steady song therefore yields no tempo changes at
+    /// all, and a song with two 2/4 bars yields exactly the two meter changes
+    /// around them.
+    ///
+    /// Returns `None` for a grid too small to describe a tempo — under two
+    /// measure boundaries there is no complete bar to measure.
+    pub fn to_tempo_map(&self) -> Option<crate::tempo::TempoMap> {
+        use crate::tempo::{TempoChange, TempoChangePosition, TempoTransition, TimeSignature};
+
+        let measures = self.measures()?;
+        let (first, rest) = measures.split_first()?;
+
+        let mut changes = Vec::new();
+        let mut current_bpm = first.bpm;
+        let mut current_beats = first.beats;
+
+        for measure in rest {
+            let tempo_moved = (measure.bpm - current_bpm).abs() / current_bpm.max(f64::EPSILON)
+                > TEMPO_CHANGE_TOLERANCE;
+            let meter_moved = measure.beats != current_beats;
+            if !tempo_moved && !meter_moved {
+                continue;
+            }
+            changes.push(TempoChange {
+                position: TempoChangePosition::MeasureBeat(measure.number, 1.0),
+                original_measure_beat: Some((measure.number, 1.0)),
+                bpm: tempo_moved.then_some(measure.bpm),
+                time_signature: meter_moved.then(|| TimeSignature::new(measure.beats as u32, 4)),
+                transition: TempoTransition::Snap,
+            });
+            if tempo_moved {
+                current_bpm = measure.bpm;
+            }
+            if meter_moved {
+                current_beats = measure.beats;
+            }
+        }
+
+        Some(crate::tempo::TempoMap::new(
+            // Bar 1 beat 1 is the first detected beat, not zero. This is the
+            // lead-in an author would otherwise have to measure by hand.
+            self.lead_in(),
+            first.bpm,
+            TimeSignature::new(first.beats as u32, 4),
+            changes,
+        ))
+    }
+
+    /// Each complete measure's 1-based number, beat count, and measured tempo.
+    /// `None` when the grid holds fewer than two measure boundaries.
+    fn measures(&self) -> Option<Vec<MeasureTempo>> {
+        if self.measure_starts.len() < 2 {
+            return None;
+        }
+
+        let mut measures = Vec::new();
+        for (index, pair) in self.measure_starts.windows(2).enumerate() {
+            let (start_beat, end_beat) = (pair[0], pair[1]);
+            let beats = end_beat.saturating_sub(start_beat);
+            let (Some(start), Some(end)) = (self.beats.get(start_beat), self.beats.get(end_beat))
+            else {
+                continue;
+            };
+            let seconds = end - start;
+            if beats == 0 || seconds <= 0.0 {
+                continue;
+            }
+            measures.push(MeasureTempo {
+                number: index as u32 + 1,
+                beats,
+                bpm: beats as f64 * 60.0 / seconds,
+            });
+        }
+
+        (!measures.is_empty()).then_some(measures)
+    }
+}
+
+/// Relative tempo movement below which a derived map emits no change. Detected
+/// beats jitter by a few milliseconds; without a tolerance a steady song would
+/// produce a tempo change at every bar.
+const TEMPO_CHANGE_TOLERANCE: f64 = 0.005;
+
+/// One measure's measured tempo, used while deriving a tempo map.
+struct MeasureTempo {
+    /// 1-based measure number.
+    number: u32,
+    /// Beats in this measure.
+    beats: usize,
+    /// Tempo measured across this measure.
+    bpm: f64,
+}
+
+#[cfg(test)]
+mod to_tempo_map_tests {
+    use super::*;
+    use crate::tempo::TimeSignature;
+
+    /// Builds a grid from measure beat-counts at a steady tempo, starting at
+    /// `lead_in` seconds.
+    fn grid(lead_in: f64, bpm: f64, measures: &[usize]) -> BeatGrid {
+        let spacing = 60.0 / bpm;
+        let mut beats = Vec::new();
+        let mut measure_starts = Vec::new();
+        let mut t = lead_in;
+        for count in measures {
+            measure_starts.push(beats.len());
+            for _ in 0..*count {
+                beats.push(t);
+                t += spacing;
+            }
+        }
+        // A trailing boundary so the last measure is complete.
+        measure_starts.push(beats.len());
+        beats.push(t);
+        BeatGrid {
+            beats,
+            measure_starts,
+        }
+    }
+
+    #[test]
+    fn steady_song_yields_no_tempo_changes() {
+        let map = grid(0.0, 120.0, &[4, 4, 4, 4]).to_tempo_map().expect("map");
+        assert!((map.initial_bpm - 120.0).abs() < 0.01);
+        assert_eq!(map.initial_time_signature, TimeSignature::new(4, 4));
+        assert!(
+            map.changes.is_empty(),
+            "a steady song should need no changes: {:?}",
+            map.changes
+        );
+    }
+
+    #[test]
+    fn a_short_bar_becomes_a_meter_change_and_back() {
+        // The shape from #337: 4/4 throughout with one 2/4 bar in the middle.
+        let map = grid(0.0, 80.0, &[4, 4, 4, 2, 4, 4])
+            .to_tempo_map()
+            .expect("map");
+        assert_eq!(map.initial_time_signature, TimeSignature::new(4, 4));
+
+        let meters: Vec<(u32, u32)> = map
+            .changes
+            .iter()
+            .filter_map(|c| {
+                c.original_measure_beat
+                    .map(|(m, _)| m)
+                    .zip(c.time_signature.map(|ts| ts.numerator))
+            })
+            .collect();
+        assert_eq!(
+            meters,
+            vec![(4, 2), (5, 4)],
+            "expected 2/4 at bar 4 and back to 4/4 at bar 5: {:?}",
+            map.changes
+        );
+        assert!(
+            map.changes.iter().all(|c| c.bpm.is_none()),
+            "tempo did not move, only the meter: {:?}",
+            map.changes
+        );
+    }
+
+    #[test]
+    fn a_real_tempo_change_is_captured() {
+        let mut g = grid(0.0, 100.0, &[4, 4]);
+        // Append two bars at 140bpm.
+        let spacing = 60.0 / 140.0;
+        let mut t = *g.beats.last().expect("beats");
+        for _ in 0..2 {
+            g.measure_starts.push(g.beats.len());
+            for _ in 0..4 {
+                g.beats.push(t);
+                t += spacing;
+            }
+        }
+        g.measure_starts.push(g.beats.len());
+        g.beats.push(t);
+
+        let map = g.to_tempo_map().expect("map");
+        let tempo_changes: Vec<f64> = map.changes.iter().filter_map(|c| c.bpm).collect();
+        assert_eq!(tempo_changes.len(), 1, "{:?}", map.changes);
+        assert!(
+            (tempo_changes[0] - 140.0).abs() < 1.0,
+            "expected ~140bpm, got {}",
+            tempo_changes[0]
+        );
+    }
+
+    #[test]
+    fn jitter_below_tolerance_emits_no_change() {
+        // Detected beats are never exact. A few milliseconds of wobble must not
+        // produce a tempo change at every bar.
+        let mut g = grid(0.0, 120.0, &[4, 4, 4, 4]);
+        for (i, beat) in g.beats.iter_mut().enumerate() {
+            *beat += if i % 2 == 0 { 0.001 } else { -0.001 };
+        }
+        let map = g.to_tempo_map().expect("map");
+        assert!(
+            map.changes.is_empty(),
+            "jitter should not read as tempo changes: {:?}",
+            map.changes
+        );
+    }
+
+    #[test]
+    fn the_lead_in_becomes_the_tempo_origin() {
+        // Bar 1 beat 1 is where the click actually starts, not zero.
+        let g = grid(2.5, 120.0, &[4, 4]);
+        assert_eq!(g.lead_in(), Duration::from_secs_f64(2.5));
+
+        let map = g.to_tempo_map().expect("map");
+        let bar1 = map
+            .measure_to_time_with_offset(1, 1.0, 0, 0.0)
+            .expect("bar 1");
+        assert!(
+            (bar1.as_secs_f64() - 2.5).abs() < 0.01,
+            "bar 1 should land on the first beat, got {bar1:?}"
+        );
+    }
+
+    #[test]
+    fn round_trips_through_the_forward_derivation() {
+        // to_tempo_map and from_tempo_map are inverses over a grid's own span.
+        let original = grid(0.0, 96.0, &[4, 4, 4, 4]);
+        let map = original.to_tempo_map().expect("map");
+        let rebuilt = BeatGrid::from_tempo_map(&map, Duration::from_secs_f64(10.0));
+
+        assert_eq!(rebuilt.measure_starts.len(), 4, "{rebuilt:?}");
+        for (a, b) in original.beats.iter().zip(rebuilt.beats.iter()) {
+            assert!((a - b).abs() < 0.01, "beat drift: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn a_grid_too_small_to_describe_a_tempo_yields_none() {
+        assert!(BeatGrid {
+            beats: vec![],
+            measure_starts: vec![]
+        }
+        .to_tempo_map()
+        .is_none());
+        assert!(BeatGrid {
+            beats: vec![0.0, 0.5],
+            measure_starts: vec![0]
+        }
+        .to_tempo_map()
+        .is_none());
+    }
 }
 
 /// Classifies onsets into "accented" (downbeat) vs "normal".

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -158,6 +158,13 @@ transition durations use a slightly different syntax: a bare number means
 beats, and `Nm` means measures (`transition: 4` = 4 beats; `transition: 2m`
 = 2 measures; `transition: snap` for an instantaneous change).
 
+A block is not always required. A show with none inherits the song's tempo —
+its `tempo:` config if it has one, otherwise a map derived from the click
+track's beat grid — so `@bar/beat` cueing works against a song whose timing was
+never hand-written. A block in the file always wins. When writing one by hand,
+check `song_details` for `lead_in_seconds` first: bar 1 beat 1 is where the
+click actually starts, and `start: 0ms` is wrong by exactly the lead-in.
+
 ### Measure offsets
 
 Inside a cue you can shift the bar/beat baseline so the next cues are

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -215,6 +215,11 @@ pub struct WritePlaylistArgs {
 pub struct ValidateLightingArgs {
     /// `.light` DSL source to validate.
     pub source: String,
+    /// Song whose tempo map should resolve musical timing when the source has
+    /// no `tempo` block of its own. Without it, a show using `@bar/beat`,
+    /// `Nbeats`, or `Nbeat` cannot be validated even though it would load fine
+    /// against that song.
+    pub song: Option<String>,
     /// Include each show's resolved cue timeline. Defaults to true; set false
     /// for a parse-only check on a very large show.
     #[serde(default = "default_true")]
@@ -780,7 +785,10 @@ impl McpServer {
         names with source file + channel, sections, lighting show references, \
         MIDI playback presence, loop flag, and (when the song's click track \
         has been analyzed) the beat-grid summary (counts + measure starts), \
-        dominant BPM, and a `tempo_segments` list that breaks the song into \
+        dominant BPM, the detected `lead_in_seconds` (where bar 1 beat 1 \
+        actually falls, which a `tempo` block written as `start: 0ms` gets \
+        wrong by exactly that much), and a `tempo_segments` list that breaks \
+        the song into \
         runs of roughly constant tempo (each with `start_seconds`, \
         `end_seconds`, `beat_count`, `bpm`). The raw per-beat times are NOT \
         included here — call `song_beat_grid` for those.")]
@@ -826,6 +834,10 @@ impl McpServer {
                 "beat_count": g.beats.len(),
                 "measure_count": g.measure_starts.len(),
                 "measure_starts": g.measure_starts,
+                // Where bar 1 beat 1 actually falls. A show's `tempo` block
+                // written as `start: 0ms` is wrong by exactly this much, and
+                // nothing else says so.
+                "lead_in_seconds": g.lead_in().as_secs_f64(),
             })
         });
         let bpm = song
@@ -1025,7 +1037,8 @@ impl McpServer {
         &self,
         Parameters(args): Parameters<ValidateLightingArgs>,
     ) -> Result<CallToolResult, McpError> {
-        match crate::lighting::parser::parse_light_shows(&args.source) {
+        let tempo = self.song_tempo_map(args.song.as_deref())?;
+        match crate::lighting::parser::parse_light_shows_with_tempo(&args.source, tempo.as_ref()) {
             Ok(shows) => {
                 let mut summary: Vec<Value> = shows
                     .iter()
@@ -1053,6 +1066,22 @@ impl McpServer {
                 "error": e.to_string(),
             }))),
         }
+    }
+
+    /// Looks up a song's lighting tempo map by name, if a name was given.
+    fn song_tempo_map(
+        &self,
+        song: Option<&str>,
+    ) -> Result<Option<crate::tempo::TempoMap>, McpError> {
+        let Some(name) = song else {
+            return Ok(None);
+        };
+        let song = self
+            .player
+            .songs()
+            .get(name)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        Ok(song_lighting_tempo(&song))
     }
 
     /// Resolves `evaluate_show`'s `song`/`source` choice into the shows to
@@ -1098,7 +1127,7 @@ impl McpServer {
                         None,
                     ));
                 }
-                Ok((shows, song.tempo_map().cloned()))
+                Ok((shows, song_lighting_tempo(&song)))
             }
             (None, Some(source)) => {
                 let shows = crate::lighting::parser::parse_light_shows(source)
@@ -1530,14 +1559,19 @@ impl McpServer {
         &self,
         Parameters(args): Parameters<WriteSongLightingArgs>,
     ) -> Result<CallToolResult, McpError> {
-        crate::lighting::parser::parse_light_shows(&args.source)
-            .map_err(|e| McpError::invalid_params(format!("invalid .light source: {e}"), None))?;
         validate_lighting_filename(&args.file)?;
         let song = self
             .player
             .songs()
             .get(&args.song)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        // Validate against the tempo this song will actually load it with,
+        // otherwise a bar/beat show is rejected here and then loads fine.
+        crate::lighting::parser::parse_light_shows_with_tempo(
+            &args.source,
+            song_lighting_tempo(&song).as_ref(),
+        )
+        .map_err(|e| McpError::invalid_params(format!("invalid .light source: {e}"), None))?;
 
         let path = match find_song_lighting_path(&song, &args.file) {
             Some(existing) => existing,
@@ -1902,6 +1936,15 @@ fn evaluation_json(
     }
 
     entry
+}
+
+/// The tempo map a song's `.light` files are parsed with: its explicit
+/// `tempo:` block if it has one, otherwise one derived from the click-derived
+/// beat grid. Mirrors what `Song` does at load time.
+fn song_lighting_tempo(song: &crate::songs::Song) -> Option<crate::tempo::TempoMap> {
+    song.tempo_map()
+        .cloned()
+        .or_else(|| song.beat_grid().and_then(|grid| grid.to_tempo_map()))
 }
 
 /// A show's cues as resolved times, in cue order.

--- a/src/lighting/parser.rs
+++ b/src/lighting/parser.rs
@@ -26,5 +26,5 @@ mod tests;
 
 // Re-export public items
 pub use fixture_venue::{parse_fixture_types, parse_venues};
-pub use show::parse_light_shows;
+pub use show::{parse_light_shows, parse_light_shows_with_tempo};
 pub use types::{Cue, Effect, LayerCommand, LayerCommandType, LightShow};

--- a/src/lighting/parser/show.rs
+++ b/src/lighting/parser/show.rs
@@ -45,6 +45,20 @@ type ParseCueResult =
 
 /// Parses light shows from DSL content.
 pub fn parse_light_shows(content: &str) -> Result<HashMap<String, LightShow>, Box<dyn Error>> {
+    parse_light_shows_with_tempo(content, None)
+}
+
+/// Parses light shows, supplying a tempo map for files that carry none.
+///
+/// Musical timing — `@bar/beat` cues, `Nbeats` durations, `Nbeat` frequencies —
+/// is resolved at parse time, so a file without a `tempo` block cannot use any
+/// of it. `external` is the song's tempo map: its `tempo:` block if it has one,
+/// otherwise one derived from the click-derived beat grid. A `tempo` block in
+/// the file still wins, keeping precedence author-first.
+pub fn parse_light_shows_with_tempo(
+    content: &str,
+    external: Option<&TempoMap>,
+) -> Result<HashMap<String, LightShow>, Box<dyn Error>> {
     let pairs = match LightingParser::parse(Rule::file, content) {
         Ok(pairs) => pairs,
         Err(e) => {
@@ -65,7 +79,9 @@ pub fn parse_light_shows(content: &str) -> Result<HashMap<String, LightShow>, Bo
 
     let mut shows = HashMap::new();
     let mut sequences = HashMap::new();
-    let mut global_tempo: Option<TempoMap> = None;
+    // Seeded with the song's map so a file with no tempo block inherits it; a
+    // file-level `tempo { }` overwrites this below.
+    let mut global_tempo: Option<TempoMap> = external.cloned();
     let mut show_pairs = Vec::new();
     let mut sequence_pairs = Vec::new();
 

--- a/src/lighting/parser/tests/tempo_end_to_end_tests.rs
+++ b/src/lighting/parser/tests/tempo_end_to_end_tests.rs
@@ -1608,3 +1608,106 @@ show "Transition Spanning Changes" {
     let bpm_after2 = tempo_map.bpm_at_time(after_change2, 0.0);
     assert!((bpm_after2 - 160.0).abs() < 0.1);
 }
+
+// ── External tempo map (#337) ──────────────────────────────────────────
+
+/// Musical timing is resolved at parse time, so a `.light` file with no
+/// `tempo` block cannot use `@bar/beat`, `Nbeats`, or `Nbeat` — the song's map
+/// has to reach the parser, not just the engine.
+#[test]
+fn musical_timing_needs_a_tempo_map_from_somewhere() {
+    let source = r#"
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 4beats
+}
+"#;
+    assert!(
+        parse_light_shows(source).is_err(),
+        "without a tempo map this cannot resolve"
+    );
+
+    let map = crate::tempo::TempoMap::new(
+        std::time::Duration::ZERO,
+        120.0,
+        crate::tempo::TimeSignature::new(4, 4),
+        vec![],
+    );
+    let shows = parse_light_shows_with_tempo(source, Some(&map))
+        .expect("the song's map should make this resolvable");
+    let show = shows.get("T").expect("show");
+
+    // 120bpm 4/4: a bar is 2s, so bar 3 beat 1 is 4.0s.
+    assert_eq!(show.cues[0].time, std::time::Duration::from_secs(4));
+    // And 4 beats is 2s, not a parse error.
+    assert_eq!(
+        show.cues[0].effects[0].total_duration(),
+        std::time::Duration::from_secs(2)
+    );
+}
+
+/// Precedence stays author-first: a `tempo` block in the file wins over the
+/// song's map.
+#[test]
+fn a_files_own_tempo_block_beats_the_external_map() {
+    let source = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+    // Half the tempo. If it won, bar 3 would land at 8.0s rather than 4.0s.
+    let slow = crate::tempo::TempoMap::new(
+        std::time::Duration::ZERO,
+        60.0,
+        crate::tempo::TimeSignature::new(4, 4),
+        vec![],
+    );
+    let shows = parse_light_shows_with_tempo(source, Some(&slow)).expect("parses");
+    let show = shows.get("T").expect("show");
+    assert_eq!(show.cues[0].time, std::time::Duration::from_secs(4));
+}
+
+/// A map derived from a click-derived grid drives cueing the same way a
+/// hand-written block does — the point of #337.
+#[test]
+fn a_grid_derived_map_resolves_bar_beat_cues() {
+    // Four 4/4 bars at 120bpm, starting 1.5s in.
+    let spacing = 0.5_f64;
+    let lead_in = 1.5_f64;
+    let mut beats = Vec::new();
+    let mut measure_starts = Vec::new();
+    for measure in 0..5 {
+        measure_starts.push(beats.len());
+        for beat in 0..4 {
+            beats.push(lead_in + (measure * 4 + beat) as f64 * spacing);
+        }
+    }
+    let grid = crate::audio::click_analysis::BeatGrid {
+        beats,
+        measure_starts,
+    };
+    let map = grid.to_tempo_map().expect("grid should yield a map");
+
+    let source = r#"
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 1measures
+}
+"#;
+    let shows = parse_light_shows_with_tempo(source, Some(&map)).expect("parses");
+    let show = shows.get("T").expect("show");
+
+    // Bar 1 is at the lead-in (1.5s); each bar is 2s, so bar 3 is at 5.5s.
+    let cue = show.cues[0].time.as_secs_f64();
+    assert!(
+        (cue - 5.5).abs() < 0.05,
+        "bar 3 should account for the 1.5s lead-in, got {cue}"
+    );
+}

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -51,7 +51,11 @@ pub struct DslLightingShow {
 
 impl DslLightingShow {
     /// Creates a new DSL lighting show, validating that the file exists and can be parsed.
-    pub fn new(start_path: &Path, config: &config::LightingShow) -> Result<Self, Box<dyn Error>> {
+    pub fn new(
+        start_path: &Path,
+        config: &config::LightingShow,
+        tempo_map: Option<&crate::tempo::TempoMap>,
+    ) -> Result<Self, Box<dyn Error>> {
         let file_path = if config.file().starts_with('/') {
             PathBuf::from(config.file())
         } else {
@@ -76,14 +80,15 @@ impl DslLightingShow {
             )
         })?;
 
-        let shows = crate::lighting::parser::parse_light_shows(&content).map_err(|e| {
-            // Prepend the file path to the error, preserving newlines in the original error
-            format!(
-                "Failed to parse DSL lighting show {}:\n{}",
-                file_path.display(),
-                e
-            )
-        })?;
+        let shows = crate::lighting::parser::parse_light_shows_with_tempo(&content, tempo_map)
+            .map_err(|e| {
+                // Prepend the file path to the error, preserving newlines in the original error
+                format!(
+                    "Failed to parse DSL lighting show {}:\n{}",
+                    file_path.display(),
+                    e
+                )
+            })?;
 
         Ok(DslLightingShow { file_path, shows })
     }
@@ -183,15 +188,6 @@ impl Song {
                 .collect::<Result<Vec<LightShow>, Box<dyn Error>>>()?,
             None => Vec::default(),
         };
-        // Resolve DSL lighting shows to absolute paths
-        let dsl_lighting_shows = match config.lighting() {
-            Some(lighting_shows) => lighting_shows
-                .iter()
-                .map(|lighting_show| DslLightingShow::new(start_path, lighting_show))
-                .collect::<Result<Vec<DslLightingShow>, Box<dyn Error>>>()?,
-            None => Vec::new(),
-        };
-
         // Calculate the number of channels and sample rate by reading the wav headers of each file.
         let tracks = config
             .tracks()
@@ -243,6 +239,23 @@ impl Song {
             ))
         } else {
             Self::analyze_click_track(start_path, &tracks)
+        };
+
+        // A show gets musical timing from its own `tempo` block, else the
+        // song's `tempo:` config, else the click-derived beat grid. Parsing has
+        // to happen here rather than earlier: the grid is what makes the third
+        // option possible, and the parser resolves `@bar/beat` up front.
+        let lighting_tempo = tempo_map
+            .clone()
+            .or_else(|| beat_grid.as_ref().and_then(|grid| grid.to_tempo_map()));
+        let dsl_lighting_shows = match config.lighting() {
+            Some(lighting_shows) => lighting_shows
+                .iter()
+                .map(|lighting_show| {
+                    DslLightingShow::new(start_path, lighting_show, lighting_tempo.as_ref())
+                })
+                .collect::<Result<Vec<DslLightingShow>, Box<dyn Error>>>()?,
+            None => Vec::new(),
         };
 
         let pilot_hints = match config.pilot() {
@@ -2592,7 +2605,7 @@ mod test {
     #[test]
     fn dsl_lighting_show_file_not_found() {
         let config = crate::config::LightingShow::new("nonexistent.dsl".to_string());
-        let err = super::DslLightingShow::new(Path::new("/tmp"), &config)
+        let err = super::DslLightingShow::new(Path::new("/tmp"), &config, None)
             .expect_err("expected error")
             .to_string();
         assert!(err.contains("does not exist"), "Error: {err}");
@@ -2603,7 +2616,7 @@ mod test {
         let tempdir = tempfile::tempdir()?;
         fs::write(tempdir.path().join("bad.dsl"), "show {")?;
         let config = crate::config::LightingShow::new("bad.dsl".to_string());
-        let err = super::DslLightingShow::new(tempdir.path(), &config)
+        let err = super::DslLightingShow::new(tempdir.path(), &config, None)
             .expect_err("expected error")
             .to_string();
         assert!(
@@ -2618,7 +2631,7 @@ mod test {
         let tempdir = tempfile::tempdir()?;
         fs::write(tempdir.path().join("valid.dsl"), "# just a comment\n")?;
         let config = crate::config::LightingShow::new("valid.dsl".to_string());
-        let show = super::DslLightingShow::new(tempdir.path(), &config)?;
+        let show = super::DslLightingShow::new(tempdir.path(), &config, None)?;
         assert_eq!(show.file_path(), tempdir.path().join("valid.dsl"));
         assert!(show.shows().is_empty());
         Ok(())
@@ -2630,7 +2643,7 @@ mod test {
         let abs_path = tempdir.path().join("absolute.dsl");
         fs::write(&abs_path, "")?;
         let config = crate::config::LightingShow::new(abs_path.to_string_lossy().to_string());
-        let show = super::DslLightingShow::new(Path::new("/some/other/path"), &config)?;
+        let show = super::DslLightingShow::new(Path::new("/some/other/path"), &config, None)?;
         assert_eq!(show.file_path(), abs_path);
         Ok(())
     }


### PR DESCRIPTION
Closes #337.

A `.light` show using `@bar/beat` had to carry its own `tempo { }` block duplicating information the server already had — the click-derived beat grid, which `song_details` will happily report for the same song.

## The issue is right about the symptom, wrong about the cause

#337 proposes adding the derived grid as a third fallback in the `set_tempo_map` chain at `dmx/engine/playback.rs:115`. That chain is not where it breaks.

Musical timing is resolved at **parse** time. A `.light` file with no `tempo` block fails outright:

| source | result |
|---|---|
| `@3/1` cue | `Measure-based timing requires a tempo section` |
| `duration: 4beats` | `Beat-based durations require a tempo section` |
| `frequency: 1beat` | `Beat-based frequency values require a tempo section` |

So the existing `song.tempo_map()` fallback could never fire: a show that needs it fails before any engine sees it, and a show that has its own block satisfies `timeline.tempo_map()` first. The map has to reach the **parser**.

## What changed

**`parse_light_shows_with_tempo(content, external)`** supplies a tempo map to files that carry none. Precedence stays author-first — a `tempo` block in the file always wins. `parse_light_shows` remains as a thin wrapper.

**`BeatGrid::to_tempo_map()`** derives that map from the click grid:

- **No BPM rounding.** The existing `compute_tempo_segments` rounds to whole BPM, which is right for display and wrong here — rounding 137.4 to 137 drifts ~0.5s across 400 beats, a visibly late cue. It keeps the measured per-measure tempo.
- **A change is emitted only when tempo moves >0.5% or the bar length changes.** Detected beats jitter by milliseconds; without a tolerance a steady song would produce a tempo change at every bar. A steady song yields none, and the #337 example — 80bpm with two 2/4 bars — yields exactly the two meter changes around them.
- **Bar 1 beat 1 is the first detected beat, not zero.** That's the lead-in an author would otherwise have to measure by hand (issue item 2).

**`song_details` reports `lead_in_seconds`** (issue item 3), so an author writing a block by hand can see what `start: 0ms` would get wrong.

**Song construction reorders.** DSL lighting was parsed at `songs.rs:187`, before the tracks were read and long before the beat grid existed at line 239. It now happens after the grid.

## Two gaps this exposed

`validate_lighting` and `write_song_lighting` both parsed with no tempo context, so after this change they'd reject a bar/beat show that the player loads without complaint. `validate_lighting` gains an optional `song`; `write_song_lighting` validates against its own song's tempo, which it already knows.

## Tests

7 unit tests on the derivation — steady song emits no changes, a short bar becomes a meter change and back, a real tempo change is captured, jitter below tolerance is ignored, the lead-in becomes the origin, a round-trip through the existing `from_tempo_map`, and a too-small grid returns `None`.

3 end-to-end parser tests — musical timing needs a map from somewhere, a file's own block beats the external map, and a grid-derived map resolves `@bar/beat` including the lead-in offset.

- `cargo test` — 3225 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

## Unblocks

#340's hardest check — "tempo block disagrees with the cached beat grid" — now has both sides available in the same place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)