### PR TITLE
Create configured directories only inside the project

### DIFF
--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -7,9 +7,19 @@
 The player configuration file (`mtrack.yaml`) controls all of mtrack's runtime settings. It is
 created automatically when mtrack starts, and can be edited through the web UI or by hand.
 
+**Directories outside the project are yours to create.** mtrack makes a configured directory —
+`songs`, `profiles_dir`, the lighting directories — only when it resolves to somewhere inside the
+project directory, and refuses with an error naming the path otherwise. This keeps a typo from
+quietly becoming an empty directory and a puzzling "no songs found", and keeps the service from
+writing outside the paths a hardened [systemd unit](../deployment/systemd.md) confines it to. A
+directory that already exists is used wherever it lives, so pointing `songs` at `/mnt/song-storage`
+works exactly as before once that directory is there.
+
 ```yaml
 # The directory where all of your songs are located, frequently referred to as the song repository.
 # If the path is not absolute, it will be relative to the location of this file.
+# mtrack creates this directory for you only when it is inside the project directory (the one
+# holding this file). An absolute path elsewhere, like the one below, is yours to create.
 songs: /mnt/song-storage
 
 # The path to the playlist file.

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -10,8 +10,8 @@ created automatically when mtrack starts, and can be edited through the web UI o
 **Directories outside the project are yours to create.** The *project directory* is simply the one
 holding this `mtrack.yaml` — wherever you put it, be that `/var/lib/mtrack`, `/home/pi/gig`, or a
 folder on a USB stick. mtrack makes a configured directory — `songs`, `profiles_dir`, the lighting
-directories — only when it resolves to somewhere inside that directory, and otherwise refuses with
-an error naming both paths.
+directories, `playlists_dir` — only when it resolves to somewhere inside that directory, and
+otherwise refuses with an error naming both paths.
 
 A directory that already exists is used wherever it lives, so pointing `songs` at
 `/mnt/song-storage` works exactly as before once that directory is there. Only creating one
@@ -22,7 +22,9 @@ elsewhere is refused, for two reasons:
 - On removable media, creating a directory under a mount point that is not currently mounted writes
   to the underlying disk instead. Everything appears to work until the drive is mounted, at which
   point the files vanish behind it. This is easy to hit on a Pi with songs on a USB stick or SD
-  card, and refusing to create the directory avoids it entirely.
+  card. Refusing to create the directory avoids it for any mount point outside the project — note
+  that a mount point *inside* the project, such as `songs: /var/lib/mtrack/usb`, is still mtrack's
+  to create and so is still exposed to this. Mount before starting mtrack if you rely on one.
 
 If you keep songs on a separate drive, create the directory once (`mkdir -p /media/usb/songs`) and
 mtrack will use it from then on.

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -22,9 +22,18 @@ elsewhere is refused, for two reasons:
 - On removable media, creating a directory under a mount point that is not currently mounted writes
   to the underlying disk instead. Everything appears to work until the drive is mounted, at which
   point the files vanish behind it. This is easy to hit on a Pi with songs on a USB stick or SD
-  card. Refusing to create the directory avoids it for any mount point outside the project — note
-  that a mount point *inside* the project, such as `songs: /var/lib/mtrack/usb`, is still mtrack's
-  to create and so is still exposed to this. Mount before starting mtrack if you rely on one.
+  card.
+
+  Refusing to create covers only part of this, so it is worth being precise: it helps when the
+  configured directory itself is **missing** and outside the project. It does **not** help when the
+  directory exists but nothing is mounted on it — `songs: /mnt/songs` where `/mnt/songs` is an empty
+  directory awaiting a mount is accepted, because an existing directory is used wherever it lives,
+  and mtrack writes to the underlying disk exactly as before. Nor does it help for a mount point
+  *inside* the project, such as `songs: /var/lib/mtrack/usb`, which is still mtrack's to create.
+
+  If you rely on a mount, make systemd wait for it. A unit generated with those paths does this for
+  you — `mtrack systemd /var/lib/mtrack /media/usb/songs` emits a `RequiresMountsFor=` naming them,
+  so the service starts only once they are mounted.
 
 If you keep songs on a separate drive, create the directory once (`mkdir -p /media/usb/songs`) and
 mtrack will use it from then on.

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -31,9 +31,10 @@ elsewhere is refused, for two reasons:
   and mtrack writes to the underlying disk exactly as before. Nor does it help for a mount point
   *inside* the project, such as `songs: /var/lib/mtrack/usb`, which is still mtrack's to create.
 
-  If you rely on a mount, make systemd wait for it. A unit generated with those paths does this for
-  you — `mtrack systemd /var/lib/mtrack /media/usb/songs` emits a `RequiresMountsFor=` naming them,
-  so the service starts only once they are mounted.
+  If you rely on a mount, mount it before mtrack starts. The generated systemd unit retries for
+  about two and a half minutes, which covers a drive that appears a little after boot; see
+  [Running on Startup](../deployment/systemd.md) for why it waits that way rather than declaring a
+  dependency on the mount itself.
 
 If you keep songs on a separate drive, create the directory once (`mkdir -p /media/usb/songs`) and
 mtrack will use it from then on.

--- a/docs/src/configuration/player-config.md
+++ b/docs/src/configuration/player-config.md
@@ -7,13 +7,25 @@
 The player configuration file (`mtrack.yaml`) controls all of mtrack's runtime settings. It is
 created automatically when mtrack starts, and can be edited through the web UI or by hand.
 
-**Directories outside the project are yours to create.** mtrack makes a configured directory —
-`songs`, `profiles_dir`, the lighting directories — only when it resolves to somewhere inside the
-project directory, and refuses with an error naming the path otherwise. This keeps a typo from
-quietly becoming an empty directory and a puzzling "no songs found", and keeps the service from
-writing outside the paths a hardened [systemd unit](../deployment/systemd.md) confines it to. A
-directory that already exists is used wherever it lives, so pointing `songs` at `/mnt/song-storage`
-works exactly as before once that directory is there.
+**Directories outside the project are yours to create.** The *project directory* is simply the one
+holding this `mtrack.yaml` — wherever you put it, be that `/var/lib/mtrack`, `/home/pi/gig`, or a
+folder on a USB stick. mtrack makes a configured directory — `songs`, `profiles_dir`, the lighting
+directories — only when it resolves to somewhere inside that directory, and otherwise refuses with
+an error naming both paths.
+
+A directory that already exists is used wherever it lives, so pointing `songs` at
+`/mnt/song-storage` works exactly as before once that directory is there. Only creating one
+elsewhere is refused, for two reasons:
+
+- A typo would otherwise become an empty directory and a puzzling "no songs found" rather than an
+  error naming the path you actually typed.
+- On removable media, creating a directory under a mount point that is not currently mounted writes
+  to the underlying disk instead. Everything appears to work until the drive is mounted, at which
+  point the files vanish behind it. This is easy to hit on a Pi with songs on a USB stick or SD
+  card, and refusing to create the directory avoids it entirely.
+
+If you keep songs on a separate drive, create the directory once (`mkdir -p /media/usb/songs`) and
+mtrack will use it from then on.
 
 ```yaml
 # The directory where all of your songs are located, frequently referred to as the song repository.

--- a/docs/src/deployment/systemd.md
+++ b/docs/src/deployment/systemd.md
@@ -58,23 +58,24 @@ it did before. An entry you add by hand without that prefix is worse: the unit
 fails namespace setup and the service never starts, so there is no message
 explaining why.
 
-The generated unit also emits `RequiresMountsFor=` for these paths, so systemd waits for whatever
-they live on before starting mtrack. Without that, a library on a USB stick or network share is
-simply absent when the service starts, and `Restart=on-failure` exhausts the default start limit in
-a few seconds — leaving the unit failed for a drive that appeared a moment later.
+If your library lives on a drive that mounts late — a USB stick, SD card or network share — the
+generated unit retries for about two and a half minutes (`RestartSec=5` with a thirty-attempt,
+three-minute start limit) rather than giving up after the systemd default of five attempts in ten
+seconds.
 
-This works only for mounts systemd knows about: an fstab entry or a `.mount` unit. A drive mounted
-on demand by udisks2 has no unit while it is unmounted, so there is nothing to wait for and the
-service starts regardless. Give anything mtrack must not start without an fstab entry.
+It deliberately does *not* emit `RequiresMountsFor=`. That would make systemd wait for the mount,
+but it also implies `Requires=`, so a drive that blinks out mid-set would take the player down with
+it — a worse failure on a machine playing a show than a slow boot. If you have a mount that takes
+longer than the retry window, add `RequiresMountsFor=` to the unit yourself, knowing that cost.
 
 > **Upgrading an existing install: regenerate your unit.** mtrack no longer creates a configured
 > directory that lies outside the project — see
 > [Player Configuration](../configuration/player-config.md). If your `songs` (or `playlists_dir`,
 > `profiles_dir`, or a lighting directory) points outside the project and might be absent at boot,
 > because it lives on a drive that mounts late, startup now fails instead of quietly writing under
