### PR TITLE
Subscribable mtrack://lighting/state resource (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mtrack://lighting/state`: subscribe to lighting instead of polling it**: a new MCP resource
+  carrying per-fixture DMX values, the effects running, and which effects drive each fixture —
+  the same payload `get_fixture_state` returns, through the same builder so the two cannot drift.
+  Subscribers get `notifications/resources/updated` with the payload attached, so a listener
+  never needs a follow-up read.
+
+  Verifying a 124-cue show previously meant polling `status` + `get_active_effects` in a tight
+  loop — around 120 requests a second — reconstructing by hand a stream the server already
+  maintains internally. That polling is the load #332's failures clustered under.
+
+  Notifications are coalesced to at most ten a second rather than firing on every 20Hz sampler
+  tick, and a tick that produced identical state sends nothing at all, so a client attached to an
+  idle rig stays quiet instead of being woken ten times a second forever.
+
 - **`diff_shows`: what changed between two versions of a light show**: reports added, removed and
   changed effects, plus the dark windows the revision opened and closed. Each side takes either a
   song or DSL source.

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -90,10 +90,13 @@ writes to disk, so a malformed edit is rejected rather than corrupting a project
 
 ### Resources
 
-Two resources can be subscribed to (via `resources/subscribe`) for live push updates:
+Three resources can be subscribed to (via `resources/subscribe`) for live push updates:
 
 - `mtrack://status` — a snapshot of player state (active playlist, current song, playback position).
 - `mtrack://config` — the current configuration as YAML, plus a checksum.
+- `mtrack://lighting/state` — live per-fixture DMX values, the effects running, and which effects
+  drive each fixture. Notifications carry the payload, are coalesced to at most 10/second, and are
+  only sent when the state actually changes, so an idle rig stays quiet.
 
 ## Security
 

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -511,6 +511,13 @@ async fn build_standalone_player(
     ));
     player.set_config_store(store);
 
+    // `cli::local::start` installs this before hardware init, and the sampler
+    // that feeds `mtrack://lighting/state` is started by that init. Without it
+    // the harness has no lighting feed while a real deployment always does.
+    let (state_tx, _state_rx) =
+        tokio::sync::watch::channel(Arc::new(crate::state::StateSnapshot::default()));
+    player.set_state_tx(state_tx);
+
     player.await_hardware_ready().await;
     Ok(player)
 }
