### PR TITLE
Disabling triggers actually disables them (#380)

### DIFF
--- a/harness/src/checks.rs
+++ b/harness/src/checks.rs
@@ -333,6 +333,18 @@ pub fn all() -> Vec<Check> {
             subsystems::a_rig_with_an_unopenable_device_comes_up_and_can_be_reconfigured
         ),
         entry!(
+            "triggers",
+            "disabling_triggers_by_file_takes_effect",
+            "Disabling triggers by saving the profile file must disable them.",
+            subsystems::disabling_triggers_by_file_takes_effect
+        ),
+        entry!(
+            "triggers",
+            "a_reload_during_init_leaves_no_stray_trigger_engine",
+            "A reload landing during init must not strand a trigger engine.",
+            subsystems::a_reload_during_init_leaves_no_stray_trigger_engine
+        ),
+        entry!(
             "subsystems",
             "first_profile_wins",
             "The first matching profile must be the one applied.",

--- a/harness/src/checks/subsystems.rs
+++ b/harness/src/checks/subsystems.rs
@@ -27,7 +27,7 @@ use crate::client::Client;
 use crate::outcome::CheckOutcome;
 use crate::project::{ProfileSpec, ProjectBuilder, Subsystem};
 use crate::server::Server;
-use crate::{check, check_eq, fail, skip};
+use crate::{check, check_eq, fail, inconclusive, skip};
 
 /// How long to watch a deliberately-broken subsystem before concluding it
 /// degraded rather than misbehaved.
@@ -515,4 +515,282 @@ pub async fn a_rig_with_an_unopenable_device_comes_up_and_can_be_reconfigured() 
         device.name
     ));
     Ok(())
+}
+
+/// A reload that lands during init must not leave a trigger engine behind.
+///
+/// Coverage caveat: this cannot attribute a failure to the install-ordering fix
+/// alone. Against a build missing `reload_from_disk` it fails because the
+/// trigger simply returns, which the sibling check already proves more
+/// directly; against a build missing `install_if_current` it fails only when a
+/// delay happens to land inside the Phase 3 window. It is kept because that
+/// window is the one the original issue diagnosed and nothing else exercises
+/// two overlapping reloads at all — but the attributable evidence for the
+/// ordering fix is the unit test in `player::hardware`, which drives the
+/// interleaving directly.
+///
+/// #380, reported from a live rig with nothing playing: disabling the triggers
+/// did not disable them, and only a restart cleared it.
+///
+/// `init_hardware_async` checked cancellation and then, further on, wrote its
+/// devices into the shared hardware state. In between it built the trigger
+/// engine, which opens a cpal input stream — so the window was as long as a
+/// device open. `reload_hardware` cancels the in-flight round and then resets
+/// the state, but a round cancelled inside that window still finished opening
+/// its stream and wrote it into the state its successor had just cleared. The
+/// engine then held the input device and fired samples with no configuration
+/// describing it and no UI able to reach it.
+///
+/// The reported trigger is "a save landing while boot init is still running",
+/// which is what this drives: start with triggers configured, then disable them
+/// over the API before init has finished. `start_degraded` returns on the first
+/// HTTP 200, which mtrack serves while init is still going, so the save lands
+/// in the window.
+///
+/// Each attempt is its own player, because the defect is permanent for the life
+/// of the process. One stray engine across the attempts fails the check.
+pub async fn a_reload_during_init_leaves_no_stray_trigger_engine() -> CheckOutcome {
+    crate::runner::require_area("triggers")?;
+    let caps = Capabilities::get();
+    if caps.audio_in.is_none() {
+        skip!("no audio input device, so no trigger engine can be built to strand");
+    }
+
+    // Two saves in quick succession, which is the other trigger the report
+    // names. Racing *boot* init cannot be driven from outside: init finishes
+    // before the HTTP surface is pollable, so the disable always lands after
+    // the trigger engine is already up and nothing is ever cancelled mid-phase.
+    //
+    // Here the first save starts a reload and the second cancels it. The delay
+    // between them sweeps, because the window that matters is Phase 3 — while
+    // `init_trigger_engine` opens its input stream — and where that falls
+    // depends on how long this rig's devices take to open.
+    const DELAYS_MS: [u64; 8] = [0, 15, 30, 50, 75, 100, 150, 250];
+    let mut attempts_made = 0;
+
+    for delay_ms in DELAYS_MS {
+        let project = ProjectBuilder::new()
+            .profiles(vec![ProfileSpec::detected("01-e2e").with_trigger()])
+            .songs(crate::checks::standard_songs())
+            .build()?;
+        let server = Server::start(&project).await?;
+        let client = Client::connect(&server).await?;
+
+        // The engine has to be up before there is anything to strand.
+        if client.subsystem_status("trigger").await? != "connected" {
+            crate::outcome::record(format!(
+                "delay {delay_ms}ms: no trigger engine came up, so nothing could be stranded"
+            ));
+            continue;
+        }
+
+        // `/config/profiles/{index}` rather than `/profiles/{file}`: the file
+        // endpoint writes YAML to disk and reloads, but the reload re-inits
+        // from the store's in-memory config, which the file write never
+        // touched — so the trigger comes straight back and the check would
+        // report a legitimate engine as a stray one. This endpoint updates the
+        // store and then reloads.
+        let store = client.get_json("config/store").await?;
+        let checksum = store["checksum"].as_str().unwrap_or_default().to_string();
+        // `["profile"]`, not the whole body: the endpoint wraps it as
+        // {"profile": ..., "yaml": ...}. `Profile` has no deny_unknown_fields
+        // and every field is optional, so PUTting the wrapper deserialises to
+        // an entirely empty profile — no audio, no controllers, no trigger.
+        // The check then passed because the rig had been blanked rather than
+        // because the trigger key was removed.
+        let profile = client.get_json("profiles/01-e2e").await?["profile"].clone();
+        let mut without_trigger = profile.clone();
+        if let Some(object) = without_trigger.as_object_mut() {
+            object.remove("trigger");
+        }
+
+        // First save: unchanged content, but the write path reloads regardless,
+        // so this starts a round that will be opening devices.
+        let (status, body) = client
+            .put_json(
+                "config/profiles/0",
+                serde_json::json!({"profile": profile, "expected_checksum": checksum}),
+            )
+            .await?;
+        if !status.is_success() {
+            crate::outcome::record(format!(
+                "delay {delay_ms}ms: the first write was rejected ({status}: {body})"
+            ));
+            continue;
+        }
+
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+
+        // Second save: cancels the round the first one started.
+        let (status, body) = client.put_json("profiles/01-e2e", without_trigger).await?;
+        if !status.is_success() {
+            crate::outcome::record(format!(
+                "delay {delay_ms}ms: the second write was rejected ({status}: {body})"
+            ));
+            continue;
+        }
+        attempts_made += 1;
+
+        // Long enough for both rounds to finish: the stray install happens at
+        // the *end* of the losing one.
+        tokio::time::sleep(SETTLE).await;
+
+        // Predicate-level, for the same reason as the sibling check above; the
+        // world-level control is running against the pre-fix install ordering.
+        let status = crate::sabotage::pick(
+            settled_status(&client, "trigger", SETTLE).await?,
+            "connected".to_string(),
+        );
+        // Whether the config still declares a trigger separates the defect — an
+        // engine no configuration accounts for — from this check simply failing
+        // to disable anything.
+        let after = client.get_json("profiles/01-e2e").await?["profile"].clone();
+        let still_configured = after.get("trigger").is_some_and(|t| !t.is_null());
+        check!(
+            status != "connected",
+            "delay {delay_ms}ms: a trigger engine is live after the triggers were \
+             disabled by a save that cancelled an in-flight reload (status: \
+             {status}; profile still declares a trigger: {still_configured}). If \
+             the profile no longer declares one, this is an engine holding the \
+             input device that no configuration accounts for."
+        );
+
+        server.check_clean_log(&[])?;
+    }
+
+    if attempts_made == 0 {
+        inconclusive!("no attempt managed two successful saves, so no reload was ever cancelled");
+    }
+    // Says what was observed, not what was hoped for: the check drives two
+    // saves and knows both were accepted, but it never sees whether the second
+    // actually cancelled the first mid-init. Claiming it did would overstate
+    // the coverage — the delay sweep makes it likely across eight attempts,
+    // not certain on any one.
+    crate::outcome::record(format!(
+        "{attempts_made} of {} delay(s) drove two accepted saves in succession; \
+         no stray engine after any of them",
+        DELAYS_MS.len()
+    ));
+    Ok(())
+}
+
+/// Disabling triggers by saving the profile file must actually disable them.
+///
+/// The other half of #380, and the half that needs no race at all. Profiles in
+/// `profiles_dir` are copied into the in-memory config by `Player::deserialize`
+/// at startup, and `reload_hardware` re-initialises from that copy. Writing the
+/// file through `PUT /api/profiles/{name}` did not touch it, so the save was
+/// acknowledged, the hardware reloaded, and the trigger engine was rebuilt from
+/// the profile as it was at boot — live, holding the input device, with the
+/// file on disk saying it should not exist.
+///
+/// That is the reported symptom exactly: nothing playing, player unlocked, the
+/// checkbox cleared, and only a restart made any difference.
+pub async fn disabling_triggers_by_file_takes_effect() -> CheckOutcome {
+    crate::runner::require_area("triggers")?;
+    let caps = Capabilities::get();
+    if caps.audio_in.is_none() {
+        skip!("no audio input device, so there is no trigger engine to disable");
+    }
+
+    let project = ProjectBuilder::new()
+        .profiles(vec![ProfileSpec::detected("01-e2e").with_trigger()])
+        .songs(crate::checks::standard_songs())
+        .build()?;
+    let server = Server::start(&project).await?;
+    let mut client = Client::connect(&server).await?;
+
+    check_eq!(
+        client.subsystem_status("trigger").await?,
+        "connected",
+        "no trigger engine came up, so disabling one proves nothing"
+    );
+
+    // `["profile"]`, not the whole body — see the sibling check.
+    let mut profile = client.get_json("profiles/01-e2e").await?["profile"].clone();
+    if let Some(object) = profile.as_object_mut() {
+        object.remove("trigger");
+    }
+    check!(
+        profile.get("audio").is_some(),
+        "the profile fetched for editing has no audio, so this would blank the rig \
+         rather than disable its trigger: {profile}"
+    );
+
+    let (status, body) = client.put_json("profiles/01-e2e", profile).await?;
+    check!(
+        status.is_success(),
+        "saving the profile file was rejected ({status}: {body})"
+    );
+
+    // The write path reloads the hardware itself; this is time for that reload
+    // to finish opening or not opening devices.
+    tokio::time::sleep(SETTLE).await;
+
+    // Asserted on the *running config*, not on whether an engine is live.
+    //
+    // "Is a trigger engine connected" cannot tell a correctly disabled trigger
+    // from one whose engine simply failed to re-open the input device — the
+    // outgoing engine is still releasing it while the new round tries, so the
+    // status often does not return to "connected" either way. A check built on
+    // that passes against the defect: verified by running it against a build
+    // without the store refresh, where it passed happily.
+    //
+    // What the defect actually is, is the player reloading from a config that
+    // no longer matches the file it just wrote. So ask the player what config
+    // it is running.
+    let running = client
+        .grpc()
+        .get_config(GetConfigRequest {})
+        .await?
+        .into_inner()
+        .yaml;
+    let running = crate::sabotage::pick(running, "  trigger:\n    device: sabotage\n".to_string());
+    // A profile with no trigger serializes it as `trigger: ~`, and the config
+    // also carries an unrelated `sample_triggers:` key — so "does it mention a
+    // trigger" is the wrong question and answers yes either way. What matters
+    // is whether the key has a *body*: a declared trigger is followed by
+    // indented fields, a disabled one by `~`.
+    let declares_trigger = running
+        .lines()
+        .any(|line| line.trim_start().starts_with("trigger:") && !line.trim_end().ends_with('~'));
+    check!(
+        !declares_trigger,
+        "the profile file no longer declares a trigger and the save was accepted, but \
+         the player is still running a config that does — so the reload re-initialised \
+         from the copy it loaded at boot, and only a restart will clear it.\n\
+         --- running config ---\n{running}"
+    );
+
+    // Recorded rather than asserted: whether the engine is up after a reload
+    // depends on device release timing, which is not what this check is about.
+    let status = settled_status(&client, "trigger", SETTLE).await?;
+    crate::outcome::record(format!("trigger subsystem after the save: {status}"));
+
+    server.check_clean_log(&[])?;
+    crate::outcome::record("a trigger disabled by saving the profile file stayed disabled");
+    Ok(())
+}
+
+/// Waits for a subsystem to stop reporting `initializing`, then returns its
+/// status.
+///
+/// Asserting `status != "connected"` straight after a reload is not the claim
+/// it appears to be: `initializing` satisfies it too, so a check can pass
+/// because the engine has not come *back* yet rather than because it is gone.
+/// `--self-test` caught exactly that — the break point left the trigger
+/// configured, the engine was still re-initialising when the assertion ran,
+/// and the check reported success against its own sabotage.
+async fn settled_status(
+    client: &Client,
+    subsystem: &str,
+    timeout: Duration,
+) -> Result<String, crate::outcome::CheckError> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last = client.subsystem_status(subsystem).await?;
+    while last == "initializing" && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        last = client.subsystem_status(subsystem).await?;
+    }
+    Ok(last)
 }

