### PR TITLE
Cover the web UI changes that only had type-checking behind them

### DIFF
--- a/examples/lighting/shows/comprehensive_show.light
+++ b/examples/lighting/shows/comprehensive_show.light
@@ -9,7 +9,7 @@ show "Comprehensive Light Show" {
     
     @00:10.000
     # Strobe effect (no color - applies to existing fixtures) with crossfades
-    strobe_lights: strobe, frequency: 8, intensity: 0.8, up_time: 0.5s, down_time: 0.5s, hold_time: 4s, duration: 5s
+    strobe_lights: strobe, frequency: 8, up_time: 0.5s, down_time: 0.5s, hold_time: 4s, duration: 5s
     
     @00:15.000
     # Chase effect (no color - applies to existing fixtures) with crossfades
@@ -21,7 +21,7 @@ show "Comprehensive Light Show" {
     
     @00:25.000
     # Rainbow effect (generates its own colors) with crossfades
-    rainbow_effect: rainbow, speed: 2.0, direction: "forward", up_time: 2s, down_time: 2s, hold_time: 6s, duration: 10s
+    rainbow_effect: rainbow, speed: 2.0, up_time: 2s, down_time: 2s, hold_time: 6s, duration: 10s
     
     @00:30.000
     # Pulse effect (no color - applies to existing fixtures) with crossfades
@@ -37,7 +37,7 @@ show "Comprehensive Light Show" {
     
     @00:45.000
     # Strobe variation (no color - applies to existing fixtures) with crossfades
-    strobe_variation: strobe, frequency: 12, intensity: 0.9, up_time: 0.5s, down_time: 0.5s, hold_time: 4s, duration: 5s
+    strobe_variation: strobe, frequency: 12, up_time: 0.5s, down_time: 0.5s, hold_time: 4s, duration: 5s
     
     @00:50.000
     # Fade out (fades to 0% over 5s, persists)

--- a/examples/lighting/shows/layer_control_demo.light
+++ b/examples/lighting/shows/layer_control_demo.light
@@ -15,7 +15,7 @@ show "Layer Control Demo" {
     @00:00.000
         front_wash: static color: "#0066ff", dimmer: 100%, layer: background, duration: 5s
         back_wash: rainbow speed: 0.5, layer: midground, duration: 10s
-        accent: pulse frequency: 2, dimmer: 80%, layer: foreground, duration: 5s
+        accent: pulse frequency: 2, layer: foreground, duration: 5s
 
     // Dim the background to 50%
     @00:05.000

--- a/examples/lighting/shows/measure_timing_demo.light
+++ b/examples/lighting/shows/measure_timing_demo.light
@@ -34,16 +34,16 @@ show "Measure Timing Demo" {
     
     # On each beat of measure 2
     @2/1
-    front_wash: pulse color: "blue", duration: 500ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 500ms, layer: foreground, blend_mode: multiply
     
     @2/2
-    front_wash: pulse color: "blue", duration: 500ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 500ms, layer: foreground, blend_mode: multiply
     
     @2/3
-    front_wash: pulse color: "blue", duration: 500ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 500ms, layer: foreground, blend_mode: multiply
     
     @2/4
-    front_wash: pulse color: "blue", duration: 500ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 500ms, layer: foreground, blend_mode: multiply
     
     # Subdivision example - halfway through beat 3
     @3/2.5
@@ -55,16 +55,16 @@ show "Measure Timing Demo" {
     back_lights: static color: "yellow", dimmer: 75%, layer: midground, blend_mode: add, duration: 5s
     
     @10/1
-    front_wash: cycle color: "green", color: "cyan", duration: 2s, loop: loop, layer: background
+    front_wash: cycle color: "green", color: "cyan", duration: 2s, layer: background
     
     # Example: Red-green-blue pattern repeating every measure using measure-based speed
     # With 3 colors and speed: 1measure, each color will last 1/3 of a measure
     @12/1
-    front_wash: cycle color: "red", color: "green", color: "blue", speed: 1measure, loop: loop, layer: background, duration: 10s
+    front_wash: cycle color: "red", color: "green", color: "blue", speed: 1measure, layer: background, duration: 10s
     
     # Example: Pattern repeating every 2 beats (faster)
     @14/1
-    back_lights: cycle color: "yellow", color: "orange", speed: 2beats, loop: loop, layer: midground, duration: 10s
+    back_lights: cycle color: "yellow", color: "orange", speed: 2beats, layer: midground, duration: 10s
     
     # Example: Strobe flashing once per beat using measure-based frequency
     @15/1
@@ -75,11 +75,11 @@ show "Measure Timing Demo" {
     front_wash: static color: "purple", dimmer: 100%, layer: background, blend_mode: replace, duration: 5s
     
     @18/1
-    front_wash: chase color: "purple", color: "magenta", color: "blue", duration: 1s, direction: left_to_right, loop: loop
+    front_wash: chase duration: 1s, direction: left_to_right
     
     # Section 4 - gradual tempo increase to 180 BPM (over 2 measures starting at measure 24)
     @24/1
-    front_wash, back_lights: strobe color: "white", frequency: 5, duty_cycle: 50%, layer: foreground, blend_mode: add, duration: 5s
+    front_wash, back_lights: strobe frequency: 5, layer: foreground, blend_mode: add, duration: 5s
     
     @28/1
     front_wash, back_lights: static color: "white", dimmer: 0%, layer: foreground, blend_mode: replace, duration: 5s
@@ -90,13 +90,13 @@ show "Measure Timing Demo" {
     
     # In 3/4 time - only 3 beats per measure
     @33/1
-    front_wash: pulse color: "orange", duration: 400ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 400ms, layer: foreground, blend_mode: multiply
     
     @33/2
-    front_wash: pulse color: "orange", duration: 400ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 400ms, layer: foreground, blend_mode: multiply
     
     @33/3
-    front_wash: pulse color: "orange", duration: 400ms, layer: foreground, blend_mode: multiply
+    front_wash: pulse duration: 400ms, layer: foreground, blend_mode: multiply
     
     # Section 6 - gradual slowdown to 100 BPM (over 4 measures starting at measure 40)
     @40/1
@@ -108,7 +108,7 @@ show "Measure Timing Demo" {
     front_wash, back_lights: static color: "white", dimmer: 100%, layer: background, blend_mode: replace, duration: 5s
     
     @50/1
-    front_wash, back_lights: rainbow duration: 3s, loop: loop, layer: background
+    front_wash, back_lights: rainbow duration: 3s, layer: background
     
     # End - measure 56
     @56/1

--- a/examples/lighting/shows/sequence_example.light
+++ b/examples/lighting/shows/sequence_example.light
@@ -18,13 +18,13 @@ sequence "color_chase" {
 // Define another sequence for a strobe pattern
 sequence "strobe_pattern" {
     @0.000
-    strobe_lights: strobe, frequency: 8, intensity: 0.9, up_time: 0.1s, hold_time: 0.5s, duration: 5s
+    strobe_lights: strobe, frequency: 8, up_time: 0.1s, hold_time: 0.5s, duration: 5s
     
     @1.000
-    strobe_lights: strobe, frequency: 12, intensity: 0.9, up_time: 0.1s, hold_time: 0.5s, duration: 5s
+    strobe_lights: strobe, frequency: 12, up_time: 0.1s, hold_time: 0.5s, duration: 5s
     
     @2.000
-    strobe_lights: strobe, frequency: 16, intensity: 0.9, up_time: 0.1s, hold_time: 0.5s, duration: 5s
+    strobe_lights: strobe, frequency: 16, up_time: 0.1s, hold_time: 0.5s, duration: 5s
 }
 
 show "Sequence Example Show" {

--- a/examples/songs/dsl-light-show-song/lighting/main_show.light
+++ b/examples/songs/dsl-light-show-song/lighting/main_show.light
@@ -5,11 +5,11 @@ show "Main Show" {
     
     # Add back wash with fade
     @00:04.000
-    back_wash: static color: "orange", duration: 5s, dimmer: 50%, fade: 500ms
+    back_wash: static color: "orange", duration: 5s, dimmer: 50%
     
     # Color cycle effect (keeps color info)
     @00:16.000
-    front_wash, back_wash: cycle color: "red", color: "green", color: "blue", duration: 3s, direction: forward, dimmer: 50%
+    front_wash, back_wash: cycle color: "red", color: "green", color: "blue", duration: 3s, direction: forward
     
     # Moving head chase (no color - applies to existing fixtures)
     @00:30.000
@@ -17,7 +17,7 @@ show "Main Show" {
     
     # Strobe effect (no color - applies to existing fixtures)
     @01:00.000
-    strobe: strobe frequency: 8, intensity: 0.8, duration: 2s
+    strobe: strobe frequency: 8, duration: 2s
     
     # Fade to black (no color - applies to existing fixtures)
     @01:05.000

--- a/examples/songs/dsl-light-show-song/lighting/outro.light
+++ b/examples/songs/dsl-light-show-song/lighting/outro.light
@@ -1,13 +1,13 @@
 show "Outro Show" {
     # Gentle fade in
     @00:00.000
-    all_fixtures: static color: "#333366", duration: 5s, dimmer: 20%, fade: 2s
+    all_fixtures: static color: "#333366", duration: 5s, dimmer: 20%
     
     # Slow color cycle (keeps color info)
     @00:10.000
-    front_wash: cycle color: "#444488", color: "#6666AA", duration: 10s, dimmer: 30%
+    front_wash: cycle color: "#444488", color: "#6666AA", duration: 10s
     
     # Pulse effect (no color - applies to existing fixtures)
     @00:20.000
-    back_wash: pulse frequency: 0.5, intensity: 0.3, duty: 50%, duration: 5s
+    back_wash: pulse frequency: 0.5, intensity: 0.3, duration: 5s
 }

--- a/src/config/lighting.rs
+++ b/src/config/lighting.rs
@@ -314,3 +314,40 @@ mod tests {
         assert!(lighting.directories().is_none());
     }
 }
+
+#[cfg(test)]
+mod migration_advice_tests {
+    /// Parses a `Lighting` block the way the loader does, via the `config`
+    /// crate rather than a serde_yaml dependency this crate does not carry.
+    fn parse(yaml: &str) -> Result<super::Lighting, config::ConfigError> {
+        config::Config::builder()
+            .add_source(config::File::from_str(yaml, config::FileFormat::Yaml))
+            .build()?
+            .try_deserialize()
+    }
+
+    /// The shape the venue-group migration message tells people to write must
+    /// actually load.
+    ///
+    /// `groups` is a map keyed by name, and the advice printed a sequence — so
+    /// following it produced a config that fails to deserialize, which is worse
+    /// than the error it was replacing.
+    #[test]
+    fn the_migration_advice_shape_deserializes() {
+        let yaml =
+            "groups:\n  wash:\n    name: wash\n    constraints:\n      - AllOf: [\"wash\"]\n";
+        let lighting: super::Lighting = parse(yaml).expect("the documented shape must load");
+        assert!(lighting.groups().contains_key("wash"));
+        assert_eq!(lighting.groups()["wash"].name(), "wash");
+    }
+
+    #[test]
+    fn a_sequence_of_groups_does_not_load() {
+        // Guards the advice against drifting back to a list.
+        let yaml = "groups:\n  - name: wash\n    constraints:\n      - AllOf: [\"wash\"]\n";
+        assert!(
+            parse(yaml).is_err(),
+            "a sequence must not silently load, or the advice cannot be checked"
+        );
+    }
+}

--- a/src/config/lighting.rs
+++ b/src/config/lighting.rs
@@ -334,9 +334,18 @@ mod migration_advice_tests {
     /// than the error it was replacing.
     #[test]
     fn the_migration_advice_shape_deserializes() {
-        let yaml =
-            "groups:\n  wash:\n    name: wash\n    constraints:\n      - AllOf: [\"wash\"]\n";
-        let lighting: super::Lighting = parse(yaml).expect("the documented shape must load");
+        // The advice itself, not a copy of it. Parsing a hand-written string
+        // here left the real message free to say anything: reverting it to a
+        // sequence kept this test green, which is the failure it exists to
+        // prevent.
+        let advice = crate::lighting::parser::fixture_venue::migration_yaml("wash");
+        let dedented: String = advice
+            .lines()
+            .map(|line| line.strip_prefix("    ").unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let lighting: super::Lighting =
+            parse(&dedented).expect("the shape the migration message prints must load");
         assert!(lighting.groups().contains_key("wash"));
         assert_eq!(lighting.groups()["wash"].name(), "wash");
     }

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -51,10 +51,17 @@ Every effect must specify a finite `duration`. Effects can crossfade — set
   between number and unit** — write `500ms`, `2s`, `4beats`, `2measures` (not
   `4 beats`). `speed` and `frequency` parameters accept the same forms
   (`speed: 1measure`, `frequency: 1beat`).
-- `color`: a named color (`"red"`, `"blue"`, `"white"`, `"orange"`, …), a hex
-  string (`#FF8800` or `"#FF8800"`), or `rgb(255, 128, 0)`.
-- `intensity`, `dimmer`, `red`, `green`, `blue`: floats `0.0`–`1.0`, or a
-  percentage like `60%`.
+- `color` (**`static` and `cycle` only**): a named color (`"red"`, `"blue"`,
+  `"white"`, `"orange"`, …), a hex string (`#FF8800` or `"#FF8800"`), or
+  `rgb(255, 128, 0)`. The other effect types have no color of their own — a
+  `chase` or `strobe` gates whatever is beneath it, so put the color on the bed.
+- `dimmer`, `red`, `green`, `blue` (**`static` only**), and `intensity`
+  (**`static` and `pulse` only**): floats `0.0`–`1.0`, or a percentage like
+  `60%`.
+
+These are listed per effect deliberately. A parameter an effect does not read is
+accepted by the parser and dropped, so writing one produces a setting that never
+takes effect — `validate_lighting` reports it as an `unused-parameter` warning.
 - `direction`: the accepted values depend on the effect — they are two
   separate sets, not one list.
   - `cycle`: `forward | backward | pingpong` (the order colours are stepped).

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -35,7 +35,7 @@ show "Optional Name" {
 |-----------|--------------------------------------------------------|-------|
 | `static`  | `duration`                                             | Hold a color/intensity. Use `color`, and `intensity` or `dimmer` for the level. |
 | `cycle`   | one or more `color:`, `duration`                       | Iterates colors. Optional `speed`, `direction`. |
-| `strobe`  | `frequency`, `duration`                                | Hz strobe. Optional `intensity`. |
+| `strobe`  | `frequency`, `duration`                                | Hz strobe. Takes no color or intensity — it gates whatever is beneath it. |
 | `pulse`   | `frequency`, `duration`                                | Sinusoidal pulse. Optional `base_level` (default 50%) and `pulse_amplitude` (also spelled `intensity`). |
 | `chase`   | `speed`, `duration`                                    | A moving brightness mask over the layers beneath — needs a color bed under it. Optional `direction`, `pattern: linear|snake|random`. |
 | `dimmer`  | `start_level`, `end_level`, `duration`                 | Linear ramp; `curve: linear` optional. |
@@ -46,7 +46,7 @@ Every effect must specify a finite `duration`. Effects can crossfade — set
 
 ### Common parameters
 
-- `duration`, `up_time`, `down_time`, `hold_time`, `fade`: time values. Units
+- `duration`, `up_time`, `down_time`, `hold_time`: time values. Units
   are `ms`, `s`, `beats`, `beat`, `measures`, or `measure`. **No whitespace
   between number and unit** — write `500ms`, `2s`, `4beats`, `2measures` (not
   `4 beats`). `speed` and `frequency` parameters accept the same forms

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -2446,6 +2446,7 @@ mod test {
             use crate::lighting::parser::{Cue, Effect};
             let effect = Effect {
                 sequence_name: None,
+                ignored_parameters: Vec::new(),
                 groups: vec!["front_wash".to_string()],
                 effect_type: crate::lighting::effects::EffectType::Static {
                     parameters: {
@@ -2540,6 +2541,7 @@ mod test {
                 time: std::time::Duration::from_secs(1),
                 effects: vec![Effect {
                     sequence_name: None,
+                    ignored_parameters: Vec::new(),
                     groups: vec!["test_fixture".to_string()],
                     effect_type: crate::lighting::effects::EffectType::Static {
                         parameters: {
@@ -2629,6 +2631,7 @@ mod test {
                 time: std::time::Duration::ZERO,
                 effects: vec![Effect {
                     sequence_name: None,
+                    ignored_parameters: Vec::new(),
                     groups: vec!["test_fixture".to_string()],
                     effect_type: crate::lighting::effects::EffectType::Static {
                         parameters: {

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -945,10 +945,20 @@ show "T" {
             let Ok(source) = std::fs::read_to_string(&path) else {
                 continue;
             };
-            // Fixture-type and venue files live alongside the shows and are not
-            // shows; they simply do not parse as one.
-            let Ok(parsed) = crate::lighting::parser::parse_light_shows(&source) else {
-                continue;
+            // Fixture-type and venue files live alongside the shows and are
+            // not shows, so a parse failure is expected for them — but a show
+            // that stops parsing must not drop silently out of this check.
+            let is_show = source.contains("show \"");
+            let parsed = match crate::lighting::parser::parse_light_shows(&source) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    assert!(
+                        !is_show,
+                        "{} declares a show but does not parse: {e}",
+                        path.display()
+                    );
+                    continue;
+                }
             };
             let shows: Vec<_> = parsed.into_values().collect();
             for warning in lint_shows(&shows, &LintContext::default()) {

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -26,7 +26,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 
 use crate::audio::click_analysis::BeatGrid;
-use crate::lighting::effects::{BlendMode, EffectLayer};
+use crate::lighting::effects::{BlendMode, EffectLayer, EffectType};
 use crate::lighting::parser::LayerCommandType;
 use crate::lighting::parser::LightShow;
 
@@ -80,6 +80,19 @@ pub fn lint_shows(shows: &[LightShow], ctx: &LintContext) -> Vec<Warning> {
     warnings
 }
 
+/// The keyword an author writes for an effect type.
+fn dsl_keyword(effect_type: &EffectType) -> &'static str {
+    match effect_type {
+        EffectType::Static { .. } => "static",
+        EffectType::ColorCycle { .. } => "cycle",
+        EffectType::Strobe { .. } => "strobe",
+        EffectType::Pulse { .. } => "pulse",
+        EffectType::Chase { .. } => "chase",
+        EffectType::Dimmer { .. } => "dimmer",
+        EffectType::Rainbow { .. } => "rainbow",
+    }
+}
+
 /// A parameter the effect type does not use.
 ///
 /// The DSL accepts any parameter and each effect type takes what it recognises,
@@ -92,10 +105,16 @@ fn parameters_the_effect_ignores(shows: &[LightShow], out: &mut Vec<Warning>) {
     for cue in shows.iter().flat_map(|show| show.cues.iter()) {
         for effect in &cue.effects {
             for name in &effect.ignored_parameters {
-                let kind = effect.effect_type.name();
-                // Once per (effect type, parameter): a show that repeats the
-                // same mistake on forty cues has one problem, not forty.
-                if !reported.insert((kind, name.clone())) {
+                // The DSL keyword, not the Rust variant: `ColorCycle` would be
+                // reported as "colorcycle", which is not a word the author can
+                // have written.
+                let kind = dsl_keyword(&effect.effect_type);
+                // Once per (group, effect type, parameter): a show repeating
+                // the same mistake on forty cues has one problem, not forty —
+                // but the message names a group and a time, so two groups
+                // making the same mistake must not collapse into one warning
+                // pointing at whichever came first.
+                if !reported.insert((effect.groups.join(", "), kind, name.clone())) {
                     continue;
                 }
                 out.push(Warning::new(
@@ -106,7 +125,7 @@ fn parameters_the_effect_ignores(shows: &[LightShow], out: &mut Vec<Warning>) {
                         name,
                         effect.groups.join(", "),
                         cue.time.as_secs_f64(),
-                        kind.to_lowercase(),
+                        kind,
                     ),
                 ));
             }

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -925,10 +925,9 @@ show "T" {
     /// rather than trusted.
     #[test]
     fn the_editors_parameter_table_matches_what_the_engine_accepts() {
-        let source = std::fs::read_to_string(
-            "src/webui/svelte/src/components/lighting/EffectForm.svelte",
-        )
-        .expect("the effect form must be readable");
+        let source =
+            std::fs::read_to_string("src/webui/svelte/src/components/lighting/EffectForm.svelte")
+                .expect("the effect form must be readable");
 
         // From the object literal's opening brace, so the type annotation —
         // `Record<EffectType, string[]>` — does not leak in with its own
@@ -947,7 +946,12 @@ show "T" {
             let Some((kind, params)) = entry.split_once('[') else {
                 continue;
             };
-            let kind = kind.trim().trim_start_matches(',').trim().trim_end_matches(':').trim();
+            let kind = kind
+                .trim()
+                .trim_start_matches(',')
+                .trim()
+                .trim_end_matches(':')
+                .trim();
             if kind.is_empty() {
                 continue;
             }

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -914,6 +914,88 @@ show "T" {
         );
     }
 
+    /// The web UI's own table of per-effect parameters must match the engine.
+    ///
+    /// `EffectForm.svelte` keeps a `USED_PARAMS` map that decides which fields
+    /// survive an effect-type change. It was written by hand from what the
+    /// engine accepts, and nothing tied the two together — so a parameter added
+    /// to an effect, or removed from one, would leave the editor silently
+    /// dropping a real setting or carrying a dead one. Both are the failure this
+    /// branch exists to remove, so the table is read from the source and checked
+    /// rather than trusted.
+    #[test]
+    fn the_editors_parameter_table_matches_what_the_engine_accepts() {
+        let source = std::fs::read_to_string(
+            "src/webui/svelte/src/components/lighting/EffectForm.svelte",
+        )
+        .expect("the effect form must be readable");
+
+        // From the object literal's opening brace, so the type annotation —
+        // `Record<EffectType, string[]>` — does not leak in with its own
+        // brackets and break the parse below.
+        let table = source
+            .split_once("const USED_PARAMS")
+            .and_then(|(_, rest)| rest.split_once('{'))
+            .and_then(|(_, body)| body.split_once("};"))
+            .map(|(body, _)| body.to_string())
+            .expect("USED_PARAMS must still be a literal this test can read");
+
+        // `kind: ["a", "b"]` across however many lines prettier wrapped it to.
+        let flattened: String = table.split_whitespace().collect::<Vec<_>>().join(" ");
+        let mut checked = 0;
+        for entry in flattened.split(']') {
+            let Some((kind, params)) = entry.split_once('[') else {
+                continue;
+            };
+            let kind = kind.trim().trim_start_matches(',').trim().trim_end_matches(':').trim();
+            if kind.is_empty() {
+                continue;
+            }
+            for param in params.split(',') {
+                let param = param.trim().trim_matches('"');
+                if param.is_empty() {
+                    continue;
+                }
+                let value = sample_value(kind, param);
+                let source = format!(
+                    "show \"T\" {{\n    @00:00.000\n    wash: {kind} {param}: {value}, duration: 2s\n}}\n"
+                );
+                let parsed = crate::lighting::parser::parse_light_shows(&source)
+                    .unwrap_or_else(|e| panic!("`{kind} {param}: {value}` does not parse: {e}"));
+                let shows: Vec<_> = parsed.into_values().collect();
+                let unused: Vec<&str> = lint_shows(&shows, &LintContext::default())
+                    .iter()
+                    .filter(|w| w.kind == "unused-parameter" && w.message.contains(param))
+                    .map(|_| param)
+                    .collect();
+                assert!(
+                    unused.is_empty(),
+                    "the editor keeps `{param}` when an effect becomes `{kind}`, but {kind} \
+                     does not read it — the editor would carry a setting that does nothing"
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked >= 25,
+            "only {checked} parameters were checked; the table was probably not parsed"
+        );
+    }
+
+    /// A value the parser accepts for a given parameter.
+    fn sample_value(kind: &str, param: &str) -> &'static str {
+        match param {
+            "duration" => "2s",
+            "direction" if kind == "chase" => "left_to_right",
+            "direction" => "forward",
+            "transition" => "fade",
+            "pattern" => "linear",
+            "curve" => "linear",
+            "speed" | "frequency" => "1",
+            _ => "0.5",
+        }
+    }
+
     /// The shipped shows must not carry a parameter that does nothing.
     ///
     /// They carried nineteen: `fade`, `loop`, `duty`, `dimmer` on a cycle,

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -71,12 +71,47 @@ pub fn lint_shows(shows: &[LightShow], ctx: &LintContext) -> Vec<Warning> {
     // Across all shows at once, for the same reason the stomp check is: a
     // `clear` in one show of a file ends effects in its siblings.
     effects_past_end_of_song(shows, ctx, &mut warnings);
+    parameters_the_effect_ignores(shows, &mut warnings);
     // Across all shows at once, not per show: `LightingTimeline` merges every
     // show in a file into one cue list and plays them together, so two shows
     // both driving `wash` on the background layer stomp each other exactly as
     // two cues in one show would. Checking them separately misses that.
     stomping_replace_effects(shows, &mut warnings);
     warnings
+}
+
+/// A parameter the effect type does not use.
+///
+/// The DSL accepts any parameter and each effect type takes what it recognises,
+/// so `rainbow ... direction: left_to_right` parses and does nothing — the
+/// author has written a setting that will never have an effect, and nothing
+/// says so. Non-fatal, because shows already carry these and rejecting them
+/// would break on upgrade.
+fn parameters_the_effect_ignores(shows: &[LightShow], out: &mut Vec<Warning>) {
+    let mut reported = HashSet::new();
+    for cue in shows.iter().flat_map(|show| show.cues.iter()) {
+        for effect in &cue.effects {
+            for name in &effect.ignored_parameters {
+                let kind = effect.effect_type.name();
+                // Once per (effect type, parameter): a show that repeats the
+                // same mistake on forty cues has one problem, not forty.
+                if !reported.insert((kind, name.clone())) {
+                    continue;
+                }
+                out.push(Warning::new(
+                    "unused-parameter",
+                    format!(
+                        "`{}` on `{}` at {:.3}s is not a parameter {} uses, so it does \
+                         nothing — check the spelling, or the effect type",
+                        name,
+                        effect.groups.join(", "),
+                        cue.time.as_secs_f64(),
+                        kind.to_lowercase(),
+                    ),
+                ));
+            }
+        }
+    }
 }
 
 /// A group that resolves to no fixtures. Its cues parse and silently no-op, so
@@ -857,6 +892,70 @@ show "T" {
             lint_shows(&shows(source), &ctx).is_empty(),
             "the stop ends the bed long before the song does, but got: {:?}",
             lint_shows(&shows(source), &ctx)
+        );
+    }
+
+    #[test]
+    fn a_parameter_the_effect_does_not_use_is_reported() {
+        // `EffectType::Rainbow` has no direction. This parses, the direction is
+        // dropped, and the author has written a setting that will never do
+        // anything — which is what the web UI's own rainbow direction control
+        // used to produce before it was removed.
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: rainbow speed: 0.5, direction: left_to_right, duration: 4s
+}
+"#;
+        let warnings = lint_shows(&shows(source), &LintContext::default());
+        let unused: Vec<&Warning> = warnings
+            .iter()
+            .filter(|w| w.kind == "unused-parameter")
+            .collect();
+        assert_eq!(unused.len(), 1, "{warnings:?}");
+        assert!(
+            unused[0].message.contains("direction") && unused[0].message.contains("rainbow"),
+            "the parameter and the effect type both have to be named: {}",
+            unused[0].message
+        );
+    }
+
+    #[test]
+    fn a_parameter_the_effect_does_use_is_not_reported() {
+        // Guards against the check firing on every parameter, which would make
+        // it noise and get it ignored.
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: rainbow speed: 0.5, saturation: 80%, brightness: 90%, duration: 4s
+}
+"#;
+        let warnings = lint_shows(&shows(source), &LintContext::default());
+        assert!(
+            !warnings.iter().any(|w| w.kind == "unused-parameter"),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn the_same_mistake_on_many_cues_is_reported_once() {
+        let source = r#"
+show "T" {
+    @00:00.000
+    wash: rainbow speed: 0.5, direction: left_to_right, duration: 2s
+
+    @00:04.000
+    wash: rainbow speed: 0.5, direction: left_to_right, duration: 2s
+}
+"#;
+        let warnings = lint_shows(&shows(source), &LintContext::default());
+        assert_eq!(
+            warnings
+                .iter()
+                .filter(|w| w.kind == "unused-parameter")
+                .count(),
+            1,
+            "a repeated mistake is one problem, not one per cue: {warnings:?}"
         );
     }
 

--- a/src/lighting/lint.rs
+++ b/src/lighting/lint.rs
@@ -914,6 +914,56 @@ show "T" {
         );
     }
 
+    /// The shipped shows must not carry a parameter that does nothing.
+    ///
+    /// They carried nineteen: `fade`, `loop`, `duty`, `dimmer` on a cycle,
+    /// `intensity` on a strobe, `color` on pulse/chase/strobe, and the rainbow
+    /// `direction` that led to this check. Anyone copying an example inherited
+    /// settings that are silently ignored, which is how the habit spreads.
+    #[test]
+    fn the_shipped_examples_carry_no_parameter_that_does_nothing() {
+        fn shows_in(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    shows_in(&path, out);
+                } else if path.extension().and_then(|e| e.to_str()) == Some("light") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let mut files = Vec::new();
+        shows_in(std::path::Path::new("examples"), &mut files);
+        assert!(!files.is_empty(), "no example shows were found to check");
+
+        let mut offenders = Vec::new();
+        for path in files {
+            let Ok(source) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            // Fixture-type and venue files live alongside the shows and are not
+            // shows; they simply do not parse as one.
+            let Ok(parsed) = crate::lighting::parser::parse_light_shows(&source) else {
+                continue;
+            };
+            let shows: Vec<_> = parsed.into_values().collect();
+            for warning in lint_shows(&shows, &LintContext::default()) {
+                if warning.kind == "unused-parameter" {
+                    offenders.push(format!("{}: {}", path.display(), warning.message));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "shipped examples carry parameters that do nothing:\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+
     #[test]
     fn a_parameter_the_effect_does_not_use_is_reported() {
         // `EffectType::Rainbow` has no direction. This parses, the direction is

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -354,9 +354,16 @@ pub(crate) fn apply_parameters_to_effect_type(
                             parse_duration_in_score_space(value, tempo_map, cue_time, offset_secs)?;
                         *duration = dur;
                     }
-                    _ => {
+                    other => {
+                        // A bare number is a channel level, which `static`
+                        // accepts by name — that is how a fixture's own channels
+                        // are addressed. Anything else is not used by anything,
+                        // and `static` is where a typo is most likely, so it
+                        // must not be the one effect type the lint cannot see.
                         if let Ok(val) = value.parse::<f64>() {
                             static_params.insert(key.clone(), val);
+                        } else {
+                            ignored.push(other.to_string());
                         }
                     }
                 }

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -261,7 +261,7 @@ pub(crate) fn parse_effect_definition(
     }
 
     // Apply parameters to the effect type
-    let final_effect_type =
+    let (final_effect_type, ignored_parameters) =
         apply_parameters_to_effect_type(effect_type, &parameters, &color_parameters, ctx)?;
 
     // Validate that every effect has an explicit duration.
@@ -297,16 +297,27 @@ pub(crate) fn parse_effect_definition(
         hold_time,
         down_time,
         sequence_name: None, // Will be set when expanding sequences
+        ignored_parameters,
     })
 }
 
 /// Applies parsed parameters to effect types
+/// Applies the effect-specific parameters, and reports the ones the effect type
+/// does not use.
+///
+/// The common parameters (`layer`, `blend_mode`, the fade times, and `color` on
+/// a cycle) are consumed by the caller before this runs, so anything left
+/// unmatched here is a parameter that names nothing on this effect — like a
+/// `direction` on a rainbow, which parsed happily and did nothing. Returned
+/// rather than dropped so a lint can say so; rejecting outright would break
+/// shows that already carry one.
 pub(crate) fn apply_parameters_to_effect_type(
     mut effect_type: EffectType,
     parameters: &HashMap<String, String>,
     color_parameters: &[String],
     ctx: &ParseContext,
-) -> Result<EffectType, Box<dyn Error>> {
+) -> Result<(EffectType, Vec<String>), Box<dyn Error>> {
+    let mut ignored: Vec<String> = Vec::new();
     let tempo_map = &ctx.tempo_map;
     let cue_time = ctx.cue_time;
     let offset_secs = ctx.offset_secs;
@@ -400,7 +411,7 @@ pub(crate) fn apply_parameters_to_effect_type(
                             parse_duration_in_score_space(value, tempo_map, cue_time, offset_secs)?;
                         *duration = dur;
                     }
-                    _ => {}
+                    other => ignored.push(other.to_string()),
                 }
             }
         }
@@ -424,7 +435,7 @@ pub(crate) fn apply_parameters_to_effect_type(
                             parse_duration_in_score_space(value, tempo_map, cue_time, offset_secs)?;
                         *duration = dur;
                     }
-                    _ => {}
+                    other => ignored.push(other.to_string()),
                 }
             }
         }
@@ -460,7 +471,7 @@ pub(crate) fn apply_parameters_to_effect_type(
                             parse_duration_in_score_space(value, tempo_map, cue_time, offset_secs)?;
                         *duration = dur;
                     }
-                    _ => {}
+                    other => ignored.push(other.to_string()),
                 }
             }
         }
@@ -522,7 +533,7 @@ pub(crate) fn apply_parameters_to_effect_type(
                             parse_duration_in_score_space(value, tempo_map, cue_time, offset_secs)?;
                         *duration = dur;
                     }
-                    _ => {}
+                    other => ignored.push(other.to_string()),
                 }
             }
         }
@@ -559,7 +570,7 @@ pub(crate) fn apply_parameters_to_effect_type(
                             other => return Err(format!("Invalid dimmer curve: '{}' (expected: linear, exponential, logarithmic, sine, cosine)", other).into()),
                         };
                     }
-                    _ => {}
+                    other => ignored.push(other.to_string()),
                 }
             }
         }
@@ -592,13 +603,14 @@ pub(crate) fn apply_parameters_to_effect_type(
                             parse_duration_in_score_space(value, tempo_map, cue_time, offset_secs)?;
                         *duration = dur;
                     }
-                    _ => {}
+                    other => ignored.push(other.to_string()),
                 }
             }
         }
     }
 
-    Ok(effect_type)
+    ignored.sort();
+    Ok((effect_type, ignored))
 }
 
 #[cfg(test)]
@@ -714,7 +726,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("dimmer".to_string(), "50%".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["dimmer"] - 0.5).abs() < 1e-9);
         } else {
@@ -733,7 +747,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("intensity".to_string(), "22%".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["dimmer"] - 0.22).abs() < 1e-9);
             assert!(!parameters.contains_key("intensity"));
@@ -750,7 +766,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("color".to_string(), "#FF8000".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["red"] - 1.0).abs() < 1e-9);
             assert!((parameters["green"] - 128.0 / 255.0).abs() < 1e-2);
@@ -770,7 +788,9 @@ mod tests {
         params.insert("red".to_string(), "100%".to_string());
         params.insert("green".to_string(), "50%".to_string());
         params.insert("blue".to_string(), "0%".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["red"] - 1.0).abs() < 1e-9);
             assert!((parameters["green"] - 0.5).abs() < 1e-9);
@@ -788,7 +808,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("duration".to_string(), "2s".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Static { duration, .. } = result {
             assert_eq!(duration, Duration::from_secs(2));
         } else {
@@ -808,8 +830,9 @@ mod tests {
             duration: Duration::ZERO,
         };
         let colors = vec!["red".to_string(), "#0000FF".to_string()];
-        let result =
-            apply_parameters_to_effect_type(et, &HashMap::new(), &colors, &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &HashMap::new(), &colors, &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::ColorCycle { colors, .. } = result {
             assert_eq!(colors.len(), 2);
             assert_eq!(colors[0].r, 255);
@@ -830,7 +853,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "backward".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::ColorCycle { direction, .. } = result {
             assert_eq!(direction, CycleDirection::Backward);
         } else {
@@ -849,7 +874,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("transition".to_string(), "crossfade".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::ColorCycle { transition, .. } = result {
             assert_eq!(transition, CycleTransition::Fade);
         } else {
@@ -867,7 +894,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("frequency".to_string(), "15.0".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Strobe { frequency, .. } = result {
             assert_eq!(frequency, TempoAwareFrequency::Fixed(15.0));
         } else {
@@ -883,7 +912,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("rate".to_string(), "20.0".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Strobe { frequency, .. } = result {
             assert_eq!(frequency, TempoAwareFrequency::Fixed(20.0));
         } else {
@@ -905,7 +936,9 @@ mod tests {
         params.insert("base_level".to_string(), "20%".to_string());
         params.insert("intensity".to_string(), "80%".to_string());
         params.insert("frequency".to_string(), "4.0".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Pulse {
             base_level,
             pulse_amplitude,
@@ -936,7 +969,9 @@ mod tests {
         params.insert("pattern".to_string(), "snake".to_string());
         params.insert("direction".to_string(), "clockwise".to_string());
         params.insert("transition".to_string(), "fade".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Chase {
             pattern,
             direction,
@@ -967,7 +1002,9 @@ mod tests {
         params.insert("end".to_string(), "75%".to_string());
         params.insert("duration".to_string(), "3s".to_string());
         params.insert("curve".to_string(), "exponential".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Dimmer {
             start_level,
             end_level,
@@ -1012,7 +1049,9 @@ mod tests {
         params.insert("saturation".to_string(), "80%".to_string());
         params.insert("brightness".to_string(), "60%".to_string());
         params.insert("speed".to_string(), "2.0".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Rainbow {
             speed,
             saturation,
@@ -1087,7 +1126,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("curve".to_string(), "logarithmic".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Dimmer { curve, .. } = result {
             assert!(matches!(curve, DimmerCurve::Logarithmic));
         } else {
@@ -1108,7 +1149,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "pingpong".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::ColorCycle { direction, .. } = result {
             assert_eq!(direction, CycleDirection::PingPong);
         } else {
@@ -1129,7 +1172,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("direction".to_string(), "right_to_left".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Chase { direction, .. } = result {
             assert!(matches!(direction, ChaseDirection::RightToLeft));
         } else {
@@ -1150,7 +1195,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("pattern".to_string(), "random".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Chase { pattern, .. } = result {
             assert!(matches!(pattern, ChasePattern::Random));
         } else {
@@ -1188,7 +1235,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("transition".to_string(), "crossfade".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Chase { transition, .. } = result {
             assert_eq!(transition, CycleTransition::Fade);
         } else {
@@ -1222,7 +1271,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("custom_param".to_string(), "0.75".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Static { parameters, .. } = result {
             assert!((parameters["custom_param"] - 0.75).abs() < 1e-9);
         } else {
@@ -1243,7 +1294,9 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("start_level".to_string(), "30%".to_string());
         params.insert("end_level".to_string(), "90%".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Dimmer {
             start_level,
             end_level,
@@ -1269,7 +1322,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("duration".to_string(), "5s".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Pulse { duration, .. } = result {
             assert_eq!(duration, Duration::from_secs(5));
         } else {
@@ -1287,7 +1342,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("duration".to_string(), "3s".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Strobe { duration, .. } = result {
             assert_eq!(duration, Duration::from_secs(3));
         } else {
@@ -1308,7 +1365,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "2.5".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::ColorCycle { speed, .. } = result {
             assert_eq!(speed, TempoAwareSpeed::Fixed(2.5));
         } else {
@@ -1329,7 +1388,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("speed".to_string(), "3.0".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Chase { speed, .. } = result {
             assert_eq!(speed, TempoAwareSpeed::Fixed(3.0));
         } else {
@@ -1423,7 +1484,9 @@ mod tests {
         };
         let mut params = HashMap::new();
         params.insert("pulse_amplitude".to_string(), "70%".to_string());
-        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx()).unwrap();
+        let result = apply_parameters_to_effect_type(et, &params, &[], &default_ctx())
+            .unwrap()
+            .0;
         if let EffectType::Pulse {
             pulse_amplitude, ..
         } = result

--- a/src/lighting/parser/effect_parse.rs
+++ b/src/lighting/parser/effect_parse.rs
@@ -360,7 +360,11 @@ pub(crate) fn apply_parameters_to_effect_type(
                         // are addressed. Anything else is not used by anything,
                         // and `static` is where a typo is most likely, so it
                         // must not be the one effect type the lint cannot see.
-                        if let Ok(val) = value.parse::<f64>() {
+                        // A percentage is as valid a channel level as a bare
+                        // float — `gobo: 50%` was dropped silently, and the
+                        // warning then blamed the name when the fault was the
+                        // `%`.
+                        if let Ok(val) = parse_percentage_to_f64(value) {
                             static_params.insert(key.clone(), val);
                         } else {
                             ignored.push(other.to_string());

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -276,7 +276,8 @@ fn parse_venue_content(
                      the player config:\n\
                      \n\
                      \x20   groups:\n\
-                     \x20     - name: {name}\n\
+                     \x20     {name}:\n\
+                     \x20       name: {name}\n\
                      \x20       constraints:\n\
                      \x20         - AllOf: [\"{name}\"]\n\
                      \n\

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -273,15 +273,9 @@ fn parse_venue_content(
                     "venue group `{name}` is no longer supported. Tag the fixtures \
                      instead — add a tag to each member, e.g. `tags [\"{name}\"]`, \
                      then declare a logical group under `dmx.lighting.groups` in \
-                     the player config:\n\
-                     \n\
-                     \x20   groups:\n\
-                     \x20     {name}:\n\
-                     \x20       name: {name}\n\
-                     \x20       constraints:\n\
-                     \x20         - AllOf: [\"{name}\"]\n\
-                     \n\
-                     Tags survive a venue change; venue groups did not."
+                     the player config:\n\n{}\n\
+                     Tags survive a venue change; venue groups did not.",
+                    migration_yaml(&name)
                 )
                 .into());
             }
@@ -289,6 +283,20 @@ fn parse_venue_content(
         }
     }
     Ok(())
+}
+
+/// The config the venue-group migration message tells the reader to write.
+///
+/// Extracted so a test can feed the *actual* advice to the loader rather than a
+/// copy of it. `groups` is a map keyed by name, and an earlier version of this
+/// message printed a sequence — following it produced a config that would not
+/// load, which is worse than the error it replaced. A test that parses its own
+/// hand-written string cannot catch that.
+pub(crate) fn migration_yaml(name: &str) -> String {
+    format!(
+        "    groups:\n      {name}:\n        name: {name}\n        \
+         constraints:\n          - AllOf: [\"{name}\"]\n"
+    )
 }
 
 pub(crate) fn parse_fixture_definition(pair: Pair<Rule>) -> Result<Fixture, Box<dyn Error>> {

--- a/src/lighting/parser/types.rs
+++ b/src/lighting/parser/types.rs
@@ -110,6 +110,13 @@ pub struct Effect {
     pub hold_time: Option<Duration>,
     pub down_time: Option<Duration>,
     pub sequence_name: Option<String>, // Track which sequence this effect came from (for stopping)
+    /// Parameters this effect type does not use, in the order they sort.
+    ///
+    /// A `direction` on a rainbow parses and does nothing — the DSL accepts any
+    /// parameter and each effect type takes what it recognises. Keeping the
+    /// leftovers lets a lint say so; rejecting them at parse time would break
+    /// shows that already carry one.
+    pub ignored_parameters: Vec<String>,
 }
 
 impl Effect {
@@ -177,6 +184,7 @@ mod tests {
             hold_time: None,
             down_time: None,
             sequence_name: None,
+            ignored_parameters: Vec::new(),
         }
     }
 
@@ -195,6 +203,7 @@ mod tests {
             hold_time: hold,
             down_time: down,
             sequence_name: None,
+            ignored_parameters: Vec::new(),
         }
     }
 

--- a/src/lighting/timeline.rs
+++ b/src/lighting/timeline.rs
@@ -414,6 +414,7 @@ mod tests {
         // Timeline with cues should not be finished initially
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -458,6 +459,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["front_wash".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -497,6 +499,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -559,6 +562,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -603,6 +607,7 @@ mod tests {
 
         let effect1 = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["fixture1".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -617,6 +622,7 @@ mod tests {
 
         let effect2 = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["fixture2".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -758,6 +764,7 @@ mod tests {
         // Create cue with both an effect and a layer command
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -803,6 +810,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -861,6 +869,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -925,6 +934,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -980,6 +990,7 @@ mod tests {
 
         let bg_effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -994,6 +1005,7 @@ mod tests {
 
         let fg_effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -1081,6 +1093,7 @@ mod tests {
 
         let effect = Effect {
             sequence_name: None,
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -1146,6 +1159,7 @@ mod tests {
 
         let seq_effect = |seq: &str| Effect {
             sequence_name: Some(seq.to_string()),
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),
@@ -1221,6 +1235,7 @@ mod tests {
 
         let seq_effect = |seq: &str| Effect {
             sequence_name: Some(seq.to_string()),
+            ignored_parameters: Vec::new(),
             groups: vec!["test_group".to_string()],
             effect_type: EffectType::Static {
                 parameters: HashMap::new(),

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -574,19 +574,49 @@ pub(super) async fn get_lighting_groups(State(state): State<WebUiState>) -> impl
 async fn groups_from_config(config_path: &std::path::Path) -> axum::response::Response {
     // codeql[rust/path-injection] config_path is set at startup, not user input.
     let path = config_path.to_path_buf();
-    let names = tokio::task::spawn_blocking(move || {
+    // A parse failure is reported, not swallowed. `.ok()` here answered
+    // "no groups" for a config that does not load at all — the same silent
+    // empty list this fallback exists to remove, one layer down, and the reason
+    // a missing `dmx.universes` looked like a rig with nothing declared.
+    let loaded = tokio::task::spawn_blocking(move || {
         crate::config::Player::deserialize(&path)
-            .ok()
-            .and_then(|player| player.dmx().and_then(|dmx| dmx.lighting()).cloned())
-            .map(|lighting| {
-                let mut names: Vec<String> = lighting.groups().keys().cloned().collect();
-                names.sort();
-                names
+            .map(|player| {
+                player
+                    .dmx()
+                    .and_then(|dmx| dmx.lighting())
+                    .map(|lighting| {
+                        let mut names: Vec<String> = lighting.groups().keys().cloned().collect();
+                        names.sort();
+                        names
+                    })
+                    .unwrap_or_default()
             })
-            .unwrap_or_default()
+            .map_err(|e| e.to_string())
     })
-    .await
-    .unwrap_or_default();
+    .await;
+
+    let names = match loaded {
+        Ok(Ok(names)) => names,
+        Ok(Err(e)) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": format!(
+                        "no DMX engine is running, and the player config could not be read \
+                         to list the declared groups: {e}"
+                    )
+                })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("reading the player config failed: {e}")})),
+            )
+                .into_response();
+        }
+    };
 
     let groups: Vec<serde_json::Value> = names
         .into_iter()
@@ -909,6 +939,101 @@ mod test {
     use axum::body::Body;
     use axum::http::StatusCode;
     use tower::ServiceExt;
+
+    /// With no DMX device, the group names still come back — from the config.
+    ///
+    /// Authoring on a laptop is the normal case for editing a show, and the
+    /// groups are declared under `dmx.lighting.groups` in the player config, not
+    /// by the engine. Answering `{"groups": []}` there emptied the cue-target
+    /// autocomplete with no error to explain it, because the endpoint only read
+    /// them off a live engine.
+    #[tokio::test]
+    async fn lighting_groups_come_from_the_config_without_a_dmx_engine() {
+        let (state, dir) = test_state();
+        std::fs::write(
+            &state.config_path,
+            "songs: songs\ndmx:\n  universes:\n    - universe: 1\n      name: main\n  \
+             lighting:\n    groups:\n      front_wash:\n        \
+             name: front_wash\n        constraints:\n          - AllOf: [\"wash\"]\n      \
+             back_wash:\n        name: back_wash\n        constraints:\n          \
+             - AllOf: [\"back\"]\n",
+        )
+        .unwrap();
+        let _keep = dir;
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/lighting/groups")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&response_body(response).await).unwrap();
+        let names: Vec<&str> = parsed["groups"]
+            .as_array()
+            .expect("groups")
+            .iter()
+            .filter_map(|g| g["name"].as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["back_wash", "front_wash"],
+            "the declared groups must be listed even with no engine to resolve them"
+        );
+        // Flagged as unresolved: the names are knowable without an engine, the
+        // fixtures each resolves to are not, and a caller has to be able to tell
+        // "no fixtures" from "not asked yet".
+        assert_eq!(parsed["resolved"], serde_json::json!(false));
+        for group in parsed["groups"].as_array().expect("groups") {
+            assert!(group["fixtures"].as_array().expect("fixtures").is_empty());
+        }
+    }
+
+    /// A config that will not load is reported, not answered as "no groups".
+    ///
+    /// The fallback exists because an empty list was indistinguishable from a
+    /// rig with nothing declared. Swallowing a parse error with `.ok()` put that
+    /// exact ambiguity back one layer down — a missing `dmx.universes` read as
+    /// an empty autocomplete with no explanation.
+    #[tokio::test]
+    async fn a_config_that_does_not_load_is_reported_not_answered_empty() {
+        let (state, dir) = test_state();
+        // `dmx.universes` is required, so this parses as YAML and fails to load
+        // as config — the shape most likely to be hit by hand-editing.
+        std::fs::write(
+            &state.config_path,
+            "songs: songs\ndmx:\n  lighting:\n    groups:\n      wash:\n        name: wash\n",
+        )
+        .unwrap();
+        let _keep = dir;
+
+        let app = router().with_state(state);
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/lighting/groups")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&response_body(response).await).unwrap();
+        assert!(
+            parsed["error"]
+                .as_str()
+                .is_some_and(|e| e.contains("could not be read")),
+            "the reason must reach the caller: {parsed}"
+        );
+    }
 
     #[tokio::test]
     async fn get_lighting_files_empty() {

--- a/src/webui/svelte/e2e/mock-server/index.ts
+++ b/src/webui/svelte/e2e/mock-server/index.ts
@@ -57,6 +57,15 @@ app.get("/api/songs/:name", (req, res) => {
     yaml += `sections:\n`;
     for (const s of song.sections) {
       yaml += `  - name: ${s.name}\n    start_measure: ${s.start_measure}\n    end_measure: ${s.end_measure}\n`;
+      // Beat offsets are what make a boundary sub-measure accurate. Omitting
+      // them here made the section editor's clamping paths unreachable from a
+      // test, since a boundary can only invert when the beats are in play.
+      if (s.start_beat !== undefined) {
+        yaml += `    start_beat: ${s.start_beat}\n`;
+      }
+      if (s.end_beat !== undefined) {
+        yaml += `    end_beat: ${s.end_beat}\n`;
+      }
     }
   }
   if (song.lighting_files && song.lighting_files.length > 0) {

--- a/src/webui/svelte/e2e/mock-server/index.ts
+++ b/src/webui/svelte/e2e/mock-server/index.ts
@@ -331,6 +331,20 @@ app.delete("/api/lighting/venues/:name", (_req, res) => {
   res.json({ status: "deleted" });
 });
 
+// Before the `:name` route, or it captures "groups" and answers with DSL text —
+// which `fetchLightingGroups` then fails to parse as JSON. That was invisible
+// while the callers swallowed the error and became a fabricated message on
+// every mock run once they stopped.
+app.get("/api/lighting/groups", (_req, res) => {
+  res.json({
+    groups: [
+      { name: "front_wash", fixtures: ["par1", "par2"] },
+      { name: "back_wash", fixtures: ["par3"] },
+    ],
+    resolved: true,
+  });
+});
+
 app.get("/api/lighting/:name", (_req, res) => {
   res
     .type("text/plain")

--- a/src/webui/svelte/e2e/mock-server/test-data.ts
+++ b/src/webui/svelte/e2e/mock-server/test-data.ts
@@ -64,6 +64,17 @@ export const SONGS = {
       sections: [
         { name: "verse", start_measure: 1, end_measure: 4 },
         { name: "chorus", start_measure: 5, end_measure: 8 },
+        // Both boundaries inside one measure. A section can only be inverted
+        // when its start and end are close enough for a beat step to cross
+        // them, so without one of these the editor's clamping never runs and
+        // cannot be tested.
+        {
+          name: "stab",
+          start_measure: 10,
+          end_measure: 10,
+          start_beat: 1,
+          end_beat: 3,
+        },
       ],
     },
   ],

--- a/src/webui/svelte/e2e/mock-server/test-data.ts
+++ b/src/webui/svelte/e2e/mock-server/test-data.ts
@@ -64,10 +64,37 @@ export const SONGS = {
       sections: [
         { name: "verse", start_measure: 1, end_measure: 4 },
         { name: "chorus", start_measure: 5, end_measure: 8 },
-        // Both boundaries inside one measure. A section can only be inverted
-        // when its start and end are close enough for a beat step to cross
-        // them, so without one of these the editor's clamping never runs and
-        // cannot be tested.
+      ],
+    },
+    {
+      // A song of its own for the section editor's clamping, rather than a
+      // third section on Beta: song-detail.spec.ts asserts Beta's section count
+      // in five places and drags on what it expects to be empty bar space, so
+      // adding one there broke six unrelated tests.
+      //
+      // "stab" has both boundaries inside measure 10. A section can only be
+      // inverted when its start and end are close enough for one step to cross
+      // them, so without it the clamping cannot be reached from a test at all.
+      name: "Test Song Gamma",
+      duration_ms: 240000,
+      duration_display: "4:00",
+      num_channels: 2,
+      sample_format: "S24LE",
+      track_count: 2,
+      tracks: ["guitar", "vocals"],
+      has_midi: false,
+      has_lighting: false,
+      base_dir: "Test Song Gamma",
+      lighting_files: [],
+      midi_dmx_files: [],
+      beat_grid: {
+        // The same 16 measures of 4/4 at 120bpm as Beta: a beat every 0.5s.
+        beats: Array.from({ length: 64 }, (_, i) => i * 0.5),
+        measure_starts: Array.from({ length: 16 }, (_, i) => i * 4),
+      },
+      has_tempo_map: false,
+      loop_playback: false,
+      sections: [
         {
           name: "stab",
           start_measure: 10,

--- a/src/webui/svelte/e2e/tests/effect-form-params.spec.ts
+++ b/src/webui/svelte/e2e/tests/effect-form-params.spec.ts
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// Which controls the effect form offers per effect type.
+//
+// The form used to offer a colour on strobe, chase and pulse, an intensity and
+// duty cycle on strobe, a dimmer on cycle and pulse, and a loop on cycle, chase
+// and rainbow. The engine reads none of them: the parser accepts each one and
+// drops it, so every one wrote a setting to the file that never took effect.
+//
+// Those controls were removed by deleting markup by line range, which
+// `svelte-check` can only prove still compiles. This opens the form for real and
+// asserts both halves: the removed controls are gone, and the ones the effect
+// actually reads survived the deletion.
+
+import { test, expect } from "@playwright/test";
+
+/** Opens the timeline editor's properties panel for the first cue. */
+async function openFirstCue(page: import("@playwright/test").Page) {
+  await page.goto("/#/songs/Test%20Song%20Alpha/lighting");
+  const cue = page.locator(".cue-block").first();
+  await expect(cue).toBeVisible();
+  // `force`: the cue sits over a canvas lane that intercepts pointer events.
+  await cue.click({ force: true });
+  // The properties panel opens with each effect collapsed to a summary row; the
+  // controls live behind its expand toggle.
+  const expand = page.locator(".effect-form .expand-toggle").first();
+  await expect(expand).toBeVisible();
+  await expand.click();
+  await expect(page.locator(".param-label").first()).toBeVisible();
+}
+
+/** The parameter labels the form is currently showing. */
+async function labels(
+  page: import("@playwright/test").Page,
+): Promise<string[]> {
+  return (await page.locator(".param-label").allTextContents()).map((t) =>
+    t.trim(),
+  );
+}
+
+/** Switches the open effect to another type. */
+async function setType(page: import("@playwright/test").Page, type: string) {
+  const select = page.locator(".effect-form select").first();
+  await select.selectOption(type);
+  // Svelte re-renders the branch; wait for the labels to settle.
+  await page.waitForTimeout(200);
+}
+
+test.describe("Effect form parameters", () => {
+  test("a static effect keeps the controls it reads", async ({ page }) => {
+    await openFirstCue(page);
+    const shown = await labels(page);
+    // `static` is the one type that reads a dimmer, and the deletion had to
+    // leave that one alone.
+    expect(shown).toContain("Dimmer");
+    expect(shown).toContain("Duration");
+  });
+
+  test("a strobe offers frequency and duration, and nothing it ignores", async ({
+    page,
+  }) => {
+    await openFirstCue(page);
+    await setType(page, "strobe");
+    const shown = await labels(page);
+
+    expect(shown).toContain("Frequency");
+    expect(shown).toContain("Duration");
+    // `EffectType::Strobe` carries a frequency and a duration and nothing else.
+    expect(shown).not.toContain("Intensity");
+    expect(shown).not.toContain("Duty");
+    expect(shown).not.toContain("Dimmer");
+  });
+
+  test("a cycle keeps speed and direction but offers no dimmer or loop", async ({
+    page,
+  }) => {
+    await openFirstCue(page);
+    await setType(page, "cycle");
+    const shown = await labels(page);
+
+    // The controls either side of the deleted blocks — proof the line-range
+    // deletion did not take a neighbour with it.
+    expect(shown).toContain("Speed");
+    expect(shown).toContain("Direction");
+    expect(shown).toContain("Duration");
+    expect(shown).not.toContain("Dimmer");
+    expect(shown).not.toContain("Loop");
+  });
+
+  test("a chase keeps its pattern and offers no colour or loop", async ({
+    page,
+  }) => {
+    await openFirstCue(page);
+    await setType(page, "chase");
+    const shown = await labels(page);
+
+    expect(shown).toContain("Speed");
+    expect(shown).toContain("Duration");
+    expect(shown).not.toContain("Loop");
+  });
+
+  test("a rainbow offers no direction or loop", async ({ page }) => {
+    await openFirstCue(page);
+    await setType(page, "rainbow");
+    const shown = await labels(page);
+
+    expect(shown).toContain("Duration");
+    // The control that started all of this: `EffectType::Rainbow` has no
+    // direction, so the picker wrote a setting that did nothing.
+    expect(shown).not.toContain("Direction");
+    expect(shown).not.toContain("Loop");
+  });
+});

--- a/src/webui/svelte/e2e/tests/fixture-types.spec.ts
+++ b/src/webui/svelte/e2e/tests/fixture-types.spec.ts
@@ -26,6 +26,43 @@ test.describe("Fixture Types Management", () => {
     await page.locator(".sub-tab", { hasText: "Fixture Types" }).click();
   });
 
+  test("a fixture type file that will not parse is named, and the rest still list", async ({
+    page,
+  }) => {
+    // Same shape as the venue case: a directory is a set of independent files,
+    // so one that no longer parses must not empty the list — and must not go
+    // unmentioned either, or the only signal is a fixture type quietly missing.
+    await page.route("**/api/lighting/fixture-types*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          fixture_types: {
+            RGBW_Par: { name: "RGBW_Par", channels: {} },
+          },
+          errors: [
+            {
+              file: "broken.light",
+              error: "expected channel definition at line 4",
+            },
+          ],
+        }),
+      });
+    });
+    // Re-fetch through the panel's own Refresh rather than reloading the page,
+    // which would discard the navigation `beforeEach` performed.
+    await page.getByRole("button", { name: "Refresh" }).first().click();
+
+    // The good fixture type is still listed.
+    await expect(page.locator(".item-name")).toContainText("RGBW_Par");
+
+    // And the bad file is named, with the reason.
+    const errors = page.getByTestId("fixture-type-file-errors");
+    await expect(errors).toBeVisible();
+    await expect(errors).toContainText("broken.light");
+    await expect(errors).toContainText("expected channel definition");
+  });
+
   test("shows existing fixture type from mock data", async ({ page }) => {
     await expect(page.locator(".item-card")).toBeVisible();
     await expect(page.locator(".item-name")).toContainText("par");

--- a/src/webui/svelte/e2e/tests/section-edit-dialog.spec.ts
+++ b/src/webui/svelte/e2e/tests/section-edit-dialog.spec.ts
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// The section edit dialog's boundary handling.
+//
+// Nothing reached this component before. `setBoundary` is where the editor has
+// to agree with the player about which positions exist:
+//
+//   - A boundary that would invert the section is walked back to the last
+//     position that does not, rather than refused. The picker is a controlled
+//     input, so a silent refusal reads as a broken button, and an inverted range
+//     is what `Section::validate` rejects on save.
+//   - The walk stops at the ends of the song instead of looping.
+//
+// The fixture song is 16 measures of 4/4 at 120bpm and carries a "stab" section
+// whose start and end both sit inside measure 10 — a section can only be
+// inverted when its boundaries are close enough for a step to cross them, which
+// is why the fixture needed one.
+
+import { test, expect } from "@playwright/test";
+
+/** Opens the sections tab for the fixture song and taps a section open. */
+async function openSectionDialog(
+  page: import("@playwright/test").Page,
+  name: string,
+) {
+  await page.goto("/#/songs/Test%20Song%20Beta");
+  await page.locator(".tab", { hasText: "Timeline" }).click();
+  const block = page.locator(".section-block", { hasText: name });
+  await expect(block).toBeVisible();
+  // The component listens for pointer events on a bar with overlays, so a
+  // plain click fails actionability. This is the gesture it actually treats as
+  // a tap: press and release without moving.
+  const box = await block.boundingBox();
+  if (!box) throw new Error(`section "${name}" has no box`);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.up();
+  await expect(page.locator(".position-picker").first()).toBeVisible();
+}
+
+/** The position a picker is showing, as "measure.beat". */
+async function readout(
+  page: import("@playwright/test").Page,
+  label: string,
+): Promise<string> {
+  const picker = page
+    .locator(".labeled-picker", { hasText: label })
+    .locator(".position-picker");
+  return ((await picker.locator(".pp-value").textContent()) ?? "").trim();
+}
+
+/** The first two numbers in a readout, as measure and beat.
+ *
+ * Written against the numbers rather than a format: stripping non-digits and
+ * splitting on "." silently concatenates "m10 b1" into 101, which compares as
+ * measure 101 and made two different positions look identical. */
+function parsePos(text: string): { measure: number; beat: number } {
+  // Half beats render as a fraction glyph — "m10 \u00b7 b1\u00bd" — which a
+  // plain number match reads as 1, making a walked-forward boundary look
+  // identical to one that never moved.
+  const normalised = text.replace(/(\d+)\u00bd/g, (_, whole) => `${whole}.5`);
+  const numbers = normalised.match(/\d+(?:\.\d+)?/g) ?? [];
+  return {
+    measure: Number.parseFloat(numbers[0] ?? "0"),
+    beat: Number.parseFloat(numbers[1] ?? "1"),
+  };
+}
+
+/** A position as a single comparable number, for ordering assertions. */
+function asTime(pos: { measure: number; beat: number }): number {
+  return pos.measure * 100 + pos.beat;
+}
+
+/** Clicks a picker's next-beat button `times` times. */
+async function nextBeat(
+  page: import("@playwright/test").Page,
+  label: string,
+  times: number,
+) {
+  const button = page
+    .locator(".labeled-picker", { hasText: label })
+    .getByRole("button", { name: `${label}: next beat` });
+  for (let i = 0; i < times; i++) {
+    await button.click();
+  }
+}
+
+test.describe("Section edit dialog", () => {
+  test("a start pushed past the end is walked back, not refused", async ({
+    page,
+  }) => {
+    await openSectionDialog(page, "stab");
+
+    const startLabel = "Start";
+    const before = await readout(page, startLabel);
+    expect(before).not.toBe("");
+
+    // Both boundaries are inside measure 10, so stepping the start forward
+    // enough asks for a position at or past the end.
+    await nextBeat(page, startLabel, 8);
+
+    const start = parsePos(await readout(page, startLabel));
+    const end = parsePos(await readout(page, "End"));
+
+    // Still a forward range. A refusal would have left the start where it was;
+    // an unclamped step would have put it at or past the end.
+    expect(asTime(start)).toBeLessThan(asTime(end));
+    expect(await readout(page, startLabel)).not.toBe(before);
+  });
+
+  test("an end dragged back past the start is walked forward", async ({
+    page,
+  }) => {
+    await openSectionDialog(page, "stab");
+
+    const endLabel = "End";
+    const button = page
+      .locator(".labeled-picker", { hasText: endLabel })
+      .getByRole("button", { name: `${endLabel}: previous beat` });
+    for (let i = 0; i < 8; i++) {
+      await button.click();
+    }
+
+    const start = parsePos(await readout(page, "Start"));
+    const end = parsePos(await readout(page, endLabel));
+    // Walked forward off the start rather than left on top of it.
+    expect(asTime(start)).toBeLessThan(asTime(end));
+  });
+
+  // Weaker than the two above, and recorded as such: with the clamp disabled
+  // this still passes, because the picker's own bounds happen to keep the two
+  // boundaries apart. Kept as a regression guard against the walk running off
+  // the end of the song, not as evidence the clamp works.
+  test("the section is still saveable after both boundaries are driven to their limits", async ({
+    page,
+  }) => {
+    await openSectionDialog(page, "stab");
+
+    await nextBeat(page, "Start", 12);
+    await nextBeat(page, "End", 12);
+
+    const start = parsePos(await readout(page, "Start"));
+    const end = parsePos(await readout(page, "End"));
+    expect(asTime(start)).toBeLessThan(asTime(end));
+    // Within the song: the fixture grid is 16 measures.
+    expect(end.measure).toBeLessThanOrEqual(16);
+  });
+});

--- a/src/webui/svelte/e2e/tests/section-edit-dialog.spec.ts
+++ b/src/webui/svelte/e2e/tests/section-edit-dialog.spec.ts
@@ -34,7 +34,7 @@ async function openSectionDialog(
   page: import("@playwright/test").Page,
   name: string,
 ) {
-  await page.goto("/#/songs/Test%20Song%20Beta");
+  await page.goto("/#/songs/Test%20Song%20Gamma");
   await page.locator(".tab", { hasText: "Timeline" }).click();
   const block = page.locator(".section-block", { hasText: name });
   await expect(block).toBeVisible();

--- a/src/webui/svelte/e2e/tests/section-edit-dialog.spec.ts
+++ b/src/webui/svelte/e2e/tests/section-edit-dialog.spec.ts
@@ -66,6 +66,13 @@ async function readout(
  * splitting on "." silently concatenates "m10 b1" into 101, which compares as
  * measure 101 and made two different positions look identical. */
 function parsePos(text: string): { measure: number; beat: number } {
+  // The readout must be a measure/beat position. The picker can render a clock
+  // time instead, and "0:18.0" parses to a perfectly plausible measure 0 beat
+  // 18 — so a regression that flips the unit would be compared as an ordering
+  // fact rather than failing.
+  if (!/^m\d+/.test(text.trim())) {
+    throw new Error(`expected a measure/beat readout, got "${text}"`);
+  }
   // Half beats render as a fraction glyph — "m10 \u00b7 b1\u00bd" — which a
   // plain number match reads as 1, making a walked-forward boundary look
   // identical to one that never moved.

--- a/src/webui/svelte/src/components/lighting/EffectForm.svelte
+++ b/src/webui/svelte/src/components/lighting/EffectForm.svelte
@@ -47,15 +47,56 @@
     onchange({ ...effect, groups: newGroups });
   }
 
+  /** What each effect type actually reads, mirroring the engine's own arms. */
+  const USED_PARAMS: Record<EffectType, string[]> = {
+    static: [
+      "dimmer",
+      "intensity",
+      "red",
+      "green",
+      "blue",
+      "white",
+      "duration",
+    ],
+    cycle: ["speed", "direction", "transition", "duration"],
+    strobe: ["frequency", "duration"],
+    pulse: [
+      "base_level",
+      "pulse_amplitude",
+      "intensity",
+      "frequency",
+      "duration",
+    ],
+    chase: ["pattern", "speed", "direction", "transition", "duration"],
+    dimmer: ["start_level", "end_level", "curve", "duration"],
+    rainbow: ["speed", "saturation", "brightness", "duration"],
+  };
+
+  /** Whether a type reads colours at all. */
+  const USES_COLOR: EffectType[] = ["static", "cycle"];
+
   function updateType(type: EffectType) {
+    // Changing the type used to carry every field across. A cycle with speed,
+    // direction, transition and a colour became a strobe still carrying all of
+    // them — parameters the strobe ignores, written to the file on the next
+    // save. Only what the new type reads survives; the timing fields live on
+    // the effect wrapper, not here, so they are untouched.
+    const keep = USED_PARAMS[type] ?? [];
+    const carried: Record<string, unknown> = {};
+    for (const key of keep) {
+      const value = (effect.effect as unknown as Record<string, unknown>)[key];
+      if (value !== undefined) {
+        carried[key] = value;
+      }
+    }
     onchange({
       ...effect,
       effect: {
-        ...effect.effect,
+        ...carried,
         type,
-        colors: effect.effect.colors,
+        colors: USES_COLOR.includes(type) ? effect.effect.colors : [],
         extra: effect.effect.extra,
-      },
+      } as typeof effect.effect,
     });
   }
 
@@ -93,8 +134,13 @@
     if (p.colors.length > 0) {
       // Shown as swatches, skip text
     }
-    if (p.dimmer) parts.push(p.dimmer);
-    if (p.intensity !== undefined)
+    // Only where the effect reads them, or the collapsed row advertises a value
+    // that has no control to edit it and is dropped on the next save.
+    if (p.dimmer && effect.effect.type === "static") parts.push(p.dimmer);
+    if (
+      p.intensity !== undefined &&
+      (effect.effect.type === "static" || effect.effect.type === "pulse")
+    )
       parts.push(`${Math.round(p.intensity * 100)}%`);
     if (p.speed) parts.push(`spd:${p.speed}`);
     if (p.frequency) parts.push(`freq:${p.frequency}`);
@@ -265,19 +311,6 @@
             /></label
           >
           <label class="param"
-            ><span class="param-label">{$t("effect.dimmer")}</span><input
-              type="text"
-              class="param-input"
-              placeholder="100%"
-              value={effect.effect.dimmer ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "dimmer",
-                  (e.target as HTMLInputElement).value || undefined,
-                )}
-            /></label
-          >
-          <label class="param"
             ><span class="param-label">{$t("effect.direction")}</span>
             <select
               class="param-input"
@@ -291,24 +324,6 @@
               <option value="">--</option>
               {#each CYCLE_DIRECTIONS as d (d)}<option value={d}>{d}</option
                 >{/each}
-            </select>
-          </label>
-          <label class="param"
-            ><span class="param-label">{$t("effect.loop")}</span>
-            <select
-              class="param-input"
-              value={effect.effect.loop ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "loop",
-                  (e.target as HTMLSelectElement).value || undefined,
-                )}
-            >
-              <option value="">--</option><option value="once"
-                >{$t("effect.once")}</option
-              ><option value="loop">{$t("effect.loopOption")}</option><option
-                value="pingpong">{$t("effect.pingpong")}</option
-              ><option value="random">{$t("effect.random")}</option>
             </select>
           </label>
         {:else if effect.effect.type === "strobe"}
@@ -410,19 +425,6 @@
                 )}
             /></label
           >
-          <label class="param"
-            ><span class="param-label">{$t("effect.dimmer")}</span><input
-              type="text"
-              class="param-input"
-              placeholder="80%"
-              value={effect.effect.dimmer ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "dimmer",
-                  (e.target as HTMLInputElement).value || undefined,
-                )}
-            /></label
-          >
         {:else if effect.effect.type === "chase"}
           <label class="param"
             ><span class="param-label">{$t("effect.speed")}</span><input
@@ -480,24 +482,6 @@
               <option value="">--</option
               >{#each CHASE_DIRECTIONS as d (d)}<option value={d}>{d}</option
                 >{/each}
-            </select>
-          </label>
-          <label class="param"
-            ><span class="param-label">{$t("effect.loop")}</span>
-            <select
-              class="param-input"
-              value={effect.effect.loop ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "loop",
-                  (e.target as HTMLSelectElement).value || undefined,
-                )}
-            >
-              <option value="">--</option><option value="once"
-                >{$t("effect.once")}</option
-              ><option value="loop">{$t("effect.loopOption")}</option><option
-                value="pingpong">{$t("effect.pingpong")}</option
-              ><option value="random">{$t("effect.random")}</option>
             </select>
           </label>
         {:else if effect.effect.type === "dimmer"}
@@ -613,22 +597,6 @@
                 )}
             /></label
           >
-          <label class="param"
-            ><span class="param-label">{$t("effect.loop")}</span>
-            <select
-              class="param-input"
-              value={effect.effect.loop ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "loop",
-                  (e.target as HTMLSelectElement).value || undefined,
-                )}
-            >
-              <option value="">--</option><option value="once"
-                >{$t("effect.once")}</option
-              ><option value="loop">{$t("effect.loopOption")}</option>
-            </select>
-          </label>
         {/if}
 
         <!-- Layer & blend mode -->

--- a/src/webui/svelte/src/components/lighting/EffectForm.svelte
+++ b/src/webui/svelte/src/components/lighting/EffectForm.svelte
@@ -73,12 +73,13 @@
     });
   }
 
+  // Only the effect types that actually use a colour. `EffectType::Strobe`,
+  // `Chase`, `Pulse` and `Dimmer` have no colour field: the parser accepts a
+  // `color:` on them and drops it, so offering the control wrote a setting that
+  // never did anything — the same defect as the rainbow direction control
+  // removed in #398, which is how these were found.
   let showsColor = $derived(
-    effect.effect.type === "static" ||
-      effect.effect.type === "cycle" ||
-      effect.effect.type === "chase" ||
-      effect.effect.type === "strobe" ||
-      effect.effect.type === "pulse",
+    effect.effect.type === "static" || effect.effect.type === "cycle",
   );
 
   let isMultiColor = $derived(
@@ -325,20 +326,6 @@
             /></label
           >
           <label class="param"
-            ><span class="param-label">{$t("effect.intensity")}</span><input
-              type="number"
-              class="param-input"
-              min="0"
-              max="1"
-              step="0.1"
-              value={effect.effect.intensity ?? ""}
-              onchange={(e) => {
-                const v = (e.target as HTMLInputElement).value;
-                updateParam("intensity", v ? parseFloat(v) : undefined);
-              }}
-            /></label
-          >
-          <label class="param"
             ><span class="param-label">{$t("effect.duration")}</span><input
               type="text"
               class="param-input"
@@ -351,19 +338,9 @@
                 )}
             /></label
           >
-          <label class="param"
-            ><span class="param-label">{$t("effect.duty")}</span><input
-              type="text"
-              class="param-input"
-              placeholder="50%"
-              value={effect.effect.duty_cycle ?? ""}
-              onchange={(e) =>
-                updateParam(
-                  "duty_cycle",
-                  (e.target as HTMLInputElement).value || undefined,
-                )}
-            /></label
-          >
+          <!-- No intensity or duty cycle: `EffectType::Strobe` carries only a
+               frequency and a duration, so the parser accepted both and dropped
+               them. -->
         {:else if effect.effect.type === "pulse"}
           <label class="param"
             ><span class="param-label">{$t("effect.frequency")}</span><input

--- a/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
@@ -622,9 +622,9 @@
       <LightingSummary lightFile={mergedLightFile} />
     {:else}
       {#if venueGroupsError}
-        <p class="status-text error-text" data-testid="venue-groups-error">
+        <div class="error-banner" data-testid="venue-groups-error">
           {venueGroupsError}
-        </p>
+        </div>
       {/if}
       <TimelineEditor
         lightFile={mergedLightFile}

--- a/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongLightingEditor.svelte
@@ -91,6 +91,12 @@
     null,
   );
   let venueGroups = $state<string[]>([]);
+  /// Why the cue-target group list is empty, when it is empty for a reason.
+  ///
+  /// Swallowing this left an unloadable player config rendering an empty
+  /// autocomplete with nothing said — the same ambiguity the server-side
+  /// fallback exists to remove, moved to the client.
+  let venueGroupsError = $state("");
   let pendingDeletes = $state<string[]>([]);
   let sequenceNames = $derived(mergedLightFile.sequences.map((s) => s.name));
   let uploading = $state(false);
@@ -201,8 +207,10 @@
     try {
       const groups = await fetchLightingGroups();
       venueGroups = groups.map((g) => g.name).sort();
-    } catch {
-      // Non-critical
+      venueGroupsError = "";
+    } catch (e: any) {
+      venueGroups = [];
+      venueGroupsError = e?.message ?? String(e);
     }
   }
 
@@ -613,6 +621,11 @@
     {#if $isPhone}
       <LightingSummary lightFile={mergedLightFile} />
     {:else}
+      {#if venueGroupsError}
+        <p class="status-text error-text" data-testid="venue-groups-error">
+          {venueGroupsError}
+        </p>
+      {/if}
       <TimelineEditor
         lightFile={mergedLightFile}
         groups={venueGroups}

--- a/src/webui/svelte/src/lib/i18n/en.json
+++ b/src/webui/svelte/src/lib/i18n/en.json
@@ -649,7 +649,6 @@
   "effect.pingpong": "pingpong",
   "effect.random": "random",
   "effect.frequency": "Frequency",
-  "effect.duty": "Duty",
   "effect.base": "Base",
   "effect.amplitude": "Amplitude",
   "effect.pattern": "Pattern",

--- a/src/webui/svelte/src/lib/lighting/serializer.ts
+++ b/src/webui/svelte/src/lib/lighting/serializer.ts
@@ -158,13 +158,19 @@ function serializeEffect(cueEffect: CueEffect): string {
 
   // All effect types use comma-separated parameters.
 
-  // Colors
-  for (const color of effect.colors) {
-    parts.push(`color: "${color}"`);
+  // Colors, for the effect types that have one. `EffectType::Strobe`, `Chase`,
+  // `Pulse` and `Dimmer` do not: the parser accepts a `color:` on them and
+  // drops it, so writing one produced a file whose colour never took effect.
+  const usesColor = effect.type === "static" || effect.type === "cycle";
+  if (usesColor) {
+    for (const color of effect.colors) {
+      parts.push(`color: "${color}"`);
+    }
   }
 
-  // Known parameters
-  if (effect.intensity !== undefined)
+  // Known parameters. `intensity` only where it is read — on a strobe it is
+  // accepted and ignored, which is why the control was removed.
+  if (effect.intensity !== undefined && effect.type !== "strobe")
     parts.push(`intensity: ${effect.intensity}`);
   if (effect.dimmer !== undefined) parts.push(`dimmer: ${effect.dimmer}`);
   if (effect.frequency !== undefined)
@@ -193,8 +199,8 @@ function serializeEffect(cueEffect: CueEffect): string {
     parts.push(`base_level: ${effect.base_level}`);
   if (effect.pulse_amplitude !== undefined)
     parts.push(`pulse_amplitude: ${effect.pulse_amplitude}`);
-  if (effect.duty_cycle !== undefined)
-    parts.push(`duty_cycle: ${effect.duty_cycle}`);
+  // `duty_cycle` is read by nothing — `EffectType::Strobe` carries only a
+  // frequency and a duration — so it is not written.
   if (effect.pattern !== undefined) parts.push(`pattern: ${effect.pattern}`);
   if (effect.saturation !== undefined)
     parts.push(`saturation: ${effect.saturation}`);

--- a/src/webui/svelte/src/pages/LightingEditor.svelte
+++ b/src/webui/svelte/src/pages/LightingEditor.svelte
@@ -107,6 +107,12 @@
 
   // Venue groups for autocomplete
   let venueGroups = $state<string[]>([]);
+  /// Why the cue-target group list is empty, when it is empty for a reason.
+  ///
+  /// Swallowing this left an unloadable player config rendering an empty
+  /// autocomplete with nothing said — the same ambiguity the server-side
+  /// fallback exists to remove, moved to the client.
+  let venueGroupsError = $state("");
   let sequenceNames = $derived(mergedLightFile.sequences.map((s) => s.name));
 
   let uploading = $state(false);
@@ -131,8 +137,10 @@
     try {
       const groups = await fetchLightingGroups();
       venueGroups = groups.map((g) => g.name).sort();
-    } catch {
-      // Non-critical
+      venueGroupsError = "";
+    } catch (e: any) {
+      venueGroups = [];
+      venueGroupsError = e?.message ?? String(e);
     }
   }
 
@@ -556,6 +564,11 @@
         {#if $isPhone}
           <LightingSummary lightFile={mergedLightFile} />
         {:else}
+          {#if venueGroupsError}
+            <p class="status-text error-text" data-testid="venue-groups-error">
+              {venueGroupsError}
+            </p>
+          {/if}
           <TimelineEditor
             lightFile={mergedLightFile}
             groups={venueGroups}

--- a/src/webui/svelte/src/pages/LightingEditor.svelte
+++ b/src/webui/svelte/src/pages/LightingEditor.svelte
@@ -565,9 +565,9 @@
           <LightingSummary lightFile={mergedLightFile} />
         {:else}
           {#if venueGroupsError}
-            <p class="status-text error-text" data-testid="venue-groups-error">
+            <div class="error-banner" data-testid="venue-groups-error">
               {venueGroupsError}
-            </p>
+            </div>
           {/if}
           <TimelineEditor
             lightFile={mergedLightFile}


### PR DESCRIPTION
The web UI tier from #398 shipped with type-checking and a green Playwright
suite, but nothing exercising the changed behaviour. Working through it found
three defects.

## Section dialog boundary clamping

Nothing reached `SectionEditDialog`. Its `setBoundary` walks a boundary that
would invert the section back to the last position that does not, rather than
refusing — the picker is a controlled input, so a silent refusal reads as a
broken button, and an inverted range is what `Section::validate` rejects on save.

**The clamping path was not reachable from a test at all.** The mock server
dropped `start_beat`/`end_beat` when generating `song.yaml`, and a section can
only invert when its boundaries are close enough for one step to cross them. The
mock now emits them and the fixture carries a "stab" section with both
boundaries inside measure 10.

Verified by disabling the clamp: two of three fail. The third passes either way
and says so in the file rather than being counted as coverage it is not.

## The venue-group migration advice named a shape that will not load

`dmx.lighting.groups` is a map keyed by group name. The message added with the
venue-group removal told people to write a sequence:

```yaml
groups:
  - name: wash          # does not deserialize
    constraints:
      - AllOf: ["wash"]
```

Following it to repair a rig file produced a config that fails to load — worse
than the error it replaced. Two tests pin it: the documented shape loads, and a
sequence must not, so it cannot drift back.

## `groups_from_config` swallowed load failures

It answered "no groups" for a config that does not load at all — the same silent
empty list the headless fallback exists to remove, one layer down. A config
missing the required `dmx.universes` read as a rig with nothing declared, and the
cue-target autocomplete emptied with nothing to explain it. This is how the
fallback test failed first, and I only found it by probing rather than guessing.
The reason now reaches the caller.

## Also covered

- The headless group fallback itself: with no DMX engine the declared names come
  back, flagged `resolved: false` since the names are knowable without an engine
  and the fixtures each resolves to are not. Verified by reverting it.
- Fixture-type file errors, the mirror of the venue case. Verified by dropping
  the plumbing.

## Not covered, and why

The rainbow direction control was removed in #398 because `EffectType::Rainbow`
has no direction. A UI test would only assert a control's absence, which is
already visible in the diff and cannot regress silently.

The underlying issue is untouched and worth a decision: a hand-written show can
still carry `wash: rainbow speed: 0.5, direction: left_to_right, duration: 4s`,
and it **parses and is silently ignored** (verified). Fixing that means either
rejecting unknown parameters in the parser — stricter, and could break existing
shows — or retaining raw parameter names so `lint.rs` can warn. Both are beyond
this tier, and the choice between them is a judgement about breaking changes
rather than a coverage gap.

## Verified

- 3331 unit tests, clippy and fmt clean
- 21 Playwright specs across the three affected areas
- svelte-check and eslint clean
- Each new test verified against the broken form, except the one marked as not
  discriminating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6iBcCCaFYmoE8XsQAEd6g