### PR TITLE
MCP surface consistency for lighting authoring (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP surface consistency (#335)**: several small inconsistencies that were most of the friction
+  in scripting against the server.
+
+  `get_cues` takes an optional `song`, so another song's cues can be read without making it
+  current — a read should not have the side effect of changing what is queued.
+
+  `play_song_from` and `play_from` no longer report success for a no-op. The player refuses to
+  start a song while one is already playing; these echoed the requested `start_time` back anyway,
+  which reads as a successful seek. They now return `started: false` with the reason and a pointer
+  to `seek`, and omit the misleading time entirely.
+
+  `delete_song_lighting`, `delete_venue` and `delete_fixture_type` exist. Deleting a song's
+  lighting file also removes its `lighting:` entry — the inverse of registering it on write —
+  since deleting the file alone leaves a dangling reference that fails the song's next load.
+
+  The DSL reference's `pulse` entry was incomplete rather than wrong: it listed only `intensity`,
+  omitting `base_level` and `pulse_amplitude`, which the parser accepts and the effects
+  documentation already described. It now also carries the sweep semantics — amplitude is added
+  *on top of* the base level, so `intensity: 16%` at the default base sweeps 50%–66%, not ±16%.
+
 - **Lighting arming is guarded and observable (#332)**: a seek or song change starts a new
   playback while the outgoing one's song-time tracker is still winding down, carrying the
   *previous* start offset. One stale write from it is enough to silence a show for its whole

--- a/docs/src/interfaces/mcp.md
+++ b/docs/src/interfaces/mcp.md
@@ -62,8 +62,10 @@ Roughly 50 tools are available. They fall into a few groups:
   `controllers` subsections, plus add / update / remove hardware profiles.
 - **Song & playlist authoring** — read, write, and patch `song.yaml` and playlist files, plus
   detailed song metadata and beat-grid queries.
-- **Lighting authoring** — read, write, validate, and patch `.light` DSL files for songs, venues,
-  and fixture types, list the lighting cues and active effects, and fetch a DSL reference primer.
+- **Lighting authoring** — read, write, validate, patch, and delete `.light` DSL files for songs,
+  venues, and fixture types, list the lighting cues and active effects, and fetch a DSL reference
+  primer. Deleting a song's lighting file also removes its `lighting:` entry, so the song is never
+  left with a dangling reference.
   `validate_lighting` returns each show's resolved cue timeline alongside the parse result, so
   "the cues land where I meant" can be checked without loading the show into the player, plus
   lint-level `warnings` for mistakes that are legal DSL but silently do nothing — an empty group,

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -36,7 +36,7 @@ show "Optional Name" {
 | `static`  | `duration`                                             | Hold a color/intensity. Use `color`, and `intensity` or `dimmer` for the level. |
 | `cycle`   | one or more `color:`, `duration`                       | Iterates colors. Optional `speed`, `direction`. |
 | `strobe`  | `frequency`, `duration`                                | Hz strobe. Optional `intensity`. |
-| `pulse`   | `frequency`, `duration`                                | Sinusoidal pulse. Optional `intensity`. |
+| `pulse`   | `frequency`, `duration`                                | Sinusoidal pulse. Optional `base_level` (default 50%) and `pulse_amplitude` (also spelled `intensity`). |
 | `chase`   | `speed`, `duration`                                    | A moving brightness mask over the layers beneath — needs a color bed under it. Optional `direction`, `pattern: linear|snake|random`. |
 | `dimmer`  | `start_level`, `end_level`, `duration`                 | Linear ramp; `curve: linear` optional. |
 | `rainbow` | `duration`                                             | Hue sweep. Optional `speed`. |
@@ -63,6 +63,11 @@ Every effect must specify a finite `duration`. Effects can crossfade — set
   - No other effect reads `direction`; on `rainbow` it is accepted and ignored.
 - `layer`: `background | midground | foreground` (grandMA-inspired layers).
 - `blend_mode`: `replace | multiply | add | overlay | screen`.
+
+A `pulse`'s amplitude is added *on top of* its base level: it sweeps
+`base_level` to `base_level + amplitude` rather than modulating around the level
+underneath. `pulse intensity: 16%` at the default base sweeps 50%–66%, not ±16%.
+Set `base_level` explicitly to place the pulse where you want it.
 
 ### Layer commands
 

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -2281,6 +2281,161 @@ async fn mcp_lighting_state_resource_pushes_on_change() -> Result<(), Box<dyn Er
 }
 
 // ---------------------------------------------------------------------------
+// Test 3c-nonies: MCP surface consistency (#335)
+// ---------------------------------------------------------------------------
+
+/// Three items from #335: `get_cues` reading another song without making it
+/// current, `play_song_from` reporting a no-op instead of echoing success, and
+/// deleting a song's lighting file taking its `song.yaml` reference with it.
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_surface_consistency_fixes() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+
+    // The bundled shows target groups this fixture's config does not declare,
+    // which fails validation at play time. Replace them with shows aimed at
+    // `all_lights`, which it does declare.
+    let song_lighting_dir = fixture.root.join("songs/dsl-light-show-song/lighting");
+    std::fs::write(
+        song_lighting_dir.join("main_show.light"),
+        "show \"Main\" {\n    @00:00.000\n    all_lights: static color: \"blue\", duration: 8s\n\n    @00:04.000\n    all_lights: static color: \"red\", duration: 4s\n}\n",
+    )?;
+    std::fs::write(
+        song_lighting_dir.join("outro.light"),
+        "show \"Outro\" {\n    @00:20.000\n    all_lights: static color: \"white\", duration: 1s\n}\n",
+    )?;
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player.clone(),
+    );
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    let song = "DSL Light Show Song";
+
+    // --- get_cues takes a song, and reading it is not a side effect ---------
+    let before = tool_json(&call_tool(&client, &url, &session, 1200, "status", json!({})).await);
+    let current_before = before["current_song"]["name"].as_str().map(str::to_owned);
+
+    let cues = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1201,
+            "get_cues",
+            json!({"song": song}),
+        )
+        .await,
+    );
+    assert_eq!(cues["song"], song, "{cues}");
+    assert!(
+        cues["cues"]
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false),
+        "expected cues for a song with a show: {cues}"
+    );
+
+    let after = tool_json(&call_tool(&client, &url, &session, 1202, "status", json!({})).await);
+    assert_eq!(
+        after["current_song"]["name"].as_str().map(str::to_owned),
+        current_before,
+        "reading another song's cues must not change which song is current"
+    );
+
+    // --- play_song_from reports a no-op rather than echoing success --------
+    let started = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1203,
+            "play_song_from",
+            json!({"song_name": song, "start_time": "0.5"}),
+        )
+        .await,
+    );
+    assert_eq!(started["started"], true, "{started}");
+
+    // Second call while playing: the player refuses, and this must say so
+    // rather than returning the requested time as though it had seeked.
+    let refused = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1204,
+            "play_song_from",
+            json!({"song_name": song, "start_time": "1:49.400"}),
+        )
+        .await,
+    );
+    assert_eq!(refused["started"], false, "{refused}");
+    assert!(
+        refused.get("start_time").is_none(),
+        "echoing the requested time is what made this misleading: {refused}"
+    );
+    assert!(
+        refused["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("already playing"),
+        "{refused}"
+    );
+
+    let _ = call_tool(&client, &url, &session, 1205, "stop", json!({})).await;
+
+    // --- deleting a song's lighting file unregisters it too -----------------
+    let deleted = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1206,
+            "delete_song_lighting",
+            json!({"song": song, "file": "outro.light"}),
+        )
+        .await,
+    );
+    assert_eq!(deleted["unregistered"], true, "{deleted}");
+
+    // The file is gone and, crucially, the song still loads — a dangling
+    // reference would fail its next load.
+    let details = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            1207,
+            "song_details",
+            json!({"name": song}),
+        )
+        .await,
+    );
+    let shows = details["dsl_lighting_shows"].as_array().expect("shows");
+    assert!(
+        !shows.iter().any(|s| s.to_string().contains("outro")),
+        "deleted show should be gone: {details}"
+    );
+    let yaml = std::fs::read_to_string(fixture.root.join("songs/dsl-light-show-song/song.yaml"))?;
+    assert!(
+        !yaml.contains("outro.light"),
+        "reference should be gone: {yaml}"
+    );
+
+    controller.shutdown();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3d: profile add → update → remove round-trip
 // ---------------------------------------------------------------------------
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -264,6 +264,14 @@ pub struct AnalyzeShowArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetCuesArgs {
+    /// Song to read cues from. Omit for the song the player currently has
+    /// loaded. Naming a song reads it without making it current — inspecting
+    /// one song's cues should not change which song is queued.
+    pub song: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DiffShowsArgs {
     /// Baseline: a song name, whose registered shows are used.
     /// Mutually exclusive with `a_source`.
@@ -425,10 +433,35 @@ impl McpServer {
     }
 
     #[tool(
-        description = "Return the cue list (time + index) for the lighting timeline \
-        of the song currently loaded by the player."
+        description = "Return the cue list for a song's lighting timeline. With \
+        no `song`, reads the timeline the player currently has loaded (index + \
+        time). With a `song`, reads that song's registered shows without making \
+        it current, reporting each cue's resolved time, musical position, and \
+        effect count."
     )]
