### PR TITLE
Cap effect ends by stop sequences, and make the subscription test able to fail

### DIFF
--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -384,6 +384,7 @@ async fn wait_for_event_sequence(
     let mut buf = String::new();
     let mut matched: Vec<Value> = Vec::new();
     let mut next = 0usize;
+    let mut seen: Vec<String> = Vec::new();
     let mut stream_error: Option<String> = None;
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline && next < predicates.len() {
@@ -413,6 +414,30 @@ async fn wait_for_event_sequence(
                     continue;
                 }
                 if let Ok(value) = serde_json::from_str::<Value>(payload) {
+                    // Every event, not just matching ones: "nothing matched"
+                    // and "nothing arrived" are different failures and the
+                    // assertion has to be able to tell them apart.
+                    let light = &value["params"]["_meta"]["mtrack.lighting"];
+                    seen.push(format!(
+                        "{} dark={} available={} fixtures={} effects={} pos={}",
+                        value["params"]["uri"].as_str().unwrap_or("(no uri)"),
+                        light["dark"],
+                        light["available"],
+                        light["fixtures"].as_array().map_or(0, |a| a.len()),
+                        light["active_effects"].as_array().map_or(0, |a| a.len()),
+                        light["position"]
+                    ));
+                    // What the effect actually resolved to: an effect running
+                    // against no fixtures is a group that resolved to nothing,
+                    // which looks identical to "not lit yet" from outside.
+                    if let Some(effects) = light["active_effects"].as_array() {
+                        for e in effects {
+                            seen.push(format!(
+                                "    effect {} -> fixtures {:?}",
+                                e["id"], e["fixtures"]
+                            ));
+                        }
+                    }
                     if next < predicates.len() && (predicates[next])(&value) {
                         matched.push(value);
                         next += 1;
@@ -424,11 +449,12 @@ async fn wait_for_event_sequence(
     assert_eq!(
         next,
         predicates.len(),
-        "only {next} of {} expected events arrived (stream error: {:?}); \
-         last matched: {:?}\nbuffer tail:\n{}",
+        "only {next} of {} expected events arrived (stream error: {:?}).\n\
+         events seen ({}):\n  {}\nbuffer tail:\n{}",
         predicates.len(),
         stream_error,
-        matched.last().map(|v| v["params"]["_meta"].clone()),
+        seen.len(),
+        seen.join("\n  "),
         &buf[buf.len().saturating_sub(600)..]
     );
     matched
@@ -2261,15 +2287,18 @@ async fn mcp_lighting_state_resource_pushes_on_change() -> Result<(), Box<dyn Er
     let song_lighting_dir = fixture.root.join("songs/dsl-light-show-song/lighting");
     std::fs::write(
         song_lighting_dir.join("main_show.light"),
-        // Finite, then dark for good: the rig lights up, the effect expires,
-        // and the dark state *holds*. That hold is what made the transition
-        // easy to lose, since the sampler keeps re-sending that identical
-        // snapshot and a filter adopting it as its baseline never reports it.
+        // Two effects on different layers, ending three seconds apart, so both
+        // transitions the test watches happen well after it has subscribed.
         //
-        // Five seconds rather than one, so the lit state is still observable on
-        // a machine running the rest of the suite in parallel — otherwise the
-        // test fails for want of the first event rather than the second.
-        "show \"Lit\" {\n    @00:00.000\n    all_lights: static color: \"green\", duration: 5s\n}\n",
+        // The subtlety this avoids: an effect is registered a frame before its
+        // fixture values are computed, so a sampler tick can catch "effect
+        // active, fixtures still dark". That transient is a state change, so it
+        // is notified — and it opens the coalescing window, inside which the
+        // entire lit period then passes unreported. Subscribing only once the
+        // rig is settled and lit removes it from the picture.
+        "show \"Lit\" {\n    @00:00.000\n    \
+         all_lights: static color: \"green\", duration: 10s, layer: background\n    \
+         all_lights: static color: \"blue\", duration: 11s, layer: foreground\n}\n",
     )?;
     std::fs::write(
         song_lighting_dir.join("outro.light"),
@@ -2279,9 +2308,15 @@ async fn mcp_lighting_state_resource_pushes_on_change() -> Result<(), Box<dyn Er
     // Widen the coalescing window so the transition below lands inside it
     // deterministically. At the production 100ms this is a race, and a test
     // that cannot hit it passes just as happily against the bug as with it.
-    // Past the effect's five seconds: the expiry has to land inside the window
-    // opened by the "lit" notification for the race to be exercised at all.
-    crate::controller::mcp::service::set_lighting_notify_interval_ms(10_000);
+    // Three seconds: long enough that the second transition (11s) lands inside
+    // the window opened by the first (10s), which is the case that regressed,
+    // and short enough that any settling notification right after subscribe has
+    // closed its own window well before either.
+    //
+    // A ten-second window looked more robust and was the opposite: it left a
+    // window open across the first transition, so the second became the first
+    // one delivered and the test passed against the bug.
+    crate::controller::mcp::service::set_lighting_notify_interval_ms(3_000);
 
     let player = build_standalone_player(&fixture).await?;
     let port = pick_free_port();
@@ -2336,6 +2371,46 @@ async fn mcp_lighting_state_resource_pushes_on_change() -> Result<(), Box<dyn Er
     assert_eq!(body["available"], true, "{body}");
     assert!(body["fixtures"].is_array(), "{body}");
 
+    // Start the show and wait for the rig to be settled and lit *before*
+    // subscribing, so the subscription's baseline is a steady lit state rather
+    // than the half-applied frame described above.
+    let play = tool_json(&call_tool(&client, &url, &session, 1103, "play", json!({})).await);
+    assert!(
+        play["now_playing"].is_object(),
+        "play did not start the song, so nothing will ever light: {play}"
+    );
+    {
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let body = tool_json(
+                &call_tool(
+                    &client,
+                    &url,
+                    &session,
+                    1104,
+                    "get_fixture_state",
+                    json!({}),
+                )
+                .await,
+            );
+            if body["dark"] == json!(false) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the rig never lit, so there is no settled state to subscribe from: {body}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+    // `get_fixture_state` reads the engine, but the subscription's baseline
+    // comes from the sampler, which lags it by up to a tick. Subscribing while
+    // those disagree makes the sampler's next tick look like a change, and that
+    // spurious notification opens the coalescing window early — putting the
+    // transitions this test watches in the wrong place relative to it. Several
+    // ticks of quiet puts the two views in agreement.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     let (_, sub) = mcp_post(
         &client,
         &url,
@@ -2389,16 +2464,15 @@ async fn mcp_lighting_state_resource_pushes_on_change() -> Result<(), Box<dyn Er
         .await
     });
 
-    // Let the listener open its GET before anything changes.
+    // Let the listener open its GET. Both transitions are ten seconds out, so
+    // this is margin, not a race.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Starting the show lights the rig, which is a real state change.
-    let _ = call_tool(&client, &url, &session, 1103, "play", json!({})).await;
-
-    // No second action is needed: the effect expires on its own a second in,
-    // and the rig goes dark while playback continues and the sampler runs.
+    // Nothing more to do: the background effect ends at 10s (rig still lit by
+    // the foreground one) and the foreground at 13s. The second lands inside
+    // the window opened by the first, which is the case that regressed.
     let events = listener.await.expect("listener task");
-    let _ = call_tool(&client, &url, &session, 1104, "stop", json!({})).await;
+    let _ = call_tool(&client, &url, &session, 1105, "stop", json!({})).await;
     assert_eq!(events.len(), 2, "{events:?}");
 
     // The payload rides along, so a listener never needs the follow-up read.

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -117,13 +117,21 @@ fn effects_past_end_of_song(shows: &[LightShow], ctx: &LintContext, out: &mut Ve
         return;
     }
     let clears: Vec<(Option<EffectLayer>, Duration)> = shows.iter().flat_map(clear_times).collect();
+    let stops: Vec<(String, Duration)> = shows.iter().flat_map(stop_times).collect();
     for cue in shows.iter().flat_map(|show| show.cues.iter()) {
         for effect in &cue.effects {
             // The authored end is not the real one. A long bed cut by a
-            // `clear` does not overrun the song, and warning that it does is
-            // the false positive the stomp check already avoids.
+            // `clear` or a `stop sequence` does not overrun the song, and
+            // warning that it does is a false positive.
             let layer = effect.layer.unwrap_or(EffectLayer::Background);
-            let end = effective_end(cue.time + effect.total_duration(), cue.time, layer, &clears);
+            let end = effective_end(
+                cue.time + effect.total_duration(),
+                cue.time,
+                layer,
+                effect.sequence_name.as_deref(),
+                &clears,
+                &stops,
+            );
             if end <= song_end {
                 continue;
             }
@@ -161,23 +169,18 @@ fn stomping_replace_effects(shows: &[LightShow], out: &mut Vec<Warning>) {
                 continue;
             }
             let layer = effect.layer.unwrap_or(EffectLayer::Background);
-            // The authored end is not the real one: a `clear` on this layer
-            // ends the effect there. Comparing authored spans would report a
-            // stomp between two effects that never coexist.
-            let mut end =
-                effective_end(cue.time + effect.total_duration(), cue.time, layer, &clears);
-            // An explicit `stop sequence` ends that sequence's effects too.
-            if let Some(sequence) = effect.sequence_name.as_deref() {
-                if let Some(stopped) = stops
-                    .iter()
-                    .filter(|(name, at)| name == sequence && *at > cue.time)
-                    .map(|(_, at)| *at)
-                    .filter(|at| *at < end)
-                    .min()
-                {
-                    end = stopped;
-                }
-            }
+            // The authored end is not the real one: a `clear` on this layer,
+            // or a `stop sequence` naming this effect's sequence, ends it
+            // there. Comparing authored spans would report a stomp between two
+            // effects that never coexist.
+            let end = effective_end(
+                cue.time + effect.total_duration(),
+                cue.time,
+                layer,
+                effect.sequence_name.as_deref(),
+                &clears,
+                &stops,
+            );
             if end <= cue.time {
                 continue;
             }
@@ -245,18 +248,35 @@ fn stop_times(show: &LightShow) -> Vec<(String, Duration)> {
     times
 }
 
-/// An effect's real end: its authored end, or the first `clear` affecting its
-/// layer after it starts, whichever comes first.
+/// An effect's real end: the earliest of its authored end, a `clear` affecting
+/// its layer, and a `stop sequence` naming the sequence it came from.
+///
+/// Both callers go through here rather than each capping by the mechanisms it
+/// happens to remember. They did not always: the stomp check capped by clears
+/// and stops while the past-end check capped by clears alone, so the two
+/// disagreed about the same effect — one treating a stopped bed as ending at
+/// the stop, the other warning that it overran the song by the difference.
 fn effective_end(
     authored_end: Duration,
     start: Duration,
     layer: EffectLayer,
+    sequence: Option<&str>,
     clears: &[(Option<EffectLayer>, Duration)],
+    stops: &[(String, Duration)],
 ) -> Duration {
-    clears
+    let cleared_at = clears
         .iter()
         .filter(|(cleared, at)| *at > start && cleared.is_none_or(|l| l == layer))
-        .map(|(_, at)| *at)
+        .map(|(_, at)| *at);
+    // `LightingEngine::stop_sequence` drops every effect carrying the
+    // sequence's id prefix, so a stop really is an end.
+    let stopped_at = stops
+        .iter()
+        .filter(|(name, at)| Some(name.as_str()) == sequence && *at > start)
+        .map(|(_, at)| *at);
+
+    cleared_at
+        .chain(stopped_at)
         .filter(|at| *at < authored_end)
         .min()
         .unwrap_or(authored_end)
@@ -803,6 +823,40 @@ show "T" {
         assert!(
             lint_shows(&shows(source), &ctx).is_empty(),
             "the clear ends the bed long before the song does"
+        );
+    }
+
+    #[test]
+    fn an_effect_cut_by_a_stop_sequence_does_not_overrun_the_song() {
+        // The same claim as the clear case, by the other mechanism that ends an
+        // effect early. `LightingEngine::stop_sequence` drops every effect whose
+        // id carries the sequence's prefix, so the 60s bed really ends at 15s —
+        // well inside a 30s song.
+        //
+        // The stomp check already reasons this way. When only that one did, two
+        // lints in the same file disagreed about the same effect.
+        let source = r#"
+sequence "X" {
+    @00:00.000
+    wash: static color: "blue", duration: 60s
+}
+
+show "T" {
+    @00:10.000
+    sequence "X"
+
+    @00:15.000
+    stop sequence "X"
+}
+"#;
+        let ctx = LintContext {
+            song_duration: Some(Duration::from_secs(30)),
+            ..Default::default()
+        };
+        assert!(
+            lint_shows(&shows(source), &ctx).is_empty(),
+            "the stop ends the bed long before the song does, but got: {:?}",
+            lint_shows(&shows(source), &ctx)
         );
     }
 


### PR DESCRIPTION
Two fixes, both from review.

## `effects_past_end_of_song` ignored stop sequences (ultrareview on #398)

#398 taught `stomping_replace_effects` that an effect's real end is capped by
clear cues *and* by a matching `stop sequence`. The sibling check got the clear
half only.

So: a 60s bed placed at 10s in a 30s song, stopped at 15s by
`stop sequence "X"`, was reported as *"runs to 70.000s, past the song's
30.000s"* — while the stomp check, three functions away, agreed it ended at
15s. `LightingEngine::stop_sequence` drops every effect carrying the sequence's
id prefix, so the stop really is an end.

Two lints in the same file disagreeing about the same effect is the exact
false-positive class #398 set out to remove. Reproduced before fixing.

`effective_end` now caps by clears and stops together, and both callers go
through it — the reviewer's preferred shape, since it stops them drifting apart
again.

## The subscription test could not fail

Added in #399, quarantined in #401 (which this supersedes — close it), and
wrong in a way that survived three rounds of tuning.

The engine registers an effect a frame before it computes fixture values, so a
sampler tick can catch *"effect active, fixtures still dark"*. That is a state
change, so it is notified — and the ten-second window it opened then swallowed
the entire lit period. The test was waiting for a lit notification the server
would never send. It failed about half of full-suite runs, and blocked #382,
which has nothing to do with lighting.

Two earlier attempts fixed real problems but not this one, and are kept:

- The test slept 200ms and assumed its SSE stream was attached. Since the
  subscription only emits on *change*, a notification sent before the stream
  attaches is lost for good. The listener now signals when the GET is
  established.
- `Player::set_state_tx` did not start the sampler when the DMX engine was
  already up, while `set_broadcast_tx` has always wired a late engine. Hardware
  init is spawned by `Player::new` and reads the sender exactly once, so a
  caller setting it afterwards could leave the lighting feed silently dead for
  the player's whole life. Production escapes this only because `cli::local`
  happens to set it first.

Rebuilt around what the bug actually needs: subscribe from a settled lit state,
two effects ending a second apart, and a window short enough that settling
noise closes its own before either transition. The wide window looked more
robust and was the opposite — it held a window open across the first
transition, so the second became the first delivered and the test passed
against the bug.

## Verified

- Test fails 1-of-2 with the subscription fix reverted, passes 2-of-2 with it
- Six consecutive full-suite runs clean, 3320 passed, nothing ignored
- Lint fix reproduced as a false positive before the change; 24 lint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6iBcCCaFYmoE8XsQAEd6g