--- a/harness/src/client.rs
+++ b/harness/src/client.rs
@@ -141,6 +141,25 @@ impl Client {
         Ok((status, parsed))
     }
 
+    /// PUTs a JSON body and returns the status and parsed response.
+    ///
+    /// Separate from [`Self::post_json`] because several config endpoints are
+    /// PUT-only, and they reject anything that is not `application/json`.
+    pub async fn put_json(
+        &self,
+        path: &str,
+        body: serde_json::Value,
+    ) -> Result<(reqwest::StatusCode, serde_json::Value), Box<dyn std::error::Error>> {
+        let url = format!("{}/api/{}", self.base_url, path.trim_start_matches('/'));
+        let response = self.http.put(&url).json(&body).send().await?;
+        let status = response.status();
+        let text = response.text().await?;
+        let parsed = serde_json::from_str(&text).map_err(|e| {
+            format!("PUT {url} returned {status} with a non-JSON body: {e}: {text}")
+        })?;
+        Ok((status, parsed))
+    }
+
     /// Sends a request with a raw body and returns the status and body text.
     ///
     /// The lighting endpoints take and return DSL text rather than JSON, and

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -151,6 +151,14 @@ async fn main() -> ExitCode {
         }
     }
 
+    // Recorded before anything prints a plan or runs: opt-in areas report
+    // themselves as not-running unless the filter asked for them, and both the
+    // listing and the run have to agree about that.
+    plan::set_selection(&options.filter);
+    if options.self_test {
+        plan::include_opt_in_areas();
+    }
+
     // Listing must not measure: discovery plays tones and sends MIDI, which is
     // not what "print the plan and exit" should do on a live rig.
     if options.list_only {

--- a/harness/src/plan.rs
+++ b/harness/src/plan.rs
@@ -95,6 +95,15 @@ pub struct Area {
     pub name: &'static str,
     pub description: &'static str,
     pub needs: &'static [Need],
+    /// Runs only when explicitly selected with `--only`.
+    ///
+    /// For areas whose cost is out of proportion to how often they change —
+    /// the trigger reload checks each start several players and sweep timing
+    /// delays, adding about a minute to a run that otherwise takes seconds per
+    /// check. They still print as not-run rather than vanishing, because a
+    /// suite that silently covers less than it appears to is the thing this
+    /// harness exists to avoid.
+    pub opt_in: bool,
 }
 
 /// Every area the suite knows about, in the order they are reported.
@@ -106,52 +115,82 @@ pub const AREAS: &[Area] = &[
         name: "startup",
         description: "config synthesis, device claim, song loading",
         needs: &[Need::AudioOut],
+        opt_in: false,
+    },
+    Area {
+        // Each check starts several players and sweeps timing delays, so this
+        // costs about a minute against seconds for everything else. It covers
+        // config-reload paths that change rarely, so it is opt-in.
+        name: "triggers",
+        description: "disabling triggers takes effect, and a cancelled reload strands nothing",
+        needs: &[Need::AudioOut],
+        opt_in: true,
     },
     Area {
         name: "devices",
         description: "device lists agree and are openable",
         needs: &[],
+        opt_in: false,
     },
     Area {
         name: "playback",
         description: "transport, clock, playlist navigation",
         needs: &[Need::AudioOut],
+        opt_in: false,
     },
     Area {
         name: "audio-routing",
         description: "tracks reach their mapped physical channels",
         needs: &[Need::AudioOut, Need::AudioLoopback],
+        opt_in: false,
     },
     Area {
         name: "midi-transmit",
         description: "notes and beat clock on the wire",
         needs: &[Need::MidiLoopback],
+        opt_in: false,
     },
     Area {
         name: "midi-config",
         description: "MIDI settings persist correctly",
         needs: &[Need::MidiOut],
+        opt_in: false,
     },
     Area {
         name: "subsystems",
         description: "subsystem presence, absence, and misconfiguration",
         needs: &[Need::AudioOut],
+        opt_in: false,
     },
     Area {
         name: "persistence",
         description: "config round-trips to disk and back",
         needs: &[],
+        opt_in: false,
     },
     Area {
         name: "lighting",
         description: "show creation, validation, cues, live effects",
         needs: &[Need::AudioOut],
+        opt_in: false,
     },
 ];
 
 /// The first unmet need of an area, if any.
 pub fn blocked_reason(area: &Area) -> Option<String> {
-    area.needs.iter().find_map(|need| need.unmet())
+    // Unmet hardware first: "you have no input device" is more useful than
+    // "you did not ask for it" when both are true.
+    if let Some(unmet) = area.needs.iter().find_map(|need| need.unmet()) {
+        return Some(unmet);
+    }
+    if area.opt_in && !was_selected(area) {
+        return Some(format!(
+            "opt-in: slow enough to skew a full run, so it runs only when asked for \
+             (--only {})",
+            area.name
+        ));
+    }
+    None
 }
 
 /// Why the named area cannot run, or `None` if it can.