-> the mount point. A unit generated before this change has neither the `RequiresMountsFor=` that
-> waits for the drive nor the widened restart window that lets a late mount recover, so it can land
-> in a permanently failed state. Regenerate it:
+> the mount point. A unit generated before this change can land
+> in a permanently failed state -- it has neither the widened restart window that lets a late mount
+> recover nor this rule's clearer diagnostics. Regenerate it:
 >
 > ```
 > $ sudo mtrack systemd /mnt/storage /mnt/nas/songs > /etc/systemd/system/mtrack.service

--- a/docs/src/deployment/systemd.md
+++ b/docs/src/deployment/systemd.md
@@ -67,6 +67,20 @@ This works only for mounts systemd knows about: an fstab entry or a `.mount` uni
 on demand by udisks2 has no unit while it is unmounted, so there is nothing to wait for and the
 service starts regardless. Give anything mtrack must not start without an fstab entry.
 
+> **Upgrading an existing install: regenerate your unit.** mtrack no longer creates a configured
+> directory that lies outside the project — see
+> [Player Configuration](../configuration/player-config.md). If your `songs` (or `playlists_dir`,
+> `profiles_dir`, or a lighting directory) points outside the project and might be absent at boot,
+> because it lives on a drive that mounts late, startup now fails instead of quietly writing under
+> the mount point. A unit generated before this change has neither the `RequiresMountsFor=` that
+> waits for the drive nor the widened restart window that lets a late mount recover, so it can land
+> in a permanently failed state. Regenerate it:
+>
+> ```
+> $ sudo mtrack systemd /mnt/storage /mnt/nas/songs > /etc/systemd/system/mtrack.service
+> $ sudo systemctl daemon-reload
+> ```
+
 These paths are baked into the unit when it is generated. They are not read from
 `$MTRACK_PATH`, so if you move your library later, regenerate the unit as well as
 editing `/etc/default/mtrack`.

--- a/docs/src/deployment/systemd.md
+++ b/docs/src/deployment/systemd.md
@@ -58,10 +58,14 @@ it did before. An entry you add by hand without that prefix is worse: the unit
 fails namespace setup and the service never starts, so there is no message
 explaining why.
 
-The generated unit also emits `RequiresMountsFor=` for these paths, so systemd starts mtrack only
-once whatever they live on is mounted. Without that, a library on a USB stick or network share is
+The generated unit also emits `RequiresMountsFor=` for these paths, so systemd waits for whatever
+they live on before starting mtrack. Without that, a library on a USB stick or network share is
 simply absent when the service starts, and `Restart=on-failure` exhausts the default start limit in
 a few seconds — leaving the unit failed for a drive that appeared a moment later.
+
+This works only for mounts systemd knows about: an fstab entry or a `.mount` unit. A drive mounted
+on demand by udisks2 has no unit while it is unmounted, so there is nothing to wait for and the
+service starts regardless. Give anything mtrack must not start without an fstab entry.
 
 These paths are baked into the unit when it is generated. They are not read from
 `$MTRACK_PATH`, so if you move your library later, regenerate the unit as well as

--- a/docs/src/deployment/systemd.md
+++ b/docs/src/deployment/systemd.md
@@ -58,6 +58,11 @@ it did before. An entry you add by hand without that prefix is worse: the unit
 fails namespace setup and the service never starts, so there is no message
 explaining why.
 
+The generated unit also emits `RequiresMountsFor=` for these paths, so systemd starts mtrack only
+once whatever they live on is mounted. Without that, a library on a USB stick or network share is
+simply absent when the service starts, and `Restart=on-failure` exhausts the default start limit in
+a few seconds — leaving the unit failed for a drive that appeared a moment later.
+
 These paths are baked into the unit when it is generated. They are not read from
 `$MTRACK_PATH`, so if you move your library later, regenerate the unit as well as
 editing `/etc/default/mtrack`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,10 +26,21 @@ use std::fmt::Display;
 const SYSTEMD_SERVICE: &str = r#"
 [Unit]
 Description=multitrack player
+# Paired with RestartSec=5 below: thirty attempts inside three minutes, so a
+# late mount has about two and a half minutes to turn up before the unit gives
+# up and stays failed for someone to look at.
+StartLimitIntervalSec=180
+StartLimitBurst=30
 {{ REQUIRES_MOUNTS_FOR }}
 [Service]
 Type=simple
 Restart=on-failure
+# Retry slowly and for long enough that a drive appearing late is recovered
+# from. The defaults give up after five attempts in ten seconds, which a USB
+# stick or network share can easily miss -- and a unit that has hit its start
+# limit stays failed even once the mount lands.
+RestartSec=5
+
 EnvironmentFile=-/etc/default/mtrack
 ExecStart={{ CURRENT_EXECUTABLE }} start "$MTRACK_PATH"
 ExecReload=/bin/kill -HUP $MAINPID
@@ -823,6 +834,24 @@ mod tests {
                 unit.contains(r#"RequiresMountsFor="/media/usb/My Songs""#),
                 "{unit}"
             );
+        }
+
+        /// A drive that mounts late must not exhaust the start limit before it
+        /// appears: the systemd defaults give up after five attempts in ten
+        /// seconds, and a unit that has hit its limit stays failed even once
+        /// the mount lands.
+        #[test]
+        fn a_late_mount_has_time_to_appear() {
+            let unit = render_systemd_service("/usr/local/bin/mtrack", &[]).unwrap();
+
+            assert!(sets_directive(&unit, "RestartSec="), "{unit}");
+            assert!(sets_directive(&unit, "StartLimitIntervalSec="), "{unit}");
+            assert!(sets_directive(&unit, "StartLimitBurst="), "{unit}");
+
+            // The limit directives order the unit and belong in [Unit].
+            let limit = unit.find("StartLimitIntervalSec=").expect("directive");
+            let service = unit.find("[Service]").expect("section");
+            assert!(limit < service, "start limits must precede [Service]");
         }
 
         /// Nothing to wait for when no path was named.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use std::fmt::Display;
 const SYSTEMD_SERVICE: &str = r#"
 [Unit]
 Description=multitrack player
-
+{{ REQUIRES_MOUNTS_FOR }}
 [Service]
 Type=simple
 Restart=on-failure
@@ -373,8 +373,33 @@ fn render_systemd_service(
         )
     };
 
+    // Ordering, not permission. A path on removable media or a network mount is
+    // simply absent until its mount unit runs, and mtrack now refuses to create
+    // a directory outside its project rather than writing under the mount point.
+    // Starting first therefore fails, `Restart=on-failure` retries, and the
+    // default start limit is spent long before a slow mount lands — leaving the
+    // unit permanently failed for a drive that turned up a second later.
+    let requires_mounts_for = if checked.is_empty() {
+        String::new()
+    } else {
+        let paths = checked.join(" ");
+        format!(
+            "\n\
+# Wait for whatever these paths live on before starting. Harmless for paths on\n\
+# the root filesystem; the point is a library or songs directory on a USB stick,\n\
+# SD card or network share, which is not mounted yet when the service would\n\
+# otherwise start. Without this, mtrack refuses to create a directory that is not\n\
+# there, Restart=on-failure retries, and the default start limit is spent long\n\
+# before a slow mount lands -- leaving the unit failed for a drive that turned up\n\
+# a second later.\n\
+RequiresMountsFor={paths}\n"
+        )
+    };
+
     Ok(SYSTEMD_SERVICE
         .replace("{{ CURRENT_EXECUTABLE }}", executable_path)
+        .replace("{{ REQUIRES_MOUNTS_FOR }}\n", &requires_mounts_for)
+        .replace("{{ REQUIRES_MOUNTS_FOR }}", &requires_mounts_for)
         .replace("{{ CHOWN_HINT }}", &chown_hint)
         .replace("{{ PROTECT_SYSTEM }}", &protect_system)
         .replace("{{ READ_WRITE_PATHS }}\n", &read_write_paths)
@@ -735,6 +760,44 @@ mod tests {
                     );
                 }
             }
+        }
+
+        /// A library on removable media is absent until its mount unit runs.
+        ///
+        /// mtrack refuses to create a directory outside its project rather than
+        /// writing under an unmounted mount point, so starting first now fails
+        /// outright; `Restart=on-failure` then spends the default start limit
+        /// in seconds and leaves the unit failed for a drive that appeared a
+        /// moment later. `RequiresMountsFor=` makes systemd wait instead.
+        #[test]
+        fn declared_paths_are_waited_for() {
+            let unit = render_systemd_service(
+                "/usr/local/bin/mtrack",
+                &[
+                    "/var/lib/mtrack".to_string(),
+                    "/media/usb/songs".to_string(),
+                ],
+            )
+            .unwrap();
+
+            assert!(
+                unit.contains("RequiresMountsFor=/var/lib/mtrack /media/usb/songs"),
+                "{unit}"
+            );
+            // It orders the unit, so it belongs in [Unit], not [Service].
+            let requires = unit.find("RequiresMountsFor=").expect("directive");
+            let service = unit.find("[Service]").expect("section");
+            assert!(
+                requires < service,
+                "RequiresMountsFor must precede [Service]"
+            );
+        }
+
+        /// Nothing to wait for when no path was named.
+        #[test]
+        fn no_paths_means_nothing_to_wait_for() {
+            let unit = render_systemd_service("/usr/local/bin/mtrack", &[]).unwrap();
+            assert!(!sets_directive(&unit, "RequiresMountsFor"), "{unit}");
         }
 
         /// The template must not leak a placeholder into the rendered unit.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,12 +26,20 @@ use std::fmt::Display;
 const SYSTEMD_SERVICE: &str = r#"
 [Unit]
 Description=multitrack player
-# Paired with RestartSec=5 below: thirty attempts inside three minutes, so a
-# late mount has about two and a half minutes to turn up before the unit gives
-# up and stays failed for someone to look at.
+# A library on a USB stick, SD card or network share is simply not there yet
+# when this service would otherwise start, and mtrack will not create a
+# directory outside its project to paper over it. Paired with RestartSec=5
+# below, this gives a late mount about two and a half minutes to turn up.
+#
+# Deliberately not RequiresMountsFor=: that would wait for the mount, but it
+# also implies Requires=, so a drive that blinks out mid-set takes the player
+# down with it. For a machine playing a show, riding out a slow boot is worth
+# more than waiting for a mount that may never be slow. If you have a mount
+# that takes longer than the window below, add RequiresMountsFor= yourself,
+# knowing that cost.
 StartLimitIntervalSec=180
 StartLimitBurst=30
-{{ REQUIRES_MOUNTS_FOR }}
+
 [Service]
 Type=simple
 Restart=on-failure
@@ -384,47 +392,8 @@ fn render_systemd_service(
         )
     };
 
-    // Ordering, not permission. A path on removable media or a network mount is
-    // simply absent until its mount unit runs, and mtrack now refuses to create
-    // a directory outside its project rather than writing under the mount point.
-    // Starting first therefore fails, `Restart=on-failure` retries, and the
-    // default start limit is spent long before a slow mount lands — leaving the
-    // unit permanently failed for a drive that turned up a second later.
-    let requires_mounts_for = if checked.is_empty() {
-        String::new()
-    } else {
-        // Quoted, exactly as ReadWritePaths= is. Unquoted, systemd splits the
-        // list on spaces: a perfectly ordinary "/media/usb/My Songs" becomes a
-        // wait on /media/usb/My and a rejection of Songs as non-absolute, so
-        // the ordering this exists to guarantee silently does not apply -- for
-        // the removable-media path it was added for.
-        let paths = checked
-            .iter()
-            .map(|p| format!("\"{p}\""))
-            .collect::<Vec<_>>()
-            .join(" ");
-        format!(
-            "\n\
-# Wait for whatever these paths live on before starting. Harmless for paths on\n\
-# the root filesystem; the point is a library or songs directory on a USB stick,\n\
-# SD card or network share, which is not mounted yet when the service would\n\
-# otherwise start. Without this, mtrack refuses to create a directory that is not\n\
-# there, Restart=on-failure retries, and the default start limit is spent long\n\
-# before a slow mount lands -- leaving the unit failed for a drive that turned up\n\
-# a second later.\n\
-#\n\
-# systemd can only order against a mount it knows about: one declared in fstab\n\
-# or by a .mount unit. A drive mounted on demand by udisks2 has no such unit\n\
-# while it is unmounted, so nothing is waited for and the service starts anyway.\n\
-# Add an fstab entry for anything mtrack must not start without.\n\
-RequiresMountsFor={paths}\n"
-        )
-    };
-
     Ok(SYSTEMD_SERVICE
         .replace("{{ CURRENT_EXECUTABLE }}", executable_path)
-        .replace("{{ REQUIRES_MOUNTS_FOR }}\n", &requires_mounts_for)
-        .replace("{{ REQUIRES_MOUNTS_FOR }}", &requires_mounts_for)
         .replace("{{ CHOWN_HINT }}", &chown_hint)
         .replace("{{ PROTECT_SYSTEM }}", &protect_system)
         .replace("{{ READ_WRITE_PATHS }}\n", &read_write_paths)
@@ -787,55 +756,6 @@ mod tests {
             }
         }
 
-        /// A library on removable media is absent until its mount unit runs.
-        ///
-        /// mtrack refuses to create a directory outside its project rather than
-        /// writing under an unmounted mount point, so starting first now fails
-        /// outright; `Restart=on-failure` then spends the default start limit
-        /// in seconds and leaves the unit failed for a drive that appeared a
-        /// moment later. `RequiresMountsFor=` makes systemd wait instead.
-        #[test]
-        fn declared_paths_are_waited_for() {
-            let unit = render_systemd_service(
-                "/usr/local/bin/mtrack",
-                &[
-                    "/var/lib/mtrack".to_string(),
-                    "/media/usb/songs".to_string(),
-                ],
-            )
-            .unwrap();
-
-            assert!(
-                unit.contains(r#"RequiresMountsFor="/var/lib/mtrack" "/media/usb/songs""#),
-                "{unit}"
-            );
-            // It orders the unit, so it belongs in [Unit], not [Service].
-            let requires = unit.find("RequiresMountsFor=").expect("directive");
-            let service = unit.find("[Service]").expect("section");
-            assert!(
-                requires < service,
-                "RequiresMountsFor must precede [Service]"
-            );
-        }
-
-        /// Unquoted, systemd splits the list on spaces: an ordinary
-        /// "/media/usb/My Songs" becomes a wait on /media/usb/My and a
-        /// rejection of Songs as non-absolute, so the ordering silently does
-        /// not apply — for the removable-media path it exists to serve.
-        #[test]
-        fn a_waited_for_path_with_a_space_stays_one_path() {
-            let unit = render_systemd_service(
-                "/usr/local/bin/mtrack",
-                &["/media/usb/My Songs".to_string()],
-            )
-            .unwrap();
-
-            assert!(
-                unit.contains(r#"RequiresMountsFor="/media/usb/My Songs""#),
-                "{unit}"
-            );
-        }
-
         /// A drive that mounts late must not exhaust the start limit before it
         /// appears: the systemd defaults give up after five attempts in ten
         /// seconds, and a unit that has hit its limit stays failed even once
@@ -852,13 +772,6 @@ mod tests {
             let limit = unit.find("StartLimitIntervalSec=").expect("directive");
             let service = unit.find("[Service]").expect("section");
             assert!(limit < service, "start limits must precede [Service]");
-        }
-
-        /// Nothing to wait for when no path was named.
-        #[test]
-        fn no_paths_means_nothing_to_wait_for() {
-            let unit = render_systemd_service("/usr/local/bin/mtrack", &[]).unwrap();
-            assert!(!sets_directive(&unit, "RequiresMountsFor"), "{unit}");
         }
 
         /// The template must not leak a placeholder into the rendered unit.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -382,7 +382,16 @@ fn render_systemd_service(
     let requires_mounts_for = if checked.is_empty() {
         String::new()
     } else {
-        let paths = checked.join(" ");
+        // Quoted, exactly as ReadWritePaths= is. Unquoted, systemd splits the
+        // list on spaces: a perfectly ordinary "/media/usb/My Songs" becomes a
+        // wait on /media/usb/My and a rejection of Songs as non-absolute, so
+        // the ordering this exists to guarantee silently does not apply -- for
+        // the removable-media path it was added for.
+        let paths = checked
+            .iter()
+            .map(|p| format!("\"{p}\""))
+            .collect::<Vec<_>>()
+            .join(" ");
         format!(
             "\n\
 # Wait for whatever these paths live on before starting. Harmless for paths on\n\
@@ -392,6 +401,11 @@ fn render_systemd_service(
 # there, Restart=on-failure retries, and the default start limit is spent long\n\
 # before a slow mount lands -- leaving the unit failed for a drive that turned up\n\
 # a second later.\n\
+#\n\
+# systemd can only order against a mount it knows about: one declared in fstab\n\
+# or by a .mount unit. A drive mounted on demand by udisks2 has no such unit\n\
+# while it is unmounted, so nothing is waited for and the service starts anyway.\n\
+# Add an fstab entry for anything mtrack must not start without.\n\
 RequiresMountsFor={paths}\n"
         )
     };
@@ -781,7 +795,7 @@ mod tests {
             .unwrap();
 
             assert!(
-                unit.contains("RequiresMountsFor=/var/lib/mtrack /media/usb/songs"),
+                unit.contains(r#"RequiresMountsFor="/var/lib/mtrack" "/media/usb/songs""#),
                 "{unit}"
             );
             // It orders the unit, so it belongs in [Unit], not [Service].
@@ -790,6 +804,24 @@ mod tests {
             assert!(
                 requires < service,
                 "RequiresMountsFor must precede [Service]"
+            );
+        }
+
+        /// Unquoted, systemd splits the list on spaces: an ordinary
+        /// "/media/usb/My Songs" becomes a wait on /media/usb/My and a
+        /// rejection of Songs as non-absolute, so the ordering silently does
+        /// not apply — for the removable-media path it exists to serve.
+        #[test]
+        fn a_waited_for_path_with_a_space_stays_one_path() {
+            let unit = render_systemd_service(
+                "/usr/local/bin/mtrack",
+                &["/media/usb/My Songs".to_string()],
+            )
+            .unwrap();
+
+            assert!(
+                unit.contains(r#"RequiresMountsFor="/media/usb/My Songs""#),
+                "{unit}"
             );
         }
 

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -184,16 +184,22 @@ pub async fn start(
         player_path.to_path_buf(),
     ));
 
-    // Ensure songs directory exists
+    // Ensure songs directory exists, if it is ours to create. A `songs:` that
+    // points outside the project is the operator's to set up: creating it here
+    // turns a typo into an empty directory and a puzzling "no songs found", and
+    // asks the service to write outside the paths the generated systemd unit
+    // fences it into.
     let songs_path = player_config.songs(player_path);
-    if !songs_path.exists() {
+    let project_dir = player_path.parent().unwrap_or_else(|| Path::new("."));
+    if !songs_path.is_dir() {
         info!("Creating songs directory at {:?}", songs_path);
-        // The library is not the only path a config can point at, and a `songs`
-        // directory somewhere else is exactly what the unit's ReadWritePaths
-        // will not cover unless it was named at generation time.
-        crate::util::create_dir_all(&songs_path)
-            .map_err(|e| annotate_write(crate::util::WriteTarget::Directory(&songs_path), e))?;
     }
+    crate::util::create_dir_within(&songs_path, project_dir).map_err(|e| match e {
+        crate::util::CreateWithinError::Io(io) => {
+            annotate_write(crate::util::WriteTarget::Directory(&songs_path), io)
+        }
+        outside => Box::<dyn Error>::from(outside.to_string()),
+    })?;
 
     let default_metronome = player_config.metronome().is_some_and(|m| m.enabled);
     let songs = songs::get_all_songs_with_defaults(&songs_path, default_metronome)?;

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -190,16 +190,19 @@ pub async fn start(
     // asks the service to write outside the paths the generated systemd unit
     // fences it into.
     let songs_path = player_config.songs(player_path);
-    let project_dir = player_path.parent().unwrap_or_else(|| Path::new("."));
-    if !songs_path.is_dir() {
-        info!("Creating songs directory at {:?}", songs_path);
-    }
-    crate::util::create_dir_within(&songs_path, project_dir).map_err(|e| match e {
+    let project_dir = crate::util::project_dir_of(player_path);
+    let creating = !songs_path.is_dir();
+    crate::util::create_dir_within(&songs_path, &project_dir).map_err(|e| match e {
         crate::util::CreateWithinError::Io(io) => {
             annotate_write(crate::util::WriteTarget::Directory(&songs_path), io)
         }
         outside => Box::<dyn Error>::from(outside.to_string()),
     })?;
+    // Logged after the fact: announcing the creation first meant a refusal
+    // arrived immediately behind "Creating songs directory at ...".
+    if creating {
+        info!("Created songs directory at {:?}", songs_path);
+    }
 
     let default_metronome = player_config.metronome().is_some_and(|m| m.enabled);
     let songs = songs::get_all_songs_with_defaults(&songs_path, default_metronome)?;

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -291,7 +291,11 @@ pub async fn start(
                 state_rx: state_rx.clone(),
                 broadcast_tx,
                 config_path: player_path.to_path_buf(),
-                songs_path: player_config.songs(player_path),
+                // The directory that exists, not the configured spelling --
+                // which no longer resolves when it holds a `..`, and left every
+                // web UI songs endpoint answering "Root directory not found"
+                // while the player itself worked fine.
+                songs_path: songs_path.as_path().to_path_buf(),
                 playlists_dir: playlists_dir.clone(),
                 legacy_playlist_path: Some(legacy_playlist_path.clone()),
                 profiles_dir,

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -192,15 +192,20 @@ pub async fn start(
     // turns a typo into an empty directory and a puzzling "no songs found", and
     // asks the service to write outside the paths the generated systemd unit
     // fences it into.
-    let songs_path = player_config.songs(player_path);
+    let configured_songs = player_config.songs(player_path);
     let project_dir = crate::util::project_dir_of(player_path);
-    let creating = !songs_path.is_dir();
-    crate::util::create_dir_within(&songs_path, &project_dir).map_err(|e| match e {
-        crate::util::CreateWithinError::Io(io) => {
-            annotate_write(crate::util::WriteTarget::Directory(&songs_path), io)
-        }
-        outside => Box::<dyn Error>::from(outside.to_string()),
-    })?;
+    let creating = !configured_songs.is_dir();
+    // The resolved directory, not the spelling it was configured as. Creation
+    // follows the resolved path, and `songs/../real` is not equivalent to it:
+    // POSIX cannot resolve that spelling unless `songs` exists, so reading the
+    // configured path back would fail with a bare "No such file or directory".
+    let songs_path =
+        crate::util::create_dir_within(&configured_songs, &project_dir).map_err(|e| match e {
+            crate::util::CreateWithinError::Io(io) => {
+                annotate_write(crate::util::WriteTarget::Directory(&configured_songs), io)
+            }
+            refused => Box::<dyn Error>::from(refused.to_string()),
+        })?;
     // Logged after the fact: announcing the creation first meant a refusal
     // arrived immediately behind "Creating songs directory at ...".
     if creating {

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -201,15 +201,18 @@ pub async fn start(
     // configured path back would fail with a bare "No such file or directory".
     let songs_path =
         crate::util::create_dir_within(&configured_songs, &project_dir).map_err(|e| match e {
-            crate::util::CreateWithinError::Io(io) => {
-                annotate_write(crate::util::WriteTarget::Directory(&configured_songs), io)
+            // The resolved path, which is what create_dir_all ran on. Naming
+            // the configured spelling would advise adding a path to
+            // ReadWritePaths= that was never touched.
+            crate::util::CreateWithinError::Io { path, source } => {
+                annotate_write(crate::util::WriteTarget::Directory(&path), source)
             }
             refused => Box::<dyn Error>::from(refused.to_string()),
         })?;
     // Logged after the fact: announcing the creation first meant a refusal
     // arrived immediately behind "Creating songs directory at ...".
     if creating {
-        info!("Created songs directory at {:?}", songs_path);
+        info!("Created songs directory at {}", songs_path.display());
     }
 
     let default_metronome = player_config.metronome().is_some_and(|m| m.enabled);
@@ -523,7 +526,7 @@ pub fn verify(
 ) -> Result<(), Box<dyn Error>> {
     let config_path = Path::new(config);
     let player_config = config::Player::deserialize(config_path)?;
-    let songs_path = player_config.songs(config_path);
+    let songs_path = crate::util::resolved_dir(&player_config.songs(config_path));
     let songs = songs::get_all_songs(&songs_path)?;
 
     if songs.is_empty() {

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -165,12 +165,15 @@ pub async fn start(
             // anywhere in the directory tree are discoverable — including via
             // bulk import after startup.
             default_config.set_songs(".");
-            if let Some(parent) = player_path.parent() {
-                if !parent.exists() {
-                    crate::util::create_dir_all(parent).map_err(|e| {
-                        annotate_write(crate::util::WriteTarget::Directory(parent), e)
-                    })?;
-                }
+            // `project_dir_of` rather than `parent()`: the latter answers
+            // `Some("")` for a bare filename, the trap this branch sat directly
+            // above, and is harmless here only because std short-circuits an
+            // empty path.
+            let config_dir = crate::util::project_dir_of(player_path);
+            if !config_dir.exists() {
+                crate::util::create_dir_all(&config_dir).map_err(|e| {
+                    annotate_write(crate::util::WriteTarget::Directory(&config_dir), e)
+                })?;
             }
             let yaml = crate::util::to_yaml_string(&default_config)?;
             crate::util::write_file(player_path, yaml.as_bytes())

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -3182,16 +3182,15 @@ impl McpServer {
         let path = store.path().to_path_buf();
         let cfg = store.read_config().await;
         let songs = cfg.songs(&path);
-        if !songs.exists() {
-            crate::util::create_dir_all_async(&songs)
-                .await
-                .map_err(|e| {
-                    McpError::internal_error(
-                        format!("failed to create songs dir {}: {e}", songs.display()),
-                        None,
-                    )
-                })?;
-        }
+        // Created only when it is inside the project. A `songs:` pointing
+        // elsewhere is the operator's to set up -- see `create_dir_within`.
+        let project = path
+            .parent()
+            .map(|parent| parent.to_path_buf())
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        crate::util::create_dir_within_async(songs.clone(), project)
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         crate::webui::safe_path::VerifiedRoot::new(&songs).map_err(safepath_err)
     }
 
@@ -3237,14 +3236,13 @@ impl McpServer {
                 .unwrap_or_else(|| std::path::PathBuf::from("."));
             parent.join(rel_path)
         };
-        if !dir.exists() {
-            crate::util::create_dir_all_async(&dir).await.map_err(|e| {
-                McpError::internal_error(
-                    format!("failed to create lighting dir {}: {e}", dir.display()),
-                    None,
-                )
-            })?;
-        }
+        let project = config_path
+            .parent()
+            .map(|parent| parent.to_path_buf())
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        crate::util::create_dir_within_async(dir.clone(), project)
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         Ok(dir)
     }
 

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1117,7 +1117,7 @@ impl McpServer {
             let project = crate::util::project_dir_of(self.config_store()?.path());
             crate::util::create_dir_within_async(parent.to_path_buf(), project)
                 .await
-                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+                .map_err(create_within_err)?;
         }
         staged_write_string(&path, &args.yaml).await?;
         // Rebuild the player's playlist set so `list_playlists` /
@@ -3186,7 +3186,7 @@ impl McpServer {
         let project = crate::util::project_dir_of(&path);
         crate::util::create_dir_within_async(songs.clone(), project)
             .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            .map_err(create_within_err)?;
         crate::webui::safe_path::VerifiedRoot::new(&songs).map_err(safepath_err)
     }
 
@@ -3227,16 +3227,12 @@ impl McpServer {
         let dir = if rel_path.is_absolute() {
             rel_path
         } else {
-            let parent = config_path
-                .parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| std::path::PathBuf::from("."));
-            parent.join(rel_path)
+            crate::util::project_dir_of(&config_path).join(rel_path)
         };
         let project = crate::util::project_dir_of(&config_path);
         crate::util::create_dir_within_async(dir.clone(), project)
             .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            .map_err(create_within_err)?;
         Ok(dir)
     }
 
@@ -3266,17 +3262,13 @@ impl McpServer {
         let songs_path = cfg.songs(&config_path);
         let playlists_dir = cfg
             .playlists_dir(&config_path)
-            .or_else(|| config_path.parent().map(|p| p.join("playlists")));
+            .or_else(|| Some(crate::util::project_dir_of(&config_path).join("playlists")));
 
         let legacy_playlist_path = cfg.playlist().map(|rel| {
             if rel.is_absolute() {
                 rel
             } else {
-                let parent = config_path
-                    .parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(|| std::path::PathBuf::from("."));
-                parent.join(rel)
+                crate::util::project_dir_of(&config_path).join(rel)
             }
         });
 
@@ -3316,11 +3308,7 @@ impl McpServer {
                 if rel.is_absolute() {
                     Ok(rel)
                 } else {
-                    let parent = config_path
-                        .parent()
-                        .map(|p| p.to_path_buf())
-                        .unwrap_or_else(|| std::path::PathBuf::from("."));
-                    Ok(parent.join(rel))
+                    Ok(crate::util::project_dir_of(&config_path).join(rel))
                 }
             }
         }
@@ -3357,6 +3345,19 @@ pub(crate) fn serde_yaml_from_str<T: for<'de> serde::Deserialize<'de>>(
         .map_err(|e| McpError::invalid_params(format!("invalid YAML: {e}"), None))?;
     cfg.try_deserialize()
         .map_err(|e| McpError::invalid_params(format!("invalid payload: {e}"), None))
+}
+
+/// Wraps a [`crate::util::CreateWithinError`] as an MCP error.
+///
+/// `invalid_params` rather than `internal_error` for the two the operator can
+/// act on — a path outside the project, or one occupied by something that is
+/// not a directory — so a client presents them as a configuration problem
+/// rather than a server fault. A genuine I/O failure stays internal.
+pub(crate) fn create_within_err(err: crate::util::CreateWithinError) -> McpError {
+    match err {
+        crate::util::CreateWithinError::Io(_) => McpError::internal_error(err.to_string(), None),
+        _ => McpError::invalid_params(err.to_string(), None),
+    }
 }
 
 /// Wraps a [`SafePathError`] as an `invalid_params` MCP error.

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1111,14 +1111,13 @@ impl McpServer {
         let _: crate::config::Playlist = serde_yaml_from_str(&args.yaml)?;
         let path = self.resolve_playlist_path(args.name.as_deref()).await?;
         if let Some(parent) = path.parent() {
-            crate::util::create_dir_all_async(parent)
+            // Same rule as the web UI's playlist write and every other
+            // configured root: created only when it is inside the project. A
+            // `playlists_dir:` pointing elsewhere is the operator's to set up.
+            let project = crate::util::project_dir_of(self.config_store()?.path());
+            crate::util::create_dir_within_async(parent.to_path_buf(), project)
                 .await
-                .map_err(|e| {
-                    McpError::internal_error(
-                        format!("failed to create {}: {e}", parent.display()),
-                        None,
-                    )
-                })?;
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         }
         staged_write_string(&path, &args.yaml).await?;
         // Rebuild the player's playlist set so `list_playlists` /

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -1110,15 +1110,23 @@ impl McpServer {
     ) -> Result<CallToolResult, McpError> {
         let _: crate::config::Playlist = serde_yaml_from_str(&args.yaml)?;
         let path = self.resolve_playlist_path(args.name.as_deref()).await?;
-        if let Some(parent) = path.parent() {
-            // Same rule as the web UI's playlist write and every other
-            // configured root: created only when it is inside the project. A
-            // `playlists_dir:` pointing elsewhere is the operator's to set up.
-            let project = crate::util::project_dir_of(self.config_store()?.path());
-            crate::util::create_dir_within_async(parent.to_path_buf(), project)
-                .await
-                .map_err(create_within_err)?;
-        }
+        // Same rule as the web UI's playlist write and every other configured
+        // root: created only when it is inside the project. A `playlists_dir:`
+        // pointing elsewhere is the operator's to set up.
+        //
+        // The file is then written under the directory that was made, not the
+        // spelling it was configured as -- those differ when the setting holds
+        // a `..`, and the spelling names a path that was never created.
+        let path = match (path.parent(), path.file_name()) {
+            (Some(parent), Some(name)) => {
+                let project = crate::util::project_dir_of(self.config_store()?.path());
+                let created = crate::util::create_dir_within_async(parent.to_path_buf(), project)
+                    .await
+                    .map_err(create_within_err)?;
+                created.as_path().join(name)
+            }
+            _ => path,
+        };
         staged_write_string(&path, &args.yaml).await?;
         // Rebuild the player's playlist set so `list_playlists` /
         // `switch_playlist` see the new file without requiring a restart.
@@ -3184,10 +3192,13 @@ impl McpServer {
         // Created only when it is inside the project. A `songs:` pointing
         // elsewhere is the operator's to set up -- see `create_dir_within`.
         let project = crate::util::project_dir_of(&path);
-        crate::util::create_dir_within_async(songs.clone(), project)
+        let created = crate::util::create_dir_within_async(songs.clone(), project)
             .await
             .map_err(create_within_err)?;
-        crate::webui::safe_path::VerifiedRoot::new(&songs).map_err(safepath_err)
+        // The created path, not the configured spelling: VerifiedRoot
+        // canonicalizes, and a `..` spelling no longer resolves now that the
+        // stray intermediate is not made.
+        crate::webui::safe_path::VerifiedRoot::new(created.as_path()).map_err(safepath_err)
     }
 
     /// Resolves the configured lighting subdirectory (venues or fixture types)
@@ -3230,10 +3241,10 @@ impl McpServer {
             crate::util::project_dir_of(&config_path).join(rel_path)
         };
         let project = crate::util::project_dir_of(&config_path);
-        crate::util::create_dir_within_async(dir.clone(), project)
+        let created = crate::util::create_dir_within_async(dir.clone(), project)
             .await
             .map_err(create_within_err)?;
-        Ok(dir)
+        Ok(created.into_path_buf())
     }
 
     /// Resolves a single `.light` filename inside a lighting subdirectory,

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -3184,10 +3184,7 @@ impl McpServer {
         let songs = cfg.songs(&path);
         // Created only when it is inside the project. A `songs:` pointing
         // elsewhere is the operator's to set up -- see `create_dir_within`.
-        let project = path
-            .parent()
-            .map(|parent| parent.to_path_buf())
-            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let project = crate::util::project_dir_of(&path);
         crate::util::create_dir_within_async(songs.clone(), project)
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
@@ -3195,8 +3192,9 @@ impl McpServer {
     }
 
     /// Resolves the configured lighting subdirectory (venues or fixture types)
-    /// to an absolute path. The directory is created if it doesn't yet exist,
-    /// so write tools work against fresh configs.
+    /// to an absolute path. The directory is created if it doesn't yet exist
+    /// *and* lies inside the project directory, so write tools work against
+    /// fresh configs without making directories wherever a config points.
     pub(crate) async fn resolve_lighting_dir(
         &self,
         kind: LightingDirKind,
@@ -3236,10 +3234,7 @@ impl McpServer {
                 .unwrap_or_else(|| std::path::PathBuf::from("."));
             parent.join(rel_path)
         };
-        let project = config_path
-            .parent()
-            .map(|parent| parent.to_path_buf())
-            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let project = crate::util::project_dir_of(&config_path);
         crate::util::create_dir_within_async(dir.clone(), project)
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -3270,7 +3270,11 @@ impl McpServer {
         let config_path = store.path().to_path_buf();
         let cfg = store.read_config().await;
 
-        let songs_path = cfg.songs(&config_path);
+        // Resolved, like songs_root_verified: the configured spelling is not
+        // always usable now that the stray intermediate is not created, and a
+        // rescan that fails here only logs a warning -- every write tool would
+        // report success while the player kept stale songs.
+        let songs_path = crate::util::resolved_dir(&cfg.songs(&config_path));
         let playlists_dir = cfg
             .playlists_dir(&config_path)
             .or_else(|| Some(crate::util::project_dir_of(&config_path).join("playlists")));
@@ -3366,7 +3370,9 @@ pub(crate) fn serde_yaml_from_str<T: for<'de> serde::Deserialize<'de>>(
 /// rather than a server fault. A genuine I/O failure stays internal.
 pub(crate) fn create_within_err(err: crate::util::CreateWithinError) -> McpError {
     match err {
-        crate::util::CreateWithinError::Io(_) => McpError::internal_error(err.to_string(), None),
+        crate::util::CreateWithinError::Io { .. } => {
+            McpError::internal_error(err.to_string(), None)
+        }
         _ => McpError::invalid_params(err.to_string(), None),
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -452,6 +452,11 @@ pub enum CreateWithinError {
         /// The project directory it had to be inside of.
         project: PathBuf,
     },
+    /// Something is already there, and it is not a directory.
+    NotADirectory {
+        /// The path that is occupied.
+        path: PathBuf,
+    },
     /// It was inside the project, and creating it failed anyway.
     Io(std::io::Error),
 }
@@ -467,6 +472,12 @@ impl std::fmt::Display for CreateWithinError {
                 path.display(),
                 project.display(),
             ),
+            CreateWithinError::NotADirectory { path } => write!(
+                f,
+                "{} is not a directory. Point the setting at a directory, or \
+                 move what is there out of the way.",
+                path.display(),
+            ),
             CreateWithinError::Io(error) => write!(f, "{error}"),
         }
     }
@@ -476,7 +487,7 @@ impl std::error::Error for CreateWithinError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             CreateWithinError::Io(error) => Some(error),
-            CreateWithinError::Outside { .. } => None,
+            CreateWithinError::Outside { .. } | CreateWithinError::NotADirectory { .. } => None,
         }
     }
 }
@@ -494,6 +505,13 @@ impl std::error::Error for CreateWithinError {
 pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinError> {
     if dir.is_dir() {
         return Ok(());
+    }
+    // Distinguished from "does not exist", which sent an operator looking for a
+    // path that is sitting right there as a file.
+    if dir.exists() {
+        return Err(CreateWithinError::NotADirectory {
+            path: dir.to_path_buf(),
+        });
     }
     if !is_within(dir, project) {
         return Err(CreateWithinError::Outside {
@@ -530,7 +548,13 @@ fn is_within(path: &Path, root: &Path) -> bool {
     resolve_as_far_as_possible(path).starts_with(root)
 }
 
-/// `path` with its existing prefix canonicalized and the remainder applied.
+/// `path` resolved as far as the filesystem allows.
+///
+/// Walks the components, canonicalizing whenever what has been built so far
+/// exists. Resolving only the longest existing *prefix* is not enough: the
+/// remainder gets pushed literally, so a `..` can walk back into existing,
+/// symlinked territory — `project/missing/../link/songs` — and land outside
+/// the project while still reading as inside it.
 fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
     // A relative path is relative to the process's directory, and comparing one
     // against an absolute root answers "outside" for everything. `mtrack start
