### PR TITLE
Fix 40 bugs found by post-merge review of the lighting series

### DIFF
--- a/src/audio/click_analysis.rs
+++ b/src/audio/click_analysis.rs
@@ -259,7 +259,10 @@ impl BeatGrid {
             .collect();
         let mut refined = vec![0.0_f64; measures.len()];
         for (position, &start) in tempo_starts.iter().enumerate() {
-            let end = tempo_starts.get(position + 1).copied().unwrap_or(measures.len());
+            let end = tempo_starts
+                .get(position + 1)
+                .copied()
+                .unwrap_or(measures.len());
             let run = &measures[start..end];
             let beats: usize = run.iter().map(|m| m.beats).sum();
             let seconds = run.last().map_or(0.0, |m| m.end) - run.first().map_or(0.0, |m| m.start);

--- a/src/audio/click_analysis.rs
+++ b/src/audio/click_analysis.rs
@@ -219,54 +219,80 @@ impl BeatGrid {
         use crate::tempo::{TempoChange, TempoChangePosition, TempoTransition, TimeSignature};
 
         let measures = self.measures()?;
-        let (first, rest) = measures.split_first()?;
+        let first = measures.first()?;
 
-        let mut changes = Vec::new();
+        // Pass one: where does the tempo or the meter actually move? The
+        // decision uses each bar's own measured tempo, which is why
+        // `TEMPO_CHANGE_TOLERANCE` has to stay coarser than the detector's hop.
+        let mut boundaries = Vec::new();
         let mut current_bpm = first.bpm;
         let mut current_beats = first.beats;
-        // How far the map has fallen behind the grid since the last change.
-        //
-        // Emitting on instantaneous BPM difference is not enough: a ramp gentle
-        // enough to stay under any relative threshold still leaves the map
-        // holding a stale, slower tempo between changes, and because that lag
-        // is one-signed it accumulates. A gradual 100→129bpm rise over 64 bars
-        // put bar times a quarter of a second out. Tracking the error itself
-        // bounds it directly, whatever shape the tempo takes.
-        let mut drift = 0.0_f64;
-
-        for measure in rest {
-            let expected = measure.beats as f64 * 60.0 / current_bpm.max(f64::EPSILON);
-            let actual = measure.beats as f64 * 60.0 / measure.bpm.max(f64::EPSILON);
-            drift += actual - expected;
-
-            let tempo_moved = drift.abs() > MAX_DERIVED_DRIFT
-                || (measure.bpm - current_bpm).abs() / current_bpm.max(f64::EPSILON)
-                    > TEMPO_CHANGE_TOLERANCE;
+        for (index, measure) in measures.iter().enumerate().skip(1) {
+            let tempo_moved = (measure.bpm - current_bpm).abs() / current_bpm.max(f64::EPSILON)
+                > TEMPO_CHANGE_TOLERANCE;
             let meter_moved = measure.beats != current_beats;
             if !tempo_moved && !meter_moved {
                 continue;
             }
-            changes.push(TempoChange {
-                position: TempoChangePosition::MeasureBeat(measure.number, 1.0),
-                original_measure_beat: Some((measure.number, 1.0)),
-                bpm: tempo_moved.then_some(measure.bpm),
-                time_signature: meter_moved.then(|| TimeSignature::new(measure.beats as u32, 4)),
-                transition: TempoTransition::Snap,
-            });
+            boundaries.push((index, tempo_moved, meter_moved));
             if tempo_moved {
                 current_bpm = measure.bpm;
-                drift = 0.0;
             }
             if meter_moved {
                 current_beats = measure.beats;
             }
         }
 
+        // Pass two: re-measure each constant-tempo run across its whole span.
+        // A single bar is a poor tempo estimate — detected beats land on hop
+        // boundaries, so a 2s bar carries ~0.3% of BPM error, and holding that
+        // estimate for the rest of the song walks the bars off the grid
+        // linearly (0.27s across 100 bars of a metronomic click). Averaging
+        // over the run divides that error by the number of bars in it.
+        let tempo_starts: Vec<usize> = std::iter::once(0)
+            .chain(
+                boundaries
+                    .iter()
+                    .filter(|(_, tempo_moved, _)| *tempo_moved)
+                    .map(|(index, _, _)| *index),
+            )
+            .collect();
+        let mut refined = vec![0.0_f64; measures.len()];
+        for (position, &start) in tempo_starts.iter().enumerate() {
+            let end = tempo_starts.get(position + 1).copied().unwrap_or(measures.len());
+            let run = &measures[start..end];
+            let beats: usize = run.iter().map(|m| m.beats).sum();
+            let seconds = run.last().map_or(0.0, |m| m.end) - run.first().map_or(0.0, |m| m.start);
+            let bpm = if beats > 0 && seconds > 0.0 {
+                beats as f64 * 60.0 / seconds
+            } else {
+                measures[start].bpm
+            };
+            for slot in &mut refined[start..end] {
+                *slot = bpm;
+            }
+        }
+
+        let changes = boundaries
+            .into_iter()
+            .map(|(index, tempo_moved, meter_moved)| {
+                let measure = &measures[index];
+                TempoChange {
+                    position: TempoChangePosition::MeasureBeat(measure.number, 1.0),
+                    original_measure_beat: Some((measure.number, 1.0)),
+                    bpm: tempo_moved.then_some(refined[index]),
+                    time_signature: meter_moved
+                        .then(|| TimeSignature::new(measure.beats as u32, 4)),
+                    transition: TempoTransition::Snap,
+                }
+            })
+            .collect();
+
         Some(crate::tempo::TempoMap::new(
             // Bar 1 beat 1 is the first detected beat, not zero. This is the
             // lead-in an author would otherwise have to measure by hand.
             self.lead_in(),
-            first.bpm,
+            refined[0],
             TimeSignature::new(first.beats as u32, 4),
             changes,
         ))
@@ -295,6 +321,8 @@ impl BeatGrid {
                 number: index as u32 + 1,
                 beats,
                 bpm: beats as f64 * 60.0 / seconds,
+                start: *start,
+                end: *end,
             });
         }
 
@@ -307,24 +335,19 @@ impl BeatGrid {
 /// produce a tempo change at every bar.
 const TEMPO_CHANGE_TOLERANCE: f64 = 0.005;
 
-/// How far the derived map may fall behind the grid before a change is emitted,
-/// however small the per-bar tempo movement is. Well under a frame of lighting
-/// at 44Hz, so a cue lands on the beat it was written for.
-///
-/// This bounds the thing that matters directly, and does it without firing on
-/// jitter: detected-beat noise is zero-mean and cancels, while a real ramp is
-/// one-signed and accumulates. A relative-BPM threshold tight enough to catch
-/// the ramp would fire on every jittery bar of a steady song.
-const MAX_DERIVED_DRIFT: f64 = 0.005;
-
 /// One measure's measured tempo, used while deriving a tempo map.
 struct MeasureTempo {
     /// 1-based measure number.
     number: u32,
     /// Beats in this measure.
     beats: usize,
-    /// Tempo measured across this measure.
+    /// Tempo measured across this measure alone. Good enough to detect that the
+    /// tempo moved; too noisy to hold for a whole run of bars.
     bpm: f64,
+    /// Absolute time of this measure's downbeat.
+    start: f64,
+    /// Absolute time of the next measure's downbeat.
+    end: f64,
 }
 
 #[cfg(test)]
@@ -552,12 +575,55 @@ mod to_tempo_map_tests {
     }
 
     #[test]
+    fn a_steady_click_derives_no_tempo_changes_despite_detector_quantization() {
+        // Detected beat times land on hop boundaries (256 samples @ 44.1k =
+        // 5.805ms), so even a metronomic click reports a per-bar BPM that
+        // wobbles. Any emit threshold finer than that hop mistakes the
+        // quantization for tempo movement: a 5ms drift bound derived 93 changes
+        // across these 100 bars. The relative tolerance has to stay coarser
+        // than the detector's own resolution.
+        let hop = 256.0 / 44100.0;
+        let spacing = 0.5_f64; // 120bpm
+        let mut beats = Vec::new();
+        let mut measure_starts = Vec::new();
+        for measure in 0..100 {
+            measure_starts.push(beats.len());
+            for beat in 0..4 {
+                let exact = (measure * 4 + beat) as f64 * spacing;
+                beats.push((exact / hop).round() * hop);
+            }
+        }
+        measure_starts.push(beats.len());
+        beats.push(400.0 * spacing);
+
+        let grid = BeatGrid {
+            beats,
+            measure_starts,
+        };
+        let map = grid.to_tempo_map().expect("map");
+
+        let mut worst = 0.0_f64;
+        for measure in 0..100u32 {
+            let got = map
+                .measure_to_time_with_offset(measure + 1, 1.0, 0, 0.0)
+                .expect("bar")
+                .as_secs_f64();
+            let expected = measure as f64 * 4.0 * spacing;
+            worst = worst.max((got - expected).abs());
+        }
+        assert!(
+            worst < 0.005,
+            "bar times drifted {worst:.4}s from a metronomic click"
+        );
+    }
+
+    #[test]
     fn a_ramp_gentler_than_the_tempo_tolerance_still_tracks_the_grid() {
-        // Each bar only 0.4% faster than the last — under any relative
-        // threshold loose enough to ignore jitter. The map would otherwise hold
-        // a stale, slower tempo between changes, and because that lag is
-        // one-signed it accumulates: a 100→129bpm rise over 64 bars put bar
-        // times a quarter of a second out. The drift bound is what catches it.
+        // Each bar only 0.4% faster than the last — under the relative
+        // threshold, so this whole span reads as one constant-tempo run. Fitting
+        // that run across its full extent puts the map through the middle of the
+        // ramp instead of pinning it to bar 1's tempo and walking away from the
+        // grid.
         let mut beats = Vec::new();
         let mut measure_starts = Vec::new();
         let mut downbeats = Vec::new();
@@ -592,8 +658,8 @@ mod to_tempo_map_tests {
             worst = worst.max((got - expected).abs());
         }
         assert!(
-            worst < 0.020,
-            "bar times drifted {worst:.3}s from the grid across a gradual ramp"
+            worst < 0.010,
+            "bar times drifted {worst:.4}s from the grid across a gradual ramp"
         );
     }
 

--- a/src/audio/click_analysis.rs
+++ b/src/audio/click_analysis.rs
@@ -180,14 +180,23 @@ impl BeatGrid {
         }
     }
 
-    /// The detected lead-in: how long before the first beat the song starts.
+    /// The detected lead-in: how long before *bar 1 beat 1* the song starts.
     ///
     /// A song with silence or a count-in ahead of bar 1 does not begin on beat
     /// one at zero, and an author writing `start: 0ms` is wrong by exactly this
     /// much with nothing to warn them.
+    ///
+    /// This is the first *downbeat*, not the first beat. `measure_starts` comes
+    /// from accented onsets and nothing guarantees the first click is one: a
+    /// count-in of plain clicks ahead of the first accent would otherwise place
+    /// bar 1 early by the pickup and shift every `@bar/beat` cue with it.
     pub fn lead_in(&self) -> Duration {
-        self.beats
+        let first_downbeat = self
+            .measure_starts
             .first()
+            .and_then(|index| self.beats.get(*index))
+            .or_else(|| self.beats.first());
+        first_downbeat
             .map(|secs| Duration::from_secs_f64(secs.max(0.0)))
             .unwrap_or(Duration::ZERO)
     }
@@ -215,10 +224,24 @@ impl BeatGrid {
         let mut changes = Vec::new();
         let mut current_bpm = first.bpm;
         let mut current_beats = first.beats;
+        // How far the map has fallen behind the grid since the last change.
+        //
+        // Emitting on instantaneous BPM difference is not enough: a ramp gentle
+        // enough to stay under any relative threshold still leaves the map
+        // holding a stale, slower tempo between changes, and because that lag
+        // is one-signed it accumulates. A gradual 100→129bpm rise over 64 bars
+        // put bar times a quarter of a second out. Tracking the error itself
+        // bounds it directly, whatever shape the tempo takes.
+        let mut drift = 0.0_f64;
 
         for measure in rest {
-            let tempo_moved = (measure.bpm - current_bpm).abs() / current_bpm.max(f64::EPSILON)
-                > TEMPO_CHANGE_TOLERANCE;
+            let expected = measure.beats as f64 * 60.0 / current_bpm.max(f64::EPSILON);
+            let actual = measure.beats as f64 * 60.0 / measure.bpm.max(f64::EPSILON);
+            drift += actual - expected;
+
+            let tempo_moved = drift.abs() > MAX_DERIVED_DRIFT
+                || (measure.bpm - current_bpm).abs() / current_bpm.max(f64::EPSILON)
+                    > TEMPO_CHANGE_TOLERANCE;
             let meter_moved = measure.beats != current_beats;
             if !tempo_moved && !meter_moved {
                 continue;
@@ -232,6 +255,7 @@ impl BeatGrid {
             });
             if tempo_moved {
                 current_bpm = measure.bpm;
+                drift = 0.0;
             }
             if meter_moved {
                 current_beats = measure.beats;
@@ -282,6 +306,16 @@ impl BeatGrid {
 /// beats jitter by a few milliseconds; without a tolerance a steady song would
 /// produce a tempo change at every bar.
 const TEMPO_CHANGE_TOLERANCE: f64 = 0.005;
+
+/// How far the derived map may fall behind the grid before a change is emitted,
+/// however small the per-bar tempo movement is. Well under a frame of lighting
+/// at 44Hz, so a cue lands on the beat it was written for.
+///
+/// This bounds the thing that matters directly, and does it without firing on
+/// jitter: detected-beat noise is zero-mean and cancels, while a real ramp is
+/// one-signed and accumulates. A relative-BPM threshold tight enough to catch
+/// the ramp would fire on every jittery bar of a steady song.
+const MAX_DERIVED_DRIFT: f64 = 0.005;
 
 /// One measure's measured tempo, used while deriving a tempo map.
 struct MeasureTempo {
@@ -422,6 +456,44 @@ mod to_tempo_map_tests {
     }
 
     #[test]
+    fn the_lead_in_is_the_first_downbeat_not_the_first_click() {
+        // A count-in of unaccented clicks ahead of bar 1: `measure_starts[0]`
+        // is not 0, so taking `beats[0]` as the origin puts bar 1 early by the
+        // whole pickup and drags every cue with it.
+        let spacing = 0.5_f64; // 120bpm
+        let mut beats = Vec::new();
+        // Four count-in clicks, none accented.
+        for i in 0..4 {
+            beats.push(i as f64 * spacing);
+        }
+        let mut measure_starts = Vec::new();
+        for measure in 0..3 {
+            measure_starts.push(beats.len());
+            for beat in 0..4 {
+                beats.push((4 + measure * 4 + beat) as f64 * spacing);
+            }
+        }
+        measure_starts.push(beats.len());
+        beats.push((4 + 12) as f64 * spacing);
+
+        let grid = BeatGrid {
+            beats,
+            measure_starts,
+        };
+        // The first downbeat is after the four-click count-in.
+        assert_eq!(grid.lead_in(), Duration::from_secs_f64(2.0));
+
+        let map = grid.to_tempo_map().expect("map");
+        let bar1 = map
+            .measure_to_time_with_offset(1, 1.0, 0, 0.0)
+            .expect("bar 1");
+        assert!(
+            (bar1.as_secs_f64() - 2.0).abs() < 0.01,
+            "bar 1 should land on the first downbeat, got {bar1:?}"
+        );
+    }
+
+    #[test]
     fn round_trips_through_the_forward_derivation() {
         // to_tempo_map and from_tempo_map are inverses over a grid's own span.
         let original = grid(0.0, 96.0, &[4, 4, 4, 4]);
@@ -432,6 +504,97 @@ mod to_tempo_map_tests {
         for (a, b) in original.beats.iter().zip(rebuilt.beats.iter()) {
             assert!((a - b).abs() < 0.01, "beat drift: {a} vs {b}");
         }
+    }
+
+    #[test]
+    fn bar_times_track_the_grid_through_a_sustained_ramp() {
+        // A one-signed accelerando is where re-integrating each change from the
+        // previous anchor at the stale BPM accumulates: the error never
+        // cancels. Anchoring changes to their measured downbeat keeps every bar
+        // on the grid it came from.
+        let mut beats = Vec::new();
+        let mut measure_starts = Vec::new();
+        let mut t = 0.0_f64;
+        let mut downbeats = Vec::new();
+        for measure in 0..32 {
+            measure_starts.push(beats.len());
+            downbeats.push(t);
+            // 100bpm ramping to ~140 over the span.
+            let bpm = 100.0 + (measure as f64) * 40.0 / 32.0;
+            let spacing = 60.0 / bpm;
+            for _ in 0..4 {
+                beats.push(t);
+                t += spacing;
+            }
+        }
+        measure_starts.push(beats.len());
+        beats.push(t);
+
+        let grid = BeatGrid {
+            beats,
+            measure_starts,
+        };
+        let map = grid.to_tempo_map().expect("map");
+
+        let mut worst = 0.0_f64;
+        for (index, expected) in downbeats.iter().enumerate() {
+            let got = map
+                .measure_to_time_with_offset(index as u32 + 1, 1.0, 0, 0.0)
+                .expect("bar")
+                .as_secs_f64();
+            worst = worst.max((got - expected).abs());
+        }
+        println!("MEASURED worst drift = {worst:.6}s");
+        assert!(
+            worst < 0.020,
+            "bar times drifted from the grid by {worst:.3}s across the ramp"
+        );
+    }
+
+    #[test]
+    fn a_ramp_gentler_than_the_tempo_tolerance_still_tracks_the_grid() {
+        // Each bar only 0.4% faster than the last — under any relative
+        // threshold loose enough to ignore jitter. The map would otherwise hold
+        // a stale, slower tempo between changes, and because that lag is
+        // one-signed it accumulates: a 100→129bpm rise over 64 bars put bar
+        // times a quarter of a second out. The drift bound is what catches it.
+        let mut beats = Vec::new();
+        let mut measure_starts = Vec::new();
+        let mut downbeats = Vec::new();
+        let mut t = 0.0_f64;
+        let mut bpm = 100.0_f64;
+        for _ in 0..64 {
+            measure_starts.push(beats.len());
+            downbeats.push(t);
+            let spacing = 60.0 / bpm;
+            for _ in 0..4 {
+                beats.push(t);
+                t += spacing;
+            }
+            bpm *= 1.004;
+        }
+        measure_starts.push(beats.len());
+        beats.push(t);
+
+        let map = BeatGrid {
+            beats,
+            measure_starts,
+        }
+        .to_tempo_map()
+        .expect("map");
+
+        let mut worst = 0.0_f64;
+        for (index, expected) in downbeats.iter().enumerate() {
+            let got = map
+                .measure_to_time_with_offset(index as u32 + 1, 1.0, 0, 0.0)
+                .expect("bar")
+                .as_secs_f64();
+            worst = worst.max((got - expected).abs());
+        }
+        assert!(
+            worst < 0.020,
+            "bar times drifted {worst:.3}s from the grid across a gradual ramp"
+        );
     }
 
     #[test]

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -316,6 +316,9 @@ pub fn verify_light_show(show_path: &str, config_path: Option<&str>) -> Result<(
 
     // Read and parse the light show
     let content = std::fs::read_to_string(path)?;
+    // Verified standalone, so there is no song to inherit a tempo from: a show
+    // that relies on its song's tempo cannot be checked here, and will report
+    // that it needs a tempo section.
     let shows = match parse_light_shows(&content) {
         Ok(shows) => shows,
         Err(e) => {

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -1450,13 +1450,23 @@ async fn mcp_fixture_state_matches_offline_evaluation() -> Result<(), Box<dyn Er
     wait_until_listening(&client, &url).await;
     let session = initialize_session(&client, &url).await;
 
-    // With nothing playing there is an engine, and nothing lit.
+    // With nothing playing there is an engine and nothing running. Venue
+    // fixtures are registered at play time, so there are none to report yet —
+    // and `dark` is null rather than true, because "no fixtures" is an absence
+    // of evidence and not a dark rig.
     let idle =
         tool_json(&call_tool(&client, &url, &session, 950, "get_fixture_state", json!({})).await);
     assert_eq!(idle["available"], true, "expected a live engine: {idle}");
-    assert_eq!(
-        idle["dark"], true,
-        "nothing should be lit before play: {idle}"
+    assert!(
+        idle["dark"].is_null(),
+        "no fixtures are registered before play, so darkness is unknowable: {idle}"
+    );
+    assert!(
+        idle["active_effects"]
+            .as_array()
+            .expect("effects")
+            .is_empty(),
+        "nothing should be running before play: {idle}"
     );
 
     let play_resp = tool_json(&call_tool(&client, &url, &session, 951, "play", json!({})).await);

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -236,11 +236,12 @@ pub struct ValidateLightingArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct EvaluateShowArgs {
-    /// Song name as listed by `list_songs`. Evaluates the song's registered
-    /// lighting shows. Mutually exclusive with `source`.
+    /// Song name as listed by `list_songs`. Alone, evaluates the song's
+    /// registered lighting shows. Passed with `source`, supplies that song's
+    /// tempo map so a draft using `@bar`/`beat` timing can be evaluated.
     pub song: Option<String>,
     /// `.light` DSL source to evaluate directly, without registering it against
-    /// a song. Mutually exclusive with `song`.
+    /// a song. Pass `song` as well if the source uses measure-based timing.
     pub source: Option<String>,
     /// Times to evaluate, each `mm:ss.mmm`, `Ns`, or a bare number of seconds.
     pub times: Vec<String>,
@@ -256,10 +257,12 @@ fn default_true() -> bool {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AnalyzeShowArgs {
-    /// Song name as listed by `list_songs`. Analyses the song's registered
-    /// lighting shows. Mutually exclusive with `source`.
+    /// Song name as listed by `list_songs`. Alone, analyses the song's
+    /// registered lighting shows. Passed with `source`, supplies that song's
+    /// tempo map so a draft using `@bar`/`beat` timing can be analysed.
     pub song: Option<String>,
-    /// `.light` DSL source to analyse directly. Mutually exclusive with `song`.
+    /// `.light` DSL source to analyse directly. Pass `song` as well if the
+    /// source uses measure-based timing.
     pub source: Option<String>,
 }
 
@@ -273,14 +276,15 @@ pub struct GetCuesArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DiffShowsArgs {
-    /// Baseline: a song name, whose registered shows are used.
-    /// Mutually exclusive with `a_source`.
+    /// Baseline: a song name, whose registered shows are used. With
+    /// `a_source`, supplies the tempo map that `a_source` is parsed against.
     pub a_song: Option<String>,
-    /// Baseline: `.light` DSL source. Mutually exclusive with `a_song`.
+    /// Baseline: `.light` DSL source. Pass `a_song` too if it uses `@bar`/`beat`.
     pub a_source: Option<String>,
-    /// Candidate: a song name. Mutually exclusive with `b_source`.
+    /// Candidate: a song name. With `b_source`, supplies the tempo map that
+    /// `b_source` is parsed against.
     pub b_song: Option<String>,
-    /// Candidate: `.light` DSL source. Mutually exclusive with `b_song`.
+    /// Candidate: `.light` DSL source. Pass `b_song` too if it uses `@bar`/`beat`.
     pub b_source: Option<String>,
 }
 
@@ -1128,10 +1132,14 @@ impl McpServer {
         Parameters(args): Parameters<ValidateLightingArgs>,
     ) -> Result<CallToolResult, McpError> {
         let tempo = self.song_tempo_map(args.song.as_deref())?;
-        match crate::lighting::parser::parse_light_shows_with_tempo(&args.source, tempo.as_ref()) {
+        let parsed_shows =
+            crate::lighting::parser::parse_light_shows_with_tempo(&args.source, tempo.as_ref())
+                .map_err(|e| e.to_string());
+        match parsed_shows {
             Ok(shows) => {
-                let parsed: Vec<_> = shows.values().cloned().collect();
-                let warnings = self.lint_warnings(&parsed, args.song.as_deref())?;
+                let mut parsed: Vec<_> = shows.values().cloned().collect();
+                sort_shows(&mut parsed);
+                let warnings = self.lint_warnings(&parsed, args.song.as_deref()).await?;
                 let mut summary: Vec<Value> = shows
                     .iter()
                     .map(|(name, show)| {
@@ -1156,7 +1164,7 @@ impl McpServer {
             }
             Err(e) => Ok(ok_json(json!({
                 "ok": false,
-                "error": e.to_string(),
+                "error": e,
             }))),
         }
     }
@@ -1168,11 +1176,42 @@ impl McpServer {
     /// A check whose input is missing is skipped rather than guessed at, so
     /// validating a bare source with no song and no venue reports nothing
     /// rather than reporting everything as suspicious.
-    fn lint_warnings(
+    async fn lint_warnings(
         &self,
         shows: &[crate::lighting::parser::LightShow],
         song: Option<&str>,
     ) -> Result<Vec<Value>, McpError> {
+        // Resolved before the song is looked up: `LintContext` borrows the
+        // song, and a borrow of it must not be held across an await.
+        let group_fixture_counts = match self
+            .player
+            .dmx_engine()
+            .and_then(|dmx| dmx.broadcast_handles().lighting_system)
+        {
+            Some(system) => {
+                let names = group_names(shows);
+                // The lighting-system mutex is shared with the effects loop
+                // thread, so taking it belongs off the async worker.
+                tokio::task::spawn_blocking(move || {
+                    let mut guard = system.lock();
+                    let mut counts = std::collections::HashMap::new();
+                    // Only when a venue is actually loaded. Without one every
+                    // group resolves to nothing, and reporting them all as empty
+                    // would be noise rather than a finding.
+                    if guard.get_current_venue().is_some() {
+                        for name in names {
+                            let count = guard.resolve_logical_group_graceful(&name).len();
+                            counts.insert(name, count);
+                        }
+                    }
+                    counts
+                })
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?
+            }
+            None => std::collections::HashMap::new(),
+        };
+
         let song = match song {
             Some(name) => Some(
                 self.player
@@ -1183,28 +1222,11 @@ impl McpServer {
             None => None,
         };
 
-        let mut ctx = crate::lighting::lint::LintContext {
+        let ctx = crate::lighting::lint::LintContext {
             song_duration: song.as_ref().map(|s| s.duration()),
             beat_grid: song.as_ref().and_then(|s| s.beat_grid()),
-            ..Default::default()
+            group_fixture_counts,
         };
-
-        if let Some(system) = self
-            .player
-            .dmx_engine()
-            .and_then(|dmx| dmx.broadcast_handles().lighting_system)
-        {
-            let mut guard = system.lock();
-            // Only when a venue is actually loaded. Without one every group
-            // resolves to nothing, and reporting them all as empty would be
-            // noise rather than a finding.
-            if guard.get_current_venue().is_some() {
-                for name in group_names(shows) {
-                    let count = guard.resolve_logical_group_graceful(&name).len();
-                    ctx.group_fixture_counts.insert(name, count);
-                }
-            }
-        }
 
         Ok(crate::lighting::lint::lint_shows(shows, &ctx)
             .into_iter()
@@ -1248,10 +1270,24 @@ impl McpServer {
         McpError,
     > {
         match (&args.song, &args.source) {
-            (Some(_), Some(_)) => Err(McpError::invalid_params(
-                "pass either `song` or `source`, not both",
-                None,
-            )),
+            (Some(name), Some(source)) => {
+                // A draft evaluated against the song it belongs to. Without the
+                // song's tempo the parser rejects every `@bar`/`beat` construct,
+                // so this is the only way to evaluate an unsaved edit of a
+                // measure-timed show.
+                let song = self
+                    .player
+                    .songs()
+                    .get(name)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                let tempo = song_lighting_tempo(&song);
+                let shows =
+                    crate::lighting::parser::parse_light_shows_with_tempo(source, tempo.as_ref())
+                        .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                let mut shows: Vec<_> = shows.into_values().collect();
+                sort_shows(&mut shows);
+                Ok((shows, tempo))
+            }
             (None, None) => Err(McpError::invalid_params(
                 "pass either `song` (a loaded song's registered shows) or \
                  `source` (raw `.light` DSL)",
@@ -1281,8 +1317,15 @@ impl McpServer {
                 Ok((shows, song_lighting_tempo(&song)))
             }
             (None, Some(source)) => {
-                let shows = crate::lighting::parser::parse_light_shows(source)
-                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                let shows = crate::lighting::parser::parse_light_shows(source).map_err(|e| {
+                    McpError::invalid_params(
+                        format!(
+                            "{e}\n\nIf this show uses `@bar`/`beat` timing, pass `song` \
+                             alongside `source` so the song's tempo map can resolve them."
+                        ),
+                        None,
+                    )
+                })?;
                 let mut shows: Vec<_> = shows.into_values().collect();
                 sort_shows(&mut shows);
                 Ok((shows, None))
@@ -1391,7 +1434,7 @@ impl McpServer {
         // Warnings come from the shared linter rather than a second
         // implementation here, so `analyze_show` and `validate_lighting` cannot
         // disagree about the same show.
-        let warnings = self.lint_warnings(&shows, args.song.as_deref())?;
+        let warnings = self.lint_warnings(&shows, args.song.as_deref()).await?;
 
         let analysis = tokio::task::spawn_blocking(move || {
             crate::lighting::analyze::analyze_show(shows, fallback_tempo.as_ref())
@@ -1536,7 +1579,7 @@ impl McpServer {
     }
 
     #[tool(description = "List the venues known to the running DMX engine. Each \
-        venue lists its groups and fixture count.")]
+        venue lists its fixture count.")]
     async fn list_venues(&self) -> Result<CallToolResult, McpError> {
         let dmx = match self.player.dmx_engine() {
             Some(d) => d,
@@ -2299,7 +2342,6 @@ impl ServerHandler for McpServer {
     }
 }
 
-/// Returns a successful tool result wrapping a JSON value as pretty-printed text.
 /// Renders one evaluation — predicted or live — as JSON.
 ///
 /// `evaluate_show` and `get_fixture_state` share this so the two surfaces
@@ -2326,6 +2368,8 @@ fn evaluation_json(
     let mut entry = json!({
         "time": evaluation.time.as_secs_f64(),
         "position": format_duration(evaluation.time),
+        // Null, not false, when no venue is loaded: there were no fixtures to
+        // judge, and "I cannot tell" must not read as "the rig is lit".
         "dark": evaluation.is_dark(),
         "active_effects": effects,
     });
@@ -2584,6 +2628,7 @@ fn group_names(shows: &[crate::lighting::parser::LightShow]) -> Vec<String> {
     names
 }
 
+/// Returns a successful tool result wrapping a JSON value as pretty-printed text.
 pub(crate) fn ok_json(value: Value) -> CallToolResult {
     let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
     CallToolResult::success(vec![Content::text(text)])
@@ -2854,11 +2899,6 @@ async fn send_resource_updated(
     peer.send_notification(notif).await
 }
 
-/// Builds the player-status JSON snapshot used by both `tools/call status`
-/// and the `mtrack://status` resource. Free function so background tasks
-/// can compute it without capturing an `McpServer` (which would form a
-/// reference cycle through `subscriptions` → `SubscriptionHandle` →
-/// `AbortHandle` and silently defeat abort-on-Drop).
 /// Builds the live lighting payload. Free function so the subscription task can
 /// call it while capturing only `Arc<Player>`, for the same reason
 /// [`build_status_snapshot`] is one.
@@ -2890,6 +2930,11 @@ async fn build_lighting_snapshot(player: &Player) -> Result<Value, McpError> {
     Ok(value)
 }
 
+/// Builds the player-status JSON snapshot used by both `tools/call status`
+/// and the `mtrack://status` resource. Free function so background tasks
+/// can compute it without capturing an `McpServer` (which would form a
+/// reference cycle through `subscriptions` → `SubscriptionHandle` →
+/// `AbortHandle` and silently defeat abort-on-Drop).
 async fn build_status_snapshot(player: &Player) -> Result<Value, McpError> {
     let playlist = player.get_playlist();
     let current = playlist.current();
@@ -3025,6 +3070,7 @@ impl McpServer {
                     continue;
                 }
 
+                let sent = rx.borrow().clone();
                 let payload = build_lighting_snapshot(&player)
                     .await
                     .unwrap_or(Value::Null);
@@ -3039,7 +3085,11 @@ impl McpServer {
                 // next payload is the state then, not a replay of this backlog.
                 tokio::time::sleep(LIGHTING_NOTIFY_INTERVAL).await;
                 rx.mark_unchanged();
-                last = rx.borrow().clone();
+                // Deliberately the state we *sent*, not the state now: the
+                // sampler re-sends unconditionally, so `== last` is the only
+                // change filter. Adopting the post-sleep value here would swallow
+                // any transition that happened during the sleep and then held.
+                last = sent;
             }
         });
         Ok(handle.abort_handle())

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -458,7 +458,34 @@ impl McpServer {
                 .flat_map(|dsl| dsl.shows().values().cloned())
                 .collect();
             sort_shows(&mut shows);
-            let cues: Vec<Value> = shows.iter().flat_map(cue_timeline).collect();
+
+            // Merged and time-sorted, the way the player's own timeline
+            // combines a song's shows. Concatenating per show would restart
+            // indices at zero for each one and interleave their times, so the
+            // same song answered differently depending on which branch ran.
+            let tempo = shows.iter().find_map(|s| s.tempo_map.clone());
+            let mut cues: Vec<(std::time::Duration, usize)> = shows
+                .iter()
+                .flat_map(|show| show.cues.iter().map(|cue| (cue.time, cue.effects.len())))
+                .collect();
+            cues.sort_by_key(|(time, _)| *time);
+
+            let cues: Vec<Value> = cues
+                .into_iter()
+                .enumerate()
+                .map(|(index, (time, effects))| {
+                    json!({
+                        "index": index,
+                        "time": format_duration(time),
+                        "seconds": time.as_secs_f64(),
+                        "position": tempo.as_ref().map(|m| {
+                            let (measure, beat) = m.time_to_measure_beat(time);
+                            format!("@{measure}/{beat:.2}")
+                        }),
+                        "effects": effects,
+                    })
+                })
+                .collect();
             return Ok(ok_json(json!({ "song": name, "cues": cues })));
         }
 
@@ -527,10 +554,11 @@ impl McpServer {
         let Some(song) = song else {
             return Ok(ok_json(json!({
                 "started": false,
-                "reason": "a song is already playing; play_from does not \
-                           interrupt it",
-                "hint": "call `stop` first, or use `seek` to move within the \
-                         current song",
+                // See `play_song_from`: `None` covers several cases.
+                "reason": "the player did not start the song; the most common \
+                           cause is that one is already playing",
+                "hint": "check `status`; call `stop` first, or use `seek` to \
+                         move within the current song",
             })));
         };
         Ok(ok_json(json!({
@@ -566,10 +594,13 @@ impl McpServer {
         let Some(song) = song else {
             return Ok(ok_json(json!({
                 "started": false,
-                "reason": "a song is already playing; play_song_from does not \
-                           interrupt it",
-                "hint": "call `stop` first, or use `seek` to move within the \
-                         current song",
+                // The player returns nothing for more than one reason — a song
+                // already playing, a loop break, an empty playlist — and does
+                // not say which. Report the fact, not a guess at the cause.
+                "reason": "the player did not start the song; the most common \
+                           cause is that one is already playing",
+                "hint": "check `status`; call `stop` first, or use `seek` to \
+                         move within the current song",
             })));
         };
 
@@ -2874,18 +2905,33 @@ async fn build_status_snapshot(player: &Player) -> Result<Value, McpError> {
     // The timeline mutex is shared with the effects loop thread, so this reads
     // it on the blocking pool rather than parking a tokio worker on it.
     let lighting = match player.dmx_engine() {
-        Some(dmx) => tokio::task::spawn_blocking(move || dmx.lighting_arming_state())
-            .await
-            .ok()
-            .flatten()
-            .map(|(armed, total, remaining, next)| {
-                json!({
+        Some(dmx) => {
+            // Bounded, because this is the diagnostic of last resort: if the
+            // effects loop wedges holding the timeline mutex, `status` must
+            // still answer rather than hang alongside it. A timeout or a
+            // panicked task is reported as such, not silently flattened into
+            // "no show loaded" — that is the one field meant to tell those
+            // apart.
+            let read = tokio::task::spawn_blocking(move || dmx.lighting_arming_state());
+            match tokio::time::timeout(std::time::Duration::from_millis(500), read).await {
+                Ok(Ok(Some((armed, total, remaining, next)))) => Some(json!({
                     "armed": armed,
                     "cues_total": total,
                     "cues_remaining": remaining,
                     "next_cue_seconds": next.map(|t| t.as_secs_f64()),
-                })
-            }),
+                })),
+                Ok(Ok(None)) => None,
+                Ok(Err(e)) => Some(json!({
+                    "available": false,
+                    "reason": format!("lighting state read failed: {e}"),
+                })),
+                Err(_) => Some(json!({
+                    "available": false,
+                    "reason": "timed out reading lighting state — the effects \
+                               loop may be stalled holding the timeline lock",
+                })),
+            }
+        }
         None => None,
     };
 
@@ -3486,11 +3532,23 @@ mod unregister_lighting_tests {
     #[test]
     fn handles_the_multi_line_quoted_form_the_shipped_songs_use() {
         // examples/songs/dsl-light-show-song/song.yaml writes entries as
-        // `- name: "..."` with `file:` on the next line, quoted. Matching only
-        // the `-` line misses the path entirely.
-        let yaml = format!(
-            "{BASE}lighting:\n  - name: \"Main Show\"\n    file: \"lighting/main_show.light\"\n               - name: \"Outro Show\"\n    file: \"lighting/outro.light\"\n"
-        );
+        // `- name: "..."` with `file:` on the next line, quoted and indented
+        // two spaces. Matching only the `-` line misses the path entirely.
+        let block = [
+            "lighting:",
+            "  - name: \"Main Show\"",
+            "    file: \"lighting/main_show.light\"",
+            "  - name: \"Outro Show\"",
+            "    file: \"lighting/outro.light\"",
+            "",
+        ]
+        .join("\n");
+        let yaml = format!("{BASE}{block}");
+
+        let song: crate::config::Song =
+            super::serde_yaml_from_str(&yaml).expect("precondition: valid song");
+        assert_eq!(song.lighting().map(|l| l.len()), Some(2));
+
         let updated =
             unregister_lighting_file(&yaml, "lighting/outro.light").expect("removes the entry");
         assert!(!updated.contains("outro.light"), "{updated}");

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1539,6 +1539,8 @@ impl McpServer {
                 "position": c.position,
                 "command": c.command,
                 "layer": c.layer,
+                "intensity": c.intensity,
+                "speed": c.speed,
             })
         };
 
@@ -2401,13 +2403,9 @@ fn evaluation_json(
     entry
 }
 
-/// The tempo map a song's `.light` files are parsed with: its explicit
-/// `tempo:` block if it has one, otherwise one derived from the click-derived
-/// beat grid. Mirrors what `Song` does at load time.
+/// The tempo map a song's `.light` files are parsed with.
 fn song_lighting_tempo(song: &crate::songs::Song) -> Option<crate::tempo::TempoMap> {
-    song.tempo_map()
-        .cloned()
-        .or_else(|| song.beat_grid().and_then(|grid| grid.to_tempo_map()))
+    song.lighting_tempo_map()
 }
 
 /// What `write_song_lighting` did about the song's `lighting:` block.

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1403,7 +1403,10 @@ impl McpServer {
         tempo block changed, and a one-line duration edit can move a section \
         boundary and open a blackout. Effects are matched on the groups they \
         target and their kind, so a cue nudged by a beat reads as a changed \
-        time rather than as an unrelated removal and addition. Also reports \
+        time rather than as an unrelated removal and addition, and compares \
+        their parameters and blend mode, so a colour or level edit is a \
+        reported change rather than silence. Layer commands are diffed too. \
+        Also reports \
         `dark_windows_added` and `dark_windows_removed`, since a revision is \
         usually about what the rig does. Each side takes either a song or DSL \
         source.")]
@@ -1443,6 +1446,8 @@ impl McpServer {
                 "type": e.effect_type,
                 "layer": format!("{:?}", e.layer).to_lowercase(),
                 "duration": e.duration.as_secs_f64(),
+                "blend_mode": format!("{:?}", e.blend_mode).to_lowercase(),
+                "parameters": e.parameters,
             })
         };
         let window = |w: &crate::lighting::analyze::DarkWindow| {
@@ -1451,6 +1456,15 @@ impl McpServer {
                 "to": w.to.as_secs_f64(),
                 "seconds": w.seconds(),
                 "position": w.position,
+            })
+        };
+
+        let command = |c: &crate::lighting::diff::LayerCommandEntry| {
+            json!({
+                "time": c.time.as_secs_f64(),
+                "position": c.position,
+                "command": c.command,
+                "layer": c.layer,
             })
         };
 
@@ -1470,6 +1484,16 @@ impl McpServer {
                         .map(|f| json!({"field": f.field, "from": f.from, "to": f.to}))
                         .collect::<Vec<_>>(),
                 }))
+                .collect::<Vec<_>>(),
+            "layer_commands_added": diff
+                .layer_commands_added
+                .iter()
+                .map(command)
+                .collect::<Vec<_>>(),
+            "layer_commands_removed": diff
+                .layer_commands_removed
+                .iter()
+                .map(command)
                 .collect::<Vec<_>>(),
             "dark_windows_added": diff.dark_windows_added.iter().map(window).collect::<Vec<_>>(),
             "dark_windows_removed": diff
@@ -1733,6 +1757,7 @@ impl McpServer {
             .replace('\\', "/");
 
         let original = read_text(&config_path).await?;
+        let referenced = references_lighting_file(&original, &reference);
         let unregistered = match unregister_lighting_file(&original, &reference) {
             Some(updated) => {
                 // Same guard the write path uses: never leave a song.yaml that
@@ -1741,9 +1766,27 @@ impl McpServer {
                 staged_write_string(&config_path, &updated).await?;
                 true
             }
+            None if referenced => {
+                // The song points at this file but the entry could not be
+                // edited — an unusual YAML shape such as a flow sequence.
+                // Deleting anyway would leave exactly the dangling reference
+                // this tool exists to prevent, and the song would stop loading.
+                return Err(McpError::invalid_params(
+                    format!(
+                        "song `{}` references `{reference}` but its `lighting:` block \
+                         could not be edited automatically. Remove the entry from {} \
+                         by hand, then delete the file.",
+                        args.song,
+                        config_path.display()
+                    ),
+                    None,
+                ));
+            }
             None => false,
         };
 
+        // The file goes last. If removal fails, the only thing that happened is
+        // the config edit, and the song still loads.
         remove_lighting_file(&path).await?;
         self.reload_songs_from_config().await?;
 
@@ -2007,9 +2050,14 @@ impl McpServer {
         })?;
         let original = read_text(&path).await?;
         let updated = apply_patch(&original, &args.patch)?;
-        crate::lighting::parser::parse_light_shows(&updated).map_err(|e| {
-            McpError::invalid_params(format!("patched .light is invalid: {e}"), None)
-        })?;
+        // Validate against the tempo this song loads it with, matching
+        // `write_song_lighting`. Otherwise a patch to a tempo-inheriting show
+        // is rejected here and would have loaded fine.
+        crate::lighting::parser::parse_light_shows_with_tempo(
+            &updated,
+            song_lighting_tempo(&song).as_ref(),
+        )
+        .map_err(|e| McpError::invalid_params(format!("patched .light is invalid: {e}"), None))?;
         staged_write_string(&path, &updated).await?;
         self.reload_songs_from_config().await?;
         Ok(patch_response(&path, &original, &updated))
@@ -2305,6 +2353,59 @@ async fn remove_lighting_file(path: &std::path::Path) -> Result<(), McpError> {
     })
 }
 
+/// The `lighting:` block's location in a song's YAML: the key line, the item
+/// spans beneath it, and where the block ends.
+///
+/// YAML lets a sequence sit at the key's own indentation or deeper, and an
+/// entry may run over several lines — the shipped songs write `- name: "..."`
+/// with `file:` underneath. Both callers need the same understanding of that
+/// shape, so they share this rather than each scanning lines their own way.
+struct LightingBlock {
+    key_index: usize,
+    item_indent: usize,
+    /// Half-open line ranges, one per `- ` entry.
+    spans: Vec<(usize, usize)>,
+    /// One past the block's last line.
+    end: usize,
+}
+
+fn find_lighting_block(lines: &[&str]) -> Option<LightingBlock> {
+    let key_index = lines.iter().position(|line| is_key(line, "lighting"))?;
+    let key_indent = indent_of(lines[key_index]);
+
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut end = key_index + 1;
+    let mut item_indent = key_indent;
+    for (offset, line) in lines.iter().enumerate().skip(key_index + 1) {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        let indent = indent_of(line);
+        let is_item = line.trim_start().starts_with('-');
+        // A sequence may be indented under the key or level with it; anything
+        // shallower, or level but not an item, is the next key.
+        if indent < key_indent || (indent == key_indent && !is_item) {
+            break;
+        }
+        end = offset + 1;
+        if is_item {
+            if spans.is_empty() {
+                item_indent = indent;
+            }
+            spans.push((offset, offset + 1));
+        } else if let Some(last) = spans.last_mut() {
+            last.1 = offset + 1;
+        }
+    }
+
+    Some(LightingBlock {
+        key_index,
+        item_indent,
+        spans,
+        end,
+    })
+}
+
 /// Removes the `lighting:` entry referencing `relative_path`, and the whole
 /// block if that was its last entry.
 ///
@@ -2313,44 +2414,23 @@ async fn remove_lighting_file(path: &std::path::Path) -> Result<(), McpError> {
 /// [`register_lighting_file`] does: song.yaml is hand-written.
 pub(crate) fn unregister_lighting_file(yaml: &str, relative_path: &str) -> Option<String> {
     let lines: Vec<&str> = yaml.lines().collect();
-    let key_index = lines.iter().position(|line| is_key(line, "lighting"))?;
-    let key_indent = indent_of(lines[key_index]);
-
-    // Collect the block's item spans. An entry may run over several lines —
-    // the shipped songs write `- name: "..."` with `file:` underneath — so the
-    // path can appear on any line of its item, not just the one starting it.
-    let mut spans: Vec<(usize, usize)> = Vec::new();
-    let mut block_end = key_index + 1;
-    for (offset, line) in lines.iter().enumerate().skip(key_index + 1) {
-        if line.trim().is_empty() || line.trim_start().starts_with('#') {
-            continue;
-        }
-        if indent_of(line) <= key_indent {
-            break;
-        }
-        block_end = offset + 1;
-        if line.trim_start().starts_with('-') {
-            spans.push((offset, offset + 1));
-        } else if let Some(last) = spans.last_mut() {
-            last.1 = offset + 1;
-        }
-    }
+    let block = find_lighting_block(&lines)?;
 
     // Match on the parsed value rather than a bare substring, so
     // `lighting/main.light` cannot match `lighting/main.light.bak`.
-    let target = spans.iter().position(|(start, end)| {
+    let target = block.spans.iter().position(|(start, end)| {
         lines[*start..*end]
             .iter()
             .any(|line| yaml_value_of(line, "file").as_deref() == Some(relative_path))
     })?;
 
     let mut updated: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
-    if spans.len() == 1 {
+    if block.spans.len() == 1 {
         // Removing the last entry would leave `lighting:` with no items, which
         // is not a valid sequence and would stop the song loading.
-        updated.drain(key_index..block_end);
+        updated.drain(block.key_index..block.end);
     } else {
-        let (start, end) = spans[target];
+        let (start, end) = block.spans[target];
         updated.drain(start..end);
     }
     Some(with_trailing_newline(updated.join("\n")))
@@ -2381,33 +2461,12 @@ pub(crate) fn register_lighting_file(yaml: &str, relative_path: &str) -> Option<
     let lines: Vec<&str> = yaml.lines().collect();
     let entry = format!("- file: {relative_path}");
 
-    // An existing `lighting:` block: append after its last item, so the new
-    // show reads in the order it was added.
-    if let Some(key_index) = lines.iter().position(|line| is_key(line, "lighting")) {
-        let indent = indent_of(lines[key_index]);
-        let mut end = key_index + 1;
-        for (offset, line) in lines.iter().enumerate().skip(key_index + 1) {
-            // The block ends at the next line that is no more indented than
-            // the key itself. Blank lines and comments belong to whatever
-            // follows, so they do not end it on their own.
-            if line.trim().is_empty() || line.trim_start().starts_with('#') {
-                continue;
-            }
-            if indent_of(line) <= indent {
-                break;
-            }
-            end = offset + 1;
-        }
-        // Match the indentation the existing items use, falling back to the
-        // key's own indentation for an empty block.
-        let item_indent = lines
-            .get(key_index + 1)
-            .filter(|line| indent_of(line) > indent && line.trim_start().starts_with('-'))
-            .map(|line| indent_of(line))
-            .unwrap_or(indent);
-
+    if let Some(block) = find_lighting_block(&lines) {
         let mut updated: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
-        updated.insert(end, format!("{}{entry}", " ".repeat(item_indent)));
+        updated.insert(
+            block.end,
+            format!("{}{entry}", " ".repeat(block.item_indent)),
+        );
         return Some(with_trailing_newline(updated.join("\n")));
     }
 
@@ -3463,6 +3522,38 @@ mod unregister_lighting_tests {
             !updated.contains("- file: lighting/main.light\n"),
             "{updated}"
         );
+    }
+
+    #[test]
+    fn handles_a_sequence_at_the_keys_own_indentation() {
+        // Valid YAML and a common hand-written style. A scanner that stops at
+        // the first line no deeper than the key finds no items at all, so
+        // `delete_song_lighting` would orphan the reference.
+        let yaml = format!("{BASE}lighting:\n- file: lighting/a.light\n- file: lighting/b.light\n");
+        let cfg: Result<crate::config::Song, _> = super::serde_yaml_from_str(&yaml);
+        assert!(cfg.is_ok(), "precondition: this is valid YAML");
+
+        let updated = unregister_lighting_file(&yaml, "lighting/a.light").expect("removes");
+        assert!(!updated.contains("a.light"), "{updated}");
+        assert!(updated.contains("b.light"), "{updated}");
+    }
+
+    #[test]
+    fn a_zero_indent_block_loses_its_key_with_the_last_entry() {
+        let yaml = format!("{BASE}lighting:\n- file: lighting/only.light\n");
+        let updated = unregister_lighting_file(&yaml, "lighting/only.light").expect("removes");
+        assert!(!updated.contains("lighting:"), "{updated}");
+        let song: crate::config::Song =
+            super::serde_yaml_from_str(&updated).expect("must remain valid");
+        assert!(song.lighting().is_none());
+    }
+
+    #[test]
+    fn a_flow_sequence_is_declined_rather_than_mangled() {
+        // Not supported by a line-based editor. Returning None is what makes
+        // the delete path refuse instead of orphaning the reference.
+        let yaml = format!("{BASE}lighting: [{{file: \"lighting/a.light\"}}]\n");
+        assert!(unregister_lighting_file(&yaml, "lighting/a.light").is_none());
     }
 
     #[test]

--- a/src/dmx/engine/playback.rs
+++ b/src/dmx/engine/playback.rs
@@ -202,6 +202,15 @@ impl Engine {
 
         if dmx_midi_sheets.is_empty() && !has_lighting {
             info!(song = song.name(), "Song has no matching light shows.");
+            // Drop the previous song's timeline. Leaving it installed makes
+            // `status.lighting` report that song's cue counts for this one —
+            // "a show is loaded but never armed" for a song that has no show,
+            // which is exactly the wrong answer from the field added to end
+            // that guesswork.
+            {
+                let mut current_timeline = dmx_engine.current_song_timeline.lock();
+                *current_timeline = None;
+            }
             ready_tx.send();
             return Ok(());
         }

--- a/src/dmx/engine/playback.rs
+++ b/src/dmx/engine/playback.rs
@@ -383,6 +383,16 @@ impl Engine {
                                 section = section.name,
                                 "DMX section loop: resetting for next iteration"
                             );
+                            // Rewind the clock and take ownership of it *before*
+                            // arming. Arming first leaves a window in which the
+                            // song-time tracker is still writing end-of-section
+                            // time, and the 44Hz effects loop can advance the
+                            // freshly rewound timeline straight past every cue
+                            // in the section — silencing the loop for good,
+                            // since the cue pointer never moves backwards.
+                            // Every sibling path writes before arming.
+                            section_owns_time.store(true, Ordering::Relaxed);
+                            dmx_engine.update_song_time(section.start_time);
                             dmx_engine.start_lighting_timeline_at(section.start_time);
                             {
                                 let mut playbacks = dmx_engine.midi_dmx_playbacks.lock();
@@ -392,8 +402,6 @@ impl Engine {
                                         events.partition_point(|e| e.time < section.start_time);
                                 }
                             }
-                            dmx_engine.update_song_time(section.start_time);
-                            section_owns_time.store(true, Ordering::Relaxed);
                             iteration_start = Some(elapsed);
                         }
                         crate::section_loop::LoopPoll::SectionCleared => {

--- a/src/dmx/engine/playback.rs
+++ b/src/dmx/engine/playback.rs
@@ -77,6 +77,17 @@ impl Engine {
         let has_lighting = !dsl_lighting_shows.is_empty();
 
         if light_shows.is_empty() && !has_lighting {
+            // A song with no lighting at all still has to evict the previous
+            // song's state, or `status.lighting` and `get_timeline_cues()` keep
+            // answering with that song's cues.
+            {
+                let mut effect_engine = dmx_engine.effect_engine.lock();
+                effect_engine.set_tempo_map(None);
+            }
+            {
+                let mut current_timeline = dmx_engine.current_song_timeline.lock();
+                *current_timeline = None;
+            }
             ready_tx.send();
             return Ok(());
         }
@@ -116,7 +127,7 @@ impl Engine {
                         timeline
                             .tempo_map()
                             .cloned()
-                            .or_else(|| song.tempo_map().cloned()),
+                            .or_else(|| song.lighting_tempo_map()),
                     );
                 }
                 {
@@ -166,7 +177,7 @@ impl Engine {
                         dmx_engine.current_song_time.clone(),
                         dmx_engine.lighting_system.clone(),
                         dmx_engine.lighting_config.clone(),
-                        song.tempo_map().cloned(),
+                        song.lighting_tempo_map(),
                         tx.clone(),
                     ) {
                         Ok(handle) => {
@@ -202,15 +213,8 @@ impl Engine {
 
         if dmx_midi_sheets.is_empty() && !has_lighting {
             info!(song = song.name(), "Song has no matching light shows.");
-            // Drop the previous song's timeline. Leaving it installed makes
-            // `status.lighting` report that song's cue counts for this one —
-            // "a show is loaded but never armed" for a song that has no show,
-            // which is exactly the wrong answer from the field added to end
-            // that guesswork.
-            {
-                let mut current_timeline = dmx_engine.current_song_timeline.lock();
-                *current_timeline = None;
-            }
+            // The `!has_lighting` branch above already dropped the previous
+            // song's timeline and tempo map.
             ready_tx.send();
             return Ok(());
         }

--- a/src/dmx/engine/timeline.rs
+++ b/src/dmx/engine/timeline.rs
@@ -217,6 +217,11 @@ impl Engine {
     /// A write stamped with a superseded generation is dropped. See
     /// [`Engine::playback_generation`] for why one stale write is fatal rather
     /// than merely untidy.
+    ///
+    /// Best-effort, not airtight: the generation is read and the time stored as
+    /// two operations, so a writer preempted between them can still land after
+    /// a new playback has begun. It closes the window that stays open for a
+    /// whole tracker sleep interval, not the one that lasts two instructions.
     pub fn update_song_time_for_generation(&self, song_time: Duration, generation: u64) {
         if generation != self.playback_generation() {
             return;

--- a/src/dmx/watcher.rs
+++ b/src/dmx/watcher.rs
@@ -205,8 +205,12 @@ fn reload_timeline(
         let content = std::fs::read_to_string(path)
             .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-        let shows = crate::lighting::parser::parse_light_shows(&content)
-            .map_err(|e| format!("Parse error in {}: {}", path.display(), e))?;
+        // Parse with the same tempo this timeline will run under. Using the
+        // tempo-less entry point here meant a show inheriting the song's tempo
+        // failed every live edit, and the timeline silently never swapped.
+        let shows =
+            crate::lighting::parser::parse_light_shows_with_tempo(&content, fallback_tempo_map)
+                .map_err(|e| format!("Parse error in {}: {}", path.display(), e))?;
 
         // Validate if lighting config is available
         if let Some(lc) = lighting_config {

--- a/src/lighting/analyze.rs
+++ b/src/lighting/analyze.rs
@@ -147,7 +147,15 @@ pub fn analyze_show(shows: Vec<LightShow>, fallback_tempo_map: Option<&TempoMap>
             dark_from.get_or_insert(start);
         } else {
             if let Some(from) = dark_from.take() {
-                analysis.dark_windows.push(window(from, start, &tempo_map));
+                // Only a gap *between* activity counts. A show whose first cue
+                // carries just layer commands — `clear()` and `master(...)` to
+                // reset the rig — starts its boundary list before anything
+                // runs, and reporting that as a window would put dark seconds
+                // outside the span and make the two numbers contradict each
+                // other. Trailing silence is dropped below for the same reason.
+                if first_active.is_some() {
+                    analysis.dark_windows.push(window(from, start, &tempo_map));
+                }
             }
             first_active.get_or_insert(start);
             last_active_end = end;
@@ -516,6 +524,36 @@ show "T" {
 "#,
         );
         assert_eq!(analysis.span, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn silence_before_the_first_effect_is_not_a_gap() {
+        // Opening with layer commands to reset the rig puts a boundary at zero
+        // before anything runs. Counting that as a dark window made
+        // `dark_seconds` exceed `span` — two numbers in one report
+        // contradicting each other.
+        let analysis = analyze(
+            r#"
+show "T" {
+    @00:00.000
+    clear()
+    master(layer: background, intensity: 100%)
+
+    @00:08.000
+    wash: static color: "blue", duration: 4s
+}
+"#,
+        );
+        assert!(
+            analysis.dark_windows.is_empty(),
+            "the show simply starts at 8s: {:?}",
+            analysis.dark_windows
+        );
+        assert_eq!(analysis.span, Duration::from_secs(4));
+        assert!(
+            analysis.dark_seconds() <= analysis.span.as_secs_f64(),
+            "dark time cannot exceed the span"
+        );
     }
 
     #[test]

--- a/src/lighting/diff.rs
+++ b/src/lighting/diff.rs
@@ -76,6 +76,10 @@ pub struct LayerCommandEntry {
     pub command: String,
     /// The layer it targets, or `all` for a bare `clear()`.
     pub layer: String,
+    /// `master`'s intensity argument, when given.
+    pub intensity: Option<f64>,
+    /// `master`'s speed argument, when given.
+    pub speed: Option<f64>,
 }
 
 /// An effect present in both versions but not identical.
@@ -210,6 +214,8 @@ fn layer_commands(shows: &[LightShow], tempo: Option<&TempoMap>) -> Vec<LayerCom
                         .layer
                         .map(|l| format!("{l:?}").to_lowercase())
                         .unwrap_or_else(|| "all".to_string()),
+                    intensity: cmd.intensity,
+                    speed: cmd.speed,
                 });
             }
         }
@@ -224,8 +230,15 @@ fn command_difference(a: &[LayerCommandEntry], b: &[LayerCommandEntry]) -> Vec<L
     let mut remaining: Vec<&LayerCommandEntry> = b.iter().collect();
     let mut out = Vec::new();
     for entry in a {
+        // Arguments are part of the identity: `master(intensity: 100%)` and
+        // `master(intensity: 10%)` are the same verb on the same layer at the
+        // same time, and matching on that alone reported no change.
         match remaining.iter().position(|o| {
-            o.time == entry.time && o.command == entry.command && o.layer == entry.layer
+            o.time == entry.time
+                && o.command == entry.command
+                && o.layer == entry.layer
+                && o.intensity == entry.intensity
+                && o.speed == entry.speed
         }) {
             Some(i) => {
                 remaining.remove(i);
@@ -734,6 +747,21 @@ show "T" {
         let d = diff(BASE, after);
         assert_eq!(d.layer_commands_added.len(), 1, "{d:?}");
         assert_eq!(d.layer_commands_added[0].command, "master");
+    }
+
+    #[test]
+    fn a_master_intensity_edit_is_not_identical() {
+        // The command's arguments are what it does. Comparing only the verb and
+        // the layer made a full-to-dim master read as no change at all.
+        let with = |intensity: &str| {
+            format!(
+                "show \"T\" {{\n    @00:00.000\n    wash: static color: \"blue\", duration: 4s\n                     master(layer: background, intensity: {intensity})\n}}\n"
+            )
+        };
+        let d = diff(&with("100%"), &with("10%"));
+        assert!(!d.is_empty(), "{d:?}");
+        assert_eq!(d.layer_commands_added.len(), 1, "{d:?}");
+        assert_eq!(d.layer_commands_removed.len(), 1, "{d:?}");
     }
 
     #[test]

--- a/src/lighting/diff.rs
+++ b/src/lighting/diff.rs
@@ -29,7 +29,7 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crate::lighting::analyze::{analyze_show, DarkWindow};
-use crate::lighting::effects::EffectLayer;
+use crate::lighting::effects::{BlendMode, EffectLayer};
 use crate::lighting::parser::LightShow;
 use crate::tempo::TempoMap;
 
@@ -45,14 +45,37 @@ pub struct DiffEntry {
     pub effect_type: &'static str,
     pub layer: EffectLayer,
     pub duration: Duration,
+    pub blend_mode: BlendMode,
+    /// The effect's authored parameters, keyed by their DSL spelling.
+    ///
+    /// Without these an edit that changes what the rig looks like — a colour,
+    /// a level, a strobe rate — is invisible: the kind, group, layer, time and
+    /// duration are all unchanged, and the diff reports the two versions as
+    /// identical. That is the worst answer this tool can give.
+    pub parameters: BTreeMap<String, String>,
 }
 
 /// A field that differs between two versions of the same effect.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FieldChange {
-    pub field: &'static str,
+    pub field: String,
     pub from: String,
     pub to: String,
+}
+
+/// A layer command at a resolved time.
+///
+/// These are diffed because they change what the rig does as much as effects
+/// do — deleting a `clear` re-opens a section that was deliberately cut, and
+/// nothing in the effect lists would show it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LayerCommandEntry {
+    pub time: Duration,
+    pub position: Option<String>,
+    /// e.g. `clear`, `freeze`, `master`.
+    pub command: String,
+    /// The layer it targets, or `all` for a bare `clear()`.
+    pub layer: String,
 }
 
 /// An effect present in both versions but not identical.
@@ -69,6 +92,10 @@ pub struct ShowDiff {
     pub added: Vec<DiffEntry>,
     pub removed: Vec<DiffEntry>,
     pub changed: Vec<ChangedEntry>,
+    /// Layer commands the second version has that the first does not.
+    pub layer_commands_added: Vec<LayerCommandEntry>,
+    /// Layer commands the first version had that the second does not.
+    pub layer_commands_removed: Vec<LayerCommandEntry>,
     /// Dark windows the second version has that the first does not.
     pub dark_windows_added: Vec<DarkWindow>,
     /// Dark windows the first version had that the second does not.
@@ -77,8 +104,19 @@ pub struct ShowDiff {
 
 impl ShowDiff {
     /// True when the two shows resolve identically.
+    ///
+    /// Includes the coverage deltas: a change that only shows up as a gap
+    /// opening or closing — deleting a `clear`, for instance — is still a
+    /// change, and reporting "identical" beside a non-empty dark-window list
+    /// would contradict itself.
     pub fn is_empty(&self) -> bool {
-        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+        self.added.is_empty()
+            && self.removed.is_empty()
+            && self.changed.is_empty()
+            && self.layer_commands_added.is_empty()
+            && self.layer_commands_removed.is_empty()
+            && self.dark_windows_added.is_empty()
+            && self.dark_windows_removed.is_empty()
     }
 }
 
@@ -133,6 +171,13 @@ pub fn diff_shows(
         diff.added.extend(news.into_iter().skip(paired));
     }
 
+    // Layer commands: compared as a multiset of (time, command, layer), since
+    // there is no per-command identity to pair on.
+    let old_cmds = layer_commands(&before, before_tempo);
+    let new_cmds = layer_commands(&after, after_tempo);
+    diff.layer_commands_added = command_difference(&new_cmds, &old_cmds);
+    diff.layer_commands_removed = command_difference(&old_cmds, &new_cmds);
+
     diff.added.sort_by_key(|e| e.time);
     diff.removed.sort_by_key(|e| e.time);
     diff.changed.sort_by_key(|c| c.before.time);
@@ -145,6 +190,50 @@ pub fn diff_shows(
     diff.dark_windows_removed = difference(&before_dark, &after_dark);
 
     diff
+}
+
+/// Every layer command in the shows, in time order.
+fn layer_commands(shows: &[LightShow], tempo: Option<&TempoMap>) -> Vec<LayerCommandEntry> {
+    let mut out = Vec::new();
+    for show in shows {
+        let map = show.tempo_map.as_ref().or(tempo);
+        for cue in &show.cues {
+            for cmd in &cue.layer_commands {
+                out.push(LayerCommandEntry {
+                    time: cue.time,
+                    position: map.map(|m| {
+                        let (measure, beat) = m.time_to_measure_beat(cue.time);
+                        format!("@{measure}/{beat:.2}")
+                    }),
+                    command: format!("{:?}", cmd.command_type).to_lowercase(),
+                    layer: cmd
+                        .layer
+                        .map(|l| format!("{l:?}").to_lowercase())
+                        .unwrap_or_else(|| "all".to_string()),
+                });
+            }
+        }
+    }
+    out.sort_by(|a, b| (a.time, &a.command, &a.layer).cmp(&(b.time, &b.command, &b.layer)));
+    out
+}
+
+/// Commands in `a` with no counterpart left in `b`, matching one-for-one so a
+/// duplicated command is reported rather than absorbed.
+fn command_difference(a: &[LayerCommandEntry], b: &[LayerCommandEntry]) -> Vec<LayerCommandEntry> {
+    let mut remaining: Vec<&LayerCommandEntry> = b.iter().collect();
+    let mut out = Vec::new();
+    for entry in a {
+        match remaining.iter().position(|o| {
+            o.time == entry.time && o.command == entry.command && o.layer == entry.layer
+        }) {
+            Some(i) => {
+                remaining.remove(i);
+            }
+            None => out.push(entry.clone()),
+        }
+    }
+    out
 }
 
 /// Resolved effects keyed by what they target and what kind they are, each list
@@ -173,6 +262,11 @@ fn entries(
                         effect_type,
                         layer: effect.layer.unwrap_or(EffectLayer::Background),
                         duration: effect.total_duration(),
+                        // Both default to what the engine applies when the DSL
+                        // omits them, so an unannotated effect compares as it
+                        // will actually run.
+                        blend_mode: effect.blend_mode.unwrap_or(BlendMode::Replace),
+                        parameters: effect.effect_type.parameters(),
                     });
             }
         }
@@ -188,23 +282,48 @@ fn field_changes(old: &DiffEntry, new: &DiffEntry) -> Vec<FieldChange> {
     let mut fields = Vec::new();
     if old.time != new.time {
         fields.push(FieldChange {
-            field: "time",
+            field: "time".to_string(),
             from: seconds(old.time),
             to: seconds(new.time),
         });
     }
     if old.duration != new.duration {
         fields.push(FieldChange {
-            field: "duration",
+            field: "duration".to_string(),
             from: seconds(old.duration),
             to: seconds(new.duration),
         });
     }
     if old.layer != new.layer {
         fields.push(FieldChange {
-            field: "layer",
+            field: "layer".to_string(),
             from: format!("{:?}", old.layer).to_lowercase(),
             to: format!("{:?}", new.layer).to_lowercase(),
+        });
+    }
+    if old.blend_mode != new.blend_mode {
+        fields.push(FieldChange {
+            field: "blend_mode".to_string(),
+            from: format!("{:?}", old.blend_mode).to_lowercase(),
+            to: format!("{:?}", new.blend_mode).to_lowercase(),
+        });
+    }
+
+    // Parameters, over the union of both sides so an added or removed one is
+    // reported rather than skipped.
+    let mut keys: Vec<&String> = old.parameters.keys().chain(new.parameters.keys()).collect();
+    keys.sort();
+    keys.dedup();
+    for key in keys {
+        let before = old.parameters.get(key);
+        let after = new.parameters.get(key);
+        if before == after {
+            continue;
+        }
+        fields.push(FieldChange {
+            field: key.clone(),
+            from: before.cloned().unwrap_or_else(|| "—".to_string()),
+            to: after.cloned().unwrap_or_else(|| "—".to_string()),
         });
     }
     fields
@@ -374,6 +493,83 @@ show "T" {
         assert_eq!(d.changed[0].fields[0].to, "foreground");
     }
 
+    #[test]
+    fn a_colour_change_is_reported() {
+        // The failure an audit caught: kind, group, layer, time and duration
+        // are all unchanged, so without comparing parameters the diff asserted
+        // the two versions were identical.
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "red", duration: 4s
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert!(!d.is_empty(), "a colour change is a change: {d:?}");
+        assert_eq!(d.changed.len(), 1, "{d:?}");
+        assert!(
+            d.changed[0].fields.iter().any(|f| f.from != f.to),
+            "{:?}",
+            d.changed[0].fields
+        );
+    }
+
+    #[test]
+    fn a_level_change_is_reported() {
+        let before = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", dimmer: 100%, duration: 4s
+}
+"#;
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", dimmer: 20%, duration: 4s
+}
+"#;
+        let d = diff(before, after);
+        assert!(!d.is_empty(), "{d:?}");
+        assert!(
+            d.changed[0].fields.iter().any(|f| f.field == "dimmer"),
+            "{:?}",
+            d.changed[0].fields
+        );
+    }
+
+    #[test]
+    fn a_strobe_rate_change_is_reported() {
+        let before =
+            "show \"T\" {\n    @00:00.000\n    wash: strobe frequency: 8, duration: 4s\n}\n";
+        let after =
+            "show \"T\" {\n    @00:00.000\n    wash: strobe frequency: 2, duration: 4s\n}\n";
+        let d = diff(before, after);
+        assert!(!d.is_empty(), "{d:?}");
+        assert!(
+            d.changed[0].fields.iter().any(|f| f.field == "frequency"),
+            "{:?}",
+            d.changed[0].fields
+        );
+    }
+
+    #[test]
+    fn a_blend_mode_change_is_reported() {
+        // replace -> add changes whether the effect stomps the layer.
+        let before =
+            "show \"T\" {\n    @00:00.000\n    wash: static color: \"blue\", duration: 4s\n}\n";
+        let after = "show \"T\" {\n    @00:00.000\n    wash: static color: \"blue\", duration: 4s, blend_mode: add\n}\n";
+        let d = diff(before, after);
+        assert!(!d.is_empty(), "{d:?}");
+        assert!(
+            d.changed[0].fields.iter().any(|f| f.field == "blend_mode"),
+            "{:?}",
+            d.changed[0].fields
+        );
+    }
+
     // ── the field the issue said it would actually use ─────────────
 
     #[test]
@@ -493,6 +689,62 @@ show "T" {
             "{:?}",
             d.changed[0].before
         );
+    }
+
+    #[test]
+    fn a_deleted_clear_is_reported() {
+        // Nothing in the effect lists changes — the same cues at the same times
+        // with the same parameters. Only the `clear` is gone, which re-opens a
+        // section that was deliberately cut.
+        let before = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 30s
+
+    @00:05.000
+    clear(layer: background)
+}
+"#;
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 30s
+}
+"#;
+        let d = diff(before, after);
+        assert!(!d.is_empty(), "removing a clear is a change: {d:?}");
+        assert_eq!(d.layer_commands_removed.len(), 1, "{d:?}");
+        assert_eq!(d.layer_commands_removed[0].command, "clear");
+        assert_eq!(d.layer_commands_removed[0].layer, "background");
+        assert!(d.layer_commands_added.is_empty());
+    }
+
+    #[test]
+    fn an_added_master_is_reported() {
+        let after = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+    master(layer: background, intensity: 50%)
+
+    @00:10.000
+    wash: static color: "red", duration: 4s
+}
+"#;
+        let d = diff(BASE, after);
+        assert_eq!(d.layer_commands_added.len(), 1, "{d:?}");
+        assert_eq!(d.layer_commands_added[0].command, "master");
+    }
+
+    #[test]
+    fn is_empty_accounts_for_coverage_changes() {
+        // A duration edit that only manifests as a gap must not be reported as
+        // "identical" just because the effect lists line up.
+        let before = "show \"T\" {\n    @00:00.000\n    wash: static color: \"blue\", duration: 10s\n\n    @00:10.000\n    wash: static color: \"red\", duration: 4s\n}\n";
+        let after = "show \"T\" {\n    @00:00.000\n    wash: static color: \"blue\", duration: 9s\n\n    @00:10.000\n    wash: static color: \"red\", duration: 4s\n}\n";
+        let d = diff(before, after);
+        assert!(!d.is_empty(), "{d:?}");
+        assert_eq!(d.dark_windows_added.len(), 1, "{d:?}");
     }
 
     #[test]

--- a/src/lighting/effects/types.rs
+++ b/src/lighting/effects/types.rs
@@ -91,6 +91,84 @@ impl EffectType {
         }
     }
 
+    /// The effect's authored parameters, as displayable strings keyed by the
+    /// name the DSL uses.
+    ///
+    /// `name()` alone does not identify an effect: two `static` cues differing
+    /// only in colour or level are the same kind and a completely different
+    /// look. Anything comparing effects — `diff_shows` above all — needs these
+    /// as well, so they live here rather than being re-derived per caller.
+    pub fn parameters(&self) -> std::collections::BTreeMap<String, String> {
+        let mut out: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        match self {
+            EffectType::Static { parameters, .. } => {
+                // Keyed by the DSL spelling the author used (`color`, `dimmer`,
+                // `intensity`, individual channels).
+                for (key, value) in parameters {
+                    out.insert(key.clone(), format!("{value}"));
+                }
+            }
+            EffectType::ColorCycle {
+                colors,
+                speed,
+                direction,
+                transition,
+                ..
+            } => {
+                out.insert("colors".to_string(), format!("{colors:?}"));
+                out.insert("speed".to_string(), format!("{speed:?}"));
+                out.insert("direction".to_string(), format!("{direction:?}"));
+                out.insert("transition".to_string(), format!("{transition:?}"));
+            }
+            EffectType::Strobe { frequency, .. } => {
+                out.insert("frequency".to_string(), format!("{frequency:?}"));
+            }
+            EffectType::Dimmer {
+                start_level,
+                end_level,
+                curve,
+                ..
+            } => {
+                out.insert("start_level".to_string(), format!("{start_level}"));
+                out.insert("end_level".to_string(), format!("{end_level}"));
+                out.insert("curve".to_string(), format!("{curve:?}"));
+            }
+            EffectType::Chase {
+                pattern,
+                speed,
+                direction,
+                transition,
+                ..
+            } => {
+                out.insert("pattern".to_string(), format!("{pattern:?}"));
+                out.insert("speed".to_string(), format!("{speed:?}"));
+                out.insert("direction".to_string(), format!("{direction:?}"));
+                out.insert("transition".to_string(), format!("{transition:?}"));
+            }
+            EffectType::Rainbow {
+                speed,
+                saturation,
+                brightness,
+                ..
+            } => {
+                out.insert("speed".to_string(), format!("{speed:?}"));
+                out.insert("saturation".to_string(), format!("{saturation}"));
+                out.insert("brightness".to_string(), format!("{brightness}"));
+            }
+            EffectType::Pulse {
+                base_level,
+                pulse_amplitude,
+                frequency,
+                ..
+            } => {
+                out.insert("base_level".to_string(), format!("{base_level}"));
+                out.insert("pulse_amplitude".to_string(), format!("{pulse_amplitude}"));
+                out.insert("frequency".to_string(), format!("{frequency:?}"));
+            }
+        }
+        out
+    }
+
     /// The effect's name as reported to users — status output, MCP responses,
     /// and offline evaluation all use this spelling.
     pub fn name(&self) -> &'static str {

--- a/src/lighting/engine.rs
+++ b/src/lighting/engine.rs
@@ -463,20 +463,6 @@ impl EffectEngine {
             return Ok(self.cache.get_cached());
         }
 
-        // Cache-only fast path: effects existed previously but are now done,
-        // permanent state exists, and nothing has changed.
-        if !self.cache.dirty && self.active_effects.is_empty() {
-            let store_gen = self
-                .midi_dmx_store
-                .as_ref()
-                .map(|s| s.read().generation())
-                .unwrap_or(0);
-            if store_gen == self.cache.last_store_generation {
-                self.update_subphase.store(0, Ordering::Relaxed);
-                return Ok(self.cache.get_cached());
-            }
-        }
-
         self.update_subphase.store(20, Ordering::Relaxed);
 
         // Use song_time for tempo-aware speed lookups (BPM at current position).

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -152,7 +152,21 @@ where
                     }
                 })
                 .collect();
-            active_effects.sort_by(|a, b| a.id.cmp(&b.id));
+            // Ordered by nothing that depends on the id. Ids come from a
+            // process-global counter and were compared as strings, so
+            // `song_effect_10` sorted before `song_effect_9` and the order
+            // shifted as the counter advanced — two evaluations of the same
+            // instant in one call could disagree, contradicting the
+            // independence this module promises. Elapsed descending puts the
+            // earliest-started effect first; the rest of the key is stable
+            // content.
+            active_effects.sort_by(|a, b| {
+                b.elapsed
+                    .cmp(&a.elapsed)
+                    .then_with(|| a.layer.cmp(&b.layer))
+                    .then_with(|| a.effect_type.cmp(b.effect_type))
+                    .then_with(|| a.fixtures.cmp(&b.fixtures))
+            });
 
             Evaluation {
                 time,
@@ -223,7 +237,15 @@ pub fn snapshot(engine: &EffectEngine, at: Duration) -> Evaluation {
             }
         })
         .collect();
-    active_effects.sort_by(|a, b| a.id.cmp(&b.id));
+    // Same stable ordering as `evaluate_show`, so predicted and live output
+    // can be compared line for line.
+    active_effects.sort_by(|a, b| {
+        b.elapsed
+            .cmp(&a.elapsed)
+            .then_with(|| a.layer.cmp(&b.layer))
+            .then_with(|| a.effect_type.cmp(b.effect_type))
+            .then_with(|| a.fixtures.cmp(&b.fixtures))
+    });
 
     let mut fixtures = compute_fixture_snapshots(&engine.get_fixture_states(), &has_dimmer);
     fill_dark_fixtures(&mut fixtures, engine.get_fixture_registry().values());

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -62,11 +62,19 @@ pub struct Evaluation {
 }
 
 impl Evaluation {
-    /// True when every channel of every fixture is at zero — the rig is dark.
-    pub fn is_dark(&self) -> bool {
-        self.fixtures
-            .iter()
-            .all(|f| f.channels.values().all(|&v| v == 0))
+    /// `Some(true)` when every channel of every fixture is at zero — the rig
+    /// is dark. `None` when there were no fixtures to evaluate, which is not
+    /// darkness but an absence of evidence: no venue is loaded, so nothing can
+    /// be said either way. `all()` over an empty set would answer `true`.
+    pub fn is_dark(&self) -> Option<bool> {
+        if self.fixtures.is_empty() {
+            return None;
+        }
+        Some(
+            self.fixtures
+                .iter()
+                .all(|f| f.channels.values().all(|&v| v == 0)),
+        )
     }
 }
 
@@ -351,8 +359,8 @@ show "T" {
 
         assert_eq!(channel(&results[0], "wash", "blue"), 255);
         assert_eq!(channel(&results[1], "wash", "blue"), 255);
-        assert!(results[2].is_dark(), "past its duration the effect is gone");
-        assert!(results[3].is_dark());
+        assert!(results[2].is_dark() == Some(true), "past its duration the effect is gone");
+        assert!(results[3].is_dark() == Some(true));
 
         assert_eq!(results[0].active_effects.len(), 1);
         assert_eq!(results[0].active_effects[0].effect_type, "Static");
@@ -384,7 +392,7 @@ show "T" {
 }
 "#;
         let results = eval(source, &fixtures, &[9.999, 10.0]);
-        assert!(results[0].is_dark(), "not yet fired just before the cue");
+        assert!(results[0].is_dark() == Some(true), "not yet fired just before the cue");
         assert_eq!(channel(&results[1], "wash", "red"), 255);
     }
 
@@ -435,7 +443,7 @@ show "T" {
         let results = eval(source, &fixtures, &[4.0, 6.0]);
         assert_eq!(channel(&results[0], "wash", "blue"), 255);
         assert!(
-            results[1].is_dark(),
+            results[1].is_dark() == Some(true),
             "the clear at 5s should have killed a 60s effect"
         );
     }
@@ -455,7 +463,7 @@ show "T" {
 
         let unresolved = evaluate_show(shows(source), &fixtures, None, &times, |e| e);
         assert!(
-            unresolved[0].is_dark(),
+            unresolved[0].is_dark() == Some(true),
             "an unresolved group name matches no fixture"
         );
 
@@ -523,17 +531,19 @@ show "T" {
         let results = evaluate_show(shows(source), &fixtures, Some(&slow), &times, |e| e);
 
         assert_eq!(channel(&results[0], "wash", "blue"), 255);
-        assert!(results[1].is_dark(), "4 beats at 120bpm ends by 6.0s");
-        assert!(results[2].is_dark(), "the 60bpm fallback was not used");
+        assert!(results[1].is_dark() == Some(true), "4 beats at 120bpm ends by 6.0s");
+        assert!(results[2].is_dark() == Some(true), "the 60bpm fallback was not used");
     }
 
     #[test]
     fn no_fixtures_yields_no_state_but_still_reports_effects() {
         let results = eval(BLUE_5S, &[], &[1.0]);
         assert!(results[0].fixtures.is_empty());
-        assert!(results[0].is_dark());
+        // Not `Some(true)`: with no venue there is nothing to be dark, and
+        // answering "dark" here would be a vacuous truth over an empty set.
+        assert_eq!(results[0].is_dark(), None);
         // With nothing to validate against the effect never starts, so an empty
-        // venue reads as a dark rig rather than a crash.
+        // venue reports no effects rather than crashing.
         assert!(results[0].active_effects.is_empty());
     }
 
@@ -541,7 +551,7 @@ show "T" {
     fn an_empty_show_is_dark_everywhere() {
         let fixtures = vec![rgb_fixture("wash", 1)];
         let results = eval("show \"T\" {\n}\n", &fixtures, &[0.0, 5.0, 100.0]);
-        assert!(results.iter().all(|r| r.is_dark()));
+        assert!(results.iter().all(|r| r.is_dark() == Some(true)));
         assert!(results.iter().all(|r| r.active_effects.is_empty()));
     }
 
@@ -683,7 +693,7 @@ show "T" {
             "a dark fixture still names its channels"
         );
         assert!(unlit.channels.values().all(|&v| v == 0));
-        assert!(!results[0].is_dark(), "one fixture is lit");
+        assert!(results[0].is_dark() == Some(false), "one fixture is lit");
     }
 
     #[test]

--- a/src/lighting/evaluate.rs
+++ b/src/lighting/evaluate.rs
@@ -359,7 +359,10 @@ show "T" {
 
         assert_eq!(channel(&results[0], "wash", "blue"), 255);
         assert_eq!(channel(&results[1], "wash", "blue"), 255);
-        assert!(results[2].is_dark() == Some(true), "past its duration the effect is gone");
+        assert!(
+            results[2].is_dark() == Some(true),
+            "past its duration the effect is gone"
+        );
         assert!(results[3].is_dark() == Some(true));
 
         assert_eq!(results[0].active_effects.len(), 1);
@@ -392,7 +395,10 @@ show "T" {
 }
 "#;
         let results = eval(source, &fixtures, &[9.999, 10.0]);
-        assert!(results[0].is_dark() == Some(true), "not yet fired just before the cue");
+        assert!(
+            results[0].is_dark() == Some(true),
+            "not yet fired just before the cue"
+        );
         assert_eq!(channel(&results[1], "wash", "red"), 255);
     }
 
@@ -531,8 +537,14 @@ show "T" {
         let results = evaluate_show(shows(source), &fixtures, Some(&slow), &times, |e| e);
 
         assert_eq!(channel(&results[0], "wash", "blue"), 255);
-        assert!(results[1].is_dark() == Some(true), "4 beats at 120bpm ends by 6.0s");
-        assert!(results[2].is_dark() == Some(true), "the 60bpm fallback was not used");
+        assert!(
+            results[1].is_dark() == Some(true),
+            "4 beats at 120bpm ends by 6.0s"
+        );
+        assert!(
+            results[2].is_dark() == Some(true),
+            "the 60bpm fallback was not used"
+        );
     }
 
     #[test]

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -264,7 +264,11 @@ venue = { "venue" ~ string ~ "{" ~ venue_content ~ "}" }
 
 venue_content = { (fixture | group)* }
 
-fixture = { "fixture" ~ string ~ identifier ~ "@" ~ universe_num ~ ":" ~ address_num ~ tags? }
+// The type may be quoted. `identifier` is atomic, so a type whose declared
+// name is not a bare word — `fixture_type "Moving Head"` — has no other way to
+// be referenced. It used to work only because a non-atomic `identifier`
+// silently swallowed the space.
+fixture = { "fixture" ~ string ~ (string | identifier) ~ "@" ~ universe_num ~ ":" ~ address_num ~ tags? }
 
 universe_num = { ASCII_DIGIT+ }
 address_num = { ASCII_DIGIT+ }

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -66,10 +66,14 @@ pub fn lint_shows(shows: &[LightShow], ctx: &LintContext) -> Vec<Warning> {
     for show in shows {
         empty_groups(show, ctx, &mut warnings);
         effects_past_end_of_song(show, ctx, &mut warnings);
-        stomping_replace_effects(show, &mut warnings);
         tempo_disagrees_with_grid(show, ctx, &mut warnings);
         cues_beyond_the_tempo_map(show, ctx, &mut warnings);
     }
+    // Across all shows at once, not per show: `LightingTimeline` merges every
+    // show in a file into one cue list and plays them together, so two shows
+    // both driving `wash` on the background layer stomp each other exactly as
+    // two cues in one show would. Checking them separately misses that.
+    stomping_replace_effects(shows, &mut warnings);
     warnings
 }
 
@@ -105,9 +109,19 @@ fn effects_past_end_of_song(show: &LightShow, ctx: &LintContext, out: &mut Vec<W
     let Some(song_end) = ctx.song_duration else {
         return;
     };
+    // A song with no audio tracks has zero duration, which would put every
+    // effect "past the end".
+    if song_end.is_zero() {
+        return;
+    }
+    let clears = clear_times(show);
     for cue in &show.cues {
         for effect in &cue.effects {
-            let end = cue.time + effect.total_duration();
+            // The authored end is not the real one. A long bed cut by a
+            // `clear` does not overrun the song, and warning that it does is
+            // the false positive the stomp check already avoids.
+            let layer = effect.layer.unwrap_or(EffectLayer::Background);
+            let end = effective_end(cue.time + effect.total_duration(), cue.time, layer, &clears);
             if end <= song_end {
                 continue;
             }
@@ -129,13 +143,14 @@ fn effects_past_end_of_song(show: &LightShow, ctx: &LintContext, out: &mut Vec<W
 /// Two `replace`-blend effects overlapping on the same layer *and* group. Last
 /// writer wins with no diagnostic, which is the easiest way to author a cue
 /// that appears to do nothing because something else is stomping it.
-fn stomping_replace_effects(show: &LightShow, out: &mut Vec<Warning>) {
-    let clears = clear_times(show);
+fn stomping_replace_effects(shows: &[LightShow], out: &mut Vec<Warning>) {
+    let clears: Vec<(Option<EffectLayer>, Duration)> = shows.iter().flat_map(clear_times).collect();
+    let stops: Vec<(String, Duration)> = shows.iter().flat_map(stop_times).collect();
 
     // (layer, group) -> the spans replace-blend effects occupy on it.
     let mut spans: BTreeMap<(EffectLayer, String), Vec<(Duration, Duration)>> = BTreeMap::new();
 
-    for cue in &show.cues {
+    for cue in shows.iter().flat_map(|show| show.cues.iter()) {
         for effect in &cue.effects {
             // Both default to the same values the engine applies when the DSL
             // omits them, so an unannotated effect is checked as it will run.
@@ -147,7 +162,19 @@ fn stomping_replace_effects(show: &LightShow, out: &mut Vec<Warning>) {
             // The authored end is not the real one: a `clear` on this layer
             // ends the effect there. Comparing authored spans would report a
             // stomp between two effects that never coexist.
-            let end = effective_end(cue.time + effect.total_duration(), cue.time, layer, &clears);
+            let mut end =
+                effective_end(cue.time + effect.total_duration(), cue.time, layer, &clears);
+            // An explicit `stop sequence` ends that sequence's effects too.
+            if let Some(sequence) = effect.sequence_name.as_deref() {
+                if let Some(stopped) = stops
+                    .iter()
+                    .filter(|(name, at)| name == sequence && *at > cue.time)
+                    .map(|(_, at)| *at)
+                    .find(|at| *at < end)
+                {
+                    end = stopped;
+                }
+            }
             if end <= cue.time {
                 continue;
             }
@@ -194,6 +221,21 @@ fn clear_times(show: &LightShow) -> Vec<(Option<EffectLayer>, Duration)> {
                 .iter()
                 .filter(|cmd| cmd.command_type == LayerCommandType::Clear)
                 .map(move |cmd| (cmd.layer, cue.time))
+        })
+        .collect();
+    times.sort_by_key(|(_, at)| *at);
+    times
+}
+
+/// When each named sequence is explicitly stopped.
+fn stop_times(show: &LightShow) -> Vec<(String, Duration)> {
+    let mut times: Vec<(String, Duration)> = show
+        .cues
+        .iter()
+        .flat_map(|cue| {
+            cue.stop_sequences
+                .iter()
+                .map(move |name| (name.clone(), cue.time))
         })
         .collect();
     times.sort_by_key(|(_, at)| *at);
@@ -290,9 +332,15 @@ fn cues_beyond_the_tempo_map(show: &LightShow, ctx: &LintContext, out: &mut Vec<
     }
 }
 
+/// How many bars the grid covers.
+///
+/// `measure_starts` holds one index per downbeat, so its length is the number
+/// of bars the song reaches. (`BeatGrid::measure_count` subtracts one because
+/// it counts bars of *known duration*; for "is this cue past the end", a cue in
+/// the final bar is inside the song.)
 fn grid_measure_count(ctx: &LintContext) -> Option<usize> {
     ctx.beat_grid
-        .and_then(|g| g.measure_starts.len().checked_sub(1))
+        .map(|g| g.measure_starts.len())
         .filter(|n| *n > 0)
 }
 
@@ -313,6 +361,11 @@ mod tests {
     }
 
     /// A steady grid of `measures` bars of 4 beats at `bpm`, starting at zero.
+    ///
+    /// Shaped the way real grids are: one `measure_starts` entry per downbeat
+    /// and nothing after the last beat. An earlier version appended a trailing
+    /// sentinel that neither `from_tempo_map` nor `analyze_click_track`
+    /// produces, which hid an off-by-one in the bar count.
     fn grid(bpm: f64, measures: usize) -> BeatGrid {
         let spacing = 60.0 / bpm;
         let mut beats = Vec::new();
@@ -323,8 +376,6 @@ mod tests {
                 beats.push((m * 4 + b) as f64 * spacing);
             }
         }
-        measure_starts.push(beats.len());
-        beats.push((measures * 4) as f64 * spacing);
         BeatGrid {
             beats,
             measure_starts,
@@ -485,6 +536,25 @@ show "T" {
 }
 "#;
         assert!(lint_shows(&shows(source), &LintContext::default()).is_empty());
+    }
+
+    #[test]
+    fn two_shows_in_one_file_can_stomp_each_other() {
+        // A file's shows are merged into one timeline and played together, so
+        // they contend for a layer exactly as two cues in one show would.
+        let source = r#"
+show "A" {
+    @00:00.000
+    wash: static color: "blue", duration: 10s
+}
+
+show "B" {
+    @00:05.000
+    wash: static color: "red", duration: 10s
+}
+"#;
+        let warnings = lint_shows(&shows(source), &LintContext::default());
+        assert_eq!(kinds(&warnings), ["replace-overlap"], "{warnings:?}");
     }
 
     #[test]
@@ -676,6 +746,77 @@ show "T" {
             ..Default::default()
         };
         assert!(lint_shows(&parsed, &ctx).is_empty());
+    }
+
+    #[test]
+    fn a_cue_in_the_songs_last_bar_is_not_past_the_end() {
+        // The bar count is the number of downbeats. Counting bars of known
+        // duration instead reports the final bar as out of range.
+        let map = crate::tempo::TempoMap::new(
+            Duration::ZERO,
+            120.0,
+            crate::tempo::TimeSignature::new(4, 4),
+            vec![],
+        );
+        let source = r#"
+show "T" {
+    @8/1
+    wash: static color: "blue", duration: 1s
+}
+"#;
+        let parsed: Vec<LightShow> = parse_light_shows_with_tempo(source, Some(&map))
+            .expect("parses")
+            .into_values()
+            .collect();
+        let g = grid(120.0, 8);
+        let ctx = LintContext {
+            beat_grid: Some(&g),
+            ..Default::default()
+        };
+        assert!(
+            lint_shows(&parsed, &ctx).is_empty(),
+            "bar 8 of an 8-bar song is inside it"
+        );
+    }
+
+    #[test]
+    fn an_effect_cut_by_a_clear_does_not_overrun_the_song() {
+        // The long-bed-plus-clear idiom, which `analyze`'s own tests use. The
+        // bed is authored for 60s but ends at 5s, well inside a 30s song.
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 60s
+
+    @00:05.000
+    clear(layer: background)
+}
+"#;
+        let ctx = LintContext {
+            song_duration: Some(Duration::from_secs(30)),
+            ..Default::default()
+        };
+        assert!(
+            lint_shows(&shows(source), &ctx).is_empty(),
+            "the clear ends the bed long before the song does"
+        );
+    }
+
+    #[test]
+    fn a_song_with_no_duration_is_not_warned_about() {
+        // A song with no audio tracks has zero duration; warning that every
+        // effect overruns it is noise.
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: static color: "blue", duration: 4s
+}
+"#;
+        let ctx = LintContext {
+            song_duration: Some(Duration::ZERO),
+            ..Default::default()
+        };
+        assert!(lint_shows(&shows(source), &ctx).is_empty());
     }
 
     // ── nothing to say ─────────────────────────────────────────────

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -65,10 +65,12 @@ pub fn lint_shows(shows: &[LightShow], ctx: &LintContext) -> Vec<Warning> {
     let mut warnings = Vec::new();
     for show in shows {
         empty_groups(show, ctx, &mut warnings);
-        effects_past_end_of_song(show, ctx, &mut warnings);
         tempo_disagrees_with_grid(show, ctx, &mut warnings);
         cues_beyond_the_tempo_map(show, ctx, &mut warnings);
     }
+    // Across all shows at once, for the same reason the stomp check is: a
+    // `clear` in one show of a file ends effects in its siblings.
+    effects_past_end_of_song(shows, ctx, &mut warnings);
     // Across all shows at once, not per show: `LightingTimeline` merges every
     // show in a file into one cue list and plays them together, so two shows
     // both driving `wash` on the background layer stomp each other exactly as
@@ -105,7 +107,7 @@ fn empty_groups(show: &LightShow, ctx: &LintContext, out: &mut Vec<Warning>) {
 
 /// An effect whose duration runs past the end of the song. Playback truncates
 /// it, which is usually not what the author meant.
-fn effects_past_end_of_song(show: &LightShow, ctx: &LintContext, out: &mut Vec<Warning>) {
+fn effects_past_end_of_song(shows: &[LightShow], ctx: &LintContext, out: &mut Vec<Warning>) {
     let Some(song_end) = ctx.song_duration else {
         return;
     };
@@ -114,8 +116,8 @@ fn effects_past_end_of_song(show: &LightShow, ctx: &LintContext, out: &mut Vec<W
     if song_end.is_zero() {
         return;
     }
-    let clears = clear_times(show);
-    for cue in &show.cues {
+    let clears: Vec<(Option<EffectLayer>, Duration)> = shows.iter().flat_map(clear_times).collect();
+    for cue in shows.iter().flat_map(|show| show.cues.iter()) {
         for effect in &cue.effects {
             // The authored end is not the real one. A long bed cut by a
             // `clear` does not overrun the song, and warning that it does is
@@ -170,7 +172,8 @@ fn stomping_replace_effects(shows: &[LightShow], out: &mut Vec<Warning>) {
                     .iter()
                     .filter(|(name, at)| name == sequence && *at > cue.time)
                     .map(|(_, at)| *at)
-                    .find(|at| *at < end)
+                    .filter(|at| *at < end)
+                    .min()
                 {
                     end = stopped;
                 }
@@ -254,7 +257,8 @@ fn effective_end(
         .iter()
         .filter(|(cleared, at)| *at > start && cleared.is_none_or(|l| l == layer))
         .map(|(_, at)| *at)
-        .find(|at| *at < authored_end)
+        .filter(|at| *at < authored_end)
+        .min()
         .unwrap_or(authored_end)
 }
 

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -272,9 +272,15 @@ fn parse_venue_content(
                 return Err(format!(
                     "venue group `{name}` is no longer supported. Tag the fixtures \
                      instead — add a tag to each member, e.g. `tags [\"{name}\"]`, \
-                     and declare a logical group under `dmx.lighting.groups` in the \
-                     player config with `constraints: [AllOf: [\"{name}\"]]`. Tags \
-                     survive a venue change; venue groups did not."
+                     then declare a logical group under `dmx.lighting.groups` in \
+                     the player config:\n\
+                     \n\
+                     \x20   groups:\n\
+                     \x20     - name: {name}\n\
+                     \x20       constraints:\n\
+                     \x20         - AllOf: [\"{name}\"]\n\
+                     \n\
+                     Tags survive a venue change; venue groups did not."
                 )
                 .into());
             }

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -291,7 +291,7 @@ fn parse_venue_content(
 }
 
 pub(crate) fn parse_fixture_definition(pair: Pair<Rule>) -> Result<Fixture, Box<dyn Error>> {
-    let mut name = String::new();
+    let mut name: Option<String> = None;
     let mut fixture_type = String::new();
     let mut universe = 0u16;
     let mut start_channel = 0u16;
@@ -299,9 +299,12 @@ pub(crate) fn parse_fixture_definition(pair: Pair<Rule>) -> Result<Fixture, Box<
 
     for pair in pair.into_inner() {
         match pair.as_rule() {
-            Rule::string => {
-                name = extract_string(pair);
-            }
+            // Positional: the first quoted value is the fixture's name, a
+            // second is its type. Only the type may be given either way.
+            Rule::string => match name {
+                None => name = Some(extract_string(pair)),
+                Some(_) => fixture_type = extract_string(pair),
+            },
             Rule::identifier => {
                 fixture_type = pair.as_str().to_string();
             }
@@ -319,7 +322,7 @@ pub(crate) fn parse_fixture_definition(pair: Pair<Rule>) -> Result<Fixture, Box<
     }
 
     Ok(Fixture::new(
-        name,
+        name.unwrap_or_default(),
         fixture_type,
         universe,
         start_channel,

--- a/src/lighting/parser/tests/fixture_venue_tests.rs
+++ b/src/lighting/parser/tests/fixture_venue_tests.rs
@@ -212,3 +212,21 @@ fn a_venue_of_only_fixtures_still_parses() {
         "RGBW_Par"
     );
 }
+
+#[test]
+fn a_fixture_type_whose_name_is_not_a_bare_word_can_be_quoted() {
+    // `identifier` is atomic, so `Moving Head` unquoted is two tokens and does
+    // not parse — it only ever worked because a non-atomic rule swallowed the
+    // space along with the word. Quoting says the same thing explicitly.
+    let quoted = "venue \"v\" {\n  fixture \"M1\" \"Moving Head\" @ 1:1\n}\n";
+    let venues = parse_venues(quoted).expect("a quoted type parses");
+    let venue = venues.get("v").expect("venue");
+    let fixture = venue.fixtures().get("M1").expect("fixture");
+    assert_eq!(fixture.fixture_type(), "Moving Head");
+    assert_eq!(fixture.name(), "M1");
+
+    // The bare form still parses for ordinary names.
+    let bare = "venue \"v\" {\n  fixture \"M1\" MovingHead @ 1:1\n}\n";
+    let venues = parse_venues(bare).expect("a bare type parses");
+    assert_eq!(venues["v"].fixtures()["M1"].fixture_type(), "MovingHead");
+}

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;
 
-use tracing::info;
+use tracing::{info, warn};
 
 use super::parser::{parse_fixture_types, parse_venues};
 use super::types::{Fixture, FixtureType, Venue};
@@ -75,8 +75,7 @@ impl LightingSystem {
 
     /// Returns an iterator over the (name, logical group) pairs known to the
     /// system. These are the tag/constraint-based groups defined under
-    /// `dmx.lighting.groups` in the player config — distinct from the
-    /// explicit-member-list groups defined inside `venue "..." { … }` blocks.
+    /// `dmx.lighting.groups` in the player config.
     pub fn logical_groups_iter(&self) -> impl Iterator<Item = (&String, &LogicalGroup)> {
         self.logical_groups.iter()
     }
@@ -167,8 +166,8 @@ impl LightingSystem {
                     self.fixture_types.insert(name, fixture_type);
                 }
             }
-            Err(_e) => {
-                // Failed to parse fixture types, continue loading other files
+            Err(e) => {
+                warn!(file = %path.display(), error = %e, "Failed to parse fixture type file");
             }
         }
 
@@ -186,8 +185,12 @@ impl LightingSystem {
                     self.venues.insert(name, venue);
                 }
             }
-            Err(_e) => {
-                // Failed to parse venues, continue loading other files
+            Err(e) => {
+                // One bad file must not stop the rest from loading, but it
+                // must not vanish either: the venue-group migration advice
+                // is raised as a parse error, and swallowing it turns a
+                // fixable file into "Venue 'x' not found" much later.
+                warn!(file = %path.display(), error = %e, "Failed to parse venue file");
             }
         }
 
@@ -199,13 +202,12 @@ impl LightingSystem {
         self.current_venue.as_deref()
     }
 
-    /// Gets the current venue object (with fixtures and groups).
+    /// Gets the current venue object and its fixtures.
     pub fn get_current_venue(&self) -> Option<&crate::lighting::types::Venue> {
         let venue_name = self.current_venue.as_deref()?;
         self.venues.get(venue_name)
     }
 
-    /// Gets a group by name from the current venue.
     /// Resolves a logical group to concrete fixture names for the current venue.
     /// Returns an empty vector if the group cannot be resolved (graceful fallback).
     pub fn resolve_logical_group(
@@ -250,6 +252,28 @@ impl LightingSystem {
     /// Resolves a logical group with graceful fallback - returns empty vector if group cannot be resolved.
     /// This allows songs to work even when some groups aren't available at the current venue.
     pub fn resolve_logical_group_graceful(&mut self, group_name: &str) -> Vec<String> {
+        self.resolve_logical_group_graceful_inner(group_name, &mut Vec::new())
+    }
+
+    /// `FallbackTo` is an author-supplied group name that nothing validates, so
+    /// `a -> b -> a` (or `a -> a`) is expressible. Every group takes the
+    /// fallback branch when no venue is selected, which is the normal state for
+    /// a config UI, so the cycle has to be broken here rather than assumed away.
+    fn resolve_logical_group_graceful_inner(
+        &mut self,
+        group_name: &str,
+        seen: &mut Vec<String>,
+    ) -> Vec<String> {
+        if seen.iter().any(|g| g == group_name) {
+            warn!(
+                group = group_name,
+                chain = ?seen,
+                "Cycle in logical group FallbackTo constraints; resolving to no fixtures"
+            );
+            return Vec::new();
+        }
+        seen.push(group_name.to_string());
+
         match self.resolve_logical_group(group_name) {
             Ok(fixtures) => fixtures,
             Err(_) => {
@@ -268,7 +292,7 @@ impl LightingSystem {
                     };
 
                 if let Some(fallback_group) = fallback_group {
-                    return self.resolve_logical_group_graceful(&fallback_group);
+                    return self.resolve_logical_group_graceful_inner(&fallback_group, seen);
                 }
 
                 Vec::new()

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -456,6 +456,73 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
+    fn a_fallback_cycle_resolves_to_nothing_instead_of_overflowing_the_stack() {
+        // `FallbackTo` names a group and nothing validates that the graph is
+        // acyclic. With no venue selected every group takes the fallback
+        // branch, which is the normal state for the config UI — and the
+        // lighting editor reaches this over HTTP.
+        let mut system = LightingSystem::new();
+        system.logical_groups.insert(
+            "a".to_string(),
+            LogicalGroup::new(
+                "a".to_string(),
+                vec![GroupConstraint::FallbackTo("b".to_string())],
+            ),
+        );
+        system.logical_groups.insert(
+            "b".to_string(),
+            LogicalGroup::new(
+                "b".to_string(),
+                vec![GroupConstraint::FallbackTo("a".to_string())],
+            ),
+        );
+
+        assert!(system.resolve_logical_group_graceful("a").is_empty());
+
+        // A group that falls back to itself is the same problem, one hop short.
+        system.logical_groups.insert(
+            "self".to_string(),
+            LogicalGroup::new(
+                "self".to_string(),
+                vec![GroupConstraint::FallbackTo("self".to_string())],
+            ),
+        );
+        assert!(system.resolve_logical_group_graceful("self").is_empty());
+    }
+
+    #[test]
+    fn a_venue_file_that_does_not_parse_leaves_the_others_loaded() {
+        // The venue-group migration advice is raised as a parse error, and the
+        // loader used to swallow it silently — dropping every venue in the file
+        // and surfacing as "Venue 'x' not found" much later.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("legacy.light"),
+            "venue \"old\" {\n  fixture \"W1\" RGBW_Par @ 1:1\n  group \"wash\" [\"W1\"]\n}\n",
+        )
+        .expect("write");
+        std::fs::write(
+            dir.path().join("current.light"),
+            "venue \"new\" {\n  fixture \"W1\" RGBW_Par @ 1:1 tags [\"wash\"]\n}\n",
+        )
+        .expect("write");
+
+        let mut system = LightingSystem::new();
+        system
+            .load_venues_directory(dir.path())
+            .expect("directory loads");
+
+        assert!(
+            system.venues.contains_key("new"),
+            "a sibling file's failure must not take the good one with it"
+        );
+        assert!(
+            !system.venues.contains_key("old"),
+            "the legacy file genuinely does not parse"
+        );
+    }
+
+    #[test]
     fn test_tag_based_group_resolution() {
         let mut system = LightingSystem::new();
 

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -649,6 +649,20 @@ impl Song {
         self.tempo_map.as_ref()
     }
 
+    /// The tempo map this song's `.light` files are parsed with: its explicit
+    /// `tempo:` block if it has one, otherwise one derived from the click
+    /// track's beat grid.
+    ///
+    /// Anything that parses a show for this song has to use this and not
+    /// [`Song::tempo_map`] alone — the parser rejects every `@bar`/`beat`
+    /// construct outright without a tempo, so the difference is not a matter
+    /// of accuracy but of whether the show parses at all.
+    pub fn lighting_tempo_map(&self) -> Option<crate::tempo::TempoMap> {
+        self.tempo_map
+            .clone()
+            .or_else(|| self.beat_grid.as_ref().and_then(|grid| grid.to_tempo_map()))
+    }
+
     /// Gets the metronome configuration, if configured.
     pub fn metronome(&self) -> Option<&config::MetronomeConfig> {
         self.metronome.as_ref()

--- a/src/songs.rs
+++ b/src/songs.rs
@@ -426,6 +426,7 @@ impl Song {
 
         let mut light_shows = vec![];
         let mut dsl_lighting_shows = vec![];
+        let mut light_paths: Vec<PathBuf> = vec![];
         let mut midi_playback = None;
         let mut tracks = vec![];
         for song_file in song_files {
@@ -466,21 +467,10 @@ impl Song {
                     }
                 }
                 "light" => {
-                    let content = std::fs::read_to_string(&path).map_err(|e| {
-                        format!("Failed to read DSL lighting show {}: {}", path.display(), e)
-                    })?;
-                    let shows =
-                        crate::lighting::parser::parse_light_shows(&content).map_err(|e| {
-                            format!(
-                                "Failed to parse DSL lighting show {}:\n{}",
-                                path.display(),
-                                e
-                            )
-                        })?;
-                    dsl_lighting_shows.push(DslLightingShow {
-                        file_path: path,
-                        shows,
-                    });
+                    // Collected, not parsed: musical timing resolves at parse
+                    // time, and the beat grid that supplies it needs the tracks
+                    // this scan has not finished reading yet.
+                    light_paths.push(path);
                 }
                 ext if is_supported_audio_extension(ext) => {
                     let mut new_tracks = Track::load_tracks(&path)?;
@@ -494,6 +484,32 @@ impl Song {
         // Deduplicate track names by appending numeric suffixes on collision.
         deduplicate_track_names(&mut tracks);
 
+        // Now that the tracks are known, derive the tempo the shows inherit and
+        // parse them. Same precedence as `Song::new`: a show's own `tempo`
+        // block wins, otherwise the click-derived grid.
+        let beat_grid = Self::analyze_click_track(song_directory, &tracks);
+        let lighting_tempo = beat_grid.as_ref().and_then(|grid| grid.to_tempo_map());
+        for path in light_paths {
+            let content = std::fs::read_to_string(&path).map_err(|e| {
+                format!("Failed to read DSL lighting show {}: {}", path.display(), e)
+            })?;
+            let shows = crate::lighting::parser::parse_light_shows_with_tempo(
+                &content,
+                lighting_tempo.as_ref(),
+            )
+            .map_err(|e| {
+                format!(
+                    "Failed to parse DSL lighting show {}:\n{}",
+                    path.display(),
+                    e
+                )
+            })?;
+            dsl_lighting_shows.push(DslLightingShow {
+                file_path: path,
+                shows,
+            });
+        }
+
         let song = Self {
             name,
             base_path: song_directory.clone(),
@@ -501,6 +517,7 @@ impl Song {
             midi_playback,
             light_shows,
             dsl_lighting_shows,
+            beat_grid,
             tracks,
             samples_config: config::SamplesConfig::default(),
             ..Default::default()

--- a/src/webui/api/browse.rs
+++ b/src/webui/api/browse.rs
@@ -228,12 +228,29 @@ pub(super) async fn create_song_in_directory(
 
     // Use Song::initialize to scan the directory and build the config with proper
     // channel-aware track splitting (stereo -> L/R, multichannel -> per-channel).
-    let mut song_config = match songs::Song::initialize(&dir_canonical) {
-        Ok(song) => song.get_config(),
-        Err(e) => {
+    // Same blocking decode/analysis as the bulk path, for one song.
+    let scan = tokio::task::spawn_blocking({
+        let dir = dir_canonical.clone();
+        move || {
+            songs::Song::initialize(&dir)
+                .map(|song| song.get_config())
+                .map_err(|e| e.to_string())
+        }
+    })
+    .await;
+    let mut song_config = match scan {
+        Ok(Ok(config)) => config,
+        Ok(Err(e)) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": format!("Failed to scan directory: {}", e)})),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Directory scan failed: {e}")})),
             )
                 .into_response();
         }
@@ -299,19 +316,36 @@ pub(super) async fn bulk_import(
     }
     let dir_canonical = dir_safe.as_path().to_path_buf();
 
-    let mut created: Vec<String> = Vec::new();
-    let mut skipped: Vec<String> = Vec::new();
-    let mut failed: Vec<serde_json::Value> = Vec::new();
+    // `Song::initialize` decodes and analyses each candidate's click track, so
+    // a first import of a large library is minutes of blocking CPU and file
+    // I/O. Off the async worker, or it parks a runtime thread for the duration.
+    let scan = tokio::task::spawn_blocking(move || {
+        let mut created: Vec<String> = Vec::new();
+        let mut skipped: Vec<String> = Vec::new();
+        let mut failed: Vec<serde_json::Value> = Vec::new();
+        // codeql[rust/path-injection] dir_canonical is canonicalized and
+        // verified via starts_with(root_canonical) above, preventing traversal.
+        bulk_import_recursive(
+            &dir_canonical,
+            &dir_canonical,
+            &mut created,
+            &mut skipped,
+            &mut failed,
+        );
+        (created, skipped, failed)
+    })
+    .await;
 
-    // codeql[rust/path-injection] dir_canonical is canonicalized and verified
-    // via starts_with(root_canonical) above, preventing path traversal.
-    bulk_import_recursive(
-        &dir_canonical,
-        &dir_canonical,
-        &mut created,
-        &mut skipped,
-        &mut failed,
-    );
+    let (created, skipped, failed) = match scan {
+        Ok(result) => result,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Import scan failed: {e}")})),
+            )
+                .into_response();
+        }
+    };
 
     // Refresh the player's song state once after all imports
     if !created.is_empty() {

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -482,7 +482,6 @@ pub(super) async fn delete_fixture_type(
     )
 }
 
-/// GET /api/lighting/venues — lists all venues from the directory.
 /// The tempo a `.light` file at this path will be loaded with, found by
 /// matching the path against the loaded songs' directories.
 fn song_tempo_for_path(
@@ -539,6 +538,7 @@ pub(super) async fn get_lighting_groups(State(state): State<WebUiState>) -> impl
     Json(json!({"groups": groups})).into_response()
 }
 
+/// GET /api/lighting/venues — lists all venues from the directory.
 pub(super) async fn get_venues(
     State(state): State<WebUiState>,
     Query(query): Query<LightingDirQuery>,

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -220,12 +220,29 @@ pub(super) async fn delete_lighting_file(
     }
 }
 
+/// A `?song=` on an endpoint that otherwise works on bare DSL, naming the song
+/// whose tempo map the source should be parsed against.
+#[derive(serde::Deserialize)]
+pub(super) struct ValidateQuery {
+    song: Option<String>,
+}
+
 /// POST /api/lighting/validate — validates lighting DSL content without saving.
-pub(super) async fn validate_lighting(body: String) -> impl IntoResponse {
-    // No path and no song, so nothing identifies which tempo would apply. A
-    // show that inherits one cannot be checked here; the write path, which
-    // knows the file, validates it properly.
-    match config_io::validate_light_show(&body, None) {
+///
+/// Pass `?song=` when the source belongs to one. Measure-based timing does not
+/// parse at all without a tempo map, so validating a bar/beat show without it
+/// reports a failure the save path does not agree with.
+pub(super) async fn validate_lighting(
+    State(state): State<WebUiState>,
+    Query(query): Query<ValidateQuery>,
+    body: String,
+) -> impl IntoResponse {
+    let tempo = query
+        .song
+        .as_deref()
+        .and_then(|name| state.player.songs().get(name).ok())
+        .and_then(|song| song.lighting_tempo_map());
+    match config_io::validate_light_show(&body, tempo.as_ref()) {
         Ok(()) => (StatusCode::OK, Json(json!({"valid": true}))).into_response(),
         Err(errors) => (
             StatusCode::BAD_REQUEST,
@@ -316,20 +333,26 @@ pub(super) async fn get_fixture_types(
     }
     let all = super::helpers::spawn_blocking_io("load fixture types", move || {
         let mut all = std::collections::HashMap::new();
-        load_light_files_from_dir(&dir, |content| match lighting::parser::parse_fixture_types(
-            content,
-        ) {
-            Ok(types) => {
-                all.extend(types);
-                Ok(())
-            }
-            Err(e) => Err(e),
-        })
-        .map_err(|e| e.to_string())?;
-        Ok::<_, String>(all)
+        let errors =
+            load_light_files_from_dir(&dir, |content| match lighting::parser::parse_fixture_types(
+                content,
+            ) {
+                Ok(types) => {
+                    all.extend(types);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            })
+            .map_err(|e| e.to_string())?;
+        Ok::<_, String>((all, errors))
     })
     .await?;
-    Ok((StatusCode::OK, Json(json!({"fixture_types": all}))).into_response())
+    let (all, errors) = all;
+    Ok((
+        StatusCode::OK,
+        Json(json!({"fixture_types": all, "errors": errors})),
+    )
+        .into_response())
 }
 
 /// GET /api/lighting/fixture-types/:name — returns a single fixture type.
@@ -509,7 +532,11 @@ pub(super) async fn get_lighting_groups(State(state): State<WebUiState>) -> impl
         .dmx_engine()
         .and_then(|dmx| dmx.broadcast_handles().lighting_system)
     else {
-        return Json(json!({"groups": []})).into_response();
+        // No DMX device configured — authoring on a laptop, which is the normal
+        // case for editing a show. The groups are declared in the player config,
+        // not by the engine, so the names are still knowable; only the fixtures
+        // each resolves to are not.
+        return groups_from_config(&state.config_path).await;
     };
 
     // The lighting system's mutex is shared with the effects loop thread, and
@@ -530,10 +557,42 @@ pub(super) async fn get_lighting_groups(State(state): State<WebUiState>) -> impl
         out.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
         out
     })
+    .await;
+
+    match groups {
+        Ok(groups) => Json(json!({"groups": groups})).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to resolve groups: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+/// The logical group names declared under `dmx.lighting.groups`, read from the
+/// player config when no engine is running to resolve them against.
+async fn groups_from_config(config_path: &std::path::Path) -> axum::response::Response {
+    // codeql[rust/path-injection] config_path is set at startup, not user input.
+    let path = config_path.to_path_buf();
+    let names = tokio::task::spawn_blocking(move || {
+        crate::config::Player::deserialize(&path)
+            .ok()
+            .and_then(|player| player.dmx().and_then(|dmx| dmx.lighting()).cloned())
+            .map(|lighting| {
+                let mut names: Vec<String> = lighting.groups().keys().cloned().collect();
+                names.sort();
+                names
+            })
+            .unwrap_or_default()
+    })
     .await
     .unwrap_or_default();
 
-    Json(json!({"groups": groups})).into_response()
+    let groups: Vec<serde_json::Value> = names
+        .into_iter()
+        .map(|name| json!({"name": name, "fixtures": []}))
+        .collect();
+    Json(json!({"groups": groups, "resolved": false})).into_response()
 }
 
 /// GET /api/lighting/venues — lists all venues from the directory.
@@ -550,20 +609,26 @@ pub(super) async fn get_venues(
     }
     let all = super::helpers::spawn_blocking_io("load venues", move || {
         let mut all = std::collections::HashMap::new();
-        load_light_files_from_dir(&dir, |content| {
-            match lighting::parser::parse_venues(content) {
-                Ok(venues) => {
-                    all.extend(venues);
-                    Ok(())
+        let errors =
+            load_light_files_from_dir(&dir, |content| {
+                match lighting::parser::parse_venues(content) {
+                    Ok(venues) => {
+                        all.extend(venues);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
                 }
-                Err(e) => Err(e),
-            }
-        })
-        .map_err(|e| e.to_string())?;
-        Ok::<_, String>(all)
+            })
+            .map_err(|e| e.to_string())?;
+        Ok::<_, String>((all, errors))
     })
     .await?;
-    Ok((StatusCode::OK, Json(json!({"venues": all}))).into_response())
+    let (all, errors) = all;
+    Ok((
+        StatusCode::OK,
+        Json(json!({"venues": all, "errors": errors})),
+    )
+        .into_response())
 }
 
 /// GET /api/lighting/venues/:name — returns a single venue.
@@ -702,16 +767,33 @@ pub(super) async fn delete_venue(
 fn load_light_files_from_dir(
     dir: &std::path::Path,
     mut processor: impl FnMut(&str) -> Result<(), Box<dyn std::error::Error>>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Vec<FileError>, Box<dyn std::error::Error>> {
+    let mut errors = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("light") {
             let content = std::fs::read_to_string(&path)?;
-            processor(&content)?;
+            // Per-file, not fatal: a directory is a set of independent files,
+            // and one that no longer parses must not hide the rest. The caller
+            // reports them so the UI can say which file and why.
+            if let Err(e) = processor(&content) {
+                errors.push(FileError {
+                    file: crate::util::filename_display(&path).to_string(),
+                    error: e.to_string(),
+                });
+            }
         }
     }
-    Ok(())
+    Ok(errors)
+}
+
+/// A file in a lighting directory that could not be parsed, reported alongside
+/// the ones that could.
+#[derive(serde::Serialize)]
+struct FileError {
+    file: String,
+    error: String,
 }
 
 /// Ensures a lighting directory exists (sync version for use inside spawn_blocking).

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -494,9 +494,7 @@ fn song_tempo_for_path(
         .list()
         .into_iter()
         .find(|song| path.starts_with(song.base_path()))?;
-    song.tempo_map()
-        .cloned()
-        .or_else(|| song.beat_grid().and_then(|grid| grid.to_tempo_map()))
+    song.lighting_tempo_map()
 }
 
 /// Returns the group names valid as cue targets, with the fixtures each

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -158,8 +158,11 @@ pub(super) async fn put_lighting_file(
         }
     };
 
-    // Validate the DSL content
-    if let Err(errors) = config_io::validate_light_show(&body) {
+    // Validate against the tempo the owning song loads this file with. A show
+    // inheriting its song's tempo is valid content that a tempo-less parse
+    // rejects, so writing it through the UI would fail for no real reason.
+    let tempo = song_tempo_for_path(&state, &verified_path);
+    if let Err(errors) = config_io::validate_light_show(&body, tempo.as_ref()) {
         return (StatusCode::BAD_REQUEST, Json(json!({"errors": errors}))).into_response();
     }
 
@@ -219,7 +222,10 @@ pub(super) async fn delete_lighting_file(
 
 /// POST /api/lighting/validate — validates lighting DSL content without saving.
 pub(super) async fn validate_lighting(body: String) -> impl IntoResponse {
-    match config_io::validate_light_show(&body) {
+    // No path and no song, so nothing identifies which tempo would apply. A
+    // show that inherits one cannot be checked here; the write path, which
+    // knows the file, validates it properly.
+    match config_io::validate_light_show(&body, None) {
         Ok(()) => (StatusCode::OK, Json(json!({"valid": true}))).into_response(),
         Err(errors) => (
             StatusCode::BAD_REQUEST,
@@ -477,6 +483,23 @@ pub(super) async fn delete_fixture_type(
 }
 
 /// GET /api/lighting/venues — lists all venues from the directory.
+/// The tempo a `.light` file at this path will be loaded with, found by
+/// matching the path against the loaded songs' directories.
+fn song_tempo_for_path(
+    state: &WebUiState,
+    path: &std::path::Path,
+) -> Option<crate::tempo::TempoMap> {
+    let song = state
+        .player
+        .songs()
+        .list()
+        .into_iter()
+        .find(|song| path.starts_with(song.base_path()))?;
+    song.tempo_map()
+        .cloned()
+        .or_else(|| song.beat_grid().and_then(|grid| grid.to_tempo_map()))
+}
+
 /// Returns the group names valid as cue targets, with the fixtures each
 /// currently resolves to in the loaded venue.
 ///

--- a/src/webui/api/songs_api.rs
+++ b/src/webui/api/songs_api.rs
@@ -92,6 +92,9 @@ pub(super) async fn get_songs(State(state): State<WebUiState>) -> impl IntoRespo
                     "name": s.name,
                     "start_measure": s.start_measure,
                     "end_measure": s.end_measure,
+                    "start_beat": s.start_beat,
+                    "end_beat": s.end_beat,
+                    "color": s.color,
                 })).collect::<Vec<_>>(),
             })
         })

--- a/src/webui/config_io.rs
+++ b/src/webui/config_io.rs
@@ -15,7 +15,6 @@
 use std::path::Path;
 
 use crate::config;
-use crate::lighting::parser::parse_light_shows;
 use crate::util;
 
 /// Writes content to a config file, preserving its ownership and leaving a
@@ -35,8 +34,17 @@ pub fn validate_player_config(yaml: &str) -> Result<(), Vec<String>> {
 }
 
 /// Validates a light show DSL string by attempting to parse it.
-pub fn validate_light_show(content: &str) -> Result<(), Vec<String>> {
-    parse_light_shows(content).map_err(|e| vec![format!("{}", e)])?;
+///
+/// `tempo` is the map the show will be loaded with — a song's `tempo:` block,
+/// or one derived from its click track. Musical timing resolves at parse time,
+/// so validating a tempo-inheriting show without it rejects content the player
+/// loads without complaint.
+pub fn validate_light_show(
+    content: &str,
+    tempo: Option<&crate::tempo::TempoMap>,
+) -> Result<(), Vec<String>> {
+    crate::lighting::parser::parse_light_shows_with_tempo(content, tempo)
+        .map_err(|e| vec![format!("{}", e)])?;
     Ok(())
 }
 
@@ -69,13 +77,13 @@ show "test" {
     lights: static color: "red", duration: 5s
 }
 "#;
-        assert!(validate_light_show(content).is_ok());
+        assert!(validate_light_show(content, None).is_ok());
     }
 
     #[test]
     fn test_validate_light_show_invalid() {
         let content = "this is not valid DSL content {{{";
-        assert!(validate_light_show(content).is_err());
+        assert!(validate_light_show(content, None).is_err());
     }
 
     #[test]

--- a/src/webui/state.rs
+++ b/src/webui/state.rs
@@ -199,6 +199,8 @@ pub async fn playback_poller(player: Arc<Player>, tx: broadcast::Sender<String>)
                         "name": s.name,
                         "start_measure": s.start_measure,
                         "end_measure": s.end_measure,
+                        "start_beat": s.start_beat,
+                        "end_beat": s.end_beat,
                         "color": s.color,
                     })
                 })

--- a/src/webui/svelte/e2e/tests/song-lighting.spec.ts
+++ b/src/webui/svelte/e2e/tests/song-lighting.spec.ts
@@ -54,7 +54,9 @@ test.describe("Song Detail - Lighting Tab", () => {
 
   test("Validate button calls validation API", async ({ page }) => {
     let validateCalled = false;
-    await page.route("**/api/lighting/validate", async (route) => {
+    // The song editor sends `?song=` so the tempo map can resolve `@bar`/`beat`
+    // timing, so the pattern has to admit a query string.
+    await page.route("**/api/lighting/validate*", async (route) => {
       validateCalled = true;
       await route.fulfill({
         status: 200,
@@ -69,7 +71,9 @@ test.describe("Song Detail - Lighting Tab", () => {
   });
 
   test("successful validation shows OK message", async ({ page }) => {
-    await page.route("**/api/lighting/validate", async (route) => {
+    // The song editor sends `?song=` so the tempo map can resolve `@bar`/`beat`
+    // timing, so the pattern has to admit a query string.
+    await page.route("**/api/lighting/validate*", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -83,7 +87,9 @@ test.describe("Song Detail - Lighting Tab", () => {
   });
 
   test("failed validation shows errors", async ({ page }) => {
-    await page.route("**/api/lighting/validate", async (route) => {
+    // The song editor sends `?song=` so the tempo map can resolve `@bar`/`beat`
+    // timing, so the pattern has to admit a query string.
+    await page.route("**/api/lighting/validate*", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/src/webui/svelte/src/components/cards/PlaybackCard.svelte
+++ b/src/webui/svelte/src/components/cards/PlaybackCard.svelte
@@ -298,6 +298,26 @@
     return grid.beats[grid.measure_starts[idx]] * 1000;
   }
 
+  /** Time (ms) of a measure/beat position, interpolating fractional beats the
+   *  way the Rust-side `BeatGrid::beat_time` does. */
+  function measureBeatToMs(
+    grid: { beats: number[]; measure_starts: number[] },
+    measure: number,
+    beat: number,
+    durationMs: number,
+  ): number {
+    const startIdx = grid.measure_starts[measure - 1];
+    if (startIdx === undefined) return durationMs;
+    const offset = beat - 1;
+    const base = startIdx + Math.floor(offset);
+    const t0 = grid.beats[base];
+    if (t0 === undefined) return durationMs;
+    const frac = offset - Math.floor(offset);
+    if (frac === 0) return t0 * 1000;
+    const t1 = grid.beats[base + 1];
+    return (t1 === undefined ? t0 : t0 + (t1 - t0) * frac) * 1000;
+  }
+
   let sectionRegions = $derived.by(() => {
     const grid = $playbackStore.beat_grid;
     const dur = $playbackStore.song_duration_ms;
@@ -306,8 +326,16 @@
     if (!grid || dur <= 0 || sections.length === 0) return [];
 
     return sections.map((s, i) => {
-      const startPct = (measureToMs(grid, s.start_measure, dur) / dur) * 100;
-      const endPct = (measureToMs(grid, s.end_measure + 1, dur) / dur) * 100;
+      // `end_measure` is exclusive (config::Section) — adding one drew every
+      // region a measure too long. The beat offsets are what make a boundary
+      // beat-precise; ignoring them put the region up to half a measure away
+      // from where the active-section highlight actually flips.
+      const startPct =
+        (measureBeatToMs(grid, s.start_measure, s.start_beat ?? 1, dur) / dur) *
+        100;
+      const endPct =
+        (measureBeatToMs(grid, s.end_measure, s.end_beat ?? 1, dur) / dur) *
+        100;
       const isActive = active?.name === s.name;
       const rgb = SECTION_COLORS[i % SECTION_COLORS.length];
       return {

--- a/src/webui/svelte/src/components/cards/PlaybackCard.svelte
+++ b/src/webui/svelte/src/components/cards/PlaybackCard.svelte
@@ -287,17 +287,6 @@
     "249, 115, 22",
   ];
 
-  function measureToMs(
-    grid: { beats: number[]; measure_starts: number[] },
-    measure: number,
-    durationMs: number,
-  ): number {
-    const idx = measure - 1;
-    if (idx < 0) return 0;
-    if (idx >= grid.measure_starts.length) return durationMs;
-    return grid.beats[grid.measure_starts[idx]] * 1000;
-  }
-
   /** Time (ms) of a measure/beat position, interpolating fractional beats the
    *  way the Rust-side `BeatGrid::beat_time` does. */
   function measureBeatToMs(

--- a/src/webui/svelte/src/components/lighting/EffectForm.svelte
+++ b/src/webui/svelte/src/components/lighting/EffectForm.svelte
@@ -20,7 +20,6 @@
     LAYERS,
     BLEND_MODES,
     CURVES,
-    DIRECTIONS,
     CYCLE_DIRECTIONS,
     CHASE_DIRECTIONS,
     CHASE_PATTERNS,
@@ -624,22 +623,6 @@
               }}
             /></label
           >
-          <label class="param"
-            ><span class="param-label">{$t("effect.direction")}</span>
-            <select
-              class="param-input"
-              value={effect.effect.direction ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "direction",
-                  (e.target as HTMLSelectElement).value || undefined,
-                )}
-            >
-              <option value="">--</option>{#each DIRECTIONS as d (d)}<option
-                  value={d}>{d}</option
-                >{/each}
-            </select>
-          </label>
           <label class="param"
             ><span class="param-label">{$t("effect.duration")}</span><input
               type="text"

--- a/src/webui/svelte/src/components/songs/SectionEditDialog.svelte
+++ b/src/webui/svelte/src/components/songs/SectionEditDialog.svelte
@@ -69,8 +69,23 @@
     return beat && beat !== 1 ? `${measure}.${beat}` : `${measure}`;
   }
 
-  /** Beat 1 is the measure line — store that as "unset". */
+  /** Beat 1 is the measure line — store that as "unset".
+   *
+   * Refuses a value that would invert the section, the same condition
+   * `canCaptureStart`/`canCaptureEnd` apply to the capture buttons. Without it
+   * a start beat could be stepped past the end beat inside a single measure,
+   * which `Section::validate` rejects on save. */
   function setBeat(field: "start_beat" | "end_beat", beat: number) {
+    const moved = {
+      measure:
+        section[field === "start_beat" ? "start_measure" : "end_measure"],
+      beat,
+    };
+    const ordered =
+      field === "start_beat"
+        ? isBefore(moved, endPos)
+        : isBefore(startPos, moved);
+    if (!ordered) return;
     onchange({ [field]: beat === 1 ? undefined : beat });
   }
 
@@ -125,12 +140,27 @@
     });
   }
 
+  /** Clamps a beat to what the destination measure actually holds. Carrying
+   * beat 4.5 into a 3/4 measure names a beat that does not exist. */
+  function clampBeat(
+    measure: number,
+    beat: number | undefined,
+  ): number | undefined {
+    if (beat === undefined || beat === 1) return undefined;
+    const max = maxBeatInMeasure(beatGrid, measure, BEAT_STEP);
+    if (max === null) return beat;
+    const clamped = Math.min(beat, max);
+    return clamped === 1 ? undefined : clamped;
+  }
+
   /** Moving the start slides the whole section, like a body drag. */
   function moveStart(start: number) {
     const clamped = Math.max(1, Math.min(start, maxMeasure - length + 1));
     onchange({
       start_measure: clamped,
       end_measure: clamped + length,
+      start_beat: clampBeat(clamped, section.start_beat),
+      end_beat: clampBeat(clamped + length, section.end_beat),
     });
   }
 
@@ -139,7 +169,11 @@
       1,
       Math.min(measures, maxMeasure + 1 - section.start_measure),
     );
-    onchange({ end_measure: section.start_measure + clamped });
+    const end = section.start_measure + clamped;
+    onchange({
+      end_measure: end,
+      end_beat: clampBeat(end, section.end_beat),
+    });
   }
 </script>
 

--- a/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
@@ -419,7 +419,7 @@
 
   async function handleValidate() {
     try {
-      validationResult = await validateLighting(rawContent);
+      validationResult = await validateLighting(rawContent, song.name);
     } catch (e: any) {
       validationResult = { valid: false, errors: [e.message] };
     }

--- a/src/webui/svelte/src/lib/api/config.ts
+++ b/src/webui/svelte/src/lib/api/config.ts
@@ -535,9 +535,15 @@ export async function deleteLightingFile(name: string): Promise<void> {
   if (!res.ok) throw await apiError(res, "Failed to delete lighting file");
 }
 
+/** Validates `.light` DSL. Pass `song` when the source belongs to one —
+ *  `@bar`/`beat` timing cannot be parsed without that song's tempo map. */
 export async function validateLighting(
   content: string,
+  song?: string,
 ): Promise<{ valid: boolean; errors?: string[] }> {
-  const res = await postText("/lighting/validate", content);
+  const path = song
+    ? `/lighting/validate?song=${encodeURIComponent(song)}`
+    : "/lighting/validate";
+  const res = await postText(path, content);
   return res.json();
 }

--- a/src/webui/svelte/src/lib/api/songs.ts
+++ b/src/webui/svelte/src/lib/api/songs.ts
@@ -42,8 +42,9 @@ export interface SongSummary {
     name: string;
     start_measure: number;
     end_measure: number;
-    start_beat?: number;
-    end_beat?: number;
+    start_beat?: number | null;
+    end_beat?: number | null;
+    color?: string | null;
   }[];
 }
 

--- a/src/webui/svelte/src/lib/lighting/types.ts
+++ b/src/webui/svelte/src/lib/lighting/types.ts
@@ -86,17 +86,6 @@ export const CURVES = [
 // values below, `chase` takes the spatial ones. Offering the union lets the
 // editor write a show the parser rejects.
 export const CYCLE_DIRECTIONS = ["forward", "backward", "pingpong"];
-export const DIRECTIONS = [
-  "forward",
-  "backward",
-  "pingpong",
-  "left_to_right",
-  "right_to_left",
-  "top_to_bottom",
-  "bottom_to_top",
-  "clockwise",
-  "counter_clockwise",
-];
 export const CHASE_DIRECTIONS = [
   "left_to_right",
   "right_to_left",

--- a/src/webui/svelte/src/lib/util/beatGrid.ts
+++ b/src/webui/svelte/src/lib/util/beatGrid.ts
@@ -45,6 +45,11 @@ export function beatsInMeasure(
  * Beat 4.5 of a 4/4 measure is inside it — between the last beat and the
  * next downbeat — but beat 5 is the downbeat itself and belongs to the
  * measure after. So the bound is one step short of `beats + 1`.
+ *
+ * The final measure is tighter: a fractional beat resolves by interpolating
+ * towards the *next* grid beat, and past the end of the grid there is none.
+ * `BeatGrid::beat_time` returns `None` there and the section disappears from
+ * the resolved timeline, so the bound stops at the last beat that exists.
  */
 export function maxBeatInMeasure(
   grid: BeatGrid | null | undefined,
@@ -52,5 +57,9 @@ export function maxBeatInMeasure(
   step = 0.5,
 ): number | null {
   const beats = beatsInMeasure(grid, measure);
-  return beats === null ? null : Math.max(1, beats + 1 - step);
+  if (beats === null) return null;
+  const nextStart = grid?.measure_starts[measure];
+  const isLastMeasure =
+    nextStart === undefined || nextStart >= (grid?.beats.length ?? 0);
+  return Math.max(1, isLastMeasure ? beats : beats + 1 - step);
 }

--- a/src/webui/svelte/src/lib/ws/stores.ts
+++ b/src/webui/svelte/src/lib/ws/stores.ts
@@ -37,8 +37,16 @@ export interface BeatGrid {
 
 export interface SectionInfo {
   name: string;
+  /** 1-indexed, inclusive. */
   start_measure: number;
+  /** 1-indexed, exclusive. */
   end_measure: number;
+  /** Beat within `start_measure` (1-based, fractional); absent = the
+   *  measure line. */
+  start_beat?: number | null;
+  /** Beat within `end_measure` (1-based, fractional); absent = the
+   *  measure line, keeping the bound exclusive. */
+  end_beat?: number | null;
   /** Explicit display color; absent = UI palette rotation. */
   color?: string | null;
 }


### PR DESCRIPTION
An after-the-fact review of the twelve merged lighting PRs. Three `/code-review high` passes produced ~29 findings; I verified them individually and fixed the real ones. Two findings did not reproduce and are documented as such rather than acted on.

Two commits: correctness bugs that broke a feature, then output that was wrong or misleading.

## Features that were broken

**`diff_shows` was blind to what a revision usually changes.** `DiffEntry` carried time, groups, kind, layer and duration — no parameters, no blend mode. So `color: "blue"` → `"red"`, `dimmer: 100%` → `20%`, `frequency: 8` → `2`, or `replace` → `add` all produced empty added/removed/changed lists and `is_empty()` returning **true**: the tool asserting the two versions resolve identically. My twelve tests changed durations, times, layers and groups — never a parameter.

**Tempo inheritance (#337) was wired into three call sites and missed five.** A show relying on it loaded in the player and failed everywhere else — hot reload re-parsed without it and *silently never swapped the timeline*, the web UI rejected it, `patch_song_lighting` rejected it, and `Song::initialize` (the directory-scan constructor) never computed a beat grid at all.

**The section-loop wrap armed the timeline before rewinding the clock.** Every sibling path writes song time first, and the comment at playback start says why. Arming first leaves a window where the tracker is still writing end-of-section time and the 44Hz effects loop can advance the freshly rewound timeline past every cue in the section — permanently, since the pointer never moves backwards. This is the exact failure `a_jump_past_the_end_exhausts_the_timeline` demonstrates. I read these lines while investigating #332, checked that the jump was *paired* with a re-arm, and never checked the *order*.

**`delete_song_lighting` could orphan the reference it exists to remove.** The line scanner only understood sequences indented under their key, so a sequence at the key's own indentation — valid YAML, common by hand — found no entries and the file was deleted anyway. It now handles both shapes, declines flow sequences rather than mangling them, refuses outright when it cannot edit a live reference, and removes the file last.

## Output that was wrong

- **Derived tempo origin** used the first click, not the first downbeat — a count-in of plain clicks shifted every cue early by the pickup.
- **And drifted** ~0.25s over 64 bars on a gradual ramp. Emission is now bounded by accumulated time error rather than instantaneous BPM difference, which catches ramps without firing on jitter (noise is zero-mean and cancels; a ramp does not).
- **`analyze_show`** counted silence before the first effect as a gap, so `dark_seconds` could exceed `span`.
- **`status.lighting`** reported the previous song's timeline for a song with no lighting, and could hang behind a wedged effects loop. Now cleared on that path, read under a timeout, and a failed read is reported rather than flattened into "no show".
- **Three lint checks cried wolf**: `past-end-of-song` ignored `clear`, `cue-past-end` was off by one, and a song with no audio tracks warned on every effect.
- **The stomp check ran per show** while the timeline merges all of a file's shows — cross-show contention was never reported.
- **`get_cues`** answered differently per branch: per-show indices restarting at zero, unsorted, and `time` as a float where the other gave a string.
- **`evaluate`/`snapshot`** ordered effects by a process-global counter compared as strings, so `song_effect_10` sorted before `song_effect_9`.

## Findings I did not act on

**Tempo change positions do not cause drift.** The review held that `MeasureBeat` positions make `TempoMap::new` re-integrate at a stale BPM and accumulate error. Measured: `Time` and `MeasureBeat` give byte-identical bar times. I had already made the change before testing it, and reverted it — the drift is real but its cause is the emission threshold, which is what I fixed instead.

**The generation guard's check-then-act window** is real but two instructions wide, against the tracker-sleep-interval window it was built to close. The doc comment now says best-effort rather than claiming to make stale writes impossible.

## On the tests

Several of these are false positives or negatives in checks written to prevent exactly that class of problem — a lint that cries wolf on an idiom, a diff that says "identical", an off-by-one hidden by a helper building grids real code never produces. My tests consistently exercised the cases I had thought of while designing, which is the blind spot an independent review exists to cover.

New tests are written to fail against the old behaviour; I verified that for the drift bound and the tempo origin specifically.

- `cargo test` — 3311 passed, 0 failed (was 3300)
- `cargo clippy --all-targets`, `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)