@@ -2129,6 +2136,146 @@ async fn mcp_diff_shows_reports_resolved_changes() -> Result<(), Box<dyn Error>>
     );
     assert_eq!(same["identical"], true, "{same}");
 
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 3c-octies: subscribable lighting state (#338)
+// ---------------------------------------------------------------------------
+
+/// The lighting feed exists — a 20Hz sampler on a watch channel that the web
+/// UI's `/ws` already streams. This connects it to MCP so a monitoring client
+/// gets pushes instead of polling `status` + `get_active_effects` at 120
+/// requests a second, which is the load #332 was suspected of being induced by.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_lighting_state_resource_pushes_on_change() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+    std::fs::create_dir_all(fixture.root.join("lighting/venues"))?;
+    std::fs::create_dir_all(fixture.root.join("lighting/fixture_types"))?;
+    copy_dir_recursive(
+        Path::new("examples/lighting/fixture_types"),
+        &fixture.root.join("lighting/fixture_types"),
+    )?;
+    std::fs::write(
+        fixture.root.join("lighting/venues/main_stage.light"),
+        "venue \"main_stage\" {\n  fixture \"Par1\" RGBW_Par @ 1:1 tags [\"wash\"]\n  fixture \"Par2\" RGBW_Par @ 1:7 tags [\"wash\"]\n}\n",
+    )?;
+    let song_lighting_dir = fixture.root.join("songs/dsl-light-show-song/lighting");
+    std::fs::write(
+        song_lighting_dir.join("main_show.light"),
+        "show \"Lit\" {\n    @00:00.000\n    all_lights: static color: \"green\", duration: 120s\n}\n",
+    )?;
+    std::fs::write(
+        song_lighting_dir.join("outro.light"),
+        "show \"Outro\" {\n    @01:00.000\n    all_lights: static color: \"white\", duration: 1s\n}\n",
+    )?;
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    // The resource is advertised alongside the existing two.
+    let (_, listed) = mcp_post(
+        &client,
+        &url,
+        Some(&session),
+        &json!({"jsonrpc": "2.0", "id": 1100, "method": "resources/list"}),
+    )
+    .await;
+    let uris: Vec<&str> = listed["result"]["resources"]
+        .as_array()
+        .expect("resources")
+        .iter()
+        .filter_map(|r| r["uri"].as_str())
+        .collect();
+    assert!(
+        uris.contains(&"mtrack://lighting/state"),
+        "lighting resource not advertised: {uris:?}"
+    );
+
+    // Reading it gives the same shape `get_fixture_state` returns.
+    let (_, read) = mcp_post(
+        &client,
+        &url,
+        Some(&session),
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1101,
+            "method": "resources/read",
+            "params": {"uri": "mtrack://lighting/state"}
+        }),
+    )
+    .await;
+    let text = read["result"]["contents"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no contents: {read}"));
+    let body: Value = serde_json::from_str(text).expect("resource payload is JSON");
+    assert_eq!(body["available"], true, "{body}");
+    assert!(body["fixtures"].is_array(), "{body}");
+
+    let (_, sub) = mcp_post(
+        &client,
+        &url,
+        Some(&session),
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1102,
+            "method": "resources/subscribe",
+            "params": {"uri": "mtrack://lighting/state"}
+        }),
+    )
+    .await;
+    assert!(
+        sub.get("error").is_none() && sub["result"].is_object(),
+        "subscribe was rejected: {sub}"
+    );
+
+    let session_clone = session.clone();
+    let url_clone = url.clone();
+    let listener_client = client.clone();
+    let listener = tokio::spawn(async move {
+        wait_for_event(
+            &listener_client,
+            &url_clone,
+            &session_clone,
+            Duration::from_secs(10),
+            |v| {
+                v.get("method").and_then(|m| m.as_str()) == Some("notifications/resources/updated")
+                    && v["params"]["uri"].as_str() == Some("mtrack://lighting/state")
+            },
+        )
+        .await
+    });
+
+    // Let the listener open its GET before anything changes.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Starting the show lights the rig, which is a real state change.
+    let _ = call_tool(&client, &url, &session, 1103, "play", json!({})).await;
+
+    let event = listener.await.expect("listener task");
+    assert_eq!(
+        event["params"]["uri"].as_str(),
+        Some("mtrack://lighting/state"),
+        "{event}"
+    );
+    // The payload rides along, so a listener never needs the follow-up read.
+    let payload = &event["params"]["_meta"]["mtrack.lighting"];
+    assert_eq!(payload["available"], true, "{event}");
+    assert!(payload["fixtures"].is_array(), "{event}");
+
+    let _ = call_tool(&client, &url, &session, 1104, "stop", json!({})).await;
     controller.shutdown();
     Ok(())
 }

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -63,6 +63,14 @@ use crate::player::Player;
 const RESOURCE_STATUS_URI: &str = "mtrack://status";
 /// Resource URI exposing the current configuration YAML plus checksum.
 const RESOURCE_CONFIG_URI: &str = "mtrack://config";
+/// Live lighting state: per-fixture DMX values and the effects driving them.
+const RESOURCE_LIGHTING_URI: &str = "mtrack://lighting/state";
+
+/// Fastest a lighting subscriber is woken. The sampler runs at 20Hz; sending
+/// every tick is more than a monitoring client needs and is the load the
+/// polling in #338 was standing in for. Ticks between notifications are
+/// coalesced — the next payload sent is the current state, not a backlog.
+const LIGHTING_NOTIFY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// MCP server handler holding shared state for tool calls.
 ///
