### PR TITLE
write_song_lighting registers the show it writes (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`write_song_lighting` registers the show it writes**: it previously wrote the `.light` file and
+  reloaded the song registry without adding a `lighting:` entry pointing at it. The result was a
+  success response with a real path, a valid file on disk, and a rig that did nothing —
+  `song_details` would report `dsl_lighting_shows: []` immediately afterwards. Registering it took
+  a separate hand-written `patch_song`.
+
+  The song's `lighting:` block is now updated when the file is not already referenced, and the
+  response reports `registered` along with the `reference` as spelled in `song.yaml`. Rewriting an
+  already-referenced show changes nothing and says so.
+
+  `song.yaml` is edited as text rather than round-tripped through the config types: it is a file
+  someone wrote by hand, and reserialising it would discard their comments, ordering, and
+  formatting to add one line. The result is checked to still parse as a song before it is written,
+  the same guard `patch_song` uses.
+
 - **`validate_lighting` reports lint-level warnings, not just parse success**: several classes of
   mistake are perfectly legal DSL and silently do nothing. The response now carries a `warnings`
   array — non-fatal, so `ok: true` still means "parses" — covering a group that resolves to no

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1904,6 +1904,138 @@ show "S" {
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-sexies: write_song_lighting registers the show (#334)
+// ---------------------------------------------------------------------------
+
+/// Writing a show used to leave an orphan: a success response, a real file on
+/// disk, and nothing playing, because `song.yaml` never referenced it. The
+/// proof is not that a `lighting:` entry appears — it is that the show is
+/// actually loaded afterwards.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_write_song_lighting_registers_the_show() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+
+    // Strip the song back to no lighting at all, before the player loads it.
+    // The name has to match the shipped fixture's, since songs are looked up
+    // by their `name:` rather than their directory.
+    let song = "DSL Light Show Song";
+    let song_dir = fixture.root.join("songs/dsl-light-show-song");
+    std::fs::write(
+        song_dir.join("song.yaml"),
+        "kind: song\nname: \"DSL Light Show Song\"\nmidi_file: \"song.mid\"\ntracks:\n  - name: \"Main Track\"\n    file: \"song.mp3\"\n    file_channel: 1\n",
+    )?;
+    let _ = std::fs::remove_dir_all(song_dir.join("lighting"));
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    let before = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            991,
+            "song_details",
+            json!({"name": song}),
+        )
+        .await,
+    );
+    assert_eq!(
+        before["dsl_lighting_shows"].as_array().map(|a| a.len()),
+        Some(0),
+        "song should start with no shows: {before}"
+    );
+
+    let source = "show \"Written\" {\n    @00:00.000\n    all_lights: static color: \"blue\", duration: 4s\n}\n";
+    let write = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            992,
+            "write_song_lighting",
+            json!({"song": song, "file": "main_show.light", "source": source}),
+        )
+        .await,
+    );
+    assert_eq!(write["registered"], true, "{write}");
+    assert_eq!(write["reference"], "lighting/main_show.light", "{write}");
+
+    // The load is the assertion that matters. An entry in song.yaml that the
+    // loader ignores would be the same silent failure in a new costume.
+    let after = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            993,
+            "song_details",
+            json!({"name": song}),
+        )
+        .await,
+    );
+    assert_eq!(
+        after["dsl_lighting_shows"].as_array().map(|a| a.len()),
+        Some(1),
+        "the written show should now be loaded: {after}"
+    );
+
+    // Rewriting the same basename must not add a second entry.
+    let rewrite = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            994,
+            "write_song_lighting",
+            json!({"song": song, "file": "main_show.light", "source": source}),
+        )
+        .await,
+    );
+    assert_eq!(rewrite["registered"], false, "{rewrite}");
+    assert_eq!(rewrite["already_registered"], true, "{rewrite}");
+
+    let yaml = std::fs::read_to_string(song_dir.join("song.yaml"))?;
+    assert_eq!(
+        yaml.matches("main_show.light").count(),
+        1,
+        "a rewrite must not duplicate the entry: {yaml}"
+    );
+
+    // And the song still loads exactly one show.
+    let again = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            995,
+            "song_details",
+            json!({"name": song}),
+        )
+        .await,
+    );
+    assert_eq!(
+        again["dsl_lighting_shows"].as_array().map(|a| a.len()),
+        Some(1),
+        "{again}"
+    );
+
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1573,10 +1573,15 @@ impl McpServer {
         song. If the song's `lighting:` block already references this \
         basename, the existing path is reused (so root-level layouts and \
         non-standard subdirectories are preserved). Otherwise the file is \
-        created under `<song>/lighting/`. The DSL is parsed first; on \
-        failure the file is not written. The player's song registry is \
-        reloaded after a successful write so the new content takes effect \
-        immediately.")]
+        created under `<song>/lighting/`. The DSL is parsed first, against the \
+        song's own tempo, so a `@bar/beat` show is accepted; on failure the \
+        file is not written. \
+        \
+        The song's `lighting:` block is updated to reference the file if it \
+        does not already — without that the show is written to disk and never \
+        loads. The response reports `registered` and the `reference` as \
+        spelled in `song.yaml`. The player's song registry is reloaded \
+        afterwards so the show takes effect immediately.")]
     async fn write_song_lighting(
         &self,
         Parameters(args): Parameters<WriteSongLightingArgs>,
@@ -1641,11 +1646,60 @@ impl McpServer {
             }
         };
         staged_write_string(&path, &args.source).await?;
+
+        // Writing the file is not enough: without a `lighting:` entry pointing
+        // at it the show never loads, and the caller gets a success response,
+        // a real path, and a rig that does nothing.
+        let registration = self.register_song_lighting(&song, &path).await?;
+
         self.reload_songs_from_config().await?;
         Ok(ok_json(json!({
             "path": path.display().to_string(),
             "bytes": args.source.len(),
+            "registered": registration.registered,
+            "already_registered": registration.already_registered,
+            "reference": registration.reference,
         })))
+    }
+
+    /// Ensures the song's `lighting:` block points at a newly written file.
+    async fn register_song_lighting(
+        &self,
+        song: &crate::songs::Song,
+        path: &std::path::Path,
+    ) -> Result<Registration, McpError> {
+        let config_path = song
+            .config_path()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| song.base_path().join("song.yaml"));
+
+        // The reference is stored relative to the song directory, matching how
+        // a hand-written block spells it.
+        let reference = path
+            .strip_prefix(song.base_path())
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let original = read_text(&config_path).await?;
+        let Some(updated) = register_lighting_file(&original, &reference) else {
+            return Ok(Registration {
+                registered: false,
+                already_registered: true,
+                reference,
+            });
+        };
+
+        // Same guard `patch_song` uses: never write a song.yaml that would not
+        // load back.
+        let _: crate::config::Song = serde_yaml_from_str(&updated)?;
+        staged_write_string(&config_path, &updated).await?;
+
+        Ok(Registration {
+            registered: true,
+            already_registered: false,
+            reference,
+        })
     }
 
     // ---- Patch (string-replace) tools ----