@@ -543,40 +567,31 @@ fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
             .map(|cwd| cwd.join(path))
             .unwrap_or_else(|_| path.to_path_buf())
     };
-    let path = path.as_path();
 
-    // The longest ancestor that exists, canonicalized. Any symlink must be in
-    // there, since a component that does not exist cannot be one.
-    let Some((prefix, canonical)) = path
-        .ancestors()
-        .find_map(|ancestor| ancestor.canonicalize().ok().map(|c| (ancestor, c)))
-    else {
-        return path.to_path_buf();
-    };
-
-    let Ok(rest) = path.strip_prefix(prefix) else {
-        return canonical;
-    };
-
-    // The remainder applied a component at a time. `..` has to be resolved
-    // here rather than left in place: `starts_with` compares components, so a
-    // path that spells its way back out -- `project/missing/../../escaped` --
-    // reads as inside the project while landing well outside it.
-    let mut resolved = canonical;
-    for component in rest.components() {
+    let mut resolved = PathBuf::new();
+    for component in path.components() {
         match component {
-            std::path::Component::Normal(part) => resolved.push(part),
+            std::path::Component::Normal(part) => {
+                resolved.push(part);
+                // Canonicalize the moment it exists, so a symlink is followed
+                // here rather than compared as though it were a directory.
+                if let Ok(canonical) = resolved.canonicalize() {
+                    resolved = canonical;
+                }
+            }
+            // Popping a canonical path is exact; popping one that still holds
+            // an unresolved symlink is what the canonicalization above avoids.
             std::path::Component::ParentDir => {
                 resolved.pop();
             }
-            // A leading `/` or `.` cannot move us out of the prefix.
-            _ => {}
+            std::path::Component::CurDir => {}
+            other => resolved.push(other.as_os_str()),
         }
     }
     resolved
 }
 
