### PR TITLE
Drain the MIDI port before capturing (#378)

### DIFF
--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -233,6 +233,22 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
     let capture = MidiCapture::open(&listen)?;
     capture.clear();
 
+    // Anything arriving here is not ours: nothing has been asked to play yet.
+    // The recorded explanation for this check's ~50% failure is contention from
+    // another player, and that is testable rather than assumable — traffic on
+    // the wire before `play` is someone else's.
+    tokio::time::sleep(Duration::from_millis(2500)).await;
+    let before_play = capture.note_ons();
+    crate::outcome::record(format!(
+        "DIAGNOSTIC before play: {} note-on(s) {:?}",
+        before_play.len(),
+        before_play
+            .iter()
+            .filter_map(|n| n.note())
+            .collect::<Vec<_>>()
+    ));
+    capture.clear();
+
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
 

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -64,13 +64,14 @@ fn quiet_window() -> Duration {
 /// driver queue — so a previous check's clock or notes arrive afterwards and are
 /// counted as this one's (#378).
 ///
-/// A port that never settles is reported as **inconclusive, not failed**. It is
-/// an environmental condition — another harness run on the same rig is a
-/// documented recurring one — and `fail!` would mint an assertion-class defect
-/// from a helper: `--self-test` reads that flag and would print
-/// "assertion fired" for all six of these checks on a busy rig, crediting them
-/// as proven capable of failing when their sabotage was never evaluated. That is
-/// the false proof the flag exists to prevent.
+/// A port that never settles fails the run, but as a *before-assertion* defect.
+/// The class matters twice over. `fail!` would mint an assertion-class defect
+/// from a helper, and `--self-test` reads that flag: on a busy rig it would
+/// print "assertion fired" for all six of these checks, crediting them as
+/// proven capable of failing when their sabotage was never evaluated — the false
+/// proof the flag exists to prevent. `inconclusive!` errs the other way, since
+/// `Outcome::is_bad` counts only Failed and HarnessError, so the run would exit
+/// zero and report no defect while six checks tested nothing.
 ///
 /// The message names both possible causes. mtrack transmitting before anything
 /// was asked to play is itself a defect, and blaming the environment for it
@@ -80,30 +81,51 @@ fn quiet_window() -> Duration {
 async fn settle_port(capture: &MidiCapture) -> Result<(), crate::outcome::CheckError> {
     let outcome = capture.drain(quiet_window(), SETTLE_DEADLINE).await;
 
-    let notes = outcome
+    // Note-*ons* specifically: `note()` also matches note-offs, and a player
+    // being torn down emits a trailing note-off burst. Counting those as
+    // "another player is on the port" would steer an operator at traffic that
+    // contains no note-on at all.
+    let note_ons = outcome.discarded.iter().filter(|m| m.is_note_on()).count();
+    let note_offs = outcome
         .discarded
         .iter()
-        .filter(|m| m.note().is_some())
+        .filter(|m| m.note().is_some() && !m.is_note_on())
         .count();
     let pulses = outcome
         .discarded
         .iter()
         .filter(|m| m.status() == Some(midi::TIMING_CLOCK))
         .count();
-    let other = outcome.discarded.len() - notes - pulses;
-    let breakdown = format!("{notes} note(s), {pulses} clock pulse(s), {other} other");
+    let other = outcome.discarded.len() - note_ons - note_offs - pulses;
+    let breakdown = format!(
+        "{note_ons} note-on(s), {note_offs} note-off(s), {pulses} clock pulse(s), {other} other"
+    );
 
     if !outcome.went_quiet {
-        inconclusive!(
+        // `before_assertion`, not `inconclusive!`: `Outcome::is_bad` counts only
+        // Failed and HarnessError, so an inconclusive result exits 0 and
+        // `run_repeated` reports "no check reported an mtrack defect". One of the
+        // two causes named below *is* a defect — a build transmitting before
+        // anything was asked to play — and it would have produced a green run
+        // with six checks silently testing nothing. This class fails the run
+        // while still telling `--self-test` the truth: it proves nothing as a
+        // negative control, because the check's own assertion never ran.
+        return Err(crate::outcome::CheckError::before_assertion(format!(
             "the MIDI port never went quiet across {}s: {} kept arriving before this check \
              asked for anything, so nothing it captured would be attributable to it. Either \
              something else is using the rig — only one harness run at a time — or this build \
              is transmitting when nothing has been asked to play, which is itself a defect.",
             SETTLE_DEADLINE.as_secs(),
             breakdown
-        );
+        )));
     }
-    if !outcome.discarded.is_empty() {
+    // Recorded either way. A quiet window proves nothing about the rig, only
+    // about that window — a concurrent run sitting in its own inter-song pause
+    // is silent for longer than this — so "the port looked idle" is itself the
+    // evidence a reader needs when a recurrence has to be explained.
+    if outcome.discarded.is_empty() {
+        crate::outcome::record("the MIDI port was already idle before play was requested");
+    } else {
         crate::outcome::record(format!(
             "caveat: {breakdown} were on the port before play was requested, and were discarded"
         ));

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -34,41 +34,79 @@ use crate::{check, check_eq, inconclusive, skip};
 /// derived from a default rather than from the file is obvious.
 const TEMPO_BPM: f32 = 104.0;
 
+/// How long to keep waiting for a port that will not go quiet.
+///
+/// Long enough to outlast traffic still draining from a stopped player, short
+/// enough that a genuinely busy rig is reported rather than hung on — the runner
+/// awaits checks without a timeout, so an unbounded wait is a silent hang of the
+/// whole suite.
+const SETTLE_DEADLINE: Duration = Duration::from_secs(10);
+
 /// How long the port must stay silent before a capture is considered clean.
 ///
 /// Two beats at [`TEMPO_BPM`]. The generated files hold each note for three
-/// quarters of a beat, so the longest gap inside a playing stream is most of a
-/// beat — a window shorter than that can land in a gap and call a
-/// still-arriving stream quiet, which is #378 at a lower rate.
+/// quarters of a beat, so the longest gap inside a *playing* stream is most of a
+/// beat, and the beat clock's 24 PPQN is a 24ms gap — both well inside this.
+///
+/// It does not bound the rig, only the last window: another run's structural
+/// silences are longer than this (a 2s pause between songs, 3s post-stop
+/// observation windows, server teardown and startup), so a drain can go quiet
+/// mid-way through someone else's timeline. One run at a time is the actual
+/// guarantee; this only catches traffic still in flight.
 fn quiet_window() -> Duration {
     Duration::from_secs_f32(2.0 * 60.0 / TEMPO_BPM)
 }
 
 /// Waits for the port to go quiet before a check captures its own traffic, and
-/// records what it found.
+/// reports what it found.
 ///
-/// Every check here clears the buffer and then acts, which does not empty the
+/// Every check here cleared the buffer and then acted, which does not empty the
 /// driver queue — so a previous check's clock or notes arrive afterwards and are
-/// counted as this one's. Recorded rather than silent, and deliberately worded
-/// as "before play was requested": the server is already running by this point,
-/// so messages seen here are not provably a *previous* player's, and calling
-/// them stale would hide a build that transmits when it should not.
+/// counted as this one's (#378).
+///
+/// A port that never settles is reported as **inconclusive, not failed**. It is
+/// an environmental condition — another harness run on the same rig is a
+/// documented recurring one — and `fail!` would mint an assertion-class defect
+/// from a helper: `--self-test` reads that flag and would print
+/// "assertion fired" for all six of these checks on a busy rig, crediting them
+/// as proven capable of failing when their sabotage was never evaluated. That is
+/// the false proof the flag exists to prevent.
+///
+/// The message names both possible causes. mtrack transmitting before anything
+/// was asked to play is itself a defect, and blaming the environment for it
+/// would hide exactly the build `beat_clock_is_silent_when_disabled` exists to
+/// catch — so the breakdown by message type is reported, since note-ons mean
+/// another player and clock pulses mean a clock that should not be running.
 async fn settle_port(capture: &MidiCapture) -> Result<(), crate::outcome::CheckError> {
-    let outcome = capture.drain(quiet_window(), Duration::from_secs(10)).await;
+    let outcome = capture.drain(quiet_window(), SETTLE_DEADLINE).await;
+
+    let notes = outcome
+        .discarded
+        .iter()
+        .filter(|m| m.note().is_some())
+        .count();
+    let pulses = outcome
+        .discarded
+        .iter()
+        .filter(|m| m.status() == Some(midi::TIMING_CLOCK))
+        .count();
+    let other = outcome.discarded.len() - notes - pulses;
+    let breakdown = format!("{notes} note(s), {pulses} clock pulse(s), {other} other");
+
+    if !outcome.went_quiet {
+        inconclusive!(
+            "the MIDI port never went quiet across {}s: {} kept arriving before this check \
+             asked for anything, so nothing it captured would be attributable to it. Either \
+             something else is using the rig — only one harness run at a time — or this build \
+             is transmitting when nothing has been asked to play, which is itself a defect.",
+            SETTLE_DEADLINE.as_secs(),
+            breakdown
+        );
+    }
     if !outcome.discarded.is_empty() {
         crate::outcome::record(format!(
-            "caveat: {} message(s) were on the port before play was requested, and were \
-             discarded",
-            outcome.discarded.len()
+            "caveat: {breakdown} were on the port before play was requested, and were discarded"
         ));
-    }
-    if !outcome.went_quiet {
-        crate::fail!(
-            "the MIDI port never went quiet: {} message(s) kept arriving before this check \
-             asked for anything, so nothing captured here would be attributable to it. \
-             Another player or harness run is probably using the rig.",
-            outcome.discarded.len()
-        );
     }
     Ok(())
 }

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -34,6 +34,45 @@ use crate::{check, check_eq, inconclusive, skip};
 /// derived from a default rather than from the file is obvious.
 const TEMPO_BPM: f32 = 104.0;
 
+/// How long the port must stay silent before a capture is considered clean.
+///
+/// Two beats at [`TEMPO_BPM`]. The generated files hold each note for three
+/// quarters of a beat, so the longest gap inside a playing stream is most of a
+/// beat — a window shorter than that can land in a gap and call a
+/// still-arriving stream quiet, which is #378 at a lower rate.
+fn quiet_window() -> Duration {
+    Duration::from_secs_f32(2.0 * 60.0 / TEMPO_BPM)
+}
+
+/// Waits for the port to go quiet before a check captures its own traffic, and
+/// records what it found.
+///
+/// Every check here clears the buffer and then acts, which does not empty the
+/// driver queue — so a previous check's clock or notes arrive afterwards and are
+/// counted as this one's. Recorded rather than silent, and deliberately worded
+/// as "before play was requested": the server is already running by this point,
+/// so messages seen here are not provably a *previous* player's, and calling
+/// them stale would hide a build that transmits when it should not.
+async fn settle_port(capture: &MidiCapture) -> Result<(), crate::outcome::CheckError> {
+    let outcome = capture.drain(quiet_window(), Duration::from_secs(10)).await;
+    if !outcome.discarded.is_empty() {
+        crate::outcome::record(format!(
+            "caveat: {} message(s) were on the port before play was requested, and were \
+             discarded",
+            outcome.discarded.len()
+        ));
+    }
+    if !outcome.went_quiet {
+        crate::fail!(
+            "the MIDI port never went quiet: {} message(s) kept arriving before this check \
+             asked for anything, so nothing captured here would be attributable to it. \
+             Another player or harness run is probably using the rig.",
+            outcome.discarded.len()
+        );
+    }
+    Ok(())
+}
+
 /// Tempo of the second song in the between-songs checks. Distinct from
 /// [`TEMPO_BPM`] by enough that a clock still running at the first song's tempo
 /// is unmistakable, and equally un-round.
@@ -231,21 +270,10 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let capture = MidiCapture::open(&listen)?;
-    capture.clear();
-
-    // Wait for the port to go quiet before capturing anything of ours.
-    //
-    // `clear` empties the harness buffer, not the driver queue, so a previous
-    // player's notes arrive after it and count as ours — which is what made
-    // this check fail about half the time (#378), and why it failed *faster*
-    // than it passed: the stale notes satisfied the expected count early.
-    let stale = capture.drain(Duration::from_millis(400)).await;
-    if !stale.is_empty() {
-        crate::outcome::record(format!(
-            "caveat: drained {} stale message(s) from the port before capturing",
-            stale.len()
-        ));
-    }
+    // `clear` alone does not empty the driver queue, so a previous check's
+    // traffic would be counted as this check's. `settle_port` subsumes it, and
+    // clearing first would discard the evidence it exists to report.
+    settle_port(&capture).await?;
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
@@ -267,11 +295,11 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
     // the other, and these numbers say which.
     let timeline: Vec<String> = notes
         .iter()
-        .scan(None::<u64>, |prev, n| {
-            let delta = prev.map(|p| n.micros.saturating_sub(p));
-            *prev = Some(n.micros);
+        .scan(None::<std::time::Instant>, |prev, n| {
+            let delta = prev.map(|p| n.at.saturating_duration_since(p));
+            *prev = Some(n.at);
             Some(match (n.note(), delta) {
-                (Some(note), Some(d)) => format!("{note}(+{}ms)", d / 1000),
+                (Some(note), Some(d)) => format!("{note}(+{}ms)", d.as_millis()),
                 (Some(note), None) => format!("{note}(first)"),
                 _ => "?".to_string(),
             })
@@ -323,7 +351,7 @@ pub async fn beat_clock_runs_at_the_song_tempo() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let capture = MidiCapture::open(&listen)?;
-    capture.clear();
+    settle_port(&capture).await?;
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
@@ -393,7 +421,7 @@ pub async fn beat_clock_is_silent_when_disabled() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let capture = MidiCapture::open(&listen)?;
-    capture.clear();
+    settle_port(&capture).await?;
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
@@ -452,7 +480,7 @@ pub async fn beat_clock_holds_tempo_after_a_song_stops() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let capture = MidiCapture::open(&listen)?;
-    capture.clear();
+    settle_port(&capture).await?;
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
@@ -542,7 +570,7 @@ pub async fn beat_clock_is_silent_after_stop_without_persist() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let capture = MidiCapture::open(&listen)?;
-    capture.clear();
+    settle_port(&capture).await?;
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
@@ -602,7 +630,7 @@ pub async fn beat_clock_bridges_the_gap_between_songs() -> CheckOutcome {
     let mut client = Client::connect(&server).await?;
 
     let capture = MidiCapture::open(&listen)?;
-    capture.clear();
+    settle_port(&capture).await?;
 
     // Song one.
     client.grpc().play(PlayRequest {}).await?;

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -233,21 +233,19 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
     let capture = MidiCapture::open(&listen)?;
     capture.clear();
 
-    // Anything arriving here is not ours: nothing has been asked to play yet.
-    // The recorded explanation for this check's ~50% failure is contention from
-    // another player, and that is testable rather than assumable — traffic on
-    // the wire before `play` is someone else's.
-    tokio::time::sleep(Duration::from_millis(2500)).await;
-    let before_play = capture.note_ons();
-    crate::outcome::record(format!(
-        "DIAGNOSTIC before play: {} note-on(s) {:?}",
-        before_play.len(),
-        before_play
-            .iter()
-            .filter_map(|n| n.note())
-            .collect::<Vec<_>>()
-    ));
-    capture.clear();
+    // Wait for the port to go quiet before capturing anything of ours.
+    //
+    // `clear` empties the harness buffer, not the driver queue, so a previous
+    // player's notes arrive after it and count as ours — which is what made
+    // this check fail about half the time (#378), and why it failed *faster*
+    // than it passed: the stale notes satisfied the expected count early.
+    let stale = capture.drain(Duration::from_millis(400)).await;
+    if !stale.is_empty() {
+        crate::outcome::record(format!(
+            "caveat: drained {} stale message(s) from the port before capturing",
+            stale.len()
+        ));
+    }
 
     client.grpc().play(PlayRequest {}).await?;
     client.wait_until_playing(Duration::from_secs(10)).await?;
@@ -279,7 +277,7 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
             })
         })
         .collect();
-    crate::outcome::record(format!("DIAGNOSTIC timeline: {}", timeline.join(" ")));
+    crate::outcome::record(format!("note timeline: {}", timeline.join(" ")));
 
     check!(
         arrived,

--- a/harness/src/checks/midi_output.rs
+++ b/harness/src/checks/midi_output.rs
@@ -246,6 +246,25 @@ pub async fn song_midi_notes_are_transmitted() -> CheckOutcome {
     client.grpc().stop(StopRequest {}).await?;
 
     let notes = capture.note_ons();
+    // The full timeline, with inter-note spacing. Two sources sending the same
+    // file put notes at roughly half the expected spacing; one source playing
+    // twice leaves a gap and then restarts. The failure signature — the first
+    // four notes twice, in half the time a clean pass takes — has to be one or
+    // the other, and these numbers say which.
+    let timeline: Vec<String> = notes
+        .iter()
+        .scan(None::<u64>, |prev, n| {
+            let delta = prev.map(|p| n.micros.saturating_sub(p));
+            *prev = Some(n.micros);
+            Some(match (n.note(), delta) {
+                (Some(note), Some(d)) => format!("{note}(+{}ms)", d / 1000),
+                (Some(note), None) => format!("{note}(first)"),
+                _ => "?".to_string(),
+            })
+        })
+        .collect();
+    crate::outcome::record(format!("DIAGNOSTIC timeline: {}", timeline.join(" ")));
+
     check!(
         arrived,
         "expected {expected_notes} note-on messages, captured {}: {:?}\n--- log ---\n{}",

--- a/harness/src/midi.rs
+++ b/harness/src/midi.rs
@@ -152,6 +152,32 @@ impl MidiCapture {
             .clear();
     }
 
+    /// Waits for the port to go quiet, then clears.
+    ///
+    /// [`Self::clear`] empties this buffer, not the driver's queue — anything
+    /// already in flight arrives afterwards and is indistinguishable from
+    /// traffic the check itself caused. That is what made
+    /// `song_midi_notes_are_transmitted` fail about half the time (#378): a
+    /// previous player's notes landed after the clear and were counted as ours,
+    /// which is why the check failed *faster* than it passed, and why the
+    /// captured notes were the first four of the file twice.
+    ///
+    /// Returns what it discarded, so a caller can record whether there was
+    /// anything to drain rather than assuming.
+    pub async fn drain(&self, quiet_for: std::time::Duration) -> Vec<TimedMessage> {
+        let mut discarded = Vec::new();
+        loop {
+            let before = self.messages.lock().expect("poisoned").len();
+            tokio::time::sleep(quiet_for).await;
+            let mut guard = self.messages.lock().expect("poisoned");
+            if guard.len() == before {
+                discarded.extend(guard.drain(..));
+                return discarded;
+            }
+            discarded.extend(guard.drain(..));
+        }
+    }
+
     /// Timing clock pulses received.
     pub fn clock_pulses(&self) -> Vec<TimedMessage> {
         self.messages()

--- a/harness/src/midi.rs
+++ b/harness/src/midi.rs
@@ -31,6 +31,17 @@ pub const START: u8 = 0xFA;
 /// MIDI real-time status byte for stop.
 pub const STOP: u8 = 0xFC;
 
+/// What [`MidiCapture::drain`] discarded, and whether the port ever went quiet.
+///
+/// `went_quiet == false` means the drain gave up: something is still
+/// transmitting, and whatever the caller captures next is not cleanly its own.
+/// Reported rather than swallowed, so a check says so instead of quietly
+/// measuring someone else's traffic.
+pub struct DrainOutcome {
+    pub discarded: Vec<TimedMessage>,
+    pub went_quiet: bool,
+}
+
 /// One received message and when it arrived.
 #[derive(Debug, Clone)]
 pub struct TimedMessage {
@@ -152,29 +163,67 @@ impl MidiCapture {
             .clear();
     }
 
-    /// Waits for the port to go quiet, then clears.
+    /// Waits for the port to go quiet, discarding whatever arrives.
     ///
     /// [`Self::clear`] empties this buffer, not the driver's queue — anything
     /// already in flight arrives afterwards and is indistinguishable from
     /// traffic the check itself caused. That is what made
     /// `song_midi_notes_are_transmitted` fail about half the time (#378): a
     /// previous player's notes landed after the clear and were counted as ours,
-    /// which is why the check failed *faster* than it passed, and why the
-    /// captured notes were the first four of the file twice.
+    /// which is why it failed *faster* than it passed.
     ///
-    /// Returns what it discarded, so a caller can record whether there was
-    /// anything to drain rather than assuming.
-    pub async fn drain(&self, quiet_for: std::time::Duration) -> Vec<TimedMessage> {
+    /// `quiet_for` must exceed the longest gap in the stream being drained, or
+    /// the window can land inside a gap and declare a still-arriving stream
+    /// quiet. The generated files hold each note for three quarters of a beat,
+    /// so the longest gap is most of a beat — pass a couple of beats at the
+    /// tempo in play, not a round number.
+    ///
+    /// Gives up after `deadline`: a port that never goes quiet is a real
+    /// condition (a persisted beat clock, a concurrent run on the same rig),
+    /// and looping forever would hang the whole suite with no report, which is
+    /// worse than any wrong answer.
+    pub async fn drain(
+        &self,
+        quiet_for: std::time::Duration,
+        deadline: std::time::Duration,
+    ) -> DrainOutcome {
+        let give_up_at = Instant::now() + deadline;
         let mut discarded = Vec::new();
         loop {
-            let before = self.messages.lock().expect("poisoned").len();
+            discarded.extend(
+                self.messages
+                    .lock()
+                    .expect("midi capture buffer poisoned")
+                    .drain(..),
+            );
             tokio::time::sleep(quiet_for).await;
-            let mut guard = self.messages.lock().expect("poisoned");
-            if guard.len() == before {
-                discarded.extend(guard.drain(..));
-                return discarded;
+            // Empty after a full window means nothing arrived during it. A
+            // length comparison would instead count a message that landed
+            // between one iteration's drain and the next iteration's snapshot
+            // as pre-existing rather than as ongoing traffic.
+            if self
+                .messages
+                .lock()
+                .expect("midi capture buffer poisoned")
+                .is_empty()
+            {
+                return DrainOutcome {
+                    discarded,
+                    went_quiet: true,
+                };
             }
-            discarded.extend(guard.drain(..));
+            if Instant::now() >= give_up_at {
+                discarded.extend(
+                    self.messages
+                        .lock()
+                        .expect("midi capture buffer poisoned")
+                        .drain(..),
+                );
+                return DrainOutcome {
+                    discarded,
+                    went_quiet: false,
+                };
+            }
         }
     }
 

--- a/harness/src/midi.rs
+++ b/harness/src/midi.rs
@@ -187,8 +187,16 @@ impl MidiCapture {
         quiet_for: std::time::Duration,
         deadline: std::time::Duration,
     ) -> DrainOutcome {
+        // A zero window would make `sleep` a bare yield, turning a busy port into
+        // a spin that holds and releases this mutex as fast as the scheduler
+        // allows and starves the midir callback. Nothing calls it that way, but
+        // the signature does not stop it.
+        let quiet_for = quiet_for.max(std::time::Duration::from_millis(1));
         let give_up_at = Instant::now() + deadline;
         let mut discarded = Vec::new();
+        // No fast path: an empty buffer now says nothing about the next second,
+        // and the whole point is to establish that nothing is still in flight.
+        // One window is the price of the guarantee, paid once per check.
         loop {
             discarded.extend(
                 self.messages


### PR DESCRIPTION
Fixes #378. `song_midi_notes_are_transmitted` failed about half of multi-check
runs and passed alone every time.

## The recorded explanation was wrong

The issue concluded contention from a concurrent player. That never fit its own
evidence table: it fails when it runs **first in its area**, where nothing
preceded it.

`MidiCapture::clear` empties the harness-side buffer, not the ALSA driver queue.
Anything already in flight arrives *after* the clear and is counted as the
check's own traffic. That accounts for both halves of the signature:

- **the first four notes twice** — on a file that ascends 60→67 with no repeats
- **failing faster than passing** (~2.3s vs ~4.6s) — the stale notes satisfied
  the expected count of 8 before playback had produced them

So "not an mtrack defect" was right; "contention" was the wrong mechanism, and
the difference matters because this one is fixable in the check.

## A correction to how I evidenced that

My first version of this PR cited a captured timeline showing four notes
arriving `+0ms` apart. Those deltas were computed from `TimedMessage::micros`,
whose own doc says it does not advance while no events are flowing and must not
be used to measure silence — every gap here *is* a silence, so correctly spaced
notes can read as simultaneous. The evidence I highlighted was an artifact of
the trap this crate documents.

The conclusion survives on two timestamp-independent facts: the captured notes
were the file's first four twice, and eight notes arrived in 2.7s when the file
needs 4.0s to produce them. But the timeline is only trustworthy now that it
uses `at`, the monotonic harness-side clock.

## The fix

`MidiCapture::drain` waits for the port to go quiet, then reports what it
discarded and whether it ever settled.

- **The window is two beats, derived from the tempo.** 400ms — my first choice —
  is shorter than the 433ms sustain gap in the stream being drained, so it could
  land inside a note and call a still-arriving stream quiet. That is #378 at a
  lower rate, which is worse than the original because it is harder to diagnose.
- **It has a deadline.** A port that never goes quiet is a real condition (a
  persisted beat clock, a concurrent run on the same rig); looping forever would
  hang the whole suite with no report, since the runner awaits checks without a
  timeout.
- **The caveat says "before play was requested", not "stale".** The server is
  already running by then, so messages seen here are not provably a previous
  player's, and calling them stale would hide a build that transmits when it
  should not.

**Five other checks in this file had the same latent defect** and now settle the
port too. `beat_clock_is_silent_when_disabled` is the sharpest: it runs straight
after a check driving a 41.6 Hz clock and asserts no pulses at all, so a single
leftover pulse fails it while claiming mtrack transmitted a clock it was told not
to. `beat_clock_bridges_the_gap_between_songs` would turn a stale pulse into a
spurious continuity failure, and `beat_clock_runs_at_the_song_tempo` would bias
its own rate measurement.

## Verified

- **Full suite: 39 passed, 2 correctly skipped as opt-in, no failures** — the
  first clean full run; every previous one had #378 failing.
- Ten repeats of the reproducer area, all six checks passing each time.
- The assertions are untouched, so genuinely wrong or missing notes still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6iBcCCaFYmoE8XsQAEd6g