@@ -1967,6 +2021,97 @@ fn song_lighting_tempo(song: &crate::songs::Song) -> Option<crate::tempo::TempoM
     song.tempo_map()
         .cloned()
         .or_else(|| song.beat_grid().and_then(|grid| grid.to_tempo_map()))
+}
+
+/// What `write_song_lighting` did about the song's `lighting:` block.
+struct Registration {
+    /// An entry was added.
+    registered: bool,
+    /// The file was already referenced, so nothing changed.
+    already_registered: bool,
+    /// How the file is spelled in `song.yaml`, relative to the song directory.
+    reference: String,
+}
+
+/// Adds a `lighting:` entry for `relative_path` to a song's YAML.
+///
+/// Returns `None` when the file is already referenced, so a rewrite of an
+/// existing show does not accumulate duplicate entries.
+///
+/// Edits the text rather than round-tripping through serde: a song.yaml is a
+/// file someone wrote by hand, and reserialising it would discard their
+/// comments, ordering, and formatting to add one line.
+pub(crate) fn register_lighting_file(yaml: &str, relative_path: &str) -> Option<String> {
+    if references_lighting_file(yaml, relative_path) {
+        return None;
+    }
+
+    let lines: Vec<&str> = yaml.lines().collect();
+    let entry = format!("- file: {relative_path}");
+
+    // An existing `lighting:` block: append after its last item, so the new
+    // show reads in the order it was added.
+    if let Some(key_index) = lines.iter().position(|line| is_key(line, "lighting")) {
+        let indent = indent_of(lines[key_index]);
+        let mut end = key_index + 1;
+        for (offset, line) in lines.iter().enumerate().skip(key_index + 1) {
+            // The block ends at the next line that is no more indented than
+            // the key itself. Blank lines and comments belong to whatever
+            // follows, so they do not end it on their own.
+            if line.trim().is_empty() || line.trim_start().starts_with('#') {
+                continue;
+            }
+            if indent_of(line) <= indent {
+                break;
+            }
+            end = offset + 1;
+        }
+        // Match the indentation the existing items use, falling back to the
+        // key's own indentation for an empty block.
+        let item_indent = lines
+            .get(key_index + 1)
+            .filter(|line| indent_of(line) > indent && line.trim_start().starts_with('-'))
+            .map(|line| indent_of(line))
+            .unwrap_or(indent);
+
+        let mut updated: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+        updated.insert(end, format!("{}{entry}", " ".repeat(item_indent)));
+        return Some(with_trailing_newline(updated.join("\n")));
+    }
+
+    // No block yet — start one at the end of the file.
+    let mut updated = yaml.trim_end().to_string();
+    updated.push_str(&format!("\nlighting:\n  {entry}"));
+    Some(with_trailing_newline(updated))
+}
+
+/// Whether a song's YAML already points at this lighting file.
+fn references_lighting_file(yaml: &str, relative_path: &str) -> bool {
+    serde_yaml_from_str::<crate::config::Song>(yaml)
+        .ok()
+        .and_then(|song| {
+            song.lighting()
+                .map(|shows| shows.iter().any(|s| s.file() == relative_path))
+        })
+        .unwrap_or(false)
+}
+
+fn is_key(line: &str, key: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed
+        .strip_prefix(key)
+        .is_some_and(|rest| rest.trim_start().starts_with(':'))
+}
+
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+fn with_trailing_newline(mut text: String) -> String {
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
 }
 
 /// A show's cues as resolved times, in cue order.