@@ -454,35 +462,7 @@ impl McpServer {
         than only counting them."
     )]
     async fn get_fixture_state(&self) -> Result<CallToolResult, McpError> {
-        let engine = match self.player.effect_engine() {
-            Some(engine) => engine,
-            None => {
-                return Ok(ok_json(json!({
-                    "available": false,
-                    "reason": "no effect engine configured",
-                })))
-            }
-        };
-
-        let elapsed = self
-            .player
-            .elapsed()
-            .await
-            .map_err(internal_err)?
-            .unwrap_or_default();
-
-        // The effect engine's mutex is shared with the effects loop thread, so
-        // never block a tokio worker on it.
-        let snapshot = tokio::task::spawn_blocking(move || {
-            let guard = engine.lock();
-            crate::lighting::evaluate::snapshot(&guard, elapsed)
-        })
-        .await
-        .map_err(|e| McpError::internal_error(format!("snapshot failed: {e}"), None))?;
-
-        let mut value = evaluation_json(&snapshot, true);
-        value["available"] = json!(true);
-        Ok(ok_json(value))
+        Ok(ok_json(self.lighting_snapshot().await?))
     }
 
     // ---- Playback control ----
@@ -1133,6 +1113,13 @@ impl McpServer {
             .into_iter()
             .map(|w| json!({"kind": w.kind, "message": w.message}))
             .collect())
+    }
+
+    /// Builds the live lighting payload returned by `get_fixture_state` and by
+    /// reading the `mtrack://lighting/state` resource, so the tool and the
+    /// resource never drift. Thin wrapper around [`build_lighting_snapshot`].
+    pub(crate) async fn lighting_snapshot(&self) -> Result<Value, McpError> {
+        build_lighting_snapshot(&self.player).await
     }
 
     /// Looks up a song's lighting tempo map by name, if a name was given.
@@ -1934,7 +1921,8 @@ impl ServerHandler for McpServer {
             "mtrack MCP server. Inspect and control the running multitrack player: \
              query playback status, list songs, edit playlists, and create lighting shows. \
              Use the `lighting_dsl_reference` tool before generating .light files. \
-             Subscribe to `mtrack://status` or `mtrack://config` for resource-updated \
+             Subscribe to `mtrack://status`, `mtrack://lighting/state`, or \
+             `mtrack://config` for resource-updated \
              notifications when playback state or configuration changes."
                 .to_string(),
         )
@@ -1955,6 +1943,27 @@ impl ServerHandler for McpServer {
                         description: Some(
                             "Live JSON snapshot of the player: active playlist, \
                              current song, playing flag, elapsed time."
+                                .to_string(),
+                        ),
+                        mime_type: Some("application/json".to_string()),
+                        size: None,
+                        icons: None,
+                        meta: None,
+                    },
+                    annotations: None,
+                },
+                Resource {
+                    raw: RawResource {
+                        uri: RESOURCE_LIGHTING_URI.to_string(),
+                        name: "Lighting State".to_string(),
+                        title: None,
+                        description: Some(
+                            "Live per-fixture DMX values (0-255, including \
+                             virtual-dimmer RGB scaling), the effects running, \
+                             and which effects drive each fixture. Subscribe for \
+                             pushes instead of polling; notifications are \
+                             coalesced to at most 10 per second and are only sent \
+                             when the state actually changes."
                                 .to_string(),
                         ),
                         mime_type: Some("application/json".to_string()),
@@ -2000,6 +2009,13 @@ impl ServerHandler for McpServer {
                     request.uri,
                 )]))
             }
