### PR TITLE
diff_shows: what changed between two versions of a show (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`diff_shows`: what changed between two versions of a light show**: reports added, removed and
+  changed effects, plus the dark windows the revision opened and closed. Each side takes either a
+  song or DSL source.
+
+  It compares *resolved* effects — real times and durations, after the tempo map — rather than
+  text. Diffing the text is close to useless here: changing one bed's duration from `8measures`
+  to `31beats` is a one-line edit that shifts a section boundary and creates a blackout, while a
+  cue moving from `@63/1` to `@63/3` looks equally small and is a completely different edit. Two
+  cues can also be character-for-character identical and land seconds apart if the tempo block
+  changed between versions.
+
+  Effects are matched on the groups they target and their kind, so a cue nudged by a beat reads
+  as a changed `time` rather than an unrelated removal and addition, while retargeting an effect
+  to a different group reads as the swap it is.
+
 - **`write_song_lighting` registers the show it writes**: it previously wrote the `.light` file and
   reloaded the song registry without adding a `lighting:` entry pointing at it. The result was a
   success response with a real path, a valid file on disk, and a rig that did nothing —

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -69,6 +69,10 @@ Roughly 50 tools are available. They fall into a few groups:
   lint-level `warnings` for mistakes that are legal DSL but silently do nothing — an empty group,
   an effect past the end of the song, two `replace` effects stomping each other, a `tempo` block
   that drifts from the click track.
+- **Show comparison** — `diff_shows` reports what changed between two versions of a show: added,
+  removed and changed effects by resolved time, plus the dark windows the revision opened and
+  closed. It compares resolved effects rather than text, since identical cue text can land in
+  different places when the tempo block changes.
 - **Show analysis** — `analyze_show` reports where the rig goes dark, how long each group and
   layer is actually doing something, and which targeted groups resolve to no fixtures. Durations
   resolve through the tempo map and layer commands are honoured, so a `clear` that truncates a

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -2036,6 +2036,104 @@ async fn mcp_write_song_lighting_registers_the_show() -> Result<(), Box<dyn Erro
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-septies: diff_shows (#341)
+// ---------------------------------------------------------------------------
+
+/// The revision the issue describes: end a section a beat early to open a
+/// blackout. A text diff shows a one-character duration edit; the useful answer
+/// is that a dark window appeared.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_diff_shows_reports_resolved_changes() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    let v1 = r#"show "S" {
+    @00:00.000
+    all_lights: static color: "blue", duration: 10s
+
+    @00:10.000
+    all_lights: static color: "red", duration: 4s
+}
+"#;
+    let v2 = r#"show "S" {
+    @00:00.000
+    all_lights: static color: "blue", duration: 9s
+
+    @00:10.000
+    all_lights: static color: "red", duration: 4s
+}
+"#;
+
+    let body = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1000,
+            "diff_shows",
+            json!({"a_source": v1, "b_source": v2}),
+        )
+        .await,
+    );
+
+    assert_eq!(body["identical"], false, "{body}");
+    // Matched by group and kind, so this is a duration change rather than a
+    // removal and an unrelated addition.
+    assert_eq!(body["added"].as_array().map(|a| a.len()), Some(0), "{body}");
+    assert_eq!(
+        body["removed"].as_array().map(|a| a.len()),
+        Some(0),
+        "{body}"
+    );
+    let changed = body["changed"].as_array().expect("changed");
+    assert_eq!(changed.len(), 1, "{body}");
+    assert_eq!(changed[0]["fields"][0]["field"], "duration");
+    assert_eq!(changed[0]["fields"][0]["from"], "10.000s");
+    assert_eq!(changed[0]["fields"][0]["to"], "9.000s");
+
+    // The field the issue said it would actually have used.
+    let opened = body["dark_windows_added"].as_array().expect("windows");
+    assert_eq!(opened.len(), 1, "{body}");
+    assert_eq!(opened[0]["from"], 9.0);
+    assert_eq!(opened[0]["to"], 10.0);
+    assert_eq!(
+        body["dark_windows_removed"].as_array().map(|a| a.len()),
+        Some(0),
+        "{body}"
+    );
+
+    // A show against itself is identical, which is the answer that lets a
+    // caller trust the rest.
+    let same = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1001,
+            "diff_shows",
+            json!({"a_source": v1, "b_source": v1}),
+        )
+        .await,
+    );
+    assert_eq!(same["identical"], true, "{same}");
+
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -256,6 +256,19 @@ pub struct AnalyzeShowArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct DiffShowsArgs {
+    /// Baseline: a song name, whose registered shows are used.
+    /// Mutually exclusive with `a_source`.
+    pub a_song: Option<String>,
+    /// Baseline: `.light` DSL source. Mutually exclusive with `a_song`.
+    pub a_source: Option<String>,
+    /// Candidate: a song name. Mutually exclusive with `b_source`.
+    pub b_song: Option<String>,
+    /// Candidate: `.light` DSL source. Mutually exclusive with `b_song`.
+    pub b_source: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SongLightingArgs {
     /// Song name as listed by `list_songs`.
     pub song: String,
@@ -1327,6 +1340,90 @@ impl McpServer {
                 .map(|(layer, secs)| (format!("{layer:?}").to_lowercase(), *secs))
                 .collect::<std::collections::BTreeMap<_, _>>(),
             "warnings": warnings,
+        })))
+    }
+
+    #[tool(description = "Report what changed between two versions of a light \
+        show. Compares resolved effects — real times and durations, after the \
+        tempo map has been applied — rather than text, because two cues can be \
+        character-for-character identical and land in different places if the \
+        tempo block changed, and a one-line duration edit can move a section \
+        boundary and open a blackout. Effects are matched on the groups they \
+        target and their kind, so a cue nudged by a beat reads as a changed \
+        time rather than as an unrelated removal and addition. Also reports \
+        `dark_windows_added` and `dark_windows_removed`, since a revision is \
+        usually about what the rig does. Each side takes either a song or DSL \
+        source.")]
+    async fn diff_shows(
+        &self,
+        Parameters(args): Parameters<DiffShowsArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (before, before_tempo) = self.resolve_shows_to_evaluate(&EvaluateShowArgs {
+            song: args.a_song.clone(),
+            source: args.a_source.clone(),
+            times: Vec::new(),
+            include_fixtures: false,
+        })?;
+        let (after, after_tempo) = self.resolve_shows_to_evaluate(&EvaluateShowArgs {
+            song: args.b_song.clone(),
+            source: args.b_source.clone(),
+            times: Vec::new(),
+            include_fixtures: false,
+        })?;
+
+        let diff = tokio::task::spawn_blocking(move || {
+            crate::lighting::diff::diff_shows(
+                before,
+                after,
+                before_tempo.as_ref(),
+                after_tempo.as_ref(),
+            )
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("diff failed: {e}"), None))?;
+
+        let entry = |e: &crate::lighting::diff::DiffEntry| {
+            json!({
+                "time": e.time.as_secs_f64(),
+                "position": e.position,
+                "groups": e.groups,
+                "type": e.effect_type,
+                "layer": format!("{:?}", e.layer).to_lowercase(),
+                "duration": e.duration.as_secs_f64(),
+            })
+        };
+        let window = |w: &crate::lighting::analyze::DarkWindow| {
+            json!({
+                "from": w.from.as_secs_f64(),
+                "to": w.to.as_secs_f64(),
+                "seconds": w.seconds(),
+                "position": w.position,
+            })
+        };
+
+        Ok(ok_json(json!({
+            "identical": diff.is_empty(),
+            "added": diff.added.iter().map(entry).collect::<Vec<_>>(),
+            "removed": diff.removed.iter().map(entry).collect::<Vec<_>>(),
+            "changed": diff
+                .changed
+                .iter()
+                .map(|c| json!({
+                    "before": entry(&c.before),
+                    "after": entry(&c.after),
+                    "fields": c
+                        .fields
+                        .iter()
+                        .map(|f| json!({"field": f.field, "from": f.from, "to": f.to}))
+                        .collect::<Vec<_>>(),
+                }))
+                .collect::<Vec<_>>(),
+            "dark_windows_added": diff.dark_windows_added.iter().map(window).collect::<Vec<_>>(),
+            "dark_windows_removed": diff
+                .dark_windows_removed
+                .iter()
+                .map(window)
+                .collect::<Vec<_>>(),
         })))
     }
 

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -15,6 +15,7 @@
 pub mod analyze;
 #[cfg(test)]
 mod consistency_tests;
