### PR TITLE
Lint-level warnings from validate_lighting (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`validate_lighting` reports lint-level warnings, not just parse success**: several classes of
+  mistake are perfectly legal DSL and silently do nothing. The response now carries a `warnings`
+  array — non-fatal, so `ok: true` still means "parses" — covering a group that resolves to no
+  fixtures, an effect whose duration runs past the end of the song, two `replace` effects
+  overlapping on the same layer *and* group (last writer wins, the earlier one appears to do
+  nothing), a `tempo` block that drifts from the click track it describes, and a cue positioned
+  past the song's last bar.
+
+  Each check is skipped when its input is missing rather than guessed at. Validating a bare
+  source with no song and no venue reports nothing rather than reporting everything as
+  suspicious, and the group check does not run at all without a loaded venue, where every group
+  would resolve to nothing.
+
+  The overlap check honours `clear`: an effect authored for 30s but cut at 5s does not overlap a
+  cue at 8s, and reporting one would be a false alarm. The tempo check reports only the first bar
+  where the block and the audio diverge, since the rest follow from it.
+
+  `analyze_show` sources its warnings from the same checks, so the two surfaces cannot disagree
+  about the same show.
+
 - **A light show inherits the song's tempo, so `@bar/beat` works without hand-writing one**:
   musical timing — `@bar/beat` cues, `Nbeats` durations, `Nbeat` frequencies — is resolved when
   the `.light` file is parsed, so a file with no `tempo` block could not use any of it. The song's

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -65,7 +65,10 @@ Roughly 50 tools are available. They fall into a few groups:
 - **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
   and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
   `validate_lighting` returns each show's resolved cue timeline alongside the parse result, so
-  "the cues land where I meant" can be checked without loading the show into the player.
+  "the cues land where I meant" can be checked without loading the show into the player, plus
+  lint-level `warnings` for mistakes that are legal DSL but silently do nothing — an empty group,
+  an effect past the end of the song, two `replace` effects stomping each other, a `tempo` block
+  that drifts from the click track.
 - **Show analysis** — `analyze_show` reports where the rig goes dark, how long each group and
   layer is actually doing something, and which targeted groups resolve to no fixtures. Durations
   resolve through the tempo map and layer commands are honoured, so a `clear` that truncates a

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1687,20 +1687,23 @@ async fn mcp_analyze_show_reports_gaps_and_coverage() -> Result<(), Box<dyn Erro
     // everything is background, and its off-phase must not read as a gap.
     assert_eq!(body["per_layer_seconds"]["background"], 9.0, "{body}");
 
-    // `movers` matches no configured group, so its cues would do nothing.
-    let warnings: Vec<&str> = body["warnings"]
+    // `movers` matches no configured group, so its cues would do nothing. The
+    // clear at 5s means the 30s bed never actually overlaps the 8s cue, so no
+    // stomp is reported alongside it.
+    let warnings: Vec<(&str, &str)> = body["warnings"]
         .as_array()
         .expect("warnings")
         .iter()
-        .filter_map(|w| w.as_str())
+        .filter_map(|w| Some((w["kind"].as_str()?, w["message"].as_str()?)))
         .collect();
-    assert!(
-        warnings.iter().any(|w| w.contains("movers")),
-        "expected a warning about `movers`: {body}"
+    assert_eq!(
+        warnings.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+        ["empty-group"],
+        "expected only the empty-group warning: {body}"
     );
     assert!(
-        !warnings.iter().any(|w| w.contains("all_lights")),
-        "`all_lights` resolves and should not be warned about: {body}"
+        warnings[0].1.contains("movers"),
+        "expected a warning about `movers`: {body}"
     );
 
     controller.shutdown();
@@ -1823,6 +1826,48 @@ show "S" {
         a["shows"][0]["timeline"][0]["position"].is_null(),
         "absolute-time show has no tempo map: {a}"
     );
+
+    // Warnings ride alongside the parse result. Nothing here is suspicious, and
+    // with no song and no venue the checks that need them stay quiet rather
+    // than guessing.
+    assert_eq!(
+        a["warnings"].as_array().map(|w| w.len()),
+        Some(0),
+        "a clean show should warn about nothing: {a}"
+    );
+
+    // A show that parses but stomps itself: two `replace` effects overlapping
+    // on the same group and layer, where the later silently wins.
+    let stomping = r#"show "S" {
+    @00:00.000
+    all: static color: "blue", duration: 10s
+
+    @00:05.000
+    all: static color: "red", duration: 10s
+}
+"#;
+    let stomp = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            984,
+            "validate_lighting",
+            json!({"source": stomping}),
+        )
+        .await,
+    );
+    assert_eq!(
+        stomp["ok"], true,
+        "it is legal DSL, just suspicious: {stomp}"
+    );
+    let kinds: Vec<&str> = stomp["warnings"]
+        .as_array()
+        .expect("warnings")
+        .iter()
+        .filter_map(|w| w["kind"].as_str())
+        .collect();
+    assert_eq!(kinds, ["replace-overlap"], "{stomp}");
 
     // The timeline can be turned off for a parse-only check.
     let lean = tool_json(

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1040,6 +1040,8 @@ impl McpServer {
         let tempo = self.song_tempo_map(args.song.as_deref())?;
         match crate::lighting::parser::parse_light_shows_with_tempo(&args.source, tempo.as_ref()) {
             Ok(shows) => {
+                let parsed: Vec<_> = shows.values().cloned().collect();
+                let warnings = self.lint_warnings(&parsed, args.song.as_deref())?;
                 let mut summary: Vec<Value> = shows
                     .iter()
                     .map(|(name, show)| {
@@ -1059,6 +1061,7 @@ impl McpServer {
                 Ok(ok_json(json!({
                     "ok": true,
                     "shows": summary,
+                    "warnings": warnings,
                 })))
             }
             Err(e) => Ok(ok_json(json!({
@@ -1066,6 +1069,57 @@ impl McpServer {
                 "error": e.to_string(),
             }))),
         }
+    }
+
+    /// Runs the non-fatal checks over parsed shows, gathering whatever context
+    /// is available: the venue's group resolution, and — when a song is named —
+    /// its duration and click-derived beat grid.
+    ///
+    /// A check whose input is missing is skipped rather than guessed at, so
+    /// validating a bare source with no song and no venue reports nothing
+    /// rather than reporting everything as suspicious.
+    fn lint_warnings(
+        &self,
+        shows: &[crate::lighting::parser::LightShow],
+        song: Option<&str>,
+    ) -> Result<Vec<Value>, McpError> {
+        let song = match song {
+            Some(name) => Some(
+                self.player
+                    .songs()
+                    .get(name)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?,
+            ),
+            None => None,
+        };
+
+        let mut ctx = crate::lighting::lint::LintContext {
+            song_duration: song.as_ref().map(|s| s.duration()),
+            beat_grid: song.as_ref().and_then(|s| s.beat_grid()),
+            ..Default::default()
+        };
+
+        if let Some(system) = self
+            .player
+            .dmx_engine()
+            .and_then(|dmx| dmx.broadcast_handles().lighting_system)
+        {
+            let mut guard = system.lock();
+            // Only when a venue is actually loaded. Without one every group
+            // resolves to nothing, and reporting them all as empty would be
+            // noise rather than a finding.
+            if guard.get_current_venue().is_some() {
+                for name in group_names(shows) {
+                    let count = guard.resolve_logical_group_graceful(&name).len();
+                    ctx.group_fixture_counts.insert(name, count);
+                }
+            }
+        }
+
+        Ok(crate::lighting::lint::lint_shows(shows, &ctx)
+            .into_iter()
+            .map(|w| json!({"kind": w.kind, "message": w.message}))
+            .collect())
     }
 
     /// Looks up a song's lighting tempo map by name, if a name was given.
@@ -1237,31 +1291,13 @@ impl McpServer {
             include_fixtures: false,
         })?;
 
-        let lighting_system = self
-            .player
-            .dmx_engine()
-            .and_then(|dmx| dmx.broadcast_handles().lighting_system);
-        let targeted = group_names(&shows);
+        // Warnings come from the shared linter rather than a second
+        // implementation here, so `analyze_show` and `validate_lighting` cannot
+        // disagree about the same show.
+        let warnings = self.lint_warnings(&shows, args.song.as_deref())?;
 
-        let (analysis, empty_groups, venue) = tokio::task::spawn_blocking(move || {
-            // Which targeted groups the current venue cannot fill. This is the
-            // warning the issue asks for, and it needs the venue — the analysis
-            // itself deliberately does not.
-            let (empty_groups, venue) = match &lighting_system {
-                Some(system) => {
-                    let mut guard = system.lock();
-                    let venue = guard.current_venue().map(str::to_owned);
-                    let empty: Vec<String> = targeted
-                        .iter()
-                        .filter(|name| guard.resolve_logical_group_graceful(name).is_empty())
-                        .cloned()
-                        .collect();
-                    (empty, venue)
-                }
-                None => (Vec::new(), None),
-            };
-            let analysis = crate::lighting::analyze::analyze_show(shows, fallback_tempo.as_ref());
-            (analysis, empty_groups, venue)
+        let analysis = tokio::task::spawn_blocking(move || {
+            crate::lighting::analyze::analyze_show(shows, fallback_tempo.as_ref())
         })
         .await
         .map_err(|e| McpError::internal_error(format!("analysis failed: {e}"), None))?;
@@ -1276,20 +1312,6 @@ impl McpServer {
                     "seconds": w.seconds(),
                     "position": w.position,
                 })
-            })
-            .collect();
-
-        let warnings: Vec<String> = empty_groups
-            .iter()
-            .map(|name| match &venue {
-                Some(venue) => format!(
-                    "group `{name}` resolves to 0 fixtures in venue `{venue}` — \
-                     its cues will do nothing"
-                ),
-                None => format!(
-                    "group `{name}` resolves to 0 fixtures — no venue is loaded, \
-                     so this may be a false alarm"
-                ),
             })
             .collect();
 

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -20,6 +20,7 @@ pub mod engine;
 pub mod evaluate;
 #[cfg(test)]
 mod layering_tests;
+pub mod lint;
 pub mod parser;
 pub mod system;
 // Tempo lives at the crate root (shared with the metronome and song config);

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -1,0 +1,701 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+//! Non-fatal checks over a parsed light show.
+//!
+//! "Does it parse" is a low bar. Several classes of mistake are perfectly legal
+//! DSL and silently do nothing, or silently do the wrong thing: a group that
+//! matches no fixture, an effect running past the end of the song, two
+//! `replace` effects fighting over the same layer and group, a `tempo` block
+//! that drifts from the click track it is supposed to describe.
+//!
+//! These are warnings, never errors. A show that parses is still valid; these
+//! only say what looks suspicious.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Duration;
+
+use crate::audio::click_analysis::BeatGrid;
+use crate::lighting::effects::{BlendMode, EffectLayer};
+use crate::lighting::parser::LayerCommandType;
+use crate::lighting::parser::LightShow;
+
+/// A non-fatal finding.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Warning {
+    /// Stable identifier, so callers can filter without matching prose.
+    pub kind: &'static str,
+    pub message: String,
+}
+
+impl Warning {
+    fn new(kind: &'static str, message: String) -> Self {
+        Warning { kind, message }
+    }
+}
+
+/// What the checks can be run against. Every field is optional; a check whose
+/// input is missing is skipped rather than guessed at, because a warning that
+/// fires on absent information is worse than no warning.
+#[derive(Default)]
+pub struct LintContext<'a> {
+    /// How many fixtures each targeted group resolves to in the current venue.
+    /// Leave empty when no venue is loaded: every group would resolve to
+    /// nothing, and reporting them all as empty is noise, not a finding.
+    pub group_fixture_counts: HashMap<String, usize>,
+    /// Length of the song the show accompanies.
+    pub song_duration: Option<Duration>,
+    /// The song's click-derived beat grid, for checking a `tempo` block against
+    /// what the audio actually does.
+    pub beat_grid: Option<&'a BeatGrid>,
+}
+
+/// Runs every applicable check over `shows`.
+pub fn lint_shows(shows: &[LightShow], ctx: &LintContext) -> Vec<Warning> {
+    let mut warnings = Vec::new();
+    for show in shows {
+        empty_groups(show, ctx, &mut warnings);
+        effects_past_end_of_song(show, ctx, &mut warnings);
+        stomping_replace_effects(show, &mut warnings);
+        tempo_disagrees_with_grid(show, ctx, &mut warnings);
+        cues_beyond_the_tempo_map(show, ctx, &mut warnings);
+    }
+    warnings
+}
+
+/// A group that resolves to no fixtures. Its cues parse and silently no-op, so
+/// a whole design layer can vanish with no signal.
+fn empty_groups(show: &LightShow, ctx: &LintContext, out: &mut Vec<Warning>) {
+    if ctx.group_fixture_counts.is_empty() {
+        return;
+    }
+    let mut reported = HashSet::new();
+    for cue in &show.cues {
+        for effect in &cue.effects {
+            for group in &effect.groups {
+                if ctx.group_fixture_counts.get(group) != Some(&0) {
+                    continue;
+                }
+                if reported.insert(group.clone()) {
+                    out.push(Warning::new(
+                        "empty-group",
+                        format!(
+                            "group `{group}` resolves to 0 fixtures — its cues will do nothing"
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// An effect whose duration runs past the end of the song. Playback truncates
+/// it, which is usually not what the author meant.
+fn effects_past_end_of_song(show: &LightShow, ctx: &LintContext, out: &mut Vec<Warning>) {
+    let Some(song_end) = ctx.song_duration else {
+        return;
+    };
+    for cue in &show.cues {
+        for effect in &cue.effects {
+            let end = cue.time + effect.total_duration();
+            if end <= song_end {
+                continue;
+            }
+            out.push(Warning::new(
+                "past-end-of-song",
+                format!(
+                    "an effect on `{}` at {:.3}s runs to {:.3}s, past the song's {:.3}s — \
+                     it will be cut short",
+                    effect.groups.join(", "),
+                    cue.time.as_secs_f64(),
+                    end.as_secs_f64(),
+                    song_end.as_secs_f64(),
+                ),
+            ));
+        }
+    }
+}
+
+/// Two `replace`-blend effects overlapping on the same layer *and* group. Last
+/// writer wins with no diagnostic, which is the easiest way to author a cue
+/// that appears to do nothing because something else is stomping it.
+fn stomping_replace_effects(show: &LightShow, out: &mut Vec<Warning>) {
+    let clears = clear_times(show);
+
+    // (layer, group) -> the spans replace-blend effects occupy on it.
+    let mut spans: BTreeMap<(EffectLayer, String), Vec<(Duration, Duration)>> = BTreeMap::new();
+
+    for cue in &show.cues {
+        for effect in &cue.effects {
+            // Both default to the same values the engine applies when the DSL
+            // omits them, so an unannotated effect is checked as it will run.
+            let blend = effect.blend_mode.unwrap_or(BlendMode::Replace);
+            if blend != BlendMode::Replace {
+                continue;
+            }
+            let layer = effect.layer.unwrap_or(EffectLayer::Background);
+            // The authored end is not the real one: a `clear` on this layer
+            // ends the effect there. Comparing authored spans would report a
+            // stomp between two effects that never coexist.
+            let end = effective_end(cue.time + effect.total_duration(), cue.time, layer, &clears);
+            if end <= cue.time {
+                continue;
+            }
+            for group in &effect.groups {
+                spans
+                    .entry((layer, group.clone()))
+                    .or_default()
+                    .push((cue.time, end));
+            }
+        }
+    }
+
+    for ((layer, group), mut occupied) in spans {
+        occupied.sort();
+        for pair in occupied.windows(2) {
+            let ((_, first_end), (second_start, _)) = (pair[0], pair[1]);
+            // Touching is fine — one ends exactly where the next begins.
+            if second_start >= first_end {
+                continue;
+            }
+            out.push(Warning::new(
+                "replace-overlap",
+                format!(
+                    "two `replace` effects overlap on `{group}` in the {} layer between \
+                     {:.3}s and {:.3}s — the later one wins and the earlier appears to do nothing",
+                    format!("{layer:?}").to_lowercase(),
+                    second_start.as_secs_f64(),
+                    first_end.as_secs_f64(),
+                ),
+            ));
+            break; // One report per layer+group is enough to send them looking.
+        }
+    }
+}
+
+/// When each layer is cleared. `None` as the layer key means `clear()` with no
+/// argument, which clears every layer.
+fn clear_times(show: &LightShow) -> Vec<(Option<EffectLayer>, Duration)> {
+    let mut times: Vec<(Option<EffectLayer>, Duration)> = show
+        .cues
+        .iter()
+        .flat_map(|cue| {
+            cue.layer_commands
+                .iter()
+                .filter(|cmd| cmd.command_type == LayerCommandType::Clear)
+                .map(move |cmd| (cmd.layer, cue.time))
+        })
+        .collect();
+    times.sort_by_key(|(_, at)| *at);
+    times
+}
+
+/// An effect's real end: its authored end, or the first `clear` affecting its
+/// layer after it starts, whichever comes first.
+fn effective_end(
+    authored_end: Duration,
+    start: Duration,
+    layer: EffectLayer,
+    clears: &[(Option<EffectLayer>, Duration)],
+) -> Duration {
+    clears
+        .iter()
+        .filter(|(cleared, at)| *at > start && cleared.is_none_or(|l| l == layer))
+        .map(|(_, at)| *at)
+        .find(|at| *at < authored_end)
+        .unwrap_or(authored_end)
+}
+
+/// A `tempo` block that disagrees with the click-derived grid. Silent, and
+/// produces a show that is right for the first N bars and wrong after the first
+/// meter change.
+fn tempo_disagrees_with_grid(show: &LightShow, ctx: &LintContext, out: &mut Vec<Warning>) {
+    let (Some(block), Some(grid)) = (show.tempo_map.as_ref(), ctx.beat_grid) else {
+        return;
+    };
+    let Some(measure_count) = grid.measure_starts.len().checked_sub(1) else {
+        return;
+    };
+    if measure_count == 0 {
+        return;
+    }
+
+    // Compare bar by bar: where does the block put each downbeat, and where
+    // does the audio? A block that agrees drifts by milliseconds; one that
+    // disagrees diverges and stays diverged.
+    const TOLERANCE: f64 = 0.050;
+    for measure in 0..measure_count {
+        let Some(&beat_index) = grid.measure_starts.get(measure) else {
+            break;
+        };
+        let Some(&grid_time) = grid.beats.get(beat_index) else {
+            break;
+        };
+        let Some(block_time) = block.measure_to_time_with_offset(measure as u32 + 1, 1.0, 0, 0.0)
+        else {
+            break;
+        };
+        let drift = (block_time.as_secs_f64() - grid_time).abs();
+        if drift <= TOLERANCE {
+            continue;
+        }
+        out.push(Warning::new(
+            "tempo-grid-mismatch",
+            format!(
+                "the tempo block puts bar {} at {:.3}s but the click track has it at {:.3}s \
+                 ({:.3}s off) — the block and the audio disagree from here on",
+                measure + 1,
+                block_time.as_secs_f64(),
+                grid_time,
+                drift,
+            ),
+        ));
+        return; // The first divergence is the useful one; the rest follow from it.
+    }
+}
+
+/// A cue positioned past the end of the tempo map. `@150/1` on a 102-measure
+/// song resolves to something rather than erroring.
+fn cues_beyond_the_tempo_map(show: &LightShow, ctx: &LintContext, out: &mut Vec<Warning>) {
+    let Some(map) = show.tempo_map.as_ref() else {
+        return;
+    };
+    // A tempo map alone is unbounded — it will happily place bar 10,000. Only
+    // the grid says where the music actually stops, so without one this check
+    // cannot run.
+    let Some(last_measure) = grid_measure_count(ctx) else {
+        return;
+    };
+
+    for (index, cue) in show.cues.iter().enumerate() {
+        let (measure, _) = map.time_to_measure_beat(cue.time);
+        if measure as usize <= last_measure {
+            continue;
+        }
+        out.push(Warning::new(
+            "cue-past-end",
+            format!("cue {index} resolves to bar {measure}, past the song's {last_measure} bars"),
+        ));
+        return;
+    }
+}
+
+fn grid_measure_count(ctx: &LintContext) -> Option<usize> {
+    ctx.beat_grid
+        .and_then(|g| g.measure_starts.len().checked_sub(1))
+        .filter(|n| *n > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lighting::parser::{parse_light_shows, parse_light_shows_with_tempo};
+
+    fn shows(source: &str) -> Vec<LightShow> {
+        parse_light_shows(source)
+            .expect("test show should parse")
+            .into_values()
+            .collect()
+    }
+
+    fn kinds(warnings: &[Warning]) -> Vec<&str> {
+        warnings.iter().map(|w| w.kind).collect()
+    }
+
+    /// A steady grid of `measures` bars of 4 beats at `bpm`, starting at zero.
+    fn grid(bpm: f64, measures: usize) -> BeatGrid {
+        let spacing = 60.0 / bpm;
+        let mut beats = Vec::new();
+        let mut measure_starts = Vec::new();
+        for m in 0..measures {
+            measure_starts.push(beats.len());
+            for b in 0..4 {
+                beats.push((m * 4 + b) as f64 * spacing);
+            }
+        }
+        measure_starts.push(beats.len());
+        beats.push((measures * 4) as f64 * spacing);
+        BeatGrid {
+            beats,
+            measure_starts,
+        }
+    }
+
+    // ── empty groups ───────────────────────────────────────────────
+
+    #[test]
+    fn a_group_resolving_to_nothing_is_reported_once() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    movers: static color: "blue", duration: 2s
+
+    @00:04.000
+    movers: static color: "red", duration: 2s
+}
+"#;
+        let ctx = LintContext {
+            group_fixture_counts: HashMap::from([("movers".to_string(), 0)]),
+            ..Default::default()
+        };
+        let warnings = lint_shows(&shows(source), &ctx);
+        assert_eq!(kinds(&warnings), ["empty-group"]);
+        assert!(warnings[0].message.contains("movers"));
+    }
+
+    #[test]
+    fn a_group_that_resolves_is_not_reported() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 2s
+}
+"#;
+        let ctx = LintContext {
+            group_fixture_counts: HashMap::from([("wash".to_string(), 4)]),
+            ..Default::default()
+        };
+        assert!(lint_shows(&shows(source), &ctx).is_empty());
+    }
+
+    #[test]
+    fn without_a_venue_the_group_check_does_not_guess() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    movers: static color: "blue", duration: 2s
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    // ── past end of song ───────────────────────────────────────────
+
+    #[test]
+    fn an_effect_running_past_the_song_is_reported() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 30s
+}
+"#;
+        let ctx = LintContext {
+            song_duration: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
+        let warnings = lint_shows(&shows(source), &ctx);
+        assert_eq!(kinds(&warnings), ["past-end-of-song"]);
+    }
+
+    #[test]
+    fn an_effect_ending_exactly_at_the_song_end_is_fine() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+}
+"#;
+        let ctx = LintContext {
+            song_duration: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
+        assert!(lint_shows(&shows(source), &ctx).is_empty());
+    }
+
+    // ── stomping replace effects ───────────────────────────────────
+
+    #[test]
+    fn overlapping_replace_effects_on_one_group_are_reported() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+
+    @00:05.000
+    wash: static color: "red", duration: 10s
+}
+"#;
+        let warnings = lint_shows(&shows(source), &LintContext::default());
+        assert_eq!(kinds(&warnings), ["replace-overlap"]);
+        assert!(warnings[0].message.contains("wash"), "{warnings:?}");
+    }
+
+    #[test]
+    fn abutting_effects_are_not_an_overlap() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 5s
+
+    @00:05.000
+    wash: static color: "red", duration: 5s
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    #[test]
+    fn overlaps_on_different_layers_do_not_stomp() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s, layer: background
+
+    @00:05.000
+    wash: static color: "red", duration: 10s, layer: foreground
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    #[test]
+    fn a_non_replace_blend_is_not_stomping() {
+        // `add` is how you deliberately stack effects; only `replace` clobbers.
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s, blend_mode: add
+
+    @00:05.000
+    wash: static color: "red", duration: 10s, blend_mode: add
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    #[test]
+    fn overlaps_on_different_groups_do_not_stomp() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+
+    @00:05.000
+    spot: static color: "red", duration: 10s
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    #[test]
+    fn a_clear_between_two_effects_prevents_the_stomp() {
+        // The bed is authored for 30s and would overlap the later cue, but the
+        // clear at 5s ends it. Reporting a stomp here would be a false alarm,
+        // and a lint that cries wolf gets ignored.
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 30s
+
+    @00:05.000
+    clear(layer: background)
+
+    @00:08.000
+    wash: static color: "red", duration: 2s
+}
+"#;
+        assert!(
+            lint_shows(&shows(source), &LintContext::default()).is_empty(),
+            "the clear ends the bed before the second cue starts"
+        );
+    }
+
+    #[test]
+    fn a_clear_on_another_layer_does_not_rescue_an_overlap() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 30s, layer: background
+
+    @00:05.000
+    clear(layer: foreground)
+
+    @00:08.000
+    wash: static color: "red", duration: 2s, layer: background
+}
+"#;
+        let warnings = lint_shows(&shows(source), &LintContext::default());
+        assert_eq!(kinds(&warnings), ["replace-overlap"], "{warnings:?}");
+    }
+
+    #[test]
+    fn a_bare_clear_ends_every_layer() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 30s, layer: foreground
+
+    @00:05.000
+    clear()
+
+    @00:08.000
+    wash: static color: "red", duration: 2s, layer: foreground
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    // ── tempo block vs beat grid ───────────────────────────────────
+
+    #[test]
+    fn a_tempo_block_matching_the_grid_is_quiet() {
+        let source = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        let g = grid(120.0, 8);
+        let ctx = LintContext {
+            beat_grid: Some(&g),
+            ..Default::default()
+        };
+        assert!(
+            lint_shows(&shows(source), &ctx).is_empty(),
+            "a correct block should be silent"
+        );
+    }
+
+    #[test]
+    fn a_tempo_block_drifting_from_the_grid_is_reported_at_first_divergence() {
+        // The block claims 120bpm; the click track is at 100. Bar 1 agrees, and
+        // everything after it does not.
+        let source = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        let g = grid(100.0, 8);
+        let ctx = LintContext {
+            beat_grid: Some(&g),
+            ..Default::default()
+        };
+        let warnings = lint_shows(&shows(source), &ctx);
+        assert_eq!(kinds(&warnings), ["tempo-grid-mismatch"], "{warnings:?}");
+        // Reported once, at the first bar that disagrees, not at all of them.
+        assert!(warnings[0].message.contains("bar 2"), "{warnings:?}");
+    }
+
+    #[test]
+    fn without_a_grid_the_tempo_check_does_not_run() {
+        let source = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    // ── cues past the end ──────────────────────────────────────────
+
+    #[test]
+    fn a_cue_past_the_last_bar_is_reported() {
+        let map = crate::tempo::TempoMap::new(
+            Duration::ZERO,
+            120.0,
+            crate::tempo::TimeSignature::new(4, 4),
+            vec![],
+        );
+        let source = r#"
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1s
+
+    @50/1
+    wash: static color: "red", duration: 1s
+}
+"#;
+        let parsed: Vec<LightShow> = parse_light_shows_with_tempo(source, Some(&map))
+            .expect("parses")
+            .into_values()
+            .collect();
+        let g = grid(120.0, 8);
+        let ctx = LintContext {
+            beat_grid: Some(&g),
+            ..Default::default()
+        };
+        let warnings = lint_shows(&parsed, &ctx);
+        assert_eq!(kinds(&warnings), ["cue-past-end"], "{warnings:?}");
+        assert!(warnings[0].message.contains("bar 50"), "{warnings:?}");
+    }
+
+    #[test]
+    fn cues_inside_the_song_are_quiet() {
+        let map = crate::tempo::TempoMap::new(
+            Duration::ZERO,
+            120.0,
+            crate::tempo::TimeSignature::new(4, 4),
+            vec![],
+        );
+        let source = r#"
+show "T" {
+    @1/1
+    wash: static color: "blue", duration: 1s
+
+    @4/1
+    wash: static color: "red", duration: 1s
+}
+"#;
+        let parsed: Vec<LightShow> = parse_light_shows_with_tempo(source, Some(&map))
+            .expect("parses")
+            .into_values()
+            .collect();
+        let g = grid(120.0, 8);
+        let ctx = LintContext {
+            beat_grid: Some(&g),
+            ..Default::default()
+        };
+        assert!(lint_shows(&parsed, &ctx).is_empty());
+    }
+
+    // ── nothing to say ─────────────────────────────────────────────
+
+    #[test]
+    fn a_clean_show_produces_no_warnings() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:04.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let ctx = LintContext {
+            group_fixture_counts: HashMap::from([("wash".to_string(), 4)]),
+            song_duration: Some(Duration::from_secs(60)),
+            ..Default::default()
+        };
+        assert!(lint_shows(&shows(source), &ctx).is_empty());
+    }
+}


