### PR TITLE
Make cue arming observable, and guard cross-playback clock writes (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Lighting arming is guarded and observable (#332)**: a seek or song change starts a new
+  playback while the outgoing one's song-time tracker is still winding down, carrying the
+  *previous* start offset. One stale write from it is enough to silence a show for its whole
+  duration — the cue pointer only moves forward, so a write past the last cue exhausts the
+  timeline permanently, and active effects expire against score time that jumped. Song-time
+  writers now carry a playback generation and a write from a superseded playback is dropped.
+
+  `status` reports `lighting.armed`, `cues_total`, `cues_remaining` and `next_cue_seconds` when a
+  show is loaded, so "will this fire?" is one call instead of polling for effects and inferring
+  from their absence. A show that is armed with no cues ahead of its pointer also logs a warning,
+  since that state produces silence and otherwise says nothing about it.
+
+  Note this is a guard against a race that was identified by inspection, not one reproduced from
+  the original report. The failure was only ever seen under heavy MCP polling, which
+  `mtrack://lighting/state` now removes the need for.
+
 - **`mtrack://lighting/state`: subscribe to lighting instead of polling it**: a new MCP resource
   carrying per-fixture DMX values, the effects running, and which effects drive each fixture —
   the same payload `get_fixture_state` returns, through the same builder so the two cannot drift.

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -374,7 +374,11 @@ impl McpServer {
     }
 
     #[tool(description = "Return the current playback status: active playlist, \
-        current song, whether a song is playing, and elapsed time.")]
+        current song, whether a song is playing, elapsed time, and — when a \
+        light show is loaded — whether its timeline is armed and where its cue \
+        pointer sits. `lighting.armed` false, or `cues_remaining` 0 while the \
+        song is still playing, means no cues will fire for the rest of this \
+        playback.")]
     async fn status(&self) -> Result<CallToolResult, McpError> {
         Ok(ok_json(self.status_snapshot().await?))
     }
@@ -2591,11 +2595,33 @@ async fn build_status_snapshot(player: &Player) -> Result<Value, McpError> {
         .await
         .map_err(internal_err)?
         .unwrap_or_default();
+    // Whether the lighting will actually fire, answerable here rather than by
+    // polling for effects and inferring from their absence (#332).
+    //
+    // The timeline mutex is shared with the effects loop thread, so this reads
+    // it on the blocking pool rather than parking a tokio worker on it.
+    let lighting = match player.dmx_engine() {
+        Some(dmx) => tokio::task::spawn_blocking(move || dmx.lighting_arming_state())
+            .await
+            .ok()
+            .flatten()
+            .map(|(armed, total, remaining, next)| {
+                json!({
+                    "armed": armed,
+                    "cues_total": total,
+                    "cues_remaining": remaining,
+                    "next_cue_seconds": next.map(|t| t.as_secs_f64()),
+                })
+            }),
+        None => None,
+    };
+
     Ok(json!({
         "playlist_name": playlist.name(),
         "current_song": current.as_ref().map(|s| song_summary(s)),
         "playing": playing,
         "elapsed": format_duration(elapsed),
+        "lighting": lighting,
     }))
 }
 

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -101,6 +101,16 @@ pub struct Engine {
     pub(super) effects_loop_handle: Mutex<Option<JoinHandle<()>>>,
     pub(super) current_song_timeline: Arc<Mutex<Option<LightingTimeline>>>,
     pub(super) current_song_time: Arc<AtomicU64>,
+    /// Which playback the song-time writers belong to.
+    ///
+    /// A seek or song change starts a new playback while the outgoing one's
+    /// song-time tracker is still winding down, and that tracker carries the
+    /// *previous* start offset. One stale write is enough to silence a show
+    /// for its whole duration: the cue pointer only moves forward, so a write
+    /// past the last cue exhausts the timeline permanently, and effects expire
+    /// against score time that jumped. Writers stamp their generation and a
+    /// write from a superseded one is dropped.
+    pub(super) playback_generation: Arc<AtomicU64>,
     pub(super) timeline_finished: Arc<AtomicBool>,
     pub(super) timeline_cancel_handle: Arc<Mutex<Option<CancelHandle>>>,
     pub(super) broadcast_tx: Mutex<Option<tokio::sync::broadcast::Sender<String>>>,
@@ -191,6 +201,7 @@ impl Engine {
         let current_song_timeline: Arc<Mutex<Option<LightingTimeline>>> =
             Arc::new(Mutex::new(None));
         let current_song_time = Arc::new(AtomicU64::new(0));
+        let playback_generation = Arc::new(AtomicU64::new(0));
         let timeline_finished = Arc::new(AtomicBool::new(true));
         let timeline_cancel_handle: Arc<Mutex<Option<CancelHandle>>> = Arc::new(Mutex::new(None));
 
@@ -209,6 +220,7 @@ impl Engine {
             lighting_system,
             lighting_config: lighting_config.cloned(),
             current_song_timeline,
+            playback_generation,
             current_song_time,
             timeline_finished,
             timeline_cancel_handle,
@@ -1836,6 +1848,94 @@ mod test {
                 ));
             }
             assert!(engine.get_timeline_cues().is_empty());
+            Ok(())
+        }
+    }
+
+    /// A stale song-time write cannot be undone: the cue pointer only moves
+    /// forward, so one jump past the end of the show silences it permanently.
+    ///
+    /// This is the failure shape #332 reports — reconstruction at the seek
+    /// point works, then not a single cue fires for the rest of the playback —
+    /// and it is why song time is now guarded by a playback generation.
+    mod stale_song_time_tests {
+        use super::*;
+        use crate::lighting::parser::{Cue, LayerCommand};
+        use crate::lighting::timeline::LightingTimeline;
+
+        fn cue_at(secs: u64) -> Cue {
+            Cue {
+                time: std::time::Duration::from_secs(secs),
+                effects: vec![],
+                layer_commands: Vec::<LayerCommand>::new(),
+                stop_sequences: vec![],
+                start_sequences: vec![],
+            }
+        }
+
+        fn armed_engine() -> Result<(Arc<Engine>, CancelHandle), Box<dyn Error>> {
+            let (engine, cancel) = create_engine()?;
+            {
+                let mut timeline = engine.current_song_timeline.lock();
+                *timeline = Some(LightingTimeline::new_with_cues(vec![
+                    cue_at(1),
+                    cue_at(2),
+                    cue_at(3),
+                ]));
+            }
+            engine.update_song_time(Duration::ZERO);
+            engine.start_lighting_timeline_at(Duration::ZERO);
+            Ok((engine, cancel))
+        }
+
+        fn cues_remaining(engine: &Engine) -> bool {
+            let timeline = engine.current_song_timeline.lock();
+            timeline.as_ref().is_some_and(|tl| !tl.is_finished())
+        }
+
+        #[test]
+        fn a_jump_past_the_end_exhausts_the_timeline() -> Result<(), Box<dyn Error>> {
+            let (engine, _cancel) = armed_engine()?;
+            assert!(cues_remaining(&engine), "freshly armed");
+
+            // What a stale tracker from the outgoing playback would write.
+            engine.update_song_lighting(Duration::from_secs(300))?;
+            assert!(!cues_remaining(&engine), "one jump exhausts every cue");
+
+            // And it never recovers: the pointer does not move backwards.
+            engine.update_song_lighting(Duration::from_secs(1))?;
+            assert!(
+                !cues_remaining(&engine),
+                "the show stays silent for the rest of the playback"
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn the_generation_guard_drops_a_stale_write() -> Result<(), Box<dyn Error>> {
+            let (engine, _cancel) = armed_engine()?;
+            let stale = engine.playback_generation();
+
+            // A new playback begins — the previous one's writers are now stale.
+            engine.begin_playback_generation();
+            engine.update_song_time(Duration::ZERO);
+
+            engine.update_song_time_for_generation(Duration::from_secs(300), stale);
+            assert_eq!(
+                engine.get_song_time(),
+                Duration::ZERO,
+                "a write from the previous playback must not land"
+            );
+
+            engine.update_song_time_for_generation(
+                Duration::from_secs(1),
+                engine.playback_generation(),
+            );
+            assert_eq!(
+                engine.get_song_time(),
+                Duration::from_secs(1),
+                "the current playback still writes normally"
+            );
             Ok(())
         }
     }

--- a/src/dmx/engine/playback.rs
+++ b/src/dmx/engine/playback.rs
@@ -137,6 +137,12 @@ impl Engine {
             }
         }
 
+        // Claim this playback's generation before anything writes song time.
+        // The outgoing playback's tracker may still be awake for up to its
+        // sleep interval, carrying the previous start offset; from here its
+        // writes are dropped rather than landing on our freshly armed timeline.
+        let generation = dmx_engine.begin_playback_generation();
+
         // Reset song time to start time for new song BEFORE starting timeline
         // This ensures the effects loop uses the correct time when updating
         dmx_engine.update_song_time(start_time);
@@ -243,6 +249,7 @@ impl Engine {
             start_time,
             clock.clone(),
             Some(section_owns_time.clone()),
+            generation,
         );
 
         // Store the cancel handle so the effects loop can notify when everything finishes
@@ -569,19 +576,24 @@ impl Engine {
         }
     }
 
-    /// Starts a thread to track song time from a specific start time
+    /// Starts a thread to track song time from a specific start time.
+    ///
+    /// Claims a fresh playback generation, so any tracker still running from a
+    /// previous playback stops being able to write.
     pub fn start_song_time_tracker_from(
         dmx_engine: Arc<Engine>,
         cancel_handle: CancelHandle,
         start_offset: Duration,
         clock: crate::clock::PlaybackClock,
     ) -> JoinHandle<()> {
+        let generation = dmx_engine.begin_playback_generation();
         Self::start_song_time_tracker_with_section(
             dmx_engine,
             cancel_handle,
             start_offset,
             clock,
             None,
+            generation,
         )
     }
 
@@ -591,6 +603,7 @@ impl Engine {
         start_offset: Duration,
         clock: crate::clock::PlaybackClock,
         section_owns_time: Option<Arc<AtomicBool>>,
+        generation: u64,
     ) -> JoinHandle<()> {
         let timeline_finished = dmx_engine.timeline_finished.clone();
         thread::spawn(move || {
@@ -605,7 +618,7 @@ impl Engine {
                 if !section_writing {
                     let elapsed = clock.elapsed();
                     let song_time = start_offset + elapsed;
-                    dmx_engine.update_song_time(song_time);
+                    dmx_engine.update_song_time_for_generation(song_time, generation);
                 }
 
                 thread::sleep(Duration::from_millis(10));

--- a/src/dmx/engine/timeline.rs
+++ b/src/dmx/engine/timeline.rs
@@ -14,7 +14,7 @@
 
 use std::{error::Error, time::Duration};
 
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::songs::Song;
 
@@ -97,6 +97,23 @@ impl Engine {
                 crate::lighting::timeline::TimelineUpdate::default()
             }
         };
+
+        // A show that is loaded but exhausted the moment it is armed will not
+        // fire anything for the whole playback, and says nothing about it. That
+        // is the shape of #332, so it is worth a line in the log.
+        {
+            let timeline = self.current_song_timeline.lock();
+            if let Some(tl) = timeline.as_ref() {
+                if tl.cue_count() > 0 && tl.cues_remaining() == 0 {
+                    warn!(
+                        cues = tl.cue_count(),
+                        start_time_ms = start_time.as_millis(),
+                        "lighting timeline armed with no cues ahead of the pointer — \
+                         no cues will fire for this playback"
+                    );
+                }
+            }
+        }
 
         // Apply the historical timeline update to ensure deterministic state
         // This must happen before the effects loop can process new cues to avoid conflicts
@@ -187,12 +204,38 @@ impl Engine {
         // or when explicitly stopping playback.
     }
 
-    /// Updates the current song time
+    /// Updates the current song time.
     pub fn update_song_time(&self, song_time: Duration) {
         self.current_song_time.store(
             song_time.as_nanos() as u64,
             std::sync::atomic::Ordering::Relaxed,
         );
+    }
+
+    /// Updates the current song time on behalf of a specific playback.
+    ///
+    /// A write stamped with a superseded generation is dropped. See
+    /// [`Engine::playback_generation`] for why one stale write is fatal rather
+    /// than merely untidy.
+    pub fn update_song_time_for_generation(&self, song_time: Duration, generation: u64) {
+        if generation != self.playback_generation() {
+            return;
+        }
+        self.update_song_time(song_time);
+    }
+
+    /// Starts a new playback generation, superseding the previous one's
+    /// song-time writers. Returns the new generation.
+    pub fn begin_playback_generation(&self) -> u64 {
+        self.playback_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1
+    }
+
+    /// The generation writes must carry to be accepted.
+    pub fn playback_generation(&self) -> u64 {
+        self.playback_generation
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Gets the current song time
@@ -223,6 +266,24 @@ impl Engine {
     /// state the live loop will go on to advance from.
     pub(crate) fn to_delayed_song_time(&self, song_time: Duration) -> Duration {
         song_time.saturating_sub(self.playback_delay)
+    }
+
+    /// A one-call answer to "is the lighting actually going to fire".
+    ///
+    /// Returns `None` when no show is loaded. Otherwise reports whether the
+    /// timeline is armed and where its cue pointer sits — the state that
+    /// previously could only be inferred by watching for effects and waiting
+    /// to see whether any arrived.
+    pub fn lighting_arming_state(&self) -> Option<(bool, usize, usize, Option<Duration>)> {
+        let timeline = self.current_song_timeline.lock();
+        timeline.as_ref().map(|tl| {
+            (
+                tl.is_armed(),
+                tl.cue_count(),
+                tl.cues_remaining(),
+                tl.next_cue_time(),
+            )
+        })
     }
 
     /// Gets all cues from the current timeline with their times and indices

--- a/src/lighting/timeline.rs
+++ b/src/lighting/timeline.rs
@@ -213,6 +213,30 @@ impl LightingTimeline {
         self.stopped_sequences.clear();
     }
 
+    /// Whether the timeline has been started and is dispatching cues.
+    ///
+    /// A timeline that is installed but never armed looks identical from the
+    /// outside to one that is armed and simply between cues — which is the
+    /// ambiguity that made #332 diagnosable only by inference.
+    pub fn is_armed(&self) -> bool {
+        self.is_playing
+    }
+
+    /// How many cues are still ahead of the pointer.
+    pub fn cues_remaining(&self) -> usize {
+        self.cues.len().saturating_sub(self.next_cue_index)
+    }
+
+    /// Total cues in the timeline.
+    pub fn cue_count(&self) -> usize {
+        self.cues.len()
+    }
+
+    /// When the next cue fires, if any remain.
+    pub fn next_cue_time(&self) -> Option<Duration> {
+        self.cues.get(self.next_cue_index).map(|cue| cue.time)
+    }
+
     /// Returns true if all cues have been processed (including empty timelines)
     pub fn is_finished(&self) -> bool {
         self.next_cue_index >= self.cues.len()


### PR DESCRIPTION
Addresses #332. **Does not claim to fix it** — see below.

## I could not reproduce the reported failure

86 trials on the reporting environment, not an approximation: host `NODE` (WSL2), profile `03-node.yaml`, the real library, *Legions of Decay* and its 132-cue show, driven over MCP using the **Aug 5 release binary** the issue was filed against — predating every PR in this series.

| scenario | trials | poll rate | failures |
|---|---|---|---|
| Cold-start playbacks, alternating `0:00` and `3:26` | 16 | ~266 req/s | 0 |
| Seeks while playing, random positions | 40 | ~250 req/s | 0 |
| Back-to-back `play_song_from` restarts | 30 | ~250 req/s | 0 |

~16,000 polling requests, all at or above the reported ~120 req/s. The report saw 8 failures in ~20 runs; at that rate these trials should have produced ~34.

The only failure I did find was **in my own harness**: an early detector flagged "no effects" at seek position `0.5s`, which is legitimately dark — this show opens with 200ms flashes separated by ~550ms gaps, confirmed with `lighting_simulator`. Worth knowing, because the same mistake is easy to make reading `get_active_effects` by hand.

## What this ships instead

**Observability — the part with real value.** `status` now returns, when a show is loaded:

```json
"lighting": {"armed": true, "cues_total": 132, "cues_remaining": 91, "next_cue_seconds": 109.5}
```

Three different causes produce identical silence from outside, and this separates them in one call:

| signal | cause |
|---|---|
| `armed: true`, `cues_remaining: 0` early in a playing song | cue pointer blown past the end |
| `armed: false` | timeline never armed |
| both healthy, nothing rendering | effects loop starved — cross-check the existing stale-heartbeat log |

Arming a show with no cues ahead of its pointer also logs a warning.

**One narrow guard.** Song-time writers carry a playback generation; a write from a superseded playback is dropped. A seek starts a new playback while the outgoing one's tracker is still awake — it exits on cancellation, but only at its 10ms sleep boundary — carrying the previous start offset.

This is worth having regardless of #332, because the cue pointer only moves forward. `a_jump_past_the_end_exhausts_the_timeline` demonstrates one bad write silencing a show permanently, with no recovery.

## Scope, precisely

The generation is **per playback**, so this guards writes from a *superseded* playback. It does **not** cover the song-time tracker and the section-loop thread handing off within one playback via `section_owns_time` — they share a generation, and the tracker can write once after the flag flips. That's the same shape of race one level down.

Left unfixed deliberately: also unobserved, and the natural fix — a threshold-based continuity check — would risk dropping legitimate writes under exactly the scheduler jitter suspected here. Better to wait for evidence than to add a knob that can cause the failure it guards against.

## On the likely cause

The player log on this box shows `Failed to set RT SCHED_FIFO for real-time thread`, so on WSL2 the effects loop runs at normal priority and can be starved under CPU pressure. The reporter's load was an agent driving MCP from the same machine, which is heavier than my polling loop was. That matches their own suspicion — *"my measurement load starving the cue dispatcher rather than an inherent race"* — and #395's push-based resource removes the need for that polling entirely.

The wall clock is `Instant`-backed, so a WSL2 clock resync is ruled out as an explanation.

## Tests

- `cargo test` — 3284 passed, 0 failed
- `cargo clippy --all-targets`, `cargo fmt --check` — clean

The arming read runs on the blocking pool; reading the timeline mutex directly from `build_status_snapshot` stalled an SSE stream in testing, since it's shared with the effects loop thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)