-/// The project directory implied by a config file's path: the directory holding
+/// The project directory implied by a config file/// The project directory implied by a config file's path: the directory holding
 /// it, and the only place mtrack creates directories on a config's behalf.
 ///
 /// [`Path::parent`] answers `Some("")` rather than `None` for a bare filename,
@@ -589,7 +604,7 @@ pub fn project_dir_of(config_path: &Path) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
-/// [`create_dir_all`] for callers on a Tokio runtime, which keeps the/// [`create_dir_all`] for callers on a Tokio runtime, which keeps the
+/// [`create_dir_all`] for callers on a Tokio runtime, which keeps the
 /// filesystem work off the async worker.
 pub async fn create_dir_all_async(path: &Path) -> std::io::Result<()> {
     let path = path.to_path_buf();
@@ -1318,6 +1333,39 @@ mod create_dir_within_tests {
         assert!(!outer.path().join("escaped-songs").exists());
     }
 
+    /// "Does not exist" sent the operator looking for a path sitting right
+    /// there — `songs: /mnt/nas/songs.tar` names a real file, just not a
+    /// directory.
+    #[test]
+    fn an_occupied_path_says_so_rather_than_claiming_it_is_missing() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let occupied = project.path().join("songs.tar");
+        std::fs::write(&occupied, b"not a directory").expect("write");
+
+        let error = create_dir_within(&occupied, project.path()).expect_err("refused");
+        let message = error.to_string();
+        assert!(message.contains("is not a directory"), "{message}");
+        assert!(!message.contains("does not exist"), "{message}");
+        // The file it named is left alone.
+        assert!(occupied.is_file());
+    }
+
+    /// A file in the way outside the project is still reported as the file it
+    /// is: the operator has to move it either way, and "outside the project"
+    /// would send them to fix the wrong thing.
+    #[test]
+    fn an_occupied_path_outside_the_project_reports_the_occupant() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let occupied = elsewhere.path().join("songs.tar");
+        std::fs::write(&occupied, b"not a directory").expect("write");
+
+        let message = create_dir_within(&occupied, project.path())
+            .expect_err("refused")
+            .to_string();
+        assert!(message.contains("is not a directory"), "{message}");
+    }
+
     /// The restriction is on *creating*, not on using. An operator who set up
     /// /mnt/nas/songs themselves must keep working.
     #[test]
@@ -1344,6 +1392,36 @@ mod create_dir_within_tests {
         let through_link = link.join("inner");
         assert!(is_outside(create_dir_within(&through_link, project.path())));
         assert!(!elsewhere.path().join("inner").exists());
+    }
+
+    /// A `..` can walk back into existing, symlinked territory.
+    ///
+    /// Canonicalizing only the longest *existing* ancestor is not enough: the
+    /// remainder is pushed literally, so `project/missing/../link/songs` hops
+    /// over `missing`, lands on a symlink that leaves the project, and reads as
+    /// inside it. The previous fix closed the lexical spelling and left this.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_reached_after_a_missing_component_is_refused() {
+        let outer = tempfile::tempdir().expect("tempdir");
+        let project = outer.path().join("project");
+        std::fs::create_dir(&project).expect("project dir");
+        let outside = outer.path().join("outside");
+        std::fs::create_dir(&outside).expect("outside dir");
+
+        std::os::unix::fs::symlink(&outside, project.join("link")).expect("symlink");
+
+        // `missing` does not exist, so resolution stops before `link`.
+        let escaped = project.join("missing/../link/songs");
+        assert!(
+            is_outside(create_dir_within(&escaped, &project)),
+            "escaped through a symlink after a missing component"
+        );
+        assert!(
+            !outside.join("songs").exists(),
+            "created {} outside",
+            outside.join("songs").display()
+        );
     }
 
     /// A symlink that stays inside the project is not the problem.

--- a/src/util.rs
+++ b/src/util.rs
@@ -447,8 +447,13 @@ pub fn create_dir_all(path: &Path) -> std::io::Result<()> {
 pub enum CreateWithinError {
     /// The directory is outside the project directory, so nothing was created.
     Outside {
-        /// The directory that was asked for.
+        /// The directory that was asked for, as it was configured.
         path: PathBuf,
+        /// Where that spelling actually lands. Reported alongside the spelling
+        /// because they differ whenever a symlink or a `..` is involved, and
+        /// naming only the spelling can tell an operator that a path plainly
+        /// inside the project is outside it.
+        resolved: PathBuf,
         /// The project directory it had to be inside of.
         project: PathBuf,
     },
@@ -462,13 +467,32 @@ pub enum CreateWithinError {
         symlink: bool,
     },
     /// It was inside the project, and creating it failed anyway.
-    Io(std::io::Error),
+    Io {
+        /// The path creation was attempted on — the resolved one, which is
+        /// what any advice about it has to name.
+        path: PathBuf,
+        /// What went wrong.
+        source: std::io::Error,
+    },
 }
 
 impl std::fmt::Display for CreateWithinError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CreateWithinError::Outside { path, project } => write!(
+            CreateWithinError::Outside {
+                path,
+                resolved,
+                project,
+            } if resolved != path => write!(
+                f,
+                "{} resolves to {}, which is outside the project directory \
+                 ({}), and mtrack only creates directories inside that. Create \
+                 it, or point the setting at a path inside the project.",
+                path.display(),
+                resolved.display(),
+                project.display(),
+            ),
+            CreateWithinError::Outside { path, project, .. } => write!(
                 f,
                 "{} does not exist, and mtrack only creates directories inside \
                  its project directory ({}). Create it, or point the setting at \
@@ -492,7 +516,7 @@ impl std::fmt::Display for CreateWithinError {
                  move what is there out of the way.",
                 path.display(),
             ),
-            CreateWithinError::Io(error) => write!(f, "{error}"),
+            CreateWithinError::Io { source, .. } => write!(f, "{source}"),
         }
     }
 }
@@ -500,28 +524,12 @@ impl std::fmt::Display for CreateWithinError {
 impl std::error::Error for CreateWithinError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            CreateWithinError::Io(error) => Some(error),
+            CreateWithinError::Io { source, .. } => Some(source),
             CreateWithinError::Outside { .. } | CreateWithinError::NotADirectory { .. } => None,
         }
     }
 }
 
-/// Creates `dir` if it is missing, but only when it lies inside `project`.
-///
-/// mtrack creates directories on behalf of a config that names them, and a
-/// config can name anywhere on the filesystem. Creating those wherever they
-/// point turns a typo into an empty directory and a puzzling "no songs found",
-/// and asks the service to write outside the very paths the generated systemd
-/// unit's `ProtectSystem=strict` exists to fence off.
-///
-/// A directory that already exists is accepted wherever it is: the restriction
-/// is on *creating* one, not on using a path the operator set up themselves.
-///
-/// Returns the directory that now exists, resolved. Callers must use it rather
-/// than the path they passed in: creation follows the resolved path, and a
-/// spelling like `songs/../real` is not equivalent to it — POSIX cannot resolve
-/// that spelling unless `songs` exists, which is exactly the stray intermediate
-/// this avoids making.
 /// A directory that [`create_dir_within`] made or accepted, resolved.
 ///
 /// A newtype rather than a bare `PathBuf` so the obligation is the compiler's
@@ -554,6 +562,22 @@ impl std::ops::Deref for CreatedDir {
     }
 }
 
+/// Creates `dir` if it is missing, but only when it lies inside `project`.
+///
+/// mtrack creates directories on behalf of a config that names them, and a
+/// config can name anywhere on the filesystem. Creating those wherever they
+/// point turns a typo into an empty directory and a puzzling "no songs found",
+/// and asks the service to write outside the very paths the generated systemd
+/// unit's `ProtectSystem=strict` exists to fence off.
+///
+/// A directory that already exists is accepted wherever it is: the restriction
+/// is on *creating* one, not on using a path the operator set up themselves.
+///
+/// Returns the directory that now exists, resolved. Callers must use it rather
+/// than the path they passed in: creation follows the resolved path, and a
+/// spelling like `songs/../real` is not equivalent to it — POSIX cannot resolve
+/// that spelling unless `songs` exists, which is exactly the stray intermediate
+/// this avoids making.
 pub fn create_dir_within(dir: &Path, project: &Path) -> Result<CreatedDir, CreateWithinError> {
     if dir.is_dir() {
         return Ok(CreatedDir(
@@ -585,6 +609,7 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<CreatedDir, Creat
     if !is_within(&resolved, project) {
         return Err(CreateWithinError::Outside {
             path: dir.to_path_buf(),
+            resolved,
             project: project.to_path_buf(),
         });
     }
@@ -594,7 +619,10 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<CreatedDir, Creat
     // `songs/../real`, and it re-walks components that were checked as
     // something else — a window in which one could have become a symlink out of
     // the project.
-    create_dir_all(&resolved).map_err(CreateWithinError::Io)?;
+    create_dir_all(&resolved).map_err(|source| CreateWithinError::Io {
+        path: resolved.clone(),
+        source,
+    })?;
     Ok(CreatedDir(resolved))
 }
 
@@ -606,7 +634,10 @@ pub async fn create_dir_within_async(
 ) -> Result<CreatedDir, CreateWithinError> {
     tokio::task::spawn_blocking(move || create_dir_within(&dir, &project))
         .await
-        .map_err(|e| CreateWithinError::Io(std::io::Error::other(e)))?
+        .map_err(|e| CreateWithinError::Io {
+            path: PathBuf::new(),
+            source: std::io::Error::other(e),
+        })?
 }
 
 /// The outcome of resolving a path as far as the filesystem allows.
@@ -682,6 +713,23 @@ fn resolve_as_far_as_possible(path: &Path) -> Resolved {
 /// `project/songs` is a symlink somewhere else.
 fn is_within(path: &Path, root: &Path) -> bool {
     root.canonicalize().is_ok_and(|root| path.starts_with(root))
+}
+
+/// A configured directory, resolved as far as the filesystem allows, for
+/// callers that only read it.
+///
+/// [`create_dir_within`] hands back what it made, but a reader has nothing to
+/// create and still needs the resolved path: the spelling in a config is not
+/// always usable now that the stray intermediate is no longer made, since POSIX
+/// cannot resolve `sub/../real` unless `sub` exists. Falls back to the path as
+/// given when nothing along it exists, which reads the same as before.
+pub fn resolved_dir(path: &Path) -> PathBuf {
+    match resolve_as_far_as_possible(path) {
+        Resolved::Path(resolved) => resolved,
+        // A link to nowhere resolves to nothing useful; hand back the original
+        // so the caller's own error names what the operator configured.
+        Resolved::Dangling(_) => path.to_path_buf(),
+    }
 }
 
 /// The project directory implied by a config file's path: the directory holding

--- a/src/util.rs
+++ b/src/util.rs
@@ -530,13 +530,31 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinE
             symlink: occupant.file_type().is_symlink(),
         });
     }
-    if !is_within(dir, project) {
+
+    let resolved = match resolve_as_far_as_possible(dir) {
+        Resolved::Path(resolved) => resolved,
+        // A link to nowhere anywhere along the path, not merely at its end.
+        Resolved::Dangling(link) => {
+            return Err(CreateWithinError::NotADirectory {
+                path: link,
+                symlink: true,
+            })
+        }
+    };
+
+    if !is_within(&resolved, project) {
         return Err(CreateWithinError::Outside {
             path: dir.to_path_buf(),
             project: project.to_path_buf(),
         });
     }
-    create_dir_all(dir).map_err(CreateWithinError::Io)
+
+    // The resolved path, not the original. Creating the original walks the
+    // literal spelling: it would materialize a stray intermediate for a benign
+    // `songs/../real`, and it re-walks components that were checked as
+    // something else — a window in which one could have become a symlink out of
+    // the project.
+    create_dir_all(&resolved).map_err(CreateWithinError::Io)
 }
 
 /// [`create_dir_within`] for callers on a Tokio runtime, which keeps the
@@ -550,19 +568,15 @@ pub async fn create_dir_within_async(
         .map_err(|e| CreateWithinError::Io(std::io::Error::other(e)))?
 }
 
-/// Whether `path` lands inside `root` once the filesystem has its say.
-///
-/// Purely lexical comparison is not enough: `project/songs` is inside the
-/// project by spelling, and outside it if `project/songs` is a symlink
-/// somewhere else. This resolves as much of the path as exists — which is where
-/// any symlink must be, since a component that does not exist cannot be one —
-/// and appends the rest.
-fn is_within(path: &Path, root: &Path) -> bool {
-    let Ok(root) = root.canonicalize() else {
-        // No project directory to be inside of.
-        return false;
-    };
-    resolve_as_far_as_possible(path).starts_with(root)
+/// The outcome of resolving a path as far as the filesystem allows.
+#[derive(Debug)]
+enum Resolved {
+    /// Resolved to this absolute path.
+    Path(PathBuf),
+    /// A symlink along the way leads nowhere. Creating through it fails with
+    /// `File exists` deep inside `create_dir_all` and says nothing about the
+    /// link, for a path the operator can see is not there.
+    Dangling(PathBuf),
 }
 
 /// `path` resolved as far as the filesystem allows.
@@ -572,7 +586,7 @@ fn is_within(path: &Path, root: &Path) -> bool {
 /// remainder gets pushed literally, so a `..` can walk back into existing,
 /// symlinked territory — `project/missing/../link/songs` — and land outside
 /// the project while still reading as inside it.
-fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
+fn resolve_as_far_as_possible(path: &Path) -> Resolved {
     // A relative path is relative to the process's directory, and comparing one
     // against an absolute root answers "outside" for everything. `mtrack start
     // mtrack.yaml` produces exactly that: a project of "." and a songs path of
@@ -592,8 +606,19 @@ fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
                 resolved.push(part);
                 // Canonicalize the moment it exists, so a symlink is followed
                 // here rather than compared as though it were a directory.
-                if let Ok(canonical) = resolved.canonicalize() {
-                    resolved = canonical;
+                match resolved.canonicalize() {
+                    Ok(canonical) => resolved = canonical,
+                    Err(_) => {
+                        // Unresolvable but present means a link to nowhere.
+                        // Checked at every component, not just the last: an
+                        // unmounted drive is as likely to sit part way along
+                        // the path as at the end of it.
+                        if std::fs::symlink_metadata(&resolved)
+                            .is_ok_and(|meta| meta.file_type().is_symlink())
+                        {
+                            return Resolved::Dangling(resolved);
+                        }
+                    }
                 }
             }
             // Popping a canonical path is exact; popping one that still holds
@@ -605,10 +630,20 @@ fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
             other => resolved.push(other.as_os_str()),
         }
     }
-    resolved
+    Resolved::Path(resolved)
 }
 
-/// The project directory implied by a config file's path: the directory holding
+/// Whether an already-resolved `path` lands inside `root`.
+///
+/// Takes the *resolved* path rather than resolving here, so the caller creates
+/// exactly what was checked. Purely lexical comparison would not do:
+/// `project/songs` is inside the project by spelling, and outside it if
+/// `project/songs` is a symlink somewhere else.
+fn is_within(path: &Path, root: &Path) -> bool {
+    root.canonicalize().is_ok_and(|root| path.starts_with(root))
+}
+
+/// The project directory implied by a config file/// The project directory implied by a config file's path: the directory holding
 /// it, and the only place mtrack creates directories on a config's behalf.
 ///
 /// [`Path::parent`] answers `Some("")` rather than `None` for a bare filename,
@@ -1390,6 +1425,44 @@ mod create_dir_within_tests {
         assert!(!message.contains("does not exist"), "{message}");
     }
 
+    /// A link to nowhere part way along the path is the same failure as one at
+    /// the end, and just as likely: an unmounted drive sits wherever the
+    /// operator mounted it, not necessarily at the leaf.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_leading_nowhere_mid_path_says_so_too() {
+        let project = tempfile::tempdir().expect("tempdir");
+        std::os::unix::fs::symlink(
+            "/media/usb/lib-that-is-not-mounted",
+            project.path().join("lib"),
+        )
+        .expect("symlink");
+
+        // The dangling link is `lib`, not the leaf being asked for.
+        let through = project.path().join("lib/songs");
+        let message = create_dir_within(&through, project.path())
+            .expect_err("refused")
+            .to_string();
+        assert!(message.contains("is a symlink"), "{message}");
+        assert!(!message.contains("File exists"), "{message}");
+    }
+
+    /// Creation must use the path that was checked, not the spelling it came
+    /// in as — which would walk components already resolved to something else
+    /// and leave stray intermediates behind.
+    #[test]
+    fn a_benign_traversal_creates_no_stray_intermediate() {
+        let project = tempfile::tempdir().expect("tempdir");
+
+        create_dir_within(&project.path().join("songs/../real"), project.path()).expect("created");
+
+        assert!(project.path().join("real").is_dir(), "target not created");
+        assert!(
+            !project.path().join("songs").exists(),
+            "left a stray intermediate behind"
+        );
+    }
+
     /// A symlink that does lead to a directory is simply used, wherever it
     /// points — the same as any other existing directory.
     #[cfg(unix)]