+pub mod diff;
 pub mod effects;
 pub mod engine;
 pub mod evaluate;

--- a/src/lighting/diff.rs
+++ b/src/lighting/diff.rs
@@ -1,0 +1,504 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+//! What changed between two versions of a light show.
+//!
+//! Diffing the text is close to useless here. Changing one bed's duration from
+//! `8measures` to `31beats` is a one-line textual change that moves a section
+//! boundary by a beat and opens a blackout; a cue moving from `@63/1` to
+//! `@63/3` looks equally small and is a completely different edit. Worse, two
+//! cues can be textually identical and land in different places if the tempo
+//! block changed between versions.
+//!
+//! So this compares *resolved* effects — real times, real durations, after the
+//! tempo map has been applied — and reports the change in coverage alongside,
+//! since a revision is usually about what the rig does rather than what the
+//! file says.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::lighting::analyze::{analyze_show, DarkWindow};
+use crate::lighting::effects::EffectLayer;
+use crate::lighting::parser::LightShow;
+use crate::tempo::TempoMap;
+
+/// One effect, resolved.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DiffEntry {
+    pub time: Duration,
+    /// Musical position of `time`, when the show has a tempo map.
+    pub position: Option<String>,
+    /// The groups the effect targets, as authored.
+    pub groups: String,
+    /// Effect kind, e.g. `Static`.
+    pub effect_type: &'static str,
+    pub layer: EffectLayer,
+    pub duration: Duration,
+}
+
+/// A field that differs between two versions of the same effect.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FieldChange {
+    pub field: &'static str,
+    pub from: String,
+    pub to: String,
+}
+
+/// An effect present in both versions but not identical.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChangedEntry {
+    pub before: DiffEntry,
+    pub after: DiffEntry,
+    pub fields: Vec<FieldChange>,
+}
+
+/// How two shows differ.
+#[derive(Clone, Debug, Default)]
+pub struct ShowDiff {
+    pub added: Vec<DiffEntry>,
+    pub removed: Vec<DiffEntry>,
+    pub changed: Vec<ChangedEntry>,
+    /// Dark windows the second version has that the first does not.
+    pub dark_windows_added: Vec<DarkWindow>,
+    /// Dark windows the first version had that the second does not.
+    pub dark_windows_removed: Vec<DarkWindow>,
+}
+
+impl ShowDiff {
+    /// True when the two shows resolve identically.
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+}
+
+/// Compares two versions of a show.
+///
+/// Effects are matched on what they target and what kind they are — the things
+/// an author does not change when revising timing — so a cue moved from one
+/// beat to another is reported as a changed `time` rather than as an unrelated
+/// removal and addition. Effects that differ in group or type have genuinely
+/// been swapped out, and are reported as such.
+pub fn diff_shows(
+    before: Vec<LightShow>,
+    after: Vec<LightShow>,
+    before_tempo: Option<&TempoMap>,
+    after_tempo: Option<&TempoMap>,
+) -> ShowDiff {
+    let mut diff = ShowDiff::default();
+
+    let mut old_entries = entries(&before, before_tempo);
+    let mut new_entries = entries(&after, after_tempo);
+
+    // Walk the union of keys so a group that only exists on one side still
+    // gets reported rather than silently dropped.
+    let mut keys: Vec<(String, &'static str)> = old_entries
+        .keys()
+        .chain(new_entries.keys())
+        .cloned()
+        .collect();
+    keys.sort();
+    keys.dedup();
+
+    for key in keys {
+        let olds = old_entries.remove(&key).unwrap_or_default();
+        let news = new_entries.remove(&key).unwrap_or_default();
+
+        // Both sides are in time order, so zipping pairs the nth occurrence
+        // with the nth. For a group whose count is unchanged this pairs every
+        // effect with its counterpart; where the count differs, the surplus
+        // falls out as added or removed.
+        let paired = olds.len().min(news.len());
+        for (old, new) in olds.iter().zip(news.iter()).take(paired) {
+            let fields = field_changes(old, new);
+            if !fields.is_empty() {
+                diff.changed.push(ChangedEntry {
+                    before: old.clone(),
+                    after: new.clone(),
+                    fields,
+                });
+            }
+        }
+        diff.removed.extend(olds.into_iter().skip(paired));
+        diff.added.extend(news.into_iter().skip(paired));
+    }
+
+    diff.added.sort_by_key(|e| e.time);
+    diff.removed.sort_by_key(|e| e.time);
+    diff.changed.sort_by_key(|c| c.before.time);
+
+    // The coverage change is usually the point of a revision — the author is
+    // asking "did I create the blackouts I meant to, and no others".
+    let before_dark = analyze_show(before, before_tempo).dark_windows;
+    let after_dark = analyze_show(after, after_tempo).dark_windows;
+    diff.dark_windows_added = difference(&after_dark, &before_dark);
+    diff.dark_windows_removed = difference(&before_dark, &after_dark);
+
+    diff
+}
+
+/// Resolved effects keyed by what they target and what kind they are, each list
+/// in time order.
+fn entries(
+    shows: &[LightShow],
+    tempo: Option<&TempoMap>,
+) -> BTreeMap<(String, &'static str), Vec<DiffEntry>> {
+    let mut out: BTreeMap<(String, &'static str), Vec<DiffEntry>> = BTreeMap::new();
+
+    for show in shows {
+        let map = show.tempo_map.as_ref().or(tempo);
+        for cue in &show.cues {
+            for effect in &cue.effects {
+                let groups = effect.groups.join(", ");
+                let effect_type = effect.effect_type.name();
+                out.entry((groups.clone(), effect_type))
+                    .or_default()
+                    .push(DiffEntry {
+                        time: cue.time,
+                        position: map.map(|m| {
+                            let (measure, beat) = m.time_to_measure_beat(cue.time);
+                            format!("@{measure}/{beat:.2}")
+                        }),
+                        groups,
+                        effect_type,
+                        layer: effect.layer.unwrap_or(EffectLayer::Background),
+                        duration: effect.total_duration(),
+                    });
+            }
+        }
+    }
+
+    for list in out.values_mut() {
+        list.sort_by_key(|e| e.time);
+    }
+    out
+}
+
+fn field_changes(old: &DiffEntry, new: &DiffEntry) -> Vec<FieldChange> {
+    let mut fields = Vec::new();
+    if old.time != new.time {
+        fields.push(FieldChange {
+            field: "time",
+            from: seconds(old.time),
+            to: seconds(new.time),
+        });
+    }
+    if old.duration != new.duration {
+        fields.push(FieldChange {
+            field: "duration",
+            from: seconds(old.duration),
+            to: seconds(new.duration),
+        });
+    }
+    if old.layer != new.layer {
+        fields.push(FieldChange {
+            field: "layer",
+            from: format!("{:?}", old.layer).to_lowercase(),
+            to: format!("{:?}", new.layer).to_lowercase(),
+        });
+    }
+    fields
+}
+
+fn seconds(d: Duration) -> String {
+    format!("{:.3}s", d.as_secs_f64())
+}
+
+/// Windows in `a` with no counterpart in `b`, compared on their bounds.
+fn difference(a: &[DarkWindow], b: &[DarkWindow]) -> Vec<DarkWindow> {
+    a.iter()
+        .filter(|w| !b.iter().any(|o| o.from == w.from && o.to == w.to))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lighting::parser::parse_light_shows;
+
+    fn shows(source: &str) -> Vec<LightShow> {
+        let mut parsed: Vec<_> = parse_light_shows(source)
+            .expect("test show should parse")
+            .into_values()
+            .collect();
+        parsed.sort_by(|a, b| a.name.cmp(&b.name));
+        parsed
+    }
+
+    fn diff(a: &str, b: &str) -> ShowDiff {
+        diff_shows(shows(a), shows(b), None, None)
+    }
+
+    const BASE: &str = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+
+    #[test]
+    fn a_show_compared_with_itself_reports_nothing() {
+        let d = diff(BASE, BASE);
+        assert!(d.is_empty(), "{d:?}");
+        assert!(d.dark_windows_added.is_empty());
+        assert!(d.dark_windows_removed.is_empty());
+    }
+
+    #[test]
+    fn an_added_cue_is_reported() {
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+
+    @00:20.000
+    wash: static color: "green", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert_eq!(d.added.len(), 1, "{d:?}");
+        assert_eq!(d.added[0].time, Duration::from_secs(20));
+        assert!(d.removed.is_empty());
+        assert!(d.changed.is_empty());
+    }
+
+    #[test]
+    fn a_removed_cue_is_reported() {
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert_eq!(d.removed.len(), 1, "{d:?}");
+        assert_eq!(d.removed[0].time, Duration::from_secs(10));
+        assert!(d.added.is_empty());
+    }
+
+    #[test]
+    fn a_duration_change_is_reported_as_a_change_not_a_swap() {
+        // The edit the issue calls out: `8measures` to `31beats` is one line of
+        // text and a real change in what the rig does.
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:10.000
+    wash: static color: "red", duration: 2s
+}
+"#;
+        let d = diff(BASE, after);
+        assert!(d.added.is_empty(), "{d:?}");
+        assert!(d.removed.is_empty(), "{d:?}");
+        assert_eq!(d.changed.len(), 1);
+        assert_eq!(d.changed[0].fields.len(), 1);
+        assert_eq!(d.changed[0].fields[0].field, "duration");
+        assert_eq!(d.changed[0].fields[0].from, "4.000s");
+        assert_eq!(d.changed[0].fields[0].to, "2.000s");
+    }
+
+    #[test]
+    fn a_moved_cue_is_a_time_change_not_an_add_and_a_remove() {
+        // Matching on what an effect targets rather than when it fires means a
+        // cue nudged by a beat reads as a move, which is what it is.
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:12.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert!(d.added.is_empty(), "{d:?}");
+        assert!(d.removed.is_empty(), "{d:?}");
+        assert_eq!(d.changed.len(), 1);
+        assert_eq!(d.changed[0].fields[0].field, "time");
+        assert_eq!(d.changed[0].fields[0].from, "10.000s");
+        assert_eq!(d.changed[0].fields[0].to, "12.000s");
+    }
+
+    #[test]
+    fn a_different_group_is_a_swap_not_a_change() {
+        // Retargeting an effect is not a tweak to the same cue.
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+
+    @00:10.000
+    spot: static color: "red", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert_eq!(d.removed.len(), 1, "{d:?}");
+        assert_eq!(d.removed[0].groups, "wash");
+        assert_eq!(d.added.len(), 1);
+        assert_eq!(d.added[0].groups, "spot");
+    }
+
+    #[test]
+    fn a_layer_move_is_reported() {
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s, layer: foreground
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert_eq!(d.changed.len(), 1, "{d:?}");
+        assert_eq!(d.changed[0].fields[0].field, "layer");
+        assert_eq!(d.changed[0].fields[0].to, "foreground");
+    }
+
+    // ── the field the issue said it would actually use ─────────────
+
+    #[test]
+    fn a_deliberately_created_blackout_shows_up_as_a_dark_window() {
+        // The whole point of the reporter's v2 revision: end a section early to
+        // open a blackout, and confirm you made the ones you meant to.
+        let before = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 9s
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let d = diff(before, after);
+        assert_eq!(d.dark_windows_added.len(), 1, "{d:?}");
+        let window = &d.dark_windows_added[0];
+        assert_eq!(window.from, Duration::from_secs(9));
+        assert_eq!(window.to, Duration::from_secs(10));
+        assert!(d.dark_windows_removed.is_empty());
+    }
+
+    #[test]
+    fn closing_a_gap_shows_up_as_a_removed_dark_window() {
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        // BASE has a 4s effect at 0 and a gap from 4s to 10s.
+        let d = diff(BASE, after);
+        assert_eq!(d.dark_windows_removed.len(), 1, "{d:?}");
+        assert_eq!(d.dark_windows_removed[0].from, Duration::from_secs(4));
+        assert!(d.dark_windows_added.is_empty());
+    }
+
+    #[test]
+    fn identical_cues_land_differently_when_the_tempo_block_changes() {
+        // The case that makes a text diff useless: not one character of the cue
+        // changed, and it fires two seconds later.
+        let before = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        let after = r#"
+tempo {
+    start: 0ms
+    bpm: 60
+    time_signature: 4/4
+}
+
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        let d = diff(before, after);
+        assert_eq!(d.changed.len(), 1, "{d:?}");
+        assert_eq!(d.changed[0].fields[0].field, "time");
+        // 120bpm puts bar 3 at 4s; 60bpm puts it at 8s.
+        assert_eq!(d.changed[0].fields[0].from, "4.000s");
+        assert_eq!(d.changed[0].fields[0].to, "8.000s");
+    }
+
+    #[test]
+    fn positions_are_reported_when_a_tempo_map_exists() {
+        let before = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        let after = r#"
+tempo {
+    start: 0ms
+    bpm: 120
+    time_signature: 4/4
+}
+
+show "T" {
+    @3/1
+    wash: static color: "blue", duration: 2s
+}
+"#;
+        let d = diff(before, after);
+        assert_eq!(d.changed.len(), 1);
+        assert!(
+            d.changed[0].before.position.is_some(),
+            "{:?}",
+            d.changed[0].before
+        );
+    }
+
+    #[test]
+    fn diffing_against_an_empty_show_reports_everything_removed() {
+        let d = diff(BASE, "show \"T\" {\n}\n");
+        assert_eq!(d.removed.len(), 2, "{d:?}");
+        assert!(d.added.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #341. Builds on `analyze_show` (#389).

There was no way to ask what changed between two versions of a show. The only workable check was diffing the *generator inputs* — which stops being an option the moment someone hand-edits a `.light` in the timeline editor.

## Why not diff the text

The issue puts it well: changing one bed's duration from `8measures` to `31beats` is a one-line textual change that shifts a section boundary by a beat and creates a blackout, while a cue moving from `@63/1` to `@63/3` looks equally small and is a completely different edit.

There's a worse case, which this has a test for: **two cues can be character-for-character identical and land seconds apart** if the tempo block changed between versions. No text diff can see that.

So the comparison is over *resolved* effects — real times and durations, after the tempo map.

## Matching

Effects are matched on **the groups they target and their kind** — the things an author doesn't change when revising timing. Consequences:

- A cue nudged by a beat → `changed` with field `time`, not a removal plus an unrelated addition.
- A duration edit → `changed` with field `duration`.
- Retargeting `wash` → `spot` → a `removed` and an `added`, which is the swap it actually is.

## `dark_window` delta

`dark_windows_added` / `dark_windows_removed` come along, because a revision is usually about what the rig does rather than what the file says. This was the field the issue said it would actually have used — the reporter's v2 was entirely about creating six blackouts, and confirming they'd made six and not seven meant hand-rolling span-coverage analysis.

```json
{"identical": false,
 "changed": [{"fields": [{"field": "duration", "from": "10.000s", "to": "9.000s"}], ...}],
 "dark_windows_added": [{"from": 9.0, "to": 10.0, "seconds": 1.0, "position": null}],
 "dark_windows_removed": []}
```

## Tests

12 unit tests: a show against itself is identical, added/removed cues, duration change reported as a change rather than a swap, a moved cue as a `time` change, a retargeted effect as a swap, a layer move, a deliberately created blackout appearing as a dark window, closing a gap removing one, **identical cue text landing differently when the tempo block changes**, positions reported when a tempo map exists, and diffing against an empty show.

Plus an MCP integration test driving the issue's exact scenario over the wire.

- `cargo test` — 3266 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)