### PR TITLE
Advise creating a missing directory, not chowning its parent

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -354,28 +354,40 @@ fn write_failure_hint_in(
                     .to_string(),
             };
             if actionable {
-                // A directory that could not be created cannot be chowned
-                // either -- `chown` on a missing path just reports that it is
-                // missing. What needs to be writable is the directory above it.
-                let grant = if env.directory_exists {
-                    dir
+                if env.directory_exists {
+                    match user {
+                        Some(user) => hint.push_str(&format!(
+                            " `chown -R {user}:{user} {}` grants it.",
+                            dir.display()
+                        )),
+                        None => hint.push_str(&format!(
+                            " Granting that account ownership of {} fixes it.",
+                            dir.display()
+                        )),
+                    }
                 } else {
-                    hint.push_str(&format!(
-                        " {} does not exist and could not be created, so the \
-                         directory above it is the one that has to be writable.",
-                        dir.display(),
-                    ));
-                    parent_of(dir).unwrap_or(dir)
-                };
-                match user {
-                    Some(user) => hint.push_str(&format!(
-                        " `chown -R {user}:{user} {}` grants it.",
-                        grant.display()
-                    )),
-                    None => hint.push_str(&format!(
-                        " Granting that account ownership of {} fixes it.",
-                        grant.display()
-                    )),
+                    // A directory that could not be created cannot be chowned
+                    // either -- `chown` on a missing path just reports that it
+                    // is missing. Granting the *parent* instead hands the
+                    // account every sibling -- for a path one level under
+                    // /var/lib, most of the system's state. Create the
+                    // directory owned by the service, which touches nothing
+                    // beside it.
+                    match user {
+                        Some(user) => hint.push_str(&format!(
+                            " {} does not exist and could not be created. \
+                             `install -d -o {user} -g {user} {}` creates it \
+                             owned by the service without touching anything \
+                             beside it.",
+                            dir.display(),
+                            dir.display(),
+                        )),
+                        None => hint.push_str(&format!(
+                            " {} does not exist and could not be created; \
+                             create it and grant that account ownership of it.",
+                            dir.display(),
+                        )),
+                    }
                 }
             }
             Some(hint)
@@ -1198,9 +1210,11 @@ mod write_failure_hint_tests {
     }
 
     /// `chown` on a path that does not exist reports only that it does not
-    /// exist. What has to be writable is the directory above it.
+    /// exist, but granting the parent instead is the reviewed bug all over
+    /// again: `chown -R mtrack:mtrack /var/lib` hands a system account every
+    /// sibling. The advice creates the directory owned by the service instead.
     #[test]
-    fn a_missing_directory_is_granted_through_its_parent() {
+    fn a_missing_directory_is_created_for_the_service_not_granted_through_its_parent() {
         let missing = HintEnv {
             directory_exists: false,
             ..env()
@@ -1215,12 +1229,41 @@ mod write_failure_hint_tests {
             hint.contains("does not exist and could not be created"),
             "{hint}"
         );
-        assert!(hint.contains("chown -R mtrack:mtrack /var/lib"), "{hint}");
-        // Not the missing directory itself, which chown would simply reject.
         assert!(
-            !hint.contains("chown -R mtrack:mtrack /var/lib/outside-songs"),
+            hint.contains("install -d -o mtrack -g mtrack /var/lib/outside-songs"),
             "{hint}"
         );
+        // Neither chowning the missing directory, which chown would reject,
+        // nor its parent, which is the whole of /var/lib.
+        assert!(!hint.contains("chown"), "{hint}");
+        assert!(!hint.contains("/var/lib "), "{hint}");
+        assert!(!hint.contains("/var/lib`"), "{hint}");
+    }
+
+    /// The same missing directory with no account to name still says what to
+    /// do, without prescribing a command that needs a user to be true.
+    #[test]
+    fn a_missing_directory_without_a_known_account_still_says_create_it() {
+        let missing = HintEnv {
+            service_user: None,
+            directory_exists: false,
+            ..env()
+        };
+        let hint = hint_for(
+            WriteTarget::Directory(Path::new("/var/lib/outside-songs")),
+            ErrorKind::PermissionDenied,
+            &missing,
+        )
+        .expect("a hint");
+        assert!(
+            hint.contains("does not exist and could not be created"),
+            "{hint}"
+        );
+        assert!(hint.contains("/var/lib/outside-songs"), "{hint}");
+        assert!(!hint.contains("chown"), "{hint}");
+        assert!(!hint.contains("install"), "{hint}");
+        assert!(!hint.contains("/var/lib "), "{hint}");
+        assert!(!hint.contains("/var/lib`"), "{hint}");
     }
 
     /// `mtrack systemd` takes the complete set of paths and drops any left out,
@@ -1315,6 +1358,7 @@ mod write_failure_hint_tests {
             assert!(!hint.contains("mtrack systemd"), "{kind:?}: {hint}");
             assert!(!hint.contains("daemon-reload"), "{kind:?}: {hint}");
             assert!(!hint.contains("chown"), "{kind:?}: {hint}");
+            assert!(!hint.contains("install -d"), "{kind:?}: {hint}");
         }
     }
 


### PR DESCRIPTION
Follow-up to #409 and #410. Not an issue fix — this came out of reviewing #409's advice.

The `PermissionDenied` branch of `write_failure_hint` climbed to the *parent* of a directory that failed to be created, on the reasoning that `chown` on a missing path only reports that it is missing. But granting the parent hands the service account every sibling — the bug #409's own review caught on the EROFS branch, reintroduced in a narrower form — and a unit test blessed the worst spelling of it verbatim:

```
chown -R mtrack:mtrack /var/lib
```

## What changes

The missing-directory advice now says to create the directory owned by the service instead of granting its parent:

```
The service runs as mtrack, which owns nothing it did not create, so this is
likely ownership rather than a missing file. /var/lib/outside-songs does not
exist and could not be created. `install -d -o mtrack -g mtrack
/var/lib/outside-songs` creates it owned by the service without touching
anything beside it.
```

With no account to name, it describes the fix rather than prescribing a command that needs a user to be true. The exists-case `chown -R` advice and the EROFS branch are untouched.

## Why it still matters after #410

#410 refuses to create directories outside the project, so no current caller can reach the `/var/lib` spelling — the containment check fires before any filesystem write. But the helper is caller-agnostic, the climb was still there, and the test asserting the `/var/lib` string as *correct* output was a green light for the next caller (or a containment regression) to walk back into the reviewed bug.

The branch also stays reachable for inside-project paths — a root-owned library whose `songs` does not exist yet, or a nested `media/audio/songs` chain. There the parent advice was no longer dangerous but was still wrong: for a nested missing chain the named parent does not exist either, so the prescribed `chown` just fails. `install -d` creates the whole chain owned by the service in one step.

## Verification

- 3382 unit tests. The test that required the `/var/lib` string is rewritten to forbid it (no `chown` at all, no bare `/var/lib`); a new case covers the missing directory with no known account, and the relative-path case now also forbids the `install -d` command.
- **Sabotage-tested.** With the parent-climb restored, the rewritten test fails on exactly the `/var/lib` string it used to require; restored, the suite is clean.
- Rebased on #410; merges cleanly, no overlap with `create_dir_within`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)