@@ -1524,14 +1597,22 @@ mod create_dir_within_tests {
     /// would race the rest of the suite.
     #[test]
     fn a_relative_path_is_measured_against_the_current_directory() {
+        let super::Resolved::Path(resolved) =
+            super::resolve_as_far_as_possible(Path::new("a-relative-name"))
+        else {
+            panic!("expected a resolved path");
+        };
+
+        let cwd = std::env::current_dir().expect("cwd");
         assert!(
-            super::is_within(Path::new("a-relative-name"), Path::new(".")),
-            "a relative name must be inside the current directory"
+            super::is_within(&resolved, &cwd),
+            "a relative name must be inside the current directory: {}",
+            resolved.display()
         );
 
         let elsewhere = tempfile::tempdir().expect("tempdir");
         assert!(
-            !super::is_within(Path::new("a-relative-name"), elsewhere.path()),
+            !super::is_within(&resolved, elsewhere.path()),
             "and outside an unrelated project"
         );
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -530,29 +530,66 @@ fn is_within(path: &Path, root: &Path) -> bool {
     resolve_as_far_as_possible(path).starts_with(root)
 }
 
-/// `path` with its existing prefix canonicalized and the remainder appended.
+/// `path` with its existing prefix canonicalized and the remainder applied.
 fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
-    let mut unresolved = Vec::new();
-    let mut cursor = path.to_path_buf();
-    loop {
-        if let Ok(canonical) = cursor.canonicalize() {
-            let mut resolved = canonical;
-            resolved.extend(unresolved.iter().rev());
-            return resolved;
-        }
-        let Some(name) = cursor.file_name().map(|name| name.to_os_string()) else {
-            // Ran out of path without finding anything that exists.
-            return path.to_path_buf();
-        };
-        unresolved.push(name);
-        match parent_of(&cursor) {
-            Some(parent) => cursor = parent.to_path_buf(),
-            None => return path.to_path_buf(),
+    // A relative path is relative to the process's directory, and comparing one
+    // against an absolute root answers "outside" for everything. `mtrack start
+    // mtrack.yaml` produces exactly that: a project of "." and a songs path of
+    // "songs", both of which mean the current directory.
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let path = path.as_path();
+
+    // The longest ancestor that exists, canonicalized. Any symlink must be in
+    // there, since a component that does not exist cannot be one.
+    let Some((prefix, canonical)) = path
+        .ancestors()
+        .find_map(|ancestor| ancestor.canonicalize().ok().map(|c| (ancestor, c)))
+    else {
+        return path.to_path_buf();
+    };
+
+    let Ok(rest) = path.strip_prefix(prefix) else {
+        return canonical;
+    };
+
+    // The remainder applied a component at a time. `..` has to be resolved
+    // here rather than left in place: `starts_with` compares components, so a
+    // path that spells its way back out -- `project/missing/../../escaped` --
+    // reads as inside the project while landing well outside it.
+    let mut resolved = canonical;
+    for component in rest.components() {
+        match component {
+            std::path::Component::Normal(part) => resolved.push(part),
+            std::path::Component::ParentDir => {
+                resolved.pop();
+            }
+            // A leading `/` or `.` cannot move us out of the prefix.
+            _ => {}
         }
     }
+    resolved
 }
 
-/// [`create_dir_all`] for callers on a Tokio runtime, which keeps the
+/// The project directory implied by a config file's path: the directory holding
+/// it, and the only place mtrack creates directories on a config's behalf.
+///
+/// [`Path::parent`] answers `Some("")` rather than `None` for a bare filename,
+/// so a fallback written against `None` never fires and leaves an empty path
+/// behind — which canonicalizes to nothing and refuses every creation. That is
+/// reachable: `mtrack start mtrack.yaml` passes exactly such a path.
+pub fn project_dir_of(config_path: &Path) -> PathBuf {
+    parent_of(config_path)
+        .map(|parent| parent.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// [`create_dir_all`] for callers on a Tokio runtime, which keeps the/// [`create_dir_all`] for callers on a Tokio runtime, which keeps the
 /// filesystem work off the async worker.
 pub async fn create_dir_all_async(path: &Path) -> std::io::Result<()> {
     let path = path.to_path_buf();
@@ -1160,6 +1197,51 @@ mod write_failure_hint_tests {
 }
 
 #[cfg(test)]
+mod project_dir_of_tests {
+    use super::project_dir_of;
+    use std::path::{Path, PathBuf};
+
+    /// The case that broke `mtrack start mtrack.yaml`.
+    ///
+    /// `Path::parent` answers `Some("")` for a bare filename, so a fallback
+    /// written against `None` never fired and left an empty path. That
+    /// canonicalizes to nothing, which made every directory look outside the
+    /// project and refused creation with an error naming no project at all.
+    #[test]
+    fn a_bare_config_filename_means_the_current_directory() {
+        assert_eq!(project_dir_of(Path::new("mtrack.yaml")), PathBuf::from("."));
+    }
+
+    #[test]
+    fn a_config_in_a_directory_means_that_directory() {
+        assert_eq!(
+            project_dir_of(Path::new("/srv/mtrack/mtrack.yaml")),
+            PathBuf::from("/srv/mtrack")
+        );
+    }
+
+    #[test]
+    fn a_relative_config_keeps_its_directory() {
+        assert_eq!(
+            project_dir_of(Path::new("gig/mtrack.yaml")),
+            PathBuf::from("gig")
+        );
+    }
+
+    /// The project directory it yields has to be one `create_dir_within`
+    /// accepts, or the fix moves the failure rather than removing it.
+    #[test]
+    fn the_directory_it_yields_accepts_a_child() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let config = project.path().join("mtrack.yaml");
+
+        let resolved = project_dir_of(&config);
+        super::create_dir_within(&resolved.join("songs"), &resolved).expect("created");
+        assert!(project.path().join("songs").is_dir());
+    }
+}
+
+#[cfg(test)]
 mod create_dir_within_tests {
     use super::{create_dir_within, CreateWithinError};
     use std::path::Path;
@@ -1220,13 +1302,20 @@ mod create_dir_within_tests {
     }
 
     /// A path that merely spells its way back out is still out.
+    ///
+    /// The project is nested inside an outer temp directory so the escape has
+    /// somewhere contained to land: a test that escapes into /tmp litters a
+    /// shared path, and the leftover then fails the next run for the wrong
+    /// reason.
     #[test]
     fn a_traversal_out_of_the_project_is_refused() {
-        let project = tempfile::tempdir().expect("tempdir");
-        let escaped = project.path().join("../escaped-songs");
+        let outer = tempfile::tempdir().expect("tempdir");
+        let project = outer.path().join("project");
+        std::fs::create_dir(&project).expect("project dir");
+        let escaped = project.join("../escaped-songs");
 
-        assert!(is_outside(create_dir_within(&escaped, project.path())));
-        assert!(!escaped.exists());
+        assert!(is_outside(create_dir_within(&escaped, &project)));
+        assert!(!outer.path().join("escaped-songs").exists());
     }
 
     /// The restriction is on *creating*, not on using. An operator who set up
@@ -1270,6 +1359,50 @@ mod create_dir_within_tests {
 
         create_dir_within(&link.join("songs"), project.path()).expect("created");
         assert!(real.join("songs").is_dir());
+    }
+
+    /// `..` after a component that does not exist used to escape entirely.
+    ///
+    /// Resolution gave up at a path ending in `..` (whose `file_name()` is
+    /// `None`), returned the path unresolved, and `starts_with` then compared
+    /// it lexically -- where `/proj/new/../../escaped` is "inside" `/proj`.
+    /// The directory really was created out there.
+    #[test]
+    fn a_traversal_through_a_missing_component_is_refused() {
+        let outer = tempfile::tempdir().expect("tempdir");
+        let project = outer.path().join("project");
+        std::fs::create_dir(&project).expect("project dir");
+        let outside = project.join("missing/../../escaped-songs");
+
+        assert!(
+            is_outside(create_dir_within(&outside, &project)),
+            "escaped the project"
+        );
+        // Where the old code actually made it: the project's sibling.
+        let escaped = outer.path().join("escaped-songs");
+        assert!(!escaped.exists(), "created {} outside", escaped.display());
+    }
+
+    /// A relative path means "relative to the process's directory", and
+    /// comparing one against an absolute root answers "outside" for everything.
+    ///
+    /// `mtrack start mtrack.yaml` produces exactly that pair — a project of "."
+    /// and a songs path of "songs" — and refused to create it, which unit tests
+    /// of the pieces missed because only running the binary puts the two
+    /// together. Reads the current directory rather than changing it, which
+    /// would race the rest of the suite.
+    #[test]
+    fn a_relative_path_is_measured_against_the_current_directory() {
+        assert!(
+            super::is_within(Path::new("a-relative-name"), Path::new(".")),
+            "a relative name must be inside the current directory"
+        );
+
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !super::is_within(Path::new("a-relative-name"), elsewhere.path()),
+            "and outside an unrelated project"
+        );
     }
 
     /// Without a project directory there is nothing to be inside of, and

--- a/src/util.rs
+++ b/src/util.rs
@@ -516,9 +516,15 @@ impl std::error::Error for CreateWithinError {
 ///
 /// A directory that already exists is accepted wherever it is: the restriction
 /// is on *creating* one, not on using a path the operator set up themselves.
-pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinError> {
+///
+/// Returns the directory that now exists, resolved. Callers must use it rather
+/// than the path they passed in: creation follows the resolved path, and a
+/// spelling like `songs/../real` is not equivalent to it — POSIX cannot resolve
+/// that spelling unless `songs` exists, which is exactly the stray intermediate
+/// this avoids making.
+pub fn create_dir_within(dir: &Path, project: &Path) -> Result<PathBuf, CreateWithinError> {
     if dir.is_dir() {
-        return Ok(());
+        return Ok(dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf()));
     }
     // `symlink_metadata` rather than `exists`, which follows the link and so
     // reports a dangling one as absent. Creation then fails deep inside
@@ -554,7 +560,8 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinE
     // `songs/../real`, and it re-walks components that were checked as
     // something else — a window in which one could have become a symlink out of
     // the project.
-    create_dir_all(&resolved).map_err(CreateWithinError::Io)
+    create_dir_all(&resolved).map_err(CreateWithinError::Io)?;
+    Ok(resolved)
 }
 
 /// [`create_dir_within`] for callers on a Tokio runtime, which keeps the
@@ -562,7 +569,7 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinE
 pub async fn create_dir_within_async(
     dir: PathBuf,
     project: PathBuf,
-) -> Result<(), CreateWithinError> {
+) -> Result<PathBuf, CreateWithinError> {
     tokio::task::spawn_blocking(move || create_dir_within(&dir, &project))
         .await
         .map_err(|e| CreateWithinError::Io(std::io::Error::other(e)))?
@@ -643,7 +650,7 @@ fn is_within(path: &Path, root: &Path) -> bool {
     root.canonicalize().is_ok_and(|root| path.starts_with(root))
 }
 
-/// The project directory implied by a config file/// The project directory implied by a config file's path: the directory holding
+/// The project directory implied by a config file's path: the directory holding
 /// it, and the only place mtrack creates directories on a config's behalf.
 ///
 /// [`Path::parent`] answers `Some("")` rather than `None` for a bare filename,
@@ -1311,9 +1318,9 @@ mod project_dir_of_tests {
 #[cfg(test)]
 mod create_dir_within_tests {
     use super::{create_dir_within, CreateWithinError};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    fn is_outside(result: Result<(), CreateWithinError>) -> bool {
+    fn is_outside(result: Result<PathBuf, CreateWithinError>) -> bool {
         matches!(result, Err(CreateWithinError::Outside { .. }))
     }
 
@@ -1447,20 +1454,52 @@ mod create_dir_within_tests {
         assert!(!message.contains("File exists"), "{message}");
     }
 
-    /// Creation must use the path that was checked, not the spelling it came
-    /// in as — which would walk components already resolved to something else
-    /// and leave stray intermediates behind.
+    /// Creation uses the path that was checked, not the spelling it came in as
+    /// — which would walk components already resolved to something else and
+    /// leave stray intermediates behind.
+    ///
+    /// The returned path is the point: POSIX cannot resolve `songs/../real`
+    /// unless `songs` exists, so a caller that kept its own spelling would be
+    /// told the directory was created and then fail to read it.
     #[test]
-    fn a_benign_traversal_creates_no_stray_intermediate() {
+    fn a_benign_traversal_returns_a_path_the_caller_can_use() {
         let project = tempfile::tempdir().expect("tempdir");
+        let configured = project.path().join("songs/../real");
 
-        create_dir_within(&project.path().join("songs/../real"), project.path()).expect("created");
+        let created = create_dir_within(&configured, project.path()).expect("created");
 
         assert!(project.path().join("real").is_dir(), "target not created");
         assert!(
             !project.path().join("songs").exists(),
             "left a stray intermediate behind"
         );
+        // The returned path resolves; the configured spelling does not.
+        assert!(
+            created.is_dir(),
+            "returned {} is unusable",
+            created.display()
+        );
+        assert!(
+            !configured.is_dir(),
+            "the spelling resolves after all — this test proves nothing"
+        );
+        assert!(
+            std::fs::read_dir(&created).is_ok(),
+            "cannot read what was made"
+        );
+    }
+
+    /// An existing directory also comes back resolved, so callers get the same
+    /// kind of path either way rather than one that depends on whether they
+    /// happened to be first.
+    #[test]
+    fn an_existing_directory_is_returned_resolved() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let songs = project.path().join("songs");
+        std::fs::create_dir(&songs).expect("songs");
+
+        let returned = create_dir_within(&songs, project.path()).expect("accepted");
+        assert_eq!(returned, songs.canonicalize().expect("canonical"));
     }
 
     /// A symlink that does lead to a directory is simply used, wherever it

--- a/src/util.rs
+++ b/src/util.rs
@@ -522,9 +522,43 @@ impl std::error::Error for CreateWithinError {
 /// spelling like `songs/../real` is not equivalent to it — POSIX cannot resolve
 /// that spelling unless `songs` exists, which is exactly the stray intermediate
 /// this avoids making.
-pub fn create_dir_within(dir: &Path, project: &Path) -> Result<PathBuf, CreateWithinError> {
+/// A directory that [`create_dir_within`] made or accepted, resolved.
+///
+/// A newtype rather than a bare `PathBuf` so the obligation is the compiler's
+/// to enforce: the caller must use *this* path, because the spelling passed in
+/// may no longer resolve — creating deliberately leaves no stray intermediate
+/// behind, so `songs/../real` names a directory that was never made. Stating
+/// that in a doc comment was not enough; it was missed twice, once leaving
+/// every web UI songs endpoint answering "Root directory not found".
+#[must_use = "use this path rather than the one passed in, which may not resolve"]
+#[derive(Debug, Clone)]
+pub struct CreatedDir(PathBuf);
+
+impl CreatedDir {
+    /// The directory, borrowed.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// The directory, owned.
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl std::ops::Deref for CreatedDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+pub fn create_dir_within(dir: &Path, project: &Path) -> Result<CreatedDir, CreateWithinError> {
     if dir.is_dir() {
-        return Ok(dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf()));
+        return Ok(CreatedDir(
+            dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf()),
+        ));
     }
     // `symlink_metadata` rather than `exists`, which follows the link and so
     // reports a dangling one as absent. Creation then fails deep inside
@@ -561,7 +595,7 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<PathBuf, CreateWi
     // something else — a window in which one could have become a symlink out of
     // the project.
     create_dir_all(&resolved).map_err(CreateWithinError::Io)?;
-    Ok(resolved)
+    Ok(CreatedDir(resolved))
 }
 
 /// [`create_dir_within`] for callers on a Tokio runtime, which keeps the
@@ -569,7 +603,7 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<PathBuf, CreateWi
 pub async fn create_dir_within_async(
     dir: PathBuf,
     project: PathBuf,
-) -> Result<PathBuf, CreateWithinError> {
+) -> Result<CreatedDir, CreateWithinError> {
     tokio::task::spawn_blocking(move || create_dir_within(&dir, &project))
         .await
         .map_err(|e| CreateWithinError::Io(std::io::Error::other(e)))?
@@ -1310,7 +1344,8 @@ mod project_dir_of_tests {
         let config = project.path().join("mtrack.yaml");
 
         let resolved = project_dir_of(&config);
-        super::create_dir_within(&resolved.join("songs"), &resolved).expect("created");
+        let _created =
+            super::create_dir_within(&resolved.join("songs"), &resolved).expect("created");
         assert!(project.path().join("songs").is_dir());
     }
 }
@@ -1318,9 +1353,9 @@ mod project_dir_of_tests {
 #[cfg(test)]
 mod create_dir_within_tests {
     use super::{create_dir_within, CreateWithinError};
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
-    fn is_outside(result: Result<PathBuf, CreateWithinError>) -> bool {
+    fn is_outside(result: Result<super::CreatedDir, CreateWithinError>) -> bool {
         matches!(result, Err(CreateWithinError::Outside { .. }))
     }
 
@@ -1331,7 +1366,7 @@ mod create_dir_within_tests {
         let project = tempfile::tempdir().expect("tempdir");
         let songs = project.path().join("songs");
 
-        create_dir_within(&songs, project.path()).expect("created");
+        let _created = create_dir_within(&songs, project.path()).expect("created");
         assert!(songs.is_dir());
     }
 
@@ -1340,7 +1375,7 @@ mod create_dir_within_tests {
         let project = tempfile::tempdir().expect("tempdir");
         let nested = project.path().join("media/audio/songs");
 
-        create_dir_within(&nested, project.path()).expect("created");
+        let _created = create_dir_within(&nested, project.path()).expect("created");
         assert!(nested.is_dir());
     }
 
@@ -1484,7 +1519,7 @@ mod create_dir_within_tests {
             "the spelling resolves after all — this test proves nothing"
         );
         assert!(
-            std::fs::read_dir(&created).is_ok(),
+            std::fs::read_dir(created.as_path()).is_ok(),
             "cannot read what was made"
         );
     }
@@ -1499,7 +1534,10 @@ mod create_dir_within_tests {
         std::fs::create_dir(&songs).expect("songs");
 
         let returned = create_dir_within(&songs, project.path()).expect("accepted");
-        assert_eq!(returned, songs.canonicalize().expect("canonical"));
+        assert_eq!(
+            returned.as_path(),
+            songs.canonicalize().expect("canonical").as_path()
+        );
     }
 
     /// A symlink that does lead to a directory is simply used, wherever it
@@ -1512,7 +1550,7 @@ mod create_dir_within_tests {
         let link = project.path().join("songs");
         std::os::unix::fs::symlink(elsewhere.path(), &link).expect("symlink");
 
-        create_dir_within(&link, project.path()).expect("accepted");
+        let _created = create_dir_within(&link, project.path()).expect("accepted");
     }
 
     /// A file in the way outside the project is still reported as the file it
@@ -1538,7 +1576,7 @@ mod create_dir_within_tests {
         let project = tempfile::tempdir().expect("tempdir");
         let elsewhere = tempfile::tempdir().expect("tempdir");
 
-        create_dir_within(elsewhere.path(), project.path()).expect("accepted");
+        let _created = create_dir_within(elsewhere.path(), project.path()).expect("accepted");
     }
 
     /// Spelling is not containment. `project/songs` looks inside the project
@@ -1600,7 +1638,7 @@ mod create_dir_within_tests {
         let link = project.path().join("link");
         std::os::unix::fs::symlink(&real, &link).expect("symlink");
 
-        create_dir_within(&link.join("songs"), project.path()).expect("created");
+        let _created = create_dir_within(&link.join("songs"), project.path()).expect("created");
         assert!(real.join("songs").is_dir());
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Serialize;
@@ -440,6 +440,116 @@ pub fn create_dir_all(path: &Path) -> std::io::Result<()> {
         ownership.apply(&std::fs::File::open(dir)?, dir)?;
     }
     Ok(())
+}
+
+/// Why [`create_dir_within`] declined to create a directory.
+#[derive(Debug)]
+pub enum CreateWithinError {
+    /// The directory is outside the project directory, so nothing was created.
+    Outside {
+        /// The directory that was asked for.
+        path: PathBuf,
+        /// The project directory it had to be inside of.
+        project: PathBuf,
+    },
+    /// It was inside the project, and creating it failed anyway.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for CreateWithinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreateWithinError::Outside { path, project } => write!(
+                f,
+                "{} does not exist, and mtrack only creates directories inside \
+                 its project directory ({}). Create it, or point the setting at \
+                 a path inside the project.",
+                path.display(),
+                project.display(),
+            ),
+            CreateWithinError::Io(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for CreateWithinError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreateWithinError::Io(error) => Some(error),
+            CreateWithinError::Outside { .. } => None,
+        }
+    }
+}
+
+/// Creates `dir` if it is missing, but only when it lies inside `project`.
+///
+/// mtrack creates directories on behalf of a config that names them, and a
+/// config can name anywhere on the filesystem. Creating those wherever they
+/// point turns a typo into an empty directory and a puzzling "no songs found",
+/// and asks the service to write outside the very paths the generated systemd
+/// unit's `ProtectSystem=strict` exists to fence off.
+///
+/// A directory that already exists is accepted wherever it is: the restriction
+/// is on *creating* one, not on using a path the operator set up themselves.
+pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinError> {
+    if dir.is_dir() {
+        return Ok(());
+    }
+    if !is_within(dir, project) {
+        return Err(CreateWithinError::Outside {
+            path: dir.to_path_buf(),
+            project: project.to_path_buf(),
+        });
+    }
+    create_dir_all(dir).map_err(CreateWithinError::Io)
+}
+
+/// [`create_dir_within`] for callers on a Tokio runtime, which keeps the
+/// filesystem work off the async worker.
+pub async fn create_dir_within_async(
+    dir: PathBuf,
+    project: PathBuf,
+) -> Result<(), CreateWithinError> {
+    tokio::task::spawn_blocking(move || create_dir_within(&dir, &project))
+        .await
+        .map_err(|e| CreateWithinError::Io(std::io::Error::other(e)))?
+}
+
+/// Whether `path` lands inside `root` once the filesystem has its say.
+///
+/// Purely lexical comparison is not enough: `project/songs` is inside the
+/// project by spelling, and outside it if `project/songs` is a symlink
+/// somewhere else. This resolves as much of the path as exists — which is where
+/// any symlink must be, since a component that does not exist cannot be one —
+/// and appends the rest.
+fn is_within(path: &Path, root: &Path) -> bool {
+    let Ok(root) = root.canonicalize() else {
+        // No project directory to be inside of.
+        return false;
+    };
+    resolve_as_far_as_possible(path).starts_with(root)
+}
+
+/// `path` with its existing prefix canonicalized and the remainder appended.
+fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
+    let mut unresolved = Vec::new();
+    let mut cursor = path.to_path_buf();
+    loop {
+        if let Ok(canonical) = cursor.canonicalize() {
+            let mut resolved = canonical;
+            resolved.extend(unresolved.iter().rev());
+            return resolved;
+        }
+        let Some(name) = cursor.file_name().map(|name| name.to_os_string()) else {
+            // Ran out of path without finding anything that exists.
+            return path.to_path_buf();
+        };
+        unresolved.push(name);
+        match parent_of(&cursor) {
+            Some(parent) => cursor = parent.to_path_buf(),
+            None => return path.to_path_buf(),
+        }
+    }
 }
 
 /// [`create_dir_all`] for callers on a Tokio runtime, which keeps the
@@ -1046,5 +1156,132 @@ mod write_failure_hint_tests {
         ] {
             assert_eq!(hint(kind), None, "{kind:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod create_dir_within_tests {
+    use super::{create_dir_within, CreateWithinError};
+    use std::path::Path;
+
+    fn is_outside(result: Result<(), CreateWithinError>) -> bool {
+        matches!(result, Err(CreateWithinError::Outside { .. }))
+    }
+
+    /// The first-run case this keeps: a relative `songs:` resolves inside the
+    /// project, and mtrack still sets it up without being asked.
+    #[test]
+    fn a_directory_inside_the_project_is_created() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let songs = project.path().join("songs");
+
+        create_dir_within(&songs, project.path()).expect("created");
+        assert!(songs.is_dir());
+    }
+
+    #[test]
+    fn nested_directories_inside_the_project_are_created() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let nested = project.path().join("media/audio/songs");
+
+        create_dir_within(&nested, project.path()).expect("created");
+        assert!(nested.is_dir());
+    }
+
+    /// The case that motivated this: a typo in an absolute path used to become
+    /// an empty directory and a puzzling "no songs found".
+    #[test]
+    fn a_directory_outside_the_project_is_refused_not_created() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let outside = elsewhere.path().join("sonsg");
+
+        assert!(is_outside(create_dir_within(&outside, project.path())));
+        assert!(!outside.exists(), "it must not have been created anyway");
+    }
+
+    /// Naming the parent is what makes the message actionable.
+    #[test]
+    fn the_refusal_names_both_the_path_and_the_project() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let outside = elsewhere.path().join("songs");
+
+        let error = create_dir_within(&outside, project.path()).expect_err("refused");
+        let message = error.to_string();
+        assert!(
+            message.contains(&outside.display().to_string()),
+            "{message}"
+        );
+        assert!(
+            message.contains(&project.path().display().to_string()),
+            "{message}"
+        );
+    }
+
+    /// A path that merely spells its way back out is still out.
+    #[test]
+    fn a_traversal_out_of_the_project_is_refused() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let escaped = project.path().join("../escaped-songs");
+
+        assert!(is_outside(create_dir_within(&escaped, project.path())));
+        assert!(!escaped.exists());
+    }
+
+    /// The restriction is on *creating*, not on using. An operator who set up
+    /// /mnt/nas/songs themselves must keep working.
+    #[test]
+    fn an_existing_directory_outside_the_project_is_accepted() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+
+        create_dir_within(elsewhere.path(), project.path()).expect("accepted");
+    }
+
+    /// Spelling is not containment. `project/songs` looks inside the project
+    /// whatever it points at, so a lexical check would create the target of a
+    /// symlink that leaves it.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_leaving_the_project_is_refused() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+
+        let link = project.path().join("songs");
+        std::os::unix::fs::symlink(elsewhere.path(), &link).expect("symlink");
+
+        // Spelled inside the project, actually somewhere else entirely.
+        let through_link = link.join("inner");
+        assert!(is_outside(create_dir_within(&through_link, project.path())));
+        assert!(!elsewhere.path().join("inner").exists());
+    }
+
+    /// A symlink that stays inside the project is not the problem.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_staying_inside_the_project_is_allowed() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let real = project.path().join("real");
+        std::fs::create_dir(&real).expect("real dir");
+
+        let link = project.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        create_dir_within(&link.join("songs"), project.path()).expect("created");
+        assert!(real.join("songs").is_dir());
+    }
+
+    /// Without a project directory there is nothing to be inside of, and
+    /// creating anywhere would be the old behaviour by another name.
+    #[test]
+    fn a_project_directory_that_does_not_exist_refuses_everything() {
+        let project = Path::new("/nonexistent-project-dir-for-tests");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+
+        assert!(is_outside(create_dir_within(
+            &elsewhere.path().join("songs"),
+            project
+        )));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -456,6 +456,10 @@ pub enum CreateWithinError {
     NotADirectory {
         /// The path that is occupied.
         path: PathBuf,
+        /// Whether the occupant is a symlink that leads nowhere useful. Worth
+        /// distinguishing: a link to unmounted media is invisible to `exists`,
+        /// and is the removable-media case this rule exists to protect.
+        symlink: bool,
     },
     /// It was inside the project, and creating it failed anyway.
     Io(std::io::Error),
@@ -472,7 +476,17 @@ impl std::fmt::Display for CreateWithinError {
                 path.display(),
                 project.display(),
             ),
-            CreateWithinError::NotADirectory { path } => write!(
+            CreateWithinError::NotADirectory {
+                path,
+                symlink: true,
+            } => write!(
+                f,
+                "{} is a symlink that does not lead to a directory. Its target \
+                 may be missing, or on media that is not mounted — mount it, \
+                 repoint the link, or remove it.",
+                path.display(),
+            ),
+            CreateWithinError::NotADirectory { path, .. } => write!(
                 f,
                 "{} is not a directory. Point the setting at a directory, or \
                  move what is there out of the way.",
@@ -506,11 +520,14 @@ pub fn create_dir_within(dir: &Path, project: &Path) -> Result<(), CreateWithinE
     if dir.is_dir() {
         return Ok(());
     }
-    // Distinguished from "does not exist", which sent an operator looking for a
-    // path that is sitting right there as a file.
-    if dir.exists() {
+    // `symlink_metadata` rather than `exists`, which follows the link and so
+    // reports a dangling one as absent. Creation then fails deep inside
+    // `create_dir_all` with `File exists` for a path the operator can see is
+    // not there, saying nothing about the link.
+    if let Ok(occupant) = std::fs::symlink_metadata(dir) {
         return Err(CreateWithinError::NotADirectory {
             path: dir.to_path_buf(),
+            symlink: occupant.file_type().is_symlink(),
         });
     }
     if !is_within(dir, project) {
@@ -591,7 +608,7 @@ fn resolve_as_far_as_possible(path: &Path) -> PathBuf {
     resolved
 }
 
-/// The project directory implied by a config file/// The project directory implied by a config file's path: the directory holding
+/// The project directory implied by a config file's path: the directory holding
 /// it, and the only place mtrack creates directories on a config's behalf.
 ///
 /// [`Path::parent`] answers `Some("")` rather than `None` for a bare filename,
@@ -1348,6 +1365,42 @@ mod create_dir_within_tests {
         assert!(!message.contains("does not exist"), "{message}");
         // The file it named is left alone.
         assert!(occupied.is_file());
+    }
+
+    /// The removable-media case this rule exists to protect, and the one that
+    /// was reported worst: `songs -> /media/usb/songs` with the stick
+    /// unmounted. `exists()` follows the link and says nothing is there, so
+    /// creation used to run on and fail inside `create_dir_all` with `File
+    /// exists` — for a path the operator can see is absent, with no mention of
+    /// the link.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_leading_nowhere_says_so_rather_than_file_exists() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let dangling = project.path().join("songs");
+        std::os::unix::fs::symlink("/media/usb/songs-that-are-not-mounted", &dangling)
+            .expect("symlink");
+
+        let message = create_dir_within(&dangling, project.path())
+            .expect_err("refused")
+            .to_string();
+        assert!(message.contains("is a symlink"), "{message}");
+        assert!(message.contains("not mounted"), "{message}");
+        assert!(!message.contains("File exists"), "{message}");
+        assert!(!message.contains("does not exist"), "{message}");
+    }
+
+    /// A symlink that does lead to a directory is simply used, wherever it
+    /// points — the same as any other existing directory.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_leading_to_a_real_directory_is_accepted() {
+        let project = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let link = project.path().join("songs");
+        std::os::unix::fs::symlink(elsewhere.path(), &link).expect("symlink");
+
+        create_dir_within(&link, project.path()).expect("accepted");
     }
 
     /// A file in the way outside the project is still reported as the file it

--- a/src/webui/api.rs
+++ b/src/webui/api.rs
@@ -231,10 +231,11 @@ async fn upload_sample_file(
 
     // Canonicalize the project root first, then build the samples path from
     // the canonical root so that all filesystem operations use a verified base.
-    let project_root = state
-        .config_path
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."));
+    // `project_dir_of`, not `parent()`: the latter answers Some("") for a bare
+    // filename, so the fallback never fires and the empty path fails to
+    // canonicalize -- a 500 for every sample upload whenever mtrack was started
+    // as `mtrack start mtrack.yaml`.
+    let project_root = crate::util::project_dir_of(&state.config_path);
     let root_canonical = project_root.canonicalize().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -18,6 +18,20 @@ use std::path::PathBuf;
 
 use super::super::safe_path::VerifiedRoot;
 
+/// The project directory: where mtrack.yaml lives.
+///
+/// The one place the server will create a directory on a config's behalf. A
+/// configured path outside it belongs to the operator — creating it turns a
+/// typo into an empty directory, and writes outside the paths the generated
+/// systemd unit fences the service into.
+pub fn project_dir(state: &crate::webui::server::WebUiState) -> PathBuf {
+    state
+        .config_path
+        .parent()
+        .map(|parent| parent.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 /// Validates a resource name for use in file paths.
 ///
 /// Rejects names that would be unsafe as filenames (empty, path traversal, etc.)

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -108,7 +108,7 @@ pub(crate) async fn ensure_configured_dir(
         tokio::task::spawn_blocking(move || crate::util::create_dir_within(&owned, &project)).await;
 
     match outcome {
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(_created)) => Ok(()),
         Ok(Err(e)) => {
             let status = match e {
                 crate::util::CreateWithinError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -92,6 +92,42 @@ pub(crate) fn resolve_resource_path(
 /// mapping errors to HTTP responses.
 ///
 /// Both the join error (task panic) and the inner result error are handled.
+/// Creates a configured directory, before anything canonicalizes it.
+///
+/// Ordering matters: [`resolve_resource_path`] verifies the root by
+/// canonicalizing it, which fails outright when the directory is not there. A
+/// creation placed after that call can never run — the request has already
+/// failed with "Root directory not found", which is also what a fresh install
+/// used to meet instead of having the directory made for it.
+///
+/// A path outside the project or blocked by a file is the operator's to fix, so
+/// it answers 400 rather than 500.
+pub(crate) async fn ensure_configured_dir(
+    dir: &std::path::Path,
+    state: &crate::webui::server::WebUiState,
+) -> Result<(), axum::response::Response> {
+    let owned = dir.to_path_buf();
+    let project = project_dir(state);
+    let outcome =
+        tokio::task::spawn_blocking(move || crate::util::create_dir_within(&owned, &project)).await;
+
+    match outcome {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => {
+            let status = match e {
+                crate::util::CreateWithinError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            Err((status, Json(json!({"error": e.to_string()}))).into_response())
+        }
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to create directory: {e}")})),
+        )
+            .into_response()),
+    }
+}
+
 pub(crate) async fn spawn_blocking_io<F, T, E>(
     label: &str,
     f: F,

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -88,10 +88,6 @@ pub(crate) fn resolve_resource_path(
     }
 }
 
-/// Wraps a blocking filesystem operation in `tokio::task::spawn_blocking`,
-/// mapping errors to HTTP responses.
-///
-/// Both the join error (task panic) and the inner result error are handled.
 /// Creates a configured directory, before anything canonicalizes it.
 ///
 /// Ordering matters: [`resolve_resource_path`] verifies the root by
@@ -128,6 +124,10 @@ pub(crate) async fn ensure_configured_dir(
     }
 }
 
+/// Wraps a blocking filesystem operation in `tokio::task::spawn_blocking`,
+/// mapping errors to HTTP responses.
+///
+/// Both the join error (task panic) and the inner result error are handled.
 pub(crate) async fn spawn_blocking_io<F, T, E>(
     label: &str,
     f: F,

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -25,11 +25,7 @@ use super::super::safe_path::VerifiedRoot;
 /// typo into an empty directory, and writes outside the paths the generated
 /// systemd unit fences the service into.
 pub fn project_dir(state: &crate::webui::server::WebUiState) -> PathBuf {
-    state
-        .config_path
-        .parent()
-        .map(|parent| parent.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."))
+    crate::util::project_dir_of(&state.config_path)
 }
 
 /// Validates a resource name for use in file paths.

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -111,7 +111,7 @@ pub(crate) async fn ensure_configured_dir(
         Ok(Ok(created)) => Ok(created.into_path_buf()),
         Ok(Err(e)) => {
             let status = match e {
-                crate::util::CreateWithinError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                crate::util::CreateWithinError::Io { .. } => StatusCode::INTERNAL_SERVER_ERROR,
                 _ => StatusCode::BAD_REQUEST,
             };
             Err((status, Json(json!({"error": e.to_string()}))).into_response())

--- a/src/webui/api/helpers.rs
+++ b/src/webui/api/helpers.rs
@@ -101,14 +101,14 @@ pub(crate) fn resolve_resource_path(
 pub(crate) async fn ensure_configured_dir(
     dir: &std::path::Path,
     state: &crate::webui::server::WebUiState,
-) -> Result<(), axum::response::Response> {
+) -> Result<PathBuf, axum::response::Response> {
     let owned = dir.to_path_buf();
     let project = project_dir(state);
     let outcome =
         tokio::task::spawn_blocking(move || crate::util::create_dir_within(&owned, &project)).await;
 
     match outcome {
-        Ok(Ok(_created)) => Ok(()),
+        Ok(Ok(created)) => Ok(created.into_path_buf()),
         Ok(Err(e)) => {
             let status = match e {
                 crate::util::CreateWithinError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -454,10 +454,11 @@ pub(super) async fn put_fixture_type(
             .into_response()
     })?;
 
-    let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
     // The same helper the playlists and profiles writes use, so a refusal is
     // reported as the configuration problem it is rather than a server fault.
-    super::helpers::ensure_configured_dir(&dir, &state).await?;
+    // The file goes under the directory that was made, not the spelling.
+    let dir = super::helpers::ensure_configured_dir(&dir, &state).await?;
+    let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
     let fp = file_path;
     let dsl_owned = dsl;
     super::helpers::spawn_blocking_io("write fixture type", move || {
@@ -744,8 +745,8 @@ pub(super) async fn put_venue(
             .into_response()
     })?;
 
+    let dir = super::helpers::ensure_configured_dir(&dir, &state).await?;
     let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
-    super::helpers::ensure_configured_dir(&dir, &state).await?;
     let fp = file_path;
     let dsl_owned = dsl;
     super::helpers::spawn_blocking_io("write venue", move || {

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -458,8 +458,9 @@ pub(super) async fn put_fixture_type(
     let dir_owned = dir;
     let fp = file_path;
     let dsl_owned = dsl;
+    let project_owned = super::helpers::project_dir(&state);
     super::helpers::spawn_blocking_io("write fixture type", move || {
-        ensure_lighting_dir_sync(&dir_owned)?;
+        ensure_lighting_dir_sync(&dir_owned, &project_owned)?;
         config_io::staged_write(&fp, &dsl_owned)
     })
     .await?;
@@ -747,8 +748,9 @@ pub(super) async fn put_venue(
     let dir_owned = dir;
     let fp = file_path;
     let dsl_owned = dsl;
+    let project_owned = super::helpers::project_dir(&state);
     super::helpers::spawn_blocking_io("write venue", move || {
-        ensure_lighting_dir_sync(&dir_owned)?;
+        ensure_lighting_dir_sync(&dir_owned, &project_owned)?;
         config_io::staged_write(&fp, &dsl_owned)
     })
     .await?;
@@ -827,12 +829,15 @@ struct FileError {
 }
 
 /// Ensures a lighting directory exists (sync version for use inside spawn_blocking).
-fn ensure_lighting_dir_sync(dir: &std::path::Path) -> Result<(), String> {
-    if !dir.exists() {
-        crate::util::create_dir_all(dir)
-            .map_err(|e| format!("Failed to create directory: {}", e))?;
-    }
-    Ok(())
+///
+/// Created only when it is inside the project directory: a lighting path
+/// pointing elsewhere is the operator's to set up, and creating it here would
+/// write outside the paths the generated systemd unit fences the service into.
+fn ensure_lighting_dir_sync(
+    dir: &std::path::Path,
+    project: &std::path::Path,
+) -> Result<(), String> {
+    crate::util::create_dir_within(dir, project).map_err(|e| e.to_string())
 }
 
 /// Converts a name to a safe filename (lowercase, spaces to underscores).
@@ -1881,15 +1886,29 @@ show "test" {
         let dir = tempfile::tempdir().unwrap();
         let sub = dir.path().join("new_subdir");
         assert!(!sub.exists());
-        ensure_lighting_dir_sync(&sub).unwrap();
+        ensure_lighting_dir_sync(&sub, dir.path()).unwrap();
         assert!(sub.is_dir());
     }
 
     #[test]
     fn ensure_lighting_dir_existing_is_ok() {
         let dir = tempfile::tempdir().unwrap();
-        ensure_lighting_dir_sync(dir.path()).unwrap();
+        ensure_lighting_dir_sync(dir.path(), dir.path()).unwrap();
         assert!(dir.path().is_dir());
+    }
+
+    /// A `lighting:` pointing outside the project is the operator's to create.
+    /// Making it here writes outside the paths the generated systemd unit
+    /// fences the service into, and turns a typo into an empty directory.
+    #[test]
+    fn ensure_lighting_dir_refuses_to_create_outside_the_project() {
+        let project = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let outside = elsewhere.path().join("lighting");
+
+        let error = ensure_lighting_dir_sync(&outside, project.path()).expect_err("refused");
+        assert!(error.contains("project directory"), "{error}");
+        assert!(!outside.exists(), "it must not have been created anyway");
     }
 
     // -----------------------------------------------------------------------

--- a/src/webui/api/lighting_api.rs
+++ b/src/webui/api/lighting_api.rs
@@ -455,12 +455,12 @@ pub(super) async fn put_fixture_type(
     })?;
 
     let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
-    let dir_owned = dir;
+    // The same helper the playlists and profiles writes use, so a refusal is
+    // reported as the configuration problem it is rather than a server fault.
+    super::helpers::ensure_configured_dir(&dir, &state).await?;
     let fp = file_path;
     let dsl_owned = dsl;
-    let project_owned = super::helpers::project_dir(&state);
     super::helpers::spawn_blocking_io("write fixture type", move || {
-        ensure_lighting_dir_sync(&dir_owned, &project_owned)?;
         config_io::staged_write(&fp, &dsl_owned)
     })
     .await?;
@@ -745,12 +745,10 @@ pub(super) async fn put_venue(
     })?;
 
     let file_path = dir.join(format!("{}.light", sanitize_filename(&name)));
-    let dir_owned = dir;
+    super::helpers::ensure_configured_dir(&dir, &state).await?;
     let fp = file_path;
     let dsl_owned = dsl;
-    let project_owned = super::helpers::project_dir(&state);
     super::helpers::spawn_blocking_io("write venue", move || {
-        ensure_lighting_dir_sync(&dir_owned, &project_owned)?;
         config_io::staged_write(&fp, &dsl_owned)
     })
     .await?;
@@ -826,18 +824,6 @@ fn load_light_files_from_dir(
 struct FileError {
     file: String,
     error: String,
-}
-
-/// Ensures a lighting directory exists (sync version for use inside spawn_blocking).
-///
-/// Created only when it is inside the project directory: a lighting path
-/// pointing elsewhere is the operator's to set up, and creating it here would
-/// write outside the paths the generated systemd unit fences the service into.
-fn ensure_lighting_dir_sync(
-    dir: &std::path::Path,
-    project: &std::path::Path,
-) -> Result<(), String> {
-    crate::util::create_dir_within(dir, project).map_err(|e| e.to_string())
 }
 
 /// Converts a name to a safe filename (lowercase, spaces to underscores).
@@ -1875,40 +1861,6 @@ show "test" {
         })
         .unwrap();
         assert_eq!(count, 0);
-    }
-
-    // -----------------------------------------------------------------------
-    // Unit tests: ensure_lighting_dir
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn ensure_lighting_dir_creates_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        let sub = dir.path().join("new_subdir");
-        assert!(!sub.exists());
-        ensure_lighting_dir_sync(&sub, dir.path()).unwrap();
-        assert!(sub.is_dir());
-    }
-
-    #[test]
-    fn ensure_lighting_dir_existing_is_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        ensure_lighting_dir_sync(dir.path(), dir.path()).unwrap();
-        assert!(dir.path().is_dir());
-    }
-
-    /// A `lighting:` pointing outside the project is the operator's to create.
-    /// Making it here writes outside the paths the generated systemd unit
-    /// fences the service into, and turns a typo into an empty directory.
-    #[test]
-    fn ensure_lighting_dir_refuses_to_create_outside_the_project() {
-        let project = tempfile::tempdir().unwrap();
-        let elsewhere = tempfile::tempdir().unwrap();
-        let outside = elsewhere.path().join("lighting");
-
-        let error = ensure_lighting_dir_sync(&outside, project.path()).expect_err("refused");
-        assert!(error.contains("project directory"), "{error}");
-        assert!(!outside.exists(), "it must not have been created anyway");
     }
 
     // -----------------------------------------------------------------------

--- a/src/webui/api/playlists.rs
+++ b/src/webui/api/playlists.rs
@@ -124,8 +124,11 @@ pub(super) async fn put_playlist_by_name(
     let dir = playlists_dir.clone();
     let fp = file_path.clone();
     let yaml_owned = yaml;
+    // Created only when it is inside the project -- a `playlists_dir:` pointing
+    // elsewhere is the operator's to set up, like `songs` and the rest.
+    let project = super::helpers::project_dir(&state);
     super::helpers::spawn_blocking_io("write playlist", move || {
-        crate::util::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        crate::util::create_dir_within(&dir, &project).map_err(|e| e.to_string())?;
         config_io::staged_write(&fp, &yaml_owned)
     })
     .await?;

--- a/src/webui/api/playlists.rs
+++ b/src/webui/api/playlists.rs
@@ -116,19 +116,20 @@ pub(super) async fn put_playlist_by_name(
         }
     };
 
+    // Before `resolve_resource_path`, which canonicalizes the directory and
+    // fails if it is missing -- a creation after that call can never run.
+    // Created only when it is inside the project: a `playlists_dir:` pointing
+    // elsewhere is the operator's to set up, like `songs` and the rest.
+    super::helpers::ensure_configured_dir(&playlists_dir, &state).await?;
+
     // codeql[rust/path-injection] name is validated by validate_playlist_name; path is
     // verified via canonicalize + starts_with containment in resolve_resource_path.
     let file_path = resolve_resource_path(&playlists_dir, &name, "yaml")?;
 
-    // Ensure directory exists and write atomically, off the async runtime.
-    let dir = playlists_dir.clone();
+    // Write atomically, off the async runtime.
     let fp = file_path.clone();
     let yaml_owned = yaml;
-    // Created only when it is inside the project -- a `playlists_dir:` pointing
-    // elsewhere is the operator's to set up, like `songs` and the rest.
-    let project = super::helpers::project_dir(&state);
     super::helpers::spawn_blocking_io("write playlist", move || {
-        crate::util::create_dir_within(&dir, &project).map_err(|e| e.to_string())?;
         config_io::staged_write(&fp, &yaml_owned)
     })
     .await?;

--- a/src/webui/api/playlists.rs
+++ b/src/webui/api/playlists.rs
@@ -120,7 +120,7 @@ pub(super) async fn put_playlist_by_name(
     // fails if it is missing -- a creation after that call can never run.
     // Created only when it is inside the project: a `playlists_dir:` pointing
     // elsewhere is the operator's to set up, like `songs` and the rest.
-    super::helpers::ensure_configured_dir(&playlists_dir, &state).await?;
+    let playlists_dir = super::helpers::ensure_configured_dir(&playlists_dir, &state).await?;
 
     // codeql[rust/path-injection] name is validated by validate_playlist_name; path is
     // verified via canonicalize + starts_with containment in resolve_resource_path.

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -197,18 +197,19 @@ pub(super) async fn put_profile(
             .into_response()
     })?;
 
+    // Before `resolve_resource_path`, which canonicalizes the directory and
+    // fails if it is missing -- a creation after that call can never run.
+    // Created only when it is inside the project: a `profiles_dir:` pointing
+    // elsewhere is the operator's to set up.
+    super::helpers::ensure_configured_dir(&profiles_dir, &state).await?;
+
     // codeql[rust/path-injection] filename is validated; path is verified via resolve_resource_path.
     let file_path = resolve_resource_path(&profiles_dir, &filename, "yaml")?;
 
-    // Write directory and file off the async runtime.
-    let dir = profiles_dir;
+    // Write the file off the async runtime.
     let fp = file_path;
     let yaml_owned = yaml;
-    // Created only when it is inside the project -- a `profiles_dir:` pointing
-    // elsewhere is the operator's to set up.
-    let project = super::helpers::project_dir(&state);
     spawn_blocking_io("write profile", move || {
-        crate::util::create_dir_within(&dir, &project).map_err(|e| e.to_string())?;
         config_io::staged_write(&fp, &yaml_owned)
     })
     .await?;

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -204,8 +204,11 @@ pub(super) async fn put_profile(
     let dir = profiles_dir;
     let fp = file_path;
     let yaml_owned = yaml;
+    // Created only when it is inside the project -- a `profiles_dir:` pointing
+    // elsewhere is the operator's to set up.
+    let project = super::helpers::project_dir(&state);
     spawn_blocking_io("write profile", move || {
-        crate::util::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        crate::util::create_dir_within(&dir, &project).map_err(|e| e.to_string())?;
         config_io::staged_write(&fp, &yaml_owned)
     })
     .await?;

--- a/src/webui/api/profiles.rs
+++ b/src/webui/api/profiles.rs
@@ -201,7 +201,7 @@ pub(super) async fn put_profile(
     // fails if it is missing -- a creation after that call can never run.
     // Created only when it is inside the project: a `profiles_dir:` pointing
     // elsewhere is the operator's to set up.
-    super::helpers::ensure_configured_dir(&profiles_dir, &state).await?;
+    let profiles_dir = super::helpers::ensure_configured_dir(&profiles_dir, &state).await?;
 
     // codeql[rust/path-injection] filename is validated; path is verified via resolve_resource_path.
     let file_path = resolve_resource_path(&profiles_dir, &filename, "yaml")?;

--- a/tests/systemd/test.sh
+++ b/tests/systemd/test.sh
@@ -175,21 +175,20 @@ echo "$denied_log" | grep -A 2 "Error:" | tail -6 | sed 's/^/    /'
 chown -R mtrack:mtrack "$MTRACK_PATH"
 
 echo ""
-echo "--- Test: A blocked directory names itself, not its parent (#408) ---"
+echo "--- Test: A songs directory outside the project is refused, not created ---"
 
-# The regression guard for the review's worst finding. `songs` is a directory,
-# and the advice used to name its *parent* -- so a blocked /var/lib/outside-songs
-# told the operator to unseal or chown /var/lib, handing a system account most
-# of the machine and defeating the sandbox this message exists to explain.
+# mtrack used to create whatever `songs:` pointed at, anywhere on the
+# filesystem. That turned a typo into an empty directory and a puzzling "no
+# songs found", and asked the service to write outside the very paths
+# ProtectSystem=strict exists to fence it into -- so the sandbox diagnostic was
+# largely explaining a conflict mtrack created for itself.
 #
-# A directory that failed to be created cannot be inspected to find out it was
-# meant to be one, which is why the caller has to say so; nothing but an
-# end-to-end run proves the caller actually does.
+# It now creates only inside the project directory and refuses the rest. The
+# unit here is the good one: the library is writable, and the refusal is
+# mtrack's own decision rather than the sandbox's.
 OUTSIDE_SONGS=/var/lib/outside-songs
 rm -rf "$OUTSIDE_SONGS"
 
-# The unit here is the good one: the library is writable, and only the songs
-# directory is out of bounds.
 cat > "$MTRACK_PATH/mtrack.yaml" <<YAML
 songs: $OUTSIDE_SONGS
 YAML
@@ -197,19 +196,19 @@ chown mtrack:mtrack "$MTRACK_PATH/mtrack.yaml"
 
 outside_log="$(run_failing_start)"
 
-check "the songs directory outside the sandbox was blocked" \
-    bash -c 'grep -qi "read-only file system" <<< "$0"' "$outside_log"
-check "the failure names the songs directory itself" \
-    bash -c "grep -q 'Add $OUTSIDE_SONGS to ReadWritePaths=' <<< \"\$0\"" "$outside_log"
-# The finding itself: /var/lib is the parent, and naming it is the bug.
-# systemd bind-mounts each ReadWritePaths= entry and cannot mount what is not
-# there, so an operator who pastes a missing path in gets a unit that fails
-# namespace setup and never starts -- no diagnostic at all, which is worse than
-# the failure they began with.
-check "the failure says to create the missing directory first" \
-    bash -c "grep -q 'Create $OUTSIDE_SONGS first' <<< \"\$0\"" "$outside_log"
-check "the failure does not name the parent directory" \
-    bash -c '! grep -q "Add /var/lib to ReadWritePaths=" <<< "$0"' "$outside_log"
+check "the refusal names the directory it would not create" \
+    bash -c "grep -q '$OUTSIDE_SONGS does not exist' <<< \"\$0\"" "$outside_log"
+check "the refusal explains the project-directory rule" \
+    bash -c 'grep -q "only creates directories inside its project directory" <<< "$0"' "$outside_log"
+check "the refusal names the project directory" \
+    bash -c "grep -q '($MTRACK_PATH)' <<< \"\$0\"" "$outside_log"
+# The behaviour itself, not just the wording: nothing was made out there.
+check "the directory outside the project was not created" \
+    bash -c '! test -e /var/lib/outside-songs'
+# And it is a refusal rather than the sandbox tripping, which would mean mtrack
+# still tried to write outside its project.
+check "the refusal is mtrack's own, not a sandbox error" \
+    bash -c '! grep -qi "read-only file system" <<< "$0"' "$outside_log"
 
 echo ""
 echo "  What the operator sees:"

--- a/tests/systemd/test.sh
+++ b/tests/systemd/test.sh
@@ -279,6 +279,40 @@ echo ""
 echo "  What the operator sees:"
 echo "$blocked_log" | grep -A 4 "Error:" | tail -12 | sed 's/^/    /'
 
+echo ""
+echo "--- Test: A blocked directory names itself, not the library (#408) ---"
+
+# Restores the guard for WriteTarget::Directory, which nothing else covers end
+# to end. The other blocked-write case above fails on `mtrack.yaml` -- a *file*
+# -- whose parent happens to be the right answer either way, so a regression to
+# WriteTarget::File for the directory branch would pass the suite unnoticed.
+#
+# The decoy unit is still installed, so the library is read-only for the
+# service. Giving it a config it can read moves the failure past the config
+# write and onto creating the songs directory, which is inside the project and
+# therefore mtrack's to make -- if only it could write there.
+cat > "$MTRACK_PATH/mtrack.yaml" <<YAML
+songs: songs
+YAML
+chown mtrack:mtrack "$MTRACK_PATH/mtrack.yaml"
+rm -rf "$MTRACK_PATH/songs"
+
+dir_log="$(run_failing_start)"
+
+check "the blocked songs directory was the failure" \
+    bash -c 'grep -qi "read-only file system" <<< "$0"' "$dir_log"
+check "the advice names the songs directory itself" \
+    bash -c "grep -q 'Add $MTRACK_PATH/songs to ReadWritePaths=' <<< \"\$0\"" "$dir_log"
+# The regression itself: naming the parent is what WriteTarget::File would do.
+check "the advice does not name the library instead" \
+    bash -c "! grep -q 'Add $MTRACK_PATH to ReadWritePaths=' <<< \"\$0\"" "$dir_log"
+
+echo ""
+echo "  What the operator sees:"
+echo "$dir_log" | grep -A 2 "Error:" | tail -6 | sed 's/^/    /'
+
+rm -f "$MTRACK_PATH/mtrack.yaml"
+
 # Put the working unit back. Without this the case has to stay last forever,
 # and a second run of this script in the same container fails the installation
 # checks against the decoy unit it left behind.

--- a/tests/systemd/test.sh
+++ b/tests/systemd/test.sh
@@ -180,14 +180,27 @@ echo "--- Test: A songs directory outside the project is refused, not created --
 # mtrack used to create whatever `songs:` pointed at, anywhere on the
 # filesystem. That turned a typo into an empty directory and a puzzling "no
 # songs found", and asked the service to write outside the very paths
-# ProtectSystem=strict exists to fence it into -- so the sandbox diagnostic was
-# largely explaining a conflict mtrack created for itself.
+# ProtectSystem=strict exists to fence it into.
 #
-# It now creates only inside the project directory and refuses the rest. The
-# unit here is the good one: the library is writable, and the refusal is
-# mtrack's own decision rather than the sandbox's.
-OUTSIDE_SONGS=/var/lib/outside-songs
-rm -rf "$OUTSIDE_SONGS"
+# The target deliberately sits somewhere the sandbox *allows* writing: a
+# declared, service-owned directory outside the project. Pointing it anywhere
+# else proves nothing -- the sandbox blocks the write, the directory is absent
+# either way, and "it was not created" passes with this feature removed
+# entirely. Here the only thing standing between mtrack and that directory is
+# mtrack.
+OUTSIDE_PARENT=/var/lib/mtrack-extra
+OUTSIDE_SONGS="$OUTSIDE_PARENT/songs"
+rm -rf "$OUTSIDE_PARENT"
+mkdir -p "$OUTSIDE_PARENT"
+chown mtrack:mtrack "$OUTSIDE_PARENT"
+
+cp /etc/systemd/system/mtrack.service /tmp/mtrack.service.beforeoutside
+if mtrack systemd "$MTRACK_PATH" "$OUTSIDE_PARENT" > /tmp/mtrack.service.outside; then
+    mv /tmp/mtrack.service.outside /etc/systemd/system/mtrack.service
+    systemctl daemon-reload
+else
+    fail "could not generate a unit declaring $OUTSIDE_PARENT writable"
+fi
 
 cat > "$MTRACK_PATH/mtrack.yaml" <<YAML
 songs: $OUTSIDE_SONGS
@@ -202,11 +215,12 @@ check "the refusal explains the project-directory rule" \
     bash -c 'grep -q "only creates directories inside its project directory" <<< "$0"' "$outside_log"
 check "the refusal names the project directory" \
     bash -c "grep -q '($MTRACK_PATH)' <<< \"\$0\"" "$outside_log"
-# The behaviour itself, not just the wording: nothing was made out there.
+# The behaviour, not the wording. The sandbox would have allowed this one.
 check "the directory outside the project was not created" \
-    bash -c '! test -e /var/lib/outside-songs'
-# And it is a refusal rather than the sandbox tripping, which would mean mtrack
-# still tried to write outside its project.
+    bash -c '! test -e "$0"' "$OUTSIDE_SONGS"
+# And it is mtrack's refusal rather than the sandbox tripping -- which here
+# would mean the writable path was not declared and the check above proves
+# nothing.
 check "the refusal is mtrack's own, not a sandbox error" \
     bash -c '! grep -qi "read-only file system" <<< "$0"' "$outside_log"
 
@@ -215,6 +229,9 @@ echo "  What the operator sees:"
 echo "$outside_log" | grep -A 2 "Error:" | tail -6 | sed 's/^/    /'
 
 rm -f "$MTRACK_PATH/mtrack.yaml"
+rm -rf "$OUTSIDE_PARENT"
+mv /tmp/mtrack.service.beforeoutside /etc/systemd/system/mtrack.service
+systemctl daemon-reload
 
 echo ""
 echo "--- Test: A blocked write explains itself (#408) ---"


### PR DESCRIPTION
Follow-up to #409. Not an issue fix — this came out of reviewing that work.

mtrack created whatever `songs:` pointed at, anywhere on the filesystem. #409
added diagnostics explaining why the systemd sandbox blocked those writes, and
the honest reading is that the sandbox was right: the conflict was mtrack's own.

## What changes

`util::create_dir_within(dir, project)` creates only what resolves inside the
project directory — wherever `mtrack.yaml` lives — and otherwise refuses:

```
Error: /mnt/nas/songs does not exist, and mtrack only creates directories
inside its project directory (/home/pi/gig). Create it, or point the setting
at a path inside the project.
```

**A directory that already exists is used wherever it lives.** The restriction
is on creating one, so `songs: /mnt/song-storage` works exactly as before once
that directory is there.

Applied to every site that made a config-derived root unbounded, so the
subsystems agree: startup `songs`, the MCP songs / lighting / playlist roots,
and the web UI's playlists, profiles and lighting writes. Two production
`create_dir_all` calls are deliberately left alone — the one creating the
project directory itself (restricting that would be circular) and one under an
already-verified root.

## Why

- **A typo stops being silent.** `songs: /mnt/nas/sonsg` used to become an empty
  directory and a puzzling "no songs found".
- **Removable media.** Creating a directory under a mount point that is not
  currently mounted writes to the disk underneath; everything looks fine until
  the drive mounts and the files vanish behind it. Easy to hit on a Pi with
  songs on a USB stick.
- **It stops fighting the sandbox** the generated unit puts the service in.

## Containment

Resolution walks the path component by component, canonicalizing as each one
lands, so a symlink is followed wherever it sits rather than only in the prefix.
That closes the escapes a lexical check leaves open — `project/../escaped`,
`project/missing/../../escaped`, and `project/missing/../link/songs` where
`link` leaves the project — and it distinguishes a symlink to unmounted media
from a path that is simply absent, which `exists()` cannot.

Creation runs on the resolved path and `create_dir_within` **returns** it, as a
`#[must_use]` `CreatedDir` newtype: the spelling passed in is not always usable,
since POSIX cannot resolve `songs/../real` unless `songs` exists and that stray
intermediate is deliberately not made. The newtype exists because stating this
in a doc comment was not enough — it was missed twice, once leaving every web UI
songs endpoint answering "Root directory not found" while the CLI player worked.

`util::project_dir_of` is the single definition of "the project", closing a trap
worth naming: `Path::parent()` answers `Some("")` for a bare filename rather
than `None`, so a fallback written against `None` never fires and leaves an
empty path that refuses everything. That broke `mtrack start mtrack.yaml`, and
the same shape existed at six other sites — including a sample-upload 500 that
predates this branch.

## Startup behaviour

Refusing means a missing configured directory now fails startup rather than
being papered over. On a rig whose library mounts late, the systemd default of
five attempts in ten seconds would make that failure permanent, so the generated
unit sets `RestartSec=5` with a thirty-attempt, three-minute start limit.

It deliberately does **not** emit `RequiresMountsFor=`. That would wait for the
mount, but it also implies `Requires=`, so a drive that blinks out mid-set would
take the player down with it — a worse failure on a machine playing a show than
a slow boot. The unit and docs record that choice and how to opt in.

`docs/src/deployment/systemd.md` carries an upgrade note: operators should
regenerate their unit, since one generated before this change has neither the
widened restart window nor the clearer diagnostics.

## Verification

- 3381 unit tests; 19 cover `create_dir_within` alone, including both symlink
  directions, a symlink reached after a missing component, a dangling symlink
  mid-path, `..` escapes, and an existing directory outside the project still
  being accepted.
- Container test 34/34 under real systemd, covering the refusal, the ownership
  and sandbox diagnostics from #409, and that the refused directory genuinely
  was not created.
- **Sabotage-tested.** With the policy removed, the refusal checks fail and the
  world-level controls still pass. That process caught a check that passed with
  the feature gone: its target sat outside the unit's `ReadWritePaths`, so the
  sandbox blocked the write and the directory was absent either way. It now
  targets a declared, service-owned directory the sandbox permits writing to, so
  only the policy can prevent it.
- Eight `/code-review high` rounds; the last returned no medium or high
  findings and cleared the containment logic for the fourth consecutive round.

## Note

The container case added in #409 asserted the old behaviour and was rewritten
rather than deleted — it now covers the refusal, that nothing was created, and
that the refusal is mtrack's rather than the sandbox's. A separate phase keeps
end-to-end cover for the `WriteTarget::Directory` branch of #409's diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6iBcCCaFYmoE8XsQAEd6g