### PR DESCRIPTION
Closes #340. Builds on #337, which unblocked the tempo-vs-grid check.

`validate_lighting` answered "does this parse". That's a low bar — several classes of mistake are perfectly legal DSL and silently do nothing, or silently do the wrong thing, with no diagnostic.

The response now carries a `warnings` array. Non-fatal, so `ok: true` still means "parses":

```json
{"ok": true,
 "shows": [...],
 "warnings": [
   {"kind": "empty-group", "message": "group `movers` resolves to 0 fixtures — its cues will do nothing"},
   {"kind": "replace-overlap", "message": "two `replace` effects overlap on `wash` in the background layer between 5.000s and 10.000s — the later one wins and the earlier appears to do nothing"}
 ]}
```

Each warning carries a stable `kind` so callers can filter without matching prose.

## All five checks from the issue

| kind | catches |
|---|---|
| `empty-group` | a group resolving to no fixtures — a whole design layer can vanish with no signal |
| `past-end-of-song` | an effect whose duration runs past the song, which playback truncates |
| `replace-overlap` | two `replace` effects on the same layer *and* group; last writer wins silently |
| `tempo-grid-mismatch` | a `tempo` block drifting from the click track — right for the first N bars, wrong after |
| `cue-past-end` | `@150/1` on a 102-bar song, which resolves to something rather than erroring |