@@ -2798,6 +2943,108 @@ pub(crate) async fn staged_write_string(
     .await
     .map_err(|e| McpError::internal_error(format!("join error: {e}"), None))?
     .map_err(|e| McpError::internal_error(format!("write failed: {e}"), None))
+}
+
+#[cfg(test)]
+mod register_lighting_tests {
+    use super::register_lighting_file;
+
+    const BASE: &str = "name: Test Song\ntracks:\n  - name: click\n    file: click.wav\n";
+
+    #[test]
+    fn adds_a_lighting_block_when_there_is_none() {
+        let updated = register_lighting_file(BASE, "lighting/main.light").expect("registers");
+        assert!(updated.contains("lighting:"), "{updated}");
+        assert!(updated.contains("- file: lighting/main.light"), "{updated}");
+        // The rest of the file survives untouched.
+        assert!(updated.contains("name: Test Song"));
+        assert!(updated.contains("    file: click.wav"));
+    }
+
+    #[test]
+    fn appends_to_an_existing_block_after_the_last_item() {
+        let yaml =
+            "name: Test Song\nlighting:\n  - file: lighting/a.light\n  - file: lighting/b.light\n";
+        let updated = register_lighting_file(yaml, "lighting/c.light").expect("registers");
+        let lines: Vec<&str> = updated.lines().collect();
+        let positions: Vec<usize> = ["a.light", "b.light", "c.light"]
+            .iter()
+            .map(|f| lines.iter().position(|l| l.contains(f)).expect(f))
+            .collect();
+        assert!(
+            positions[0] < positions[1] && positions[1] < positions[2],
+            "new entry should come last: {updated}"
+        );
+        // Indentation matches the entries already there.
+        assert!(lines[positions[2]].starts_with("  - file:"), "{updated}");
+    }
+
+    #[test]
+    fn a_block_followed_by_other_keys_keeps_them_below() {
+        let yaml = "name: Test Song\nlighting:\n  - file: lighting/a.light\nmidi_file: song.mid\n";
+        let updated = register_lighting_file(yaml, "lighting/b.light").expect("registers");
+        let lines: Vec<&str> = updated.lines().collect();
+        let b = lines.iter().position(|l| l.contains("b.light")).expect("b");
+        let midi = lines
+            .iter()
+            .position(|l| l.contains("midi_file"))
+            .expect("midi");
+        assert!(
+            b < midi,
+            "the entry belongs inside the block, not after the next key: {updated}"
+        );
+    }
+
+    #[test]
+    fn an_already_registered_file_is_left_alone() {
+        // A complete song, since the check reads the parsed `lighting:` block
+        // rather than matching text — the caller always has a loaded song.
+        let yaml = format!("{BASE}lighting:\n  - file: lighting/main.light\n");
+        let yaml = yaml.as_str();
+        assert!(
+            register_lighting_file(yaml, "lighting/main.light").is_none(),
+            "rewriting a registered show must not duplicate its entry"
+        );
+    }
+
+    #[test]
+    fn comments_and_formatting_survive() {
+        let yaml = "# The song\nname: Test Song\n\n# Lighting shows\nlighting:\n  - file: lighting/a.light\n";
+        let updated = register_lighting_file(yaml, "lighting/b.light").expect("registers");
+        assert!(updated.contains("# The song"), "{updated}");
+        assert!(updated.contains("# Lighting shows"), "{updated}");
+    }
+
+    #[test]
+    fn a_trailing_comment_after_the_block_stays_below_the_entry() {
+        let yaml = "name: Test Song\nlighting:\n  - file: lighting/a.light\n\n# trailing note\n";
+        let updated = register_lighting_file(yaml, "lighting/b.light").expect("registers");
+        let lines: Vec<&str> = updated.lines().collect();
+        let b = lines.iter().position(|l| l.contains("b.light")).expect("b");
+        let note = lines
+            .iter()
+            .position(|l| l.contains("# trailing note"))
+            .expect("note");
+        assert!(b < note, "{updated}");
+    }
+
+    #[test]
+    fn the_result_still_parses_as_a_song() {
+        let updated = register_lighting_file(BASE, "lighting/main.light").expect("registers");
+        let song: crate::config::Song =
+            super::serde_yaml_from_str(&updated).expect("must remain valid YAML");
+        assert_eq!(
+            song.lighting().map(|l| l.len()),
+            Some(1),
+            "the entry must actually register"
+        );
+    }
+
+    #[test]
+    fn output_always_ends_with_a_newline() {
+        let updated = register_lighting_file("name: Test Song", "lighting/main.light").unwrap();
+        assert!(updated.ends_with('\n'), "{updated:?}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #334.

`write_song_lighting` wrote the `.light` file and reloaded the song registry, but never added a `lighting:` entry pointing at it. So this succeeded:

```json
{"bytes": 18770, "path": ".../Legions of Decay/lighting/main_show.light"}
```

…and the show still didn't load, because `song.yaml` had no reference to it. `song_details` would report `"dsl_lighting_shows": []` immediately afterwards.

The failure is the worst shape available: a success response, a real path, a valid file on disk, and a rig that does nothing — indistinguishable from success until someone presses play.

## What changed

The tool now adds the entry when the file is not already referenced, and reports what it did:

```json
{"path": ".../lighting/main_show.light", "bytes": 120,
 "registered": true, "already_registered": false,
 "reference": "lighting/main_show.light"}
```

Rewriting an already-referenced show changes nothing and says so, so repeated writes can't accumulate duplicate entries.

## song.yaml is edited as text, not round-tripped

A `song.yaml` is a file someone wrote by hand. Reserialising it through the config types to add one line would discard their comments, ordering, and formatting — so the entry is inserted textually, after the last item of an existing `lighting:` block or as a new block at the end of the file. Indentation matches whatever the existing entries use.

The result is checked to still parse as a `config::Song` before it's written, the same guard `patch_song` uses.

## The test asserts the show loads

Not that an entry appeared. An entry the loader ignored would be the same silent failure in a new costume, so the integration test writes a show to a song stripped of all lighting, then asserts `song_details` reports it loaded — and that a rewrite neither duplicates the entry nor changes the count.

8 unit tests cover the YAML editing: adding a block where none exists, appending after the last item, keeping the entry inside the block when other keys follow, leaving an already-registered file alone, preserving comments, keeping a trailing comment below the new entry, the result still parsing as a song, and always ending with a newline.

## Incidental finding

`config::LightingShow` has only a `file` field, and the config types don't set `deny_unknown_fields` — so the `name:` key that both the issue's example and the shipped `examples/songs/dsl-light-show-song/song.yaml` use is accepted and silently ignored. Not changed here, since it's harmless and removing it would churn user files, but worth knowing: the name in a `lighting:` entry does nothing.

## Tests

- `cargo test` — 3253 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)