+            RESOURCE_LIGHTING_URI => {
+                let json = self.lighting_snapshot().await?;
+                Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                    serde_json::to_string_pretty(&json).unwrap_or_else(|_| json.to_string()),
+                    request.uri,
+                )]))
+            }
             RESOURCE_CONFIG_URI => {
                 let store = self.config_store()?;
                 let (yaml, checksum) = store.read_yaml().await.map_err(internal_err)?;
@@ -2029,6 +2045,7 @@ impl ServerHandler for McpServer {
         }
         let handle = match uri.as_str() {
             RESOURCE_STATUS_URI => self.spawn_status_subscription(ctx.peer.clone())?,
+            RESOURCE_LIGHTING_URI => self.spawn_lighting_subscription(ctx.peer.clone())?,
             RESOURCE_CONFIG_URI => self.spawn_config_subscription(ctx.peer.clone())?,
             other => {
                 return Err(McpError::invalid_params(
@@ -2534,6 +2551,37 @@ async fn send_resource_updated(
 /// can compute it without capturing an `McpServer` (which would form a
 /// reference cycle through `subscriptions` → `SubscriptionHandle` →
 /// `AbortHandle` and silently defeat abort-on-Drop).
+/// Builds the live lighting payload. Free function so the subscription task can
+/// call it while capturing only `Arc<Player>`, for the same reason
+/// [`build_status_snapshot`] is one.
+async fn build_lighting_snapshot(player: &Player) -> Result<Value, McpError> {
+    let Some(engine) = player.effect_engine() else {
+        return Ok(json!({
+            "available": false,
+            "reason": "no effect engine configured",
+        }));
+    };
+
+    let elapsed = player
+        .elapsed()
+        .await
+        .map_err(internal_err)?
+        .unwrap_or_default();
+
+    // The effect engine's mutex is shared with the effects loop thread, so
+    // never block a tokio worker on it.
+    let snapshot = tokio::task::spawn_blocking(move || {
+        let guard = engine.lock();
+        crate::lighting::evaluate::snapshot(&guard, elapsed)
+    })
+    .await
+    .map_err(|e| McpError::internal_error(format!("snapshot failed: {e}"), None))?;
+
+    let mut value = evaluation_json(&snapshot, true);
+    value["available"] = json!(true);
+    Ok(value)
+}
+
 async fn build_status_snapshot(player: &Player) -> Result<Value, McpError> {
     let playlist = player.get_playlist();
     let current = playlist.current();
@@ -2589,6 +2637,64 @@ impl McpServer {
                 {
                     break;
                 }
+            }
+        });
+        Ok(handle.abort_handle())
+    }
+
+    /// Watches the 20Hz state sampler and pushes lighting updates to the
+    /// subscribed peer.
+    ///
+    /// Two behaviours matter more than the plumbing. Notifications are
+    /// coalesced to [`LIGHTING_NOTIFY_INTERVAL`], because a monitoring client
+    /// does not need every sampler tick and the request load is the thing this
+    /// resource exists to remove. And a tick that produced the same state sends
+    /// nothing at all, so a subscriber attached to an idle rig stays quiet
+    /// rather than being woken ten times a second forever.
+    ///
+    /// The payload rides along under `_meta["mtrack.lighting"]`, so a listener
+    /// never needs the follow-up `resources/read` round trip.
+    fn spawn_lighting_subscription(&self, peer: Peer<RoleServer>) -> Result<AbortHandle, McpError> {
+        let mut rx = self.player.state_rx().ok_or_else(|| {
+            McpError::internal_error(
+                "lighting state is not available (no state sampler is running)",
+                None,
+            )
+        })?;
+        // Captures only `Arc<Player>`, never the whole `McpServer` — the
+        // subscriptions map holds this task's abort handle, so capturing the
+        // server would keep it alive and defeat abort-on-drop at session end.
+        let player = self.player.clone();
+
+        let handle = tokio::spawn(async move {
+            // Whatever is on the channel now is what a fresh `resources/read`
+            // would return, so only emit on change from here.
+            rx.mark_unchanged();
+            let mut last = rx.borrow().clone();
+
+            loop {
+                if rx.changed().await.is_err() {
+                    break;
+                }
+                if *rx.borrow_and_update() == last {
+                    continue;
+                }
+
+                let payload = build_lighting_snapshot(&player)
+                    .await
+                    .unwrap_or(Value::Null);
+                if send_resource_updated(&peer, RESOURCE_LIGHTING_URI, "mtrack.lighting", payload)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+
+                // Coalesce the ticks that arrive while we were sending. The
+                // next payload is the state then, not a replay of this backlog.
+                tokio::time::sleep(LIGHTING_NOTIFY_INTERVAL).await;
+                rx.mark_unchanged();
+                last = rx.borrow().clone();
             }
         });
         Ok(handle.abort_handle())

--- a/src/state.rs
+++ b/src/state.rs
@@ -24,14 +24,18 @@ use crate::lighting::effects::{is_multiplier_channel, FixtureState};
 use crate::lighting::EffectEngine;
 
 /// Pre-computed fixture display state: all non-multiplier channels at 0-255.
-#[derive(Clone, Debug)]
+///
+/// `PartialEq` so a push-based consumer can tell a real change from a sampler
+/// tick that produced the same values — an idle rig must not wake subscribers
+/// twenty times a second.
+#[derive(Clone, Debug, PartialEq)]
 pub struct FixtureSnapshot {
     pub name: String,
     pub channels: HashMap<String, u8>,
 }
 
 /// State snapshot broadcast to all display consumers.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct StateSnapshot {
     pub fixtures: Vec<FixtureSnapshot>,
     pub active_effects: Vec<String>,


### PR DESCRIPTION
Closes #338.

There was no push-based way to observe lighting state over MCP. Verifying a 124-cue show meant polling `status` + `get_active_effects` in a tight loop — about 120 requests a second — reconstructing by hand a stream the server already maintains internally.

As the issue puts it: *starving the cue dispatcher in order to watch the cue dispatcher.* That load is what #332's failures clustered under.

## Both halves already existed

- `src/state.rs` runs a 20Hz sampler publishing `StateSnapshot` on a `tokio::sync::watch`.
- `src/webui/server.rs` streams it to the web UI over `/ws`.
- The MCP server already advertised `"resources": {"subscribe": true}`.

They were simply not connected. This connects them.

## What it exposes

`mtrack://lighting/state` — readable and subscribable — carrying the same payload `get_fixture_state` returns: per-fixture DMX values (0–255, including virtual-dimmer RGB scaling), the effects running, and which effects drive each fixture. Both go through one builder, so the tool and the resource can't drift.

Notifications carry the payload under `_meta["mtrack.lighting"]`, so a listener never needs the follow-up `resources/read` round trip.

## Two behaviours that matter more than the plumbing

**Coalesced to at most 10/second.** The sampler runs at 20Hz; a monitoring client doesn't need every tick, and request load is the thing this resource exists to remove. Ticks arriving during a send are collapsed — the next payload is the state *then*, not a replay of a backlog.

**An idle rig sends nothing.** A tick that produced identical state is skipped, so a client attached to a stopped player stays quiet rather than being woken ten times a second forever. This is why `StateSnapshot` and `FixtureSnapshot` gain `PartialEq` — cheap change detection on the sampler's own output, before the richer payload is built.

## A harness gap this exposed

The subscription initially failed with "no state sampler is running". `cli::local::start` installs the state channel unconditionally, before hardware init — so a real deployment always has the feed, including headless MCP-only ones. The MCP test harness never installed it, despite its builder's comment saying it mirrors that path. Fixed there, which brings the harness closer to production for every test in the file.

## Tests

An integration test drives the whole path over the wire: the resource is advertised in `resources/list`, `resources/read` returns the expected shape, `resources/subscribe` is accepted, and starting a show produces a `notifications/resources/updated` with the payload attached.

- `cargo test` — 3282 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

## Relevance to #332

This removes the polling pressure the reporter suspected of inducing the arming failure, and gives a push-based way to watch cue dispatch without perturbing it — which is what makes #332 diagnosable rather than guessable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)