The tempo check is the one the issue most wanted, and it needed #337 to make both sides available in one place. It reports only the **first** bar where block and audio diverge, since the rest follow from it.

## Missing input means silence, not guesses

A warning that fires on absent information is worse than no warning. Validating a bare source with no song and no venue reports nothing rather than flagging everything as suspicious. `song_duration` gates the past-end check; the beat grid gates the tempo and cue-past-end checks; a loaded venue gates the group check.

## Two false positives, found by tests and fixed in the checks

**The overlap check ignored `clear`.** A bed authored for 30s and cut by a `clear` at 5s was reported as stomping a cue at 8s — but it never runs then. Spans are now truncated at the first `clear` affecting their layer, and a bare `clear()` ends every layer. This surfaced when the existing `analyze_show` integration test started failing with a warning that shouldn't exist.

**The group check ran without a venue.** With no venue loaded every group resolves to nothing, so every group was reported empty. It now runs only when a venue is actually loaded. This surfaced when a deliberately clean show came back with warnings.

Both were fixed in the checks, not papered over in the tests. A lint that cries wolf gets ignored, which costs more than the check is worth.

## Shared with `analyze_show`

`analyze_show` had its own empty-group warning. It now sources warnings from the same checks, so the two surfaces cannot drift on the same question.

## Tests

19 unit tests over the checks — including that abutting effects are not an overlap, that different layers and different groups don't stomp, that a non-`replace` blend is deliberate stacking, that a clear on *another* layer does not rescue an overlap, and that a correct tempo block is silent. Plus integration assertions on both `validate_lighting` and `analyze_show`.

- `cargo test` — 3244 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)