-    async fn get_cues(&self) -> Result<CallToolResult, McpError> {
+    async fn get_cues(
+        &self,
+        Parameters(args): Parameters<GetCuesArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        // A named song is read from its registered shows rather than by making
+        // it current: inspecting cues is a read, and it should not have the
+        // side effect of changing what is queued.
+        if let Some(name) = args.song.as_deref() {
+            let song = self
+                .player
+                .songs()
+                .get(name)
+                .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+            let mut shows: Vec<_> = song
+                .dsl_lighting_shows()
+                .iter()
+                .flat_map(|dsl| dsl.shows().values().cloned())
+                .collect();
+            sort_shows(&mut shows);
+            let cues: Vec<Value> = shows.iter().flat_map(cue_timeline).collect();
+            return Ok(ok_json(json!({ "song": name, "cues": cues })));
+        }
+
         let cues: Vec<Value> = self
             .player
             .get_cues()
@@ -489,8 +522,20 @@ impl McpServer {
     ) -> Result<CallToolResult, McpError> {
         let start = parse_duration(&args.start_time)?;
         let song = self.player.play_from(start).await.map_err(internal_err)?;
+        // Same no-op as `play_song_from`: echoing the requested time back when
+        // nothing started is what made this misleading.
+        let Some(song) = song else {
+            return Ok(ok_json(json!({
+                "started": false,
+                "reason": "a song is already playing; play_from does not \
+                           interrupt it",
+                "hint": "call `stop` first, or use `seek` to move within the \
+                         current song",
+            })));
+        };
         Ok(ok_json(json!({
-            "now_playing": song.as_ref().map(|s| song_summary(s)),
+            "started": true,
+            "now_playing": song_summary(&song),
             "start_time": format_duration(start),
         })))
     }
@@ -512,8 +557,25 @@ impl McpServer {
             .play_song_from(&args.song_name, start)
             .await
             .map_err(internal_err)?;
+
+        // The player refuses to start a song while one is already playing, and
+        // returns nothing. Echoing the requested `start_time` back in that case
+        // reads as success and is how this silently answered the wrong
+        // question — the caller believes they are at 1:49 while playback
+        // continues from wherever it was.
+        let Some(song) = song else {
+            return Ok(ok_json(json!({
+                "started": false,
+                "reason": "a song is already playing; play_song_from does not \
+                           interrupt it",
+                "hint": "call `stop` first, or use `seek` to move within the \
+                         current song",
+            })));
+        };
+
         Ok(ok_json(json!({
-            "now_playing": song.as_ref().map(|s| song_summary(s)),
+            "started": true,
+            "now_playing": song_summary(&song),
             "start_time": format_duration(start),
         })))
     }
@@ -1608,6 +1670,90 @@ impl McpServer {
         })))
     }
 