@@ -160,6 +199,43 @@ pub fn blocked_reason_for(name: &str) -> Option<String> {
         .iter()
         .find(|a| a.name == name)
         .and_then(blocked_reason)
+}
+
+/// The `--only` filter, so opt-in areas can tell whether they were asked for.
+static SELECTION: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+/// Records the run's filter. Called once, before anything runs.
+pub fn set_selection(filter: &Option<String>) {
+    let _ = SELECTION.set(filter.clone());
+}
+
+/// Set when the run is a self-test, which must cover opt-in areas too.
+static INCLUDE_OPT_IN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Includes opt-in areas regardless of the filter.
+///
+/// `--self-test` exists to prove every check can fail. Letting opt-in areas sit
+/// it out would put the hole exactly where the slow, rarely-run checks are —
+/// the ones least likely to be noticed going vacuous.
+pub fn include_opt_in_areas() {
+    INCLUDE_OPT_IN.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether an opt-in area was named by the filter.
+fn was_selected(area: &Area) -> bool {
+    if INCLUDE_OPT_IN.load(std::sync::atomic::Ordering::Relaxed) {
+        return true;
+    }
+    match SELECTION.get().and_then(|f| f.as_deref()) {
+        // A filter naming the area, or one of its checks, counts as asking.
+        Some(needle) => {
+            area.name.contains(needle)
+                || crate::checks::all()
+                    .iter()
+                    .any(|c| c.area == area.name && c.name.contains(needle))
+        }
+        None => false,
+    }
 }
 
 /// Prints the plan before anything runs.

--- a/harness/src/project.rs
+++ b/harness/src/project.rs
@@ -74,6 +74,9 @@ pub struct ProfileSpec {
     pub midi_extra: BTreeMap<String, String>,
     /// Whether to emit a `dmx.lighting` block referencing the generated venue.
     pub lighting: bool,
+    /// Whether to emit a `trigger:` block with one audio input, which makes
+    /// the player build a trigger engine and open an input stream.
+    pub trigger: bool,
 }
 
 impl ProfileSpec {
@@ -89,6 +92,7 @@ impl ProfileSpec {
             audio_extra: BTreeMap::new(),
             midi_extra: BTreeMap::new(),
             lighting: false,
+            trigger: false,
         }
     }
 
@@ -110,6 +114,13 @@ impl ProfileSpec {
         self
     }
 
+    /// Emits a `trigger:` block, so the player builds a trigger engine and
+    /// holds an input stream.
+    pub fn with_trigger(mut self) -> ProfileSpec {
+        self.trigger = true;
+        self
+    }
+
     /// Renders the profile as YAML.
     fn render(&self, caps: &Capabilities, songs: &[SongSpec], grpc_port: u16) -> String {
         let mut out = String::new();
@@ -122,6 +133,7 @@ impl ProfileSpec {
         self.render_audio(&mut out, caps, songs);
         self.render_midi(&mut out, caps);
         self.render_dmx(&mut out, caps);
+        self.render_trigger(&mut out, caps);
 
         // Controllers belong to the profile: when `profiles` is present mtrack
         // ignores top-level `controller`/`controllers` entirely. Every profile
@@ -204,6 +216,28 @@ impl ProfileSpec {
                 .join(", ");
             let _ = writeln!(out, "    \"{}\": [{}]", escape(track), list);
         }
+    }
+
+    /// A `trigger:` block with a single audio input.
+    ///
+    /// The point is only that the player builds a trigger engine and opens an
+    /// input stream — the threshold is set high enough that ambient noise on an
+    /// unpatched input will not fire it, and the sample it names need not
+    /// exist, since nothing here waits for it to fire.
+    fn render_trigger(&self, out: &mut String, caps: &Capabilities) {
+        if !self.trigger {
+            return;
+        }
+        let Some(input) = caps.audio_in.as_ref() else {
+            return;
+        };
+        out.push_str("trigger:\n");
+        let _ = writeln!(out, "  device: \"{}\"", escape(&input.name));
+        out.push_str("  inputs:\n");
+        out.push_str("    - kind: audio\n");
+        out.push_str("      channel: 1\n");
+        out.push_str("      sample: \"e2e-trigger-sample\"\n");
+        out.push_str("      threshold: 0.95\n");
     }
 
     fn render_midi(&self, out: &mut String, caps: &Capabilities) {

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -77,6 +77,7 @@ enum SubsystemUpdate {
     Audio(Option<Audio>),
     Midi(Option<Midi>),
     Dmx(Option<Dmx>),
+    Controllers(Vec<Controller>),
 }
 
 impl SubsystemUpdate {
@@ -87,6 +88,7 @@ impl SubsystemUpdate {
             SubsystemUpdate::Audio(audio) => profile.set_audio(audio),
             SubsystemUpdate::Midi(midi) => profile.set_midi(midi),
             SubsystemUpdate::Dmx(dmx) => profile.set_dmx(dmx),
+            SubsystemUpdate::Controllers(controllers) => profile.set_controllers(controllers),
         }
     }
 
@@ -97,6 +99,7 @@ impl SubsystemUpdate {
             SubsystemUpdate::Audio(audio) => config.set_audio(audio),
             SubsystemUpdate::Midi(midi) => config.set_midi(midi),
             SubsystemUpdate::Dmx(dmx) => config.set_dmx(dmx),
+            SubsystemUpdate::Controllers(controllers) => config.set_controllers(controllers),
         }
     }
 }
@@ -150,6 +153,39 @@ impl ConfigStore {
     /// Returns a clone of the current config.
     pub async fn read_config(&self) -> Player {
         self.inner.read().await.clone()
+    }
+
+    /// Re-reads the config from disk, including any profiles in `profiles_dir`,
+    /// and replaces the in-memory copy.
+    ///
+    /// The file-based profile endpoints write YAML straight to `profiles_dir`,
+    /// and `Player::reload_hardware` re-initialises from *this* copy — which
+    /// `Player::deserialize` populated from those files at startup and which a
+    /// later file write does not touch. Without this, saving a profile is
+    /// written, acknowledged with a 200, followed by a hardware reload, and
+    /// still has no effect until the process restarts: the reload rebuilds
+    /// everything from the profile as it was at boot.
+    ///
+    /// That is what made a disabled trigger stay live — the checkbox wrote a
+    /// profile with no trigger, and the reload built one anyway from the copy
+    /// that still had it.
+    pub async fn reload_from_disk(&self) -> Result<(), ConfigError> {
+        // The write lock is taken *before* the read, not after it. Reading disk
+        // first and swapping afterwards leaves a window in which another
+        // mutation can commit to memory and disk between the two — that value
+        // is then overwritten in memory by this older snapshot, the client that
+        // wrote it holds a checksum that is already stale, and the next persist
+        // writes the pre-mutation value back over the file.
+        let mut guard = self.inner.write().await;
+        let path = self.path.clone();
+        let config = tokio::task::spawn_blocking(move || Player::deserialize(&path))
+            .await
+            .map_err(|e| ConfigError::StoreSerialization(e.to_string()))??;
+        *guard = config;
+        drop(guard);
+        // Ignored deliberately: no subscribers is normal.
+        let _ = self.change_tx.send(());
+        Ok(())
     }
 
     /// Returns the path to the on-disk config file.
@@ -449,15 +485,21 @@ impl ConfigStore {
     }
 
     /// Updates the controllers configuration.
+    ///
+    /// Routed through [`Self::update_subsystem`] like audio, MIDI and DMX,
+    /// rather than writing the top-level `controllers` field. Everything that
+    /// *reads* controllers — `init_hardware_async`, `reload_controllers` —
+    /// takes them from the active profile, and `Player::normalize` discards the
+    /// top-level list whenever profiles are present, which after normalization
+    /// is always. Writing there returned a fresh checksum, persisted a value,
+    /// reloaded, changed nothing, and lost the value on the next restart.
     pub async fn update_controllers(
         &self,
         controllers: Vec<Controller>,
         checksum: &str,
     ) -> Result<ConfigSnapshot, ConfigError> {
-        self.mutate(checksum, |config| {
-            config.set_controllers(controllers);
-        })
-        .await
+        self.update_subsystem(SubsystemUpdate::Controllers(controllers), checksum)
+            .await
     }
 
     /// Updates the inline sample definitions.
@@ -722,6 +764,52 @@ profiles:
         let midi = profile.midi().expect("the update must land on the profile");
         assert_eq!(midi.device(), "new-midi");
         assert!(midi.persist_tempo(), "persist_tempo was discarded");
+    }
+
+    /// Controllers must land on the active profile, like every other subsystem.
+    ///
+    /// They used to be written to the top-level `controllers` field, which
+    /// nothing reads once profiles exist — `init_hardware_async` and
+    /// `reload_controllers` both take them from the active profile, and
+    /// `normalize` discards the top-level list. An `UpdateControllers` call
+    /// therefore returned a fresh checksum, persisted a value, reloaded,
+    /// changed nothing, and lost the value on the next restart.
+    #[tokio::test]
+    async fn update_controllers_reaches_the_active_profile() {
+        let yaml = "songs: songs\nprofiles:\n  - audio:\n      device: a\n      track_mappings:\n        click: [1]\n    controllers:\n      - kind: grpc\n        port: 1111\n";
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        let player = Player::deserialize(&path).unwrap();
+
+        let store = ConfigStore::new(player, path.clone());
+        let snap = store.read().await.unwrap();
+        store
+            .update_controllers(
+                vec![Controller::Grpc(super::super::GrpcController::new(2222))],
+                &snap.checksum,
+            )
+            .await
+            .unwrap();
+
+        // Survives a full reload, which is what the player does on restart.
+        let mut reloaded = Player::deserialize(&path).unwrap();
+        let profile = reloaded
+            .active_profile_mut(&super::super::hostname::resolve_hostname())
+            .expect("a hostname-less profile matches every host");
+        let ports: Vec<u16> = profile
+            .controllers()
+            .iter()
+            .filter_map(|c| match c {
+                Controller::Grpc(g) => Some(g.port()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            ports,
+            vec![2222],
+            "the update did not reach the profile, so nothing reads it"
+        );
     }
 
     /// The same, on a `profiles_dir` layout: the owning file is rewritten and

--- a/src/controller/grpc.rs
+++ b/src/controller/grpc.rs
@@ -15,7 +15,7 @@ use std::{error::Error, io, net::SocketAddr, sync::Arc};
 
 use tokio::task::JoinHandle;
 use tonic::{transport::Server, Request, Response, Status};
-use tracing::{info, span, Level};
+use tracing::{info, span, warn, Level};
 
 use crate::{
     config,
@@ -140,6 +140,51 @@ impl PlayerServer {
         Ok(Response::new(PlayResponse {
             song: Some(song.to_proto()?),
         }))
+    }
+
+    /// Reloads the hardware so a config mutation takes effect, then builds the
+    /// response.
+    ///
+    /// The web UI's mutation endpoints have always reloaded; these had not, so
+    /// a client could change the audio device, receive a fresh checksum, and
+    /// find the running hardware unchanged until the process restarted. That
+    /// asymmetry is the same shape as the profile-file bug: the write is
+    /// acknowledged and quietly has no effect.
+    ///
+    /// Safe to do from inside a gRPC call because `start_controllers` leaves
+    /// controllers running when their config has not changed — otherwise this
+    /// would tear down the very transport carrying the response.
+    #[allow(clippy::result_large_err)]
+    async fn reload_and_respond(
+        &self,
+        snapshot: config::store::ConfigSnapshot,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        // Flattened immediately: `Box<dyn Error>` is not Send and must not live
+        // across the await that follows.
+        if let Err(e) = self
+            .player
+            .reload_hardware()
+            .await
+            .map_err(|e| e.to_string())
+        {
+            // Reported, not just logged. The most common cause is playback —
+            // `reload_hardware` refuses during it — and answering with a fresh
+            // checksum while nothing was applied is precisely the "acknowledged
+            // and quietly ineffective" behaviour this helper exists to end. The
+            // config *is* persisted at this point, so the message has to say so
+            // rather than implying the write was rolled back.
+            warn!("Hardware reload after config update failed: {}", e);
+            return Err(Status::failed_precondition(format!(
+                "the config was saved but the running hardware was not reloaded, so it \
+                 will not take effect until the next reload or restart: {e}"
+            )));
+        }
+        // Deliberately not `reload_controllers`: that forces a restart, which
+        // would tear down the transport carrying this response. The hardware
+        // reload above already restarts controllers when their config actually
+        // changed, and leaves them alone when it did not — so a caller is only
+        // disconnected by a change it made to the controllers themselves.
+        snapshot_to_update_response(snapshot)
     }
 
     /// Why the player declined to start, determined from its current state
@@ -466,7 +511,7 @@ impl PlayerService for PlayerServer {
             .update_audio(audio, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn update_midi(
@@ -487,7 +532,7 @@ impl PlayerService for PlayerServer {
             .update_midi(midi, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn update_dmx(
@@ -508,7 +553,7 @@ impl PlayerService for PlayerServer {
             .update_dmx(dmx, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn update_controllers(
@@ -523,7 +568,7 @@ impl PlayerService for PlayerServer {
             .update_controllers(controllers, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn add_profile(
@@ -538,7 +583,7 @@ impl PlayerService for PlayerServer {
             .add_profile(profile, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn update_profile(
@@ -553,7 +598,7 @@ impl PlayerService for PlayerServer {
             .update_profile(req.index as usize, profile, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn remove_profile(
@@ -566,7 +611,7 @@ impl PlayerService for PlayerServer {
             .remove_profile(req.index as usize, &req.expected_checksum)
             .await
             .map_err(config_error_to_status)?;
-        snapshot_to_update_response(snapshot)
+        self.reload_and_respond(snapshot).await
     }
 
     async fn loop_section(

--- a/src/player.rs
+++ b/src/player.rs
@@ -307,6 +307,15 @@ pub struct Player {
     /// Cancellation token for the current hardware init round. On reload,
     /// the old token is cancelled and a new one is created.
     init_cancel: Arc<parking_lot::Mutex<CancellationToken>>,
+    /// Serializes `reload_hardware` from start to spawn.
+    ///
+    /// The config is read before the cancellation token is replaced, and that
+    /// read awaits — so two concurrent reloads could interleave such that the
+    /// one holding the *older* config cancelled the newer round and spawned
+    /// last, leaving the rig built from a config the store had already
+    /// superseded. Serializing means the last reload to run is the one that
+    /// read the newest config.
+    reload_lock: Arc<tokio::sync::Mutex<()>>,
     /// Broadcast channel sender, stored so async init can wire DMX engine.
     broadcast_tx: Arc<parking_lot::Mutex<Option<tokio::sync::broadcast::Sender<String>>>>,
     /// Watch channel to signal hardware init completion.
@@ -324,6 +333,10 @@ pub struct Player {
     locked: Arc<AtomicBool>,
     /// Active controllers (gRPC, OSC, MIDI). Replaced on reload.
     controller: Arc<parking_lot::Mutex<Option<crate::controller::Controller>>>,
+    /// The controller config the running controllers were started from,
+    /// serialized. Lets a reload leave them alone when nothing about them
+    /// changed — see [`Player::start_controllers`].
+    controller_config: Arc<parking_lot::Mutex<Option<String>>>,
     /// Signal to break out of a song loop gracefully (not a hard cancel).
     /// Set by play()/next() when the current song is looping. The playback
     /// loop checks this flag and exits cleanly, allowing the cleanup task
@@ -450,12 +463,18 @@ impl Player {
         // Use send_modify() because send() is a no-op when no receivers exist yet.
         player.init_done_tx.send_modify(|v| *v = false);
 
-        // Spawn async hardware init.
+        // Spawn async hardware init, capturing the cancellation token now
+        // rather than letting the task read it when it is first polled — by
+        // then a reload may have replaced it, and the round would adopt its
+        // successor's token and never be cancelled.
         let init_player = player.clone();
         let config = config.clone();
         let bp = base_path.map(Path::to_path_buf);
+        let init_cancel = player.init_cancel.lock().clone();
         tokio::spawn(async move {
-            init_player.init_hardware_async(config, bp).await;
+            init_player
+                .init_hardware_async(config, bp, init_cancel)
+                .await;
         });
 
         // Spawn the low-rate transport-state poller. Holds a `Weak` so it
@@ -556,6 +575,7 @@ impl Player {
             config_store: Arc::new(parking_lot::Mutex::new(None)),
             default_metronome: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             init_cancel: Arc::new(parking_lot::Mutex::new(CancellationToken::new())),
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             broadcast_tx: Arc::new(parking_lot::Mutex::new(None)),
             init_done_tx: Arc::new(init_done_tx),
             state_tx: Arc::new(parking_lot::Mutex::new(None)),
@@ -563,6 +583,7 @@ impl Player {
             gain_persist_task: Arc::new(parking_lot::Mutex::new(None)),
             locked: Arc::new(AtomicBool::new(true)),
             controller: Arc::new(parking_lot::Mutex::new(None)),
+            controller_config: Arc::new(parking_lot::Mutex::new(None)),
             loop_break: Arc::new(AtomicBool::new(false)),
             active_section: Arc::new(parking_lot::RwLock::new(None)),
             section_loop_break: Arc::new(AtomicBool::new(false)),

--- a/src/player/hardware.rs
+++ b/src/player/hardware.rs
@@ -102,13 +102,22 @@ impl Player {
     ///   Phase 1: Audio + DMX (parallel)
     ///   Phase 2: MIDI (needs DMX), Sample engine (needs Audio) — parallel
     ///   Phase 3: Trigger engine (needs Sample engine), status reporting
+    /// `cancel` is captured by the *spawner*, not read here.
+    ///
+    /// Reading `init_cancel` inside the task takes effect at first poll, which
+    /// is after the spawning function returned — so a reload landing in that
+    /// window installs its replacement token and the older round then picks
+    /// *that* one up. Both rounds would hold an uncancelled token, both would
+    /// pass every `install_if_current`, and both would install: two audio
+    /// opens, two trigger engines, and whichever finished last winning, with
+    /// the other's input stream stranded. The guard is only ever as good as
+    /// the token the round is holding.
     pub(super) async fn init_hardware_async(
         self: &Arc<Self>,
         config: config::Player,
         base_path: Option<PathBuf>,
+        cancel: CancellationToken,
     ) {
-        let cancel = self.init_cancel.lock().clone();
-
         let hostname = config::resolve_hostname();
         info!(hostname = %hostname, "Resolved hostname for hardware profiles");
 
@@ -117,9 +126,14 @@ impl Player {
             Some(p) => (*p).clone(),
             None => {
                 info!("No matching hardware profile found; starting with no hardware");
-                {
-                    let mut hw = self.hardware.write();
+                if !install_if_current(&self.hardware, &cancel, |hw| {
                     hw.hostname = Some(hostname);
+                }) {
+                    return;
+                }
+                // Re-checked under the lock for the same reason as the tail.
+                if !install_if_current(&self.hardware, &cancel, |_| {}) {
+                    return;
                 }
                 self.init_done_tx.send_modify(|v| *v = true);
                 return;
@@ -127,10 +141,11 @@ impl Player {
         };
 
         // Store the active profile name and hostname.
-        {
-            let mut hw = self.hardware.write();
+        if !install_if_current(&self.hardware, &cancel, |hw| {
             hw.profile_name = Some(profile.hostname().unwrap_or("default").to_string());
             hw.hostname = Some(hostname);
+        }) {
+            return;
         }
 
         info!(
@@ -169,7 +184,7 @@ impl Player {
                         }
                     })
                     .await;
-                    self.record_init_outcome("audio", outcome)
+                    self.record_init_outcome("audio", outcome, &cancel)
                 } else {
                     info!("Audio not configured in profile; proceeding without audio");
                     None
@@ -183,7 +198,7 @@ impl Player {
                             .map_err(|e| e.to_string())
                     })
                     .await;
-                    self.record_init_outcome("dmx", outcome).flatten()
+                    self.record_init_outcome("dmx", outcome, &cancel).flatten()
                 } else {
                     info!("DMX not configured in profile; proceeding without DMX");
                     None
@@ -222,18 +237,26 @@ impl Player {
                 // sounds) for songs that don't override them.
                 device.set_metronome_defaults(config.metronome().cloned());
 
-                let mut hw = self.hardware.write();
-                hw.device = Some(device.clone());
-                hw.mappings = Some(Arc::new(mappings.clone()));
-                hw.track_gains = Some(track_gains);
-                hw.clock_source = clock_source;
+                let installed = install_if_current(&self.hardware, &cancel, |hw| {
+                    hw.device = Some(device.clone());
+                    hw.mappings = Some(Arc::new(mappings.clone()));
+                    hw.track_gains = Some(track_gains);
+                    hw.clock_source = clock_source;
+                });
+                if !installed {
+                    return;
+                }
                 (Some(device), Some(mappings), Some(resolved_audio))
             }
             None => (None, None, None),
         };
 
         if let Some(ref dmx_engine) = dmx_result {
-            self.hardware.write().dmx_engine = Some(dmx_engine.clone());
+            if !install_if_current(&self.hardware, &cancel, |hw| {
+                hw.dmx_engine = Some(dmx_engine.clone());
+            }) {
+                return;
+            }
             // Wire the broadcast channel if one has been set.
             if let Some(ref tx) = *self.broadcast_tx.lock() {
                 dmx_engine.set_broadcast_tx(tx.clone());
@@ -267,7 +290,7 @@ impl Player {
                             .map_err(|e| e.to_string())
                     })
                     .await;
-                    self.record_init_outcome("midi", outcome).flatten()
+                    self.record_init_outcome("midi", outcome, &cancel).flatten()
                 } else {
                     info!("MIDI not configured in profile; proceeding without MIDI");
                     None
@@ -292,13 +315,28 @@ impl Player {
 
         // Write Phase 2 results.
         if let Some(ref midi_device) = midi_result {
-            self.hardware.write().midi_device = Some(midi_device.clone());
+            if !install_if_current(&self.hardware, &cancel, |hw| {
+                hw.midi_device = Some(midi_device.clone());
+            }) {
+                return;
+            }
         }
         if let Some(ref se) = sample_engine {
-            self.hardware.write().sample_engine = Some(se.clone());
+            if !install_if_current(&self.hardware, &cancel, |hw| {
+                hw.sample_engine = Some(se.clone());
+            }) {
+                return;
+            }
         }
 
         // Phase 3: Trigger engine (needs sample engine) + post-init wiring.
+        //
+        // Checked before constructing as well as before installing: this opens
+        // a cpal input stream, and a round that is already dead should not take
+        // the device from the round that replaced it even briefly.
+        if cancel.is_cancelled() {
+            return;
+        }
         let trigger_engine = match init_trigger_engine(&profile, &sample_engine) {
             Ok(te) => te,
             Err(e) => {
@@ -307,7 +345,20 @@ impl Player {
             }
         };
         if let Some(ref te) = trigger_engine {
-            self.hardware.write().trigger_engine = Some(te.clone());
+            if !install_if_current(&self.hardware, &cancel, |hw| {
+                hw.trigger_engine = Some(te.clone());
+            }) {
+                // Dropping it here closes the input stream it just opened.
+                return;
+            }
+        }
+
+        // Nothing past here belongs to a round that has been replaced: starting
+        // controllers would restart the successor's, and announcing init_done
+        // would let playback past the "still initializing" gate against a rig
+        // this round no longer owns.
+        if cancel.is_cancelled() {
+            return;
         }
 
         // Start controllers now that all hardware is ready.
@@ -342,6 +393,14 @@ impl Player {
             }
         }
 
+        // Under the hardware lock, like every other write in this function: a
+        // bare check leaves a window in which the round is cancelled, the
+        // successor sets init_done false, and this then sets it back to true —
+        // opening the "still initializing" gate for a rig this round no longer
+        // owns.
+        if !install_if_current(&self.hardware, &cancel, |_| {}) {
+            return;
+        }
         self.init_done_tx.send_modify(|v| *v = true);
         info!("Hardware initialization complete");
     }
@@ -353,19 +412,29 @@ impl Player {
     /// "not connected", which is indistinguishable from "not configured" and
     /// leaves the operator exactly where the perpetual retry did — except now
     /// it is quiet about it too.
+    /// Records a subsystem's init outcome, ignoring it if this round has been
+    /// cancelled.
+    ///
+    /// Cancellation is only checked at the bottom of `retry_until_ready`'s
+    /// loop, after the constructor has run, so a round cancelled while a device
+    /// open was in flight can still come back with a terminal failure. Writing
+    /// that unguarded put a dead round's reason into the state its successor
+    /// had just cleared — reporting a subsystem as failed, with an error
+    /// describing a device the new config may not even mention, until some
+    /// later reload cleared it.
     fn record_init_outcome<T>(
         &self,
         subsystem: &str,
         outcome: Result<T, InitFailure>,
+        cancel: &CancellationToken,
     ) -> Option<T> {
         match outcome {
             Ok(value) => Some(value),
             Err(InitFailure::Cancelled) => None,
             Err(InitFailure::Terminal(why)) => {
-                self.hardware
-                    .write()
-                    .init_errors
-                    .insert(subsystem.to_string(), why);
+                install_if_current(&self.hardware, cancel, |hw| {
+                    hw.init_errors.insert(subsystem.to_string(), why);
+                });
                 None
             }
         }
@@ -492,41 +561,62 @@ impl Player {
             return Err("Cannot reload hardware during playback".into());
         }
 
+        // Held until this reload has spawned its round, so a concurrent reload
+        // cannot read a newer config, spawn, and then be cancelled by an older
+        // one that had already read its own.
+        let _reload_guard = self.reload_lock.clone().lock_owned().await;
+
         let config = self
             .config_store()
             .ok_or("No config store available")?
             .read_config()
             .await;
 
-        // Cancel the previous init round.
-        {
-            let mut cancel = self.init_cancel.lock();
-            cancel.cancel();
-            *cancel = CancellationToken::new();
-        }
+        // Cancel the previous init round and take the replacement token here,
+        // so the round spawned below carries it from the start.
+        let cancel = {
+            let mut guard = self.init_cancel.lock();
+            guard.cancel();
+            *guard = CancellationToken::new();
+            guard.clone()
+        };
 
         // Reset hardware to empty.
-        *self.hardware.write() = HardwareState {
-            device: None,
-            mappings: None,
-            track_gains: None,
-            midi_device: None,
-            dmx_engine: None,
-            sample_engine: None,
-            trigger_engine: None,
-            clock_source: ClockSource::Wall,
-            song_change_notifiers: Vec::new(),
-            profile_name: None,
-            hostname: None,
-            init_errors: HashMap::new(),
-        };
+        //
+        // Song-change notifiers are deliberately carried over: they are
+        // registered by the controllers, and a reload no longer necessarily
+        // restarts those. Clearing them here while the controller that owns
+        // them keeps running left `emit_song_change` iterating an empty list
+        // for the rest of the process — a Morningstar pedalboard would simply
+        // stop receiving song changes, with nothing logged. They are cleared
+        // by `start_controllers_inner` instead, at the point the controllers
+        // that own them are actually torn down.
+        {
+            let mut hw = self.hardware.write();
+            let notifiers = std::mem::take(&mut hw.song_change_notifiers);
+            *hw = HardwareState {
+                device: None,
+                mappings: None,
+                track_gains: None,
+                midi_device: None,
+                dmx_engine: None,
+                sample_engine: None,
+                trigger_engine: None,
+                clock_source: ClockSource::Wall,
+                song_change_notifiers: notifiers,
+                profile_name: None,
+                hostname: None,
+                init_errors: HashMap::new(),
+            };
+        }
         self.init_done_tx.send_modify(|v| *v = false);
 
-        // Spawn new async init.
+        // Spawn new async init, handing it the token captured above rather
+        // than letting it read the shared cell when it is first polled.
         let init_player = self.clone();
         let bp = self.base_path.clone();
         tokio::spawn(async move {
-            init_player.init_hardware_async(config, bp).await;
+            init_player.init_hardware_async(config, bp, cancel).await;
         });
 
         info!("Hardware reload initiated");
@@ -640,19 +730,68 @@ impl Player {
     /// Starts controllers from the given config. Called at startup and on reload.
     /// Requires `Arc<Player>` because controllers hold a reference to the player.
     pub fn start_controllers(self: &Arc<Self>, config: Vec<config::Controller>) {
-        // Shut down any existing controllers.
+        self.start_controllers_inner(config, false);
+    }
+
+    /// Starts controllers, restarting them even if their config is unchanged.
+    ///
+    /// "Restart controllers" means restart them. Skipping on an unchanged
+    /// fingerprint would make that button a no-op that still reports success —
+    /// and it is precisely the button reached for when a driver failed to bind
+    /// at boot, where the config is unchanged and the controllers are dead.
+    pub fn restart_controllers_forced(self: &Arc<Self>, config: Vec<config::Controller>) {
+        self.start_controllers_inner(config, true);
+    }
+
+    fn start_controllers_inner(self: &Arc<Self>, config: Vec<config::Controller>, force: bool) {
+        // Restarting controllers tears down the transport a caller may be
+        // speaking on: a config change requested over gRPC would drop that
+        // client's own connection mid-response. Since a hardware reload runs
+        // this every time, leaving unchanged controllers alone is what makes it
+        // safe for those paths to reload at all.
+        let fingerprint = crate::util::to_yaml_string(&config).ok();
+        if !force && fingerprint.is_some() && *self.controller_config.lock() == fingerprint {
+            info!("Controllers unchanged; leaving them running");
+            return;
+        }
+
+        // Shut down any existing controllers, and drop the notifiers they
+        // registered — the replacements register their own.
         if let Some(old) = self.controller.lock().take() {
             info!("Shutting down existing controllers");
             old.shutdown();
         }
+        self.hardware.write().song_change_notifiers.clear();
 
         if config.is_empty() {
             info!("No controllers configured");
+            *self.controller_config.lock() = fingerprint;
             return;
         }
 
         let controller = crate::controller::Controller::new(config, Arc::clone(self));
+        // Only a clean start is remembered. `Controller::new` records per-driver
+        // failures and carries on, and a reload restarts controllers *before*
+        // the init round has installed any devices — so the MIDI driver finds no
+        // device and errors. Recording the fingerprint there would make the next
+        // call, the init round's own, skip the restart that heals it, and the
+        // controller would stay dead with nothing logged until someone pressed
+        // Restart Controllers. A failed start stays retryable.
+        let healthy = controller.statuses().iter().all(|s| s.status != "error");
+        if !healthy {
+            let failed: Vec<&str> = controller
+                .statuses()
+                .iter()
+                .filter(|s| s.status == "error")
+                .map(|s| s.kind.as_str())
+                .collect();
+            warn!(
+                failed = ?failed,
+                "Some controllers did not start; they will be retried on the next reload"
+            );
+        }
         *self.controller.lock() = Some(controller);
+        *self.controller_config.lock() = healthy.then_some(fingerprint).flatten();
         info!("Controllers started");
     }
 
@@ -672,7 +811,10 @@ impl Player {
             .map(|p| p.controllers().to_vec())
             .unwrap_or_default();
 
-        self.start_controllers(controllers);
+        // Forced: this is only reached from the operator's explicit "restart
+        // controllers", and from the config paths that have just changed them.
+        // Both mean "do it", not "do it if you think something changed".
+        self.restart_controllers_forced(controllers);
         Ok(())
     }
 
@@ -794,6 +936,35 @@ pub(super) fn init_sample_engine(
 /// Initializes the trigger engine if configured and sample engine is available.
 /// Unlike audio/MIDI devices, triggers are non-essential — fail immediately
 /// rather than retrying indefinitely.
+/// Applies `install` to the hardware state, but only if `cancel` says this init
+/// round is still the current one. Returns whether it did.
+///
+/// The cancellation check happens *while holding the write lock*, and that is
+/// what makes it correct. `reload_hardware` cancels the in-flight round and
+/// then resets the state, so either this round takes the lock first and the
+/// reset clears what it wrote, or it takes the lock afterwards and sees the
+/// cancellation. Checking before acquiring the lock leaves a window as long as
+/// whatever runs in between — for the trigger engine that is a cpal device
+/// open, which is not short. A round cancelled inside that window used to
+/// install its input stream into the state its successor had just cleared,
+/// leaving a trigger engine live and firing with no configuration anywhere
+/// describing it, and nothing short of a restart able to remove it (#380).
+///
+/// A free function rather than a method so the invariant can be tested without
+/// standing up a whole player.
+fn install_if_current(
+    hardware: &parking_lot::RwLock<HardwareState>,
+    cancel: &CancellationToken,
+    install: impl FnOnce(&mut HardwareState),
+) -> bool {
+    let mut hw = hardware.write();
+    if cancel.is_cancelled() {
+        return false;
+    }
+    install(&mut hw);
+    true
+}
+
 pub(super) fn init_trigger_engine(
     profile: &config::Profile,
     sample_engine: &Option<Arc<RwLock<SampleEngine>>>,
@@ -879,6 +1050,155 @@ mod test {
     }
 
     const SHORT_GRACE: Duration = Duration::from_millis(200);
+
+    fn empty_hardware() -> parking_lot::RwLock<HardwareState> {
+        parking_lot::RwLock::new(HardwareState {
+            device: None,
+            mappings: None,
+            track_gains: None,
+            midi_device: None,
+            dmx_engine: None,
+            sample_engine: None,
+            trigger_engine: None,
+            clock_source: ClockSource::Wall,
+            song_change_notifiers: Vec::new(),
+            profile_name: None,
+            hostname: None,
+            init_errors: std::collections::HashMap::new(),
+        })
+    }
+
+    /// Restarting controllers on every reload would drop the connection of the
+    /// very client that asked for the change.
+    ///
+    /// The web UI escapes this because the web server is not a controller; a
+    /// gRPC client is not so lucky, which is why its config mutations did not
+    /// reload at all. Leaving unchanged controllers alone is what makes those
+    /// paths able to reload.
+    #[test]
+    fn unchanged_controllers_are_left_running() {
+        let a = vec![config::Controller::Grpc(config::GrpcController::new(7654))];
+        let b = vec![config::Controller::Grpc(config::GrpcController::new(7654))];
+        let different = vec![config::Controller::Grpc(config::GrpcController::new(7655))];
+
+        let fingerprint = |c: &Vec<config::Controller>| crate::util::to_yaml_string(c).ok();
+        assert_eq!(
+            fingerprint(&a),
+            fingerprint(&b),
+            "the same controller config must compare equal, or every reload restarts them"
+        );
+        assert_ne!(
+            fingerprint(&a),
+            fingerprint(&different),
+            "a changed port must compare different, or a real change would be ignored"
+        );
+    }
+
+    /// #380: a cancelled init round must not install anything.
+    ///
+    /// It used to. `init_hardware_async` checked cancellation, then opened a
+    /// cpal input stream for the trigger engine, then wrote it in — and a
+    /// reload landing inside that window had already cleared the state the
+    /// write then landed in. The engine stayed live and firing, described by no
+    /// configuration and reachable by no UI, until mtrack was restarted.
+    #[test]
+    fn a_cancelled_round_installs_nothing() {
+        let hardware = empty_hardware();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let installed = install_if_current(&hardware, &cancel, |hw| {
+            hw.profile_name = Some("from the round that was replaced".to_string());
+        });
+
+        assert!(!installed, "a cancelled round reported that it installed");
+        assert_eq!(
+            hardware.read().profile_name,
+            None,
+            "a cancelled round wrote into the state its successor had cleared"
+        );
+    }
+
+    /// The actual race, with a real interleaving rather than a token that was
+    /// already cancelled on entry.
+    ///
+    /// A round is current when it starts installing and is not by the time it
+    /// gets the lock — which is what happens when a reload lands while the
+    /// trigger engine is opening its device. Checking cancellation before
+    /// acquiring the lock passes here and then writes anyway; checking it under
+    /// the lock is what makes the write impossible.
+    #[test]
+    fn a_round_cancelled_while_it_waits_for_the_lock_installs_nothing() {
+        let hardware = std::sync::Arc::new(empty_hardware());
+        let cancel = CancellationToken::new();
+
+        // Held the way `reload_hardware`'s reset holds it.
+        let guard = hardware.write();
+
+        let installer = {
+            let hardware = hardware.clone();
+            let cancel = cancel.clone();
+            std::thread::spawn(move || {
+                install_if_current(&hardware, &cancel, |hw| {
+                    hw.profile_name = Some("from the round that was replaced".to_string());
+                })
+            })
+        };
+
+        // Long enough that a check made *before* acquiring the lock has already
+        // passed, and the thread is parked waiting for it.
+        std::thread::sleep(Duration::from_millis(100));
+
+        // The reload cancels, then releases the lock it cleared under.
+        cancel.cancel();
+        drop(guard);
+
+        let installed = installer.join().expect("installer thread");
+        assert!(
+            !installed,
+            "a round cancelled while waiting for the lock reported that it installed"
+        );
+        assert_eq!(
+            hardware.read().profile_name,
+            None,
+            "a cancelled round installed into the state its successor had cleared"
+        );
+    }
+
+    /// The other half: the guard must not stop a live round from installing.
+    #[test]
+    fn a_live_round_installs_normally() {
+        let hardware = empty_hardware();
+        let cancel = CancellationToken::new();
+
+        let installed = install_if_current(&hardware, &cancel, |hw| {
+            hw.profile_name = Some("current".to_string());
+        });
+
+        assert!(installed);
+        assert_eq!(hardware.read().profile_name.as_deref(), Some("current"));
+    }
+
+    /// Cancellation is observed under the lock, so a round cancelled *while*
+    /// it was constructing still writes nothing — which is the actual race,
+    /// rather than one where the token is already cancelled on entry.
+    #[test]
+    fn cancellation_during_the_slow_work_is_still_caught() {
+        let hardware = empty_hardware();
+        let cancel = CancellationToken::new();
+
+        // Stands in for `init_trigger_engine` opening a device: the round was
+        // current when it started this work and is not by the time it installs.
+        let expensive_result = "an input stream this round no longer owns";
+        cancel.cancel();
+
+        let installed = install_if_current(&hardware, &cancel, |hw| {
+            hw.profile_name = Some(expensive_result.to_string());
+        });
+
+        assert!(!installed);
+        assert_eq!(hardware.read().profile_name, None);
+    }
 
     /// The defect this exists to fix: a device that will never open used to
     /// spin forever, and because subsystems are joined by phase, held the whole

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -22,6 +22,8 @@ use serde_json::json;
 
 use super::super::config_io;
 use super::super::server::WebUiState;
+use tracing::warn;
+
 use super::config_api::{reject_if_playing, reload_hardware_after_mutation};
 use super::helpers::{
     require_configured_dir, resolve_resource_path, spawn_blocking_io, validate_resource_name,
@@ -208,6 +210,29 @@ pub(super) async fn put_profile(
     })
     .await?;
 
+    // The store's copy is what the reload re-initialises from, and writing the
+    // file did not touch it. Without this the save is acknowledged and then
+    // ignored until restart.
+    // A failure here is not cosmetic: the reload below would re-initialise from
+    // the boot-time copy and the save would be silently ignored, which is the
+    // whole defect this call exists to close. `Player::deserialize` validates
+    // the entire config, so one unrelated bad file in the directory is enough
+    // to cause it — the caller has to be told rather than left with a 200.
+    if let Some(store) = state.player.config_store() {
+        if let Err(e) = store.reload_from_disk().await {
+            warn!("Config reload after profile write failed: {}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": format!(
+                        "the profile was written but the running config could not be \
+                         reloaded, so it will not take effect until restart: {e}"
+                    )
+                })),
+            )
+                .into_response());
+        }
+    }
     reload_hardware_after_mutation(&state).await;
 
     Ok::<_, axum::response::Response>(
@@ -251,6 +276,29 @@ pub(super) async fn delete_profile_file(
     };
     spawn_blocking_io("delete profile", move || std::fs::remove_file(&target)).await?;
 
+    // The store's copy is what the reload re-initialises from, and writing the
+    // file did not touch it. Without this the save is acknowledged and then
+    // ignored until restart.
+    // A failure here is not cosmetic: the reload below would re-initialise from
+    // the boot-time copy and the save would be silently ignored, which is the
+    // whole defect this call exists to close. `Player::deserialize` validates
+    // the entire config, so one unrelated bad file in the directory is enough
+    // to cause it — the caller has to be told rather than left with a 200.
+    if let Some(store) = state.player.config_store() {
+        if let Err(e) = store.reload_from_disk().await {
+            warn!("Config reload after profile write failed: {}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": format!(
+                        "the profile was deleted but the running config could not be \
+                         reloaded, so it will not take effect until restart: {e}"
+                    )
+                })),
+            )
+                .into_response());
+        }
+    }
     reload_hardware_after_mutation(&state).await;
 
     Ok::<_, axum::response::Response>(
@@ -433,6 +481,69 @@ mod test {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert!(profiles_dir.join("new-host.yaml").exists());
+    }
+
+    /// Saving a profile file must reach the config the player reloads from.
+    ///
+    /// `Player::deserialize` copies `profiles_dir` files into the in-memory
+    /// config at startup, and `reload_hardware` re-initialises from that copy.
+    /// Writing the file alone left the save acknowledged with a 200, followed
+    /// by a hardware reload that rebuilt everything from the profile as it was
+    /// at boot — so a trigger disabled through the editor stayed live until the
+    /// process restarted, which is what #380 was reported as.
+    #[tokio::test]
+    async fn put_profile_updates_the_config_the_reload_reads() {
+        let (mut state, dir) = test_state_with_store();
+        let profiles_dir = dir.path().join("profiles");
+        std::fs::create_dir(&profiles_dir).unwrap();
+        std::fs::write(
+            profiles_dir.join("rig.yaml"),
+            "hostname: rig\naudio:\n  device: dev-x\n  track_mappings:\n    drums: [1]\n",
+        )
+        .unwrap();
+        std::fs::write(&state.config_path, "songs: songs\nprofiles_dir: profiles\n").unwrap();
+        state.profiles_dir = Some(profiles_dir.clone());
+
+        // Reload so the store starts from what is on disk, the way startup does.
+        let store = state.player.config_store().expect("store");
+        store.reload_from_disk().await.expect("initial load");
+        let loaded = store.read_config().await;
+        assert_eq!(
+            loaded.profile_list().unwrap_or_default().len(),
+            1,
+            "the profile file should be in the store to begin with"
+        );
+        drop(loaded);
+
+        let app = router().with_state(state.clone());
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .method("PUT")
+                    .uri("/profiles/rig")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"hostname": "rig", "audio": {"device": "dev-changed", "track_mappings": {"drums": [1]}}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // The store — not just the file — must reflect the edit, because that
+        // is what the hardware reload reads.
+        let after = store.read_config().await;
+        let profiles = after.profile_list().unwrap_or_default();
+        let device = profiles
+            .first()
+            .and_then(|p| p.audio_config())
+            .map(|ac| ac.audio().device().to_string());
+        assert_eq!(
+            device.as_deref(),
+            Some("dev-changed"),
+            "the reload would re-initialise from the pre-save profile"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #380 — reported from a live rig, with nothing playing: clearing the
Trigger checkbox did not disable the triggers, and only a restart cleared it.

Chasing it against real hardware turned up **four** defects, not the one the
issue diagnosed. Each produces that symptom, or one like it, on its own.

## 1. A saved profile file never reached the config the reload reads

`Player::deserialize` copies `profiles_dir` files into the in-memory config at
startup, and `reload_hardware` re-initialises from that copy. `PUT
/api/profiles/{name}` — what the config editor uses — wrote the YAML, returned
200, and reloaded from the profile *as it was at boot*. So the checkbox wrote a
trigger-less profile and the reload rebuilt the trigger engine anyway: live,
holding the input device, with the file on disk saying it should not exist.

Deterministic, needs no race, and consistent with every condition the issue
ruled out. **This is almost certainly what was reported.** The store now
re-reads from disk after a profile file is written or deleted, and a failure is
reported rather than leaving a 200 over a save that will not apply.

## 2. A cancelled init round installed into the round that replaced it

The window the issue diagnosed. `install_if_current` now takes the write lock
*first* and checks cancellation while holding it — the ordering is the fix, not
the check, since re-checking before acquiring the lock leaves the same window
only narrower.

The round is also handed its cancellation token by the spawner rather than
reading the shared cell when first polled: reading it late meant a reload
landing before the task was polled left the older round holding its
*successor's* token, so both were uncancelled and both installed.
`reload_hardware` is serialized, because its config read awaits before the
cancellation.

## 3. gRPC config mutations never reloaded at all

All seven config-mutating RPCs wrote config and reloaded nothing, while every
web UI equivalent reloaded. Made safe by leaving controllers running when their
config is unchanged — otherwise the reload would tear down the gRPC transport
carrying the response.

Only a *healthy* controller start is remembered: `Controller::new` records
per-driver failures and continues, and a reload restarts controllers before any
devices are installed, so the MIDI driver errors. Recording the fingerprint
there would make the init round's own call skip the restart that heals it.
Song-change notifiers are cleared where their owning controllers are torn down
rather than on every reset, so a Morningstar pedalboard does not silently stop
receiving song changes.

## 4. Controller updates reached a field nothing reads

`update_controllers` wrote the top-level `controllers`, which `normalize`
discards whenever profiles exist. Now routed through `update_subsystem`.

## Coverage

Two hardware checks in an opt-in `triggers` area (about a minute against seconds
for everything else, so a default run skips them **with a printed reason** —
`--self-test` still covers them, since exempting the slow rarely-run checks from
the run that proves checks can fail puts the hole where nobody looks).

Both verified against builds without these fixes. `disabling_triggers_by_file_
takes_effect` asserts on the **running config**, not on whether an engine is
live: the outgoing engine is still releasing the input device while the new
round tries to open it, so engine-liveness cannot distinguish a disabled trigger
from one that failed to come back — an earlier version of this check passed
against the defect for exactly that reason.

## Review history

Two `/code-review high` passes, both of which found things worth having:

- The first found my hardware checks were PUTting a wrapper object, which
  deserialized to an *empty* profile — so they were blanking the rig rather than
  removing the trigger, and my A/B evidence was accidental. It also found the
  lazy token capture above.
- The second found that my fixes for the first had introduced two regressions:
  a permanently dead controller after any web UI save, and song-change notifiers
  lost for the life of the process.

## Verified

- Rig: 38 passed, 2 correctly skipped as opt-in; `--only triggers` 2/2;
  `controllers_restart_while_idle`, `midi_beat_clock_persists` and
  `beat_clock_runs_at_the_song_tempo` all pass, which is what the controller
  lifecycle changes could have broken.
- The one rig failure is #378, a pre-existing ~50% flake that reproduces on
  unmodified `main`, identified by its documented 2.3s-fail / 4.6s-pass
  signature.
- Local: 3327 tests, clippy and fmt clean.

Supersedes #403 — please close it, it contains one of these four fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6iBcCCaFYmoE8XsQAEd6g