+    #[tool(description = "Delete a venue `.light` file from the configured \
+        venues directory.")]
+    async fn delete_venue(
+        &self,
+        Parameters(args): Parameters<LightingFileArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let path = self
+            .resolve_lighting_file(LightingDirKind::Venues, &args.file)
+            .await?;
+        remove_lighting_file(&path).await?;
+        Ok(ok_json(json!({"deleted": path.display().to_string()})))
+    }
+
+    #[tool(description = "Delete a fixture-type `.light` file from the \
+        configured fixture types directory.")]
+    async fn delete_fixture_type(
+        &self,
+        Parameters(args): Parameters<LightingFileArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let path = self
+            .resolve_lighting_file(LightingDirKind::FixtureTypes, &args.file)
+            .await?;
+        remove_lighting_file(&path).await?;
+        Ok(ok_json(json!({"deleted": path.display().to_string()})))
+    }
+
+    #[tool(description = "Delete a lighting `.light` file belonging to a song, \
+        and remove the `lighting:` entry that references it. Deleting the file \
+        alone would leave a dangling reference that fails the song's next load, \
+        so both go together — the inverse of what `write_song_lighting` does \
+        when it registers a new show. The player's song registry is reloaded \
+        afterwards.")]
+    async fn delete_song_lighting(
+        &self,
+        Parameters(args): Parameters<SongLightingArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        validate_lighting_filename(&args.file)?;
+        let song = self
+            .player
+            .songs()
+            .get(&args.song)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let path = find_song_lighting_path(&song, &args.file).ok_or_else(|| {
+            McpError::invalid_params(
+                format!(
+                    "song `{}` has no lighting file named `{}`",
+                    args.song, args.file
+                ),
+                None,
+            )
+        })?;
+
+        let config_path = song
+            .config_path()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| song.base_path().join("song.yaml"));
+        let reference = path
+            .strip_prefix(song.base_path())
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let original = read_text(&config_path).await?;
+        let unregistered = match unregister_lighting_file(&original, &reference) {
+            Some(updated) => {
+                // Same guard the write path uses: never leave a song.yaml that
+                // would not load back.
+                let _: crate::config::Song = serde_yaml_from_str(&updated)?;
+                staged_write_string(&config_path, &updated).await?;
+                true
+            }
+            None => false,
+        };
+
+        remove_lighting_file(&path).await?;
+        self.reload_songs_from_config().await?;
+
+        Ok(ok_json(json!({
+            "deleted": path.display().to_string(),
+            "unregistered": unregistered,
+            "reference": reference,
+        })))
+    }
+
     #[tool(description = "List the fixture-type `.light` files in the \
         configured fixture types directory.")]
     async fn list_fixture_type_files(&self) -> Result<CallToolResult, McpError> {
@@ -2149,6 +2295,74 @@ struct Registration {
     already_registered: bool,
     /// How the file is spelled in `song.yaml`, relative to the song directory.
     reference: String,
+}
+
+/// Removes the file, mapping a missing path to a clear error rather than an
+/// opaque io message.
+async fn remove_lighting_file(path: &std::path::Path) -> Result<(), McpError> {
+    tokio::fs::remove_file(path).await.map_err(|e| {
+        McpError::internal_error(format!("failed to delete {}: {e}", path.display()), None)
+    })
+}
+
+/// Removes the `lighting:` entry referencing `relative_path`, and the whole
+/// block if that was its last entry.
+///
+/// Returns `None` when nothing referenced it. Edits text rather than
+/// round-tripping through the config types, for the same reason
+/// [`register_lighting_file`] does: song.yaml is hand-written.
+pub(crate) fn unregister_lighting_file(yaml: &str, relative_path: &str) -> Option<String> {
+    let lines: Vec<&str> = yaml.lines().collect();
+    let key_index = lines.iter().position(|line| is_key(line, "lighting"))?;
+    let key_indent = indent_of(lines[key_index]);
+
+    // Collect the block's item spans. An entry may run over several lines —
+    // the shipped songs write `- name: "..."` with `file:` underneath — so the
+    // path can appear on any line of its item, not just the one starting it.
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut block_end = key_index + 1;
+    for (offset, line) in lines.iter().enumerate().skip(key_index + 1) {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        if indent_of(line) <= key_indent {
+            break;
+        }
+        block_end = offset + 1;
+        if line.trim_start().starts_with('-') {
+            spans.push((offset, offset + 1));
+        } else if let Some(last) = spans.last_mut() {
+            last.1 = offset + 1;
+        }
+    }
+
+    // Match on the parsed value rather than a bare substring, so
+    // `lighting/main.light` cannot match `lighting/main.light.bak`.
+    let target = spans.iter().position(|(start, end)| {
+        lines[*start..*end]
+            .iter()
+            .any(|line| yaml_value_of(line, "file").as_deref() == Some(relative_path))
+    })?;
+
+    let mut updated: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+    if spans.len() == 1 {
+        // Removing the last entry would leave `lighting:` with no items, which
+        // is not a valid sequence and would stop the song loading.
+        updated.drain(key_index..block_end);
+    } else {
+        let (start, end) = spans[target];
+        updated.drain(start..end);
+    }
+    Some(with_trailing_newline(updated.join("\n")))
+}
+
+/// The value of `key:` on a line, unquoted. `None` if the line sets a different
+/// key or none at all.
+fn yaml_value_of(line: &str, key: &str) -> Option<String> {
+    let trimmed = line.trim_start().trim_start_matches('-').trim_start();
+    let rest = trimmed.strip_prefix(key)?.trim_start();
+    let value = rest.strip_prefix(':')?.trim();
+    Some(value.trim_matches('"').trim_matches('\'').to_string())
 }
 
 /// Adds a `lighting:` entry for `relative_path` to a song's YAML.
@@ -3172,6 +3386,106 @@ pub(crate) async fn staged_write_string(
     .await
     .map_err(|e| McpError::internal_error(format!("join error: {e}"), None))?
     .map_err(|e| McpError::internal_error(format!("write failed: {e}"), None))
+}
+
+#[cfg(test)]
+mod unregister_lighting_tests {
+    use super::unregister_lighting_file;
+
+    const BASE: &str = "name: Test Song\ntracks:\n  - name: click\n    file: click.wav\n";
+
+    #[test]
+    fn removes_one_entry_and_keeps_the_others() {
+        let yaml =
+            format!("{BASE}lighting:\n  - file: lighting/a.light\n  - file: lighting/b.light\n");
+        let updated = unregister_lighting_file(&yaml, "lighting/a.light").expect("removes");
+        assert!(!updated.contains("a.light"), "{updated}");
+        assert!(updated.contains("b.light"), "{updated}");
+        assert!(updated.contains("lighting:"), "block survives: {updated}");
+    }
+
+    #[test]
+    fn removing_the_last_entry_takes_the_block_with_it() {
+        // `lighting:` with no items is not a valid sequence, and the song would
+        // stop loading.
+        let yaml = format!("{BASE}lighting:\n  - file: lighting/only.light\n");
+        let updated = unregister_lighting_file(&yaml, "lighting/only.light").expect("removes");
+        assert!(!updated.contains("lighting:"), "{updated}");
+        let song: crate::config::Song =
+            super::serde_yaml_from_str(&updated).expect("must remain valid");
+        assert!(song.lighting().is_none());
+    }
+
+    #[test]
+    fn keys_after_the_block_survive() {
+        let yaml = format!("{BASE}lighting:\n  - file: lighting/only.light\nmidi_file: song.mid\n");
+        let updated = unregister_lighting_file(&yaml, "lighting/only.light").expect("removes");
+        assert!(updated.contains("midi_file: song.mid"), "{updated}");
+        assert!(updated.contains("file: click.wav"), "{updated}");
+    }
+
+    #[test]
+    fn handles_the_multi_line_quoted_form_the_shipped_songs_use() {
+        // examples/songs/dsl-light-show-song/song.yaml writes entries as
+        // `- name: "..."` with `file:` on the next line, quoted. Matching only
+        // the `-` line misses the path entirely.
+        let yaml = format!(
+            "{BASE}lighting:\n  - name: \"Main Show\"\n    file: \"lighting/main_show.light\"\n               - name: \"Outro Show\"\n    file: \"lighting/outro.light\"\n"
+        );
+        let updated =
+            unregister_lighting_file(&yaml, "lighting/outro.light").expect("removes the entry");
+        assert!(!updated.contains("outro.light"), "{updated}");
+        assert!(
+            !updated.contains("Outro Show"),
+            "the whole entry goes: {updated}"
+        );
+        assert!(updated.contains("main_show.light"), "{updated}");
+        assert!(updated.contains("Main Show"), "{updated}");
+        let song: crate::config::Song =
+            super::serde_yaml_from_str(&updated).expect("must remain valid");
+        assert_eq!(song.lighting().map(|l| l.len()), Some(1));
+    }
+
+    #[test]
+    fn a_prefix_of_another_path_is_not_matched() {
+        let yaml = format!(
+            "{BASE}lighting:\n  - file: lighting/main.light\n  - file: lighting/main.light.bak\n"
+        );
+        let updated = unregister_lighting_file(&yaml, "lighting/main.light").expect("removes");
+        assert!(updated.contains("main.light.bak"), "{updated}");
+        // The exact path goes; the one it is a prefix of stays.
+        assert_eq!(
+            updated.matches("lighting/main.light").count(),
+            1,
+            "{updated}"
+        );
+        assert!(
+            !updated.contains("- file: lighting/main.light\n"),
+            "{updated}"
+        );
+    }
+
+    #[test]
+    fn an_unreferenced_file_changes_nothing() {
+        let yaml = format!("{BASE}lighting:\n  - file: lighting/a.light\n");
+        assert!(unregister_lighting_file(&yaml, "lighting/other.light").is_none());
+    }
+
+    #[test]
+    fn a_song_with_no_block_changes_nothing() {
+        assert!(unregister_lighting_file(BASE, "lighting/a.light").is_none());
+    }
+
+    #[test]
+    fn round_trips_with_register() {
+        // Adding then removing returns a song that still loads and has no block.
+        let added = super::register_lighting_file(BASE, "lighting/x.light").expect("adds");
+        let removed = unregister_lighting_file(&added, "lighting/x.light").expect("removes");
+        let song: crate::config::Song =
+            super::serde_yaml_from_str(&removed).expect("must remain valid");
+        assert!(song.lighting().is_none());
+        assert!(removed.contains("file: click.wav"), "{removed}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #335. The last of the twelve lighting issues.

Two of its five items were already resolved by earlier work in this series. The rest are here.

## `get_cues` takes a song

It read only the song the player had loaded, so inspecting any other song's cues meant making it current — a side effect, to perform a read. A named song is now read from its registered shows, leaving the queue alone. The test asserts `status.current_song` is unchanged across the call.

## `play_song_from` / `play_from` stop reporting success for a no-op

The player refuses to start a song while one is already playing and returns nothing. These echoed the requested `start_time` back anyway:

```json
{"now_playing": null, "start_time": "1:49.400"}
```

That reads as a successful seek, and cost the reporter a debugging pass spent reading effects at 2:26 while believing they were at 1:49. Now:

```json
{"started": false,
 "reason": "a song is already playing; play_song_from does not interrupt it",
 "hint": "call `stop` first, or use `seek` to move within the current song"}
```

The misleading time is omitted entirely. I did **not** make it seek instead — `Player::play_song_from`'s refusal is deliberate and has an existing test asserting it, and gRPC/OSC share that path. Changing player semantics to fix an MCP reporting problem would be the wrong layer.

## Delete tools

`delete_song_lighting`, `delete_venue`, `delete_fixture_type`.

Deleting a song's lighting file also drops its `lighting:` entry — the inverse of registering it on write (#334) — because deleting the file alone leaves a dangling reference that fails the song's next load. Removing the last entry takes the empty `lighting:` key with it, since a keyless sequence won't deserialize.

**A bug the integration test caught:** my first matcher checked whether the `-` line contained the path. The shipped songs write entries as

```yaml
lighting:
  - name: "Outro Show"
    file: "lighting/outro.light"
```

— so the path is on the *next* line, quoted, and nothing matched. The unregister path now treats an entry as the span of lines it occupies and compares the parsed `file:` value, so `lighting/main.light` also can't match `lighting/main.light.bak`. Both cases have tests.

## The `pulse` docs drift runs the other way

The issue reports that `docs/src/lighting/effects.md` documents `base_level`/`pulse_amplitude` while the tool says `intensity`, and concludes *"the tool output is the accurate one"* with a suggestion to generate the page from it.

I checked all four spellings against the parser — **every one is accepted**:

| source | result |
|---|---|
| `base_level: 20%, pulse_amplitude: 30%` | ok |
| `intensity: 30%` | ok |
| `base_level: 20%, intensity: 30%` | ok |
| `pulse_amplitude: 30%` | ok |

So the docs page was the *complete* account and the DSL reference was the partial one — generating the page from the reference would have **lost** information, including its warning that amplitude is added *on top of* the base level (`intensity: 16%` at the default base sweeps 50%–66%, not ±16%). The reference now carries both.

## Deliberately unchanged

`get_active_effects` still returns prose. It is the human-facing summary behind the `active-effects` CLI command; `get_fixture_state` is the structured surface and returns strictly more, including which fixtures each effect drives. Its description already points there. Converting it would churn a CLI path to duplicate a tool that already exists.

## Tests

8 unit tests on the unregister helper — including the multi-line quoted form the shipped songs use, prefix-safety, taking the block with the last entry, and a register→unregister round trip — plus an integration test covering all three behavioural fixes over the wire.

- `cargo test` — 3293 passed, 0 failed
- `cargo clippy --all-targets`, `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)