### PR TITLE
fix(webui): light mode for this release's timeline and metronome UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The new timeline, metronome and pilot UI works in light mode**: several colours added
+  alongside this release's timeline and metronome work were written against the dark theme
+  only — either as literals, or as `var(--token, #fallback)` naming a token that was never
+  defined, which resolves to the fallback in *both* themes, so the theme switch could not
+  reach them.
+
+  The worst was the drag-to-create ghost on the section bar: a white fill and a white dashed
+  border on a white bar, a contrast ratio of exactly 1.00. Dragging out a new section in light
+  mode drew nothing at all — the element was there, at full opacity, the same colour as what
+  was behind it, so the gesture gave no feedback until the section already existed.
+
+  The rest were amber on white at 1.8:1: the live pilot cue on the player card, the timeline's
+  playhead readout and its drag pill, the live preview-transport button, the pilot hint ticks
+  on the scrub bar, and the metronome's missing-beat-grid warning. The pilot cue was the one
+  that mattered on stage — highlighting it made it *less* legible than the grey cues beside it,
+  which sit at 5.15:1.
+
+  There is now an amber ramp whose darker steps can carry text on a light surface, and an
+  `--nc-amber-fg` that resolves to a dark step in light mode and the bright brand amber in
+  dark. Fills that carry ink text on top of them are unchanged. `theme-contrast.spec.ts`
+  measures the computed colours of these elements in both themes and holds them to the WCAG
+  contrast floors, so the next one fails CI instead of waiting to be noticed.
+
 - **Software audio devices no longer advertise a channel count they cannot honour**: `alsa:default`
   and `alsa:pulse` were listed as 32-channel devices. That number is what ALSA's plugin advertises,
   not a width any hardware promised, and picking one of those for a 32-channel show would have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measures the computed colours of these elements in both themes and holds them to the WCAG
   contrast floors, so the next one fails CI instead of waiting to be noticed.
 
+  The same test scans the source for every custom property referenced with a fallback and
+  fails if one was never defined, which is the trap underneath all of the above. That scan
+  immediately found one more: the timeline's position picker asked for `--font-mono`, which
+  does not exist — the token is `--mono` — so its numerals had been rendering in the
+  browser's generic monospace rather than JetBrains Mono.
+
 - **Software audio devices no longer advertise a channel count they cannot honour**: `alsa:default`
   and `alsa:pulse` were listed as 32-channel devices. That number is what ALSA's plugin advertises,
   not a width any hardware promised, and picking one of those for a 32-channel show would have

--- a/src/webui/svelte/e2e/tests/theme-contrast.spec.ts
+++ b/src/webui/svelte/e2e/tests/theme-contrast.spec.ts
@@ -1,0 +1,399 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+// Light/dark contrast regressions.
+//
+// The web UI ships two themes off one set of CSS custom properties, so a
+// colour written as a literal — or as `var(--token, #fallback)` where the
+// token was never defined — silently pins one theme's value into both. That
+// is invisible to type-checking and to every other test here: the element
+// still renders, still carries its class, still passes a visibility check.
+// It is only wrong to look at.
+//
+// These tests read the *computed* colour of the elements where that went
+// wrong, composite them over their real background chain, and assert a WCAG
+// contrast floor in each theme. Text is held to 4.5:1; marks that carry
+// meaning by being seen at all (the playhead line, the drag-create ghost,
+// hint ticks) are held to the 3:1 non-text floor.
+
+import { test, expect, type Page } from "@playwright/test";
+
+let testCounter = 0;
+
+function freshWsId(label: string): string {
+  return `theme-${label}-${test.info().parallelIndex}-${++testCounter}-${Date.now()}`;
+}
+
+async function sendWsMessage(page: Page, wsId: string, msg: object) {
+  await expect(async () => {
+    const res = await page.request.post("http://127.0.0.1:3111/test/send-ws", {
+      data: { ...msg, _wsId: wsId },
+    });
+    expect((await res.json()).sent).toBe(1);
+  }).toPass({ timeout: 10000 });
+}
+
+type Theme = "light" | "dark";
+const THEMES: Theme[] = ["light", "dark"];
+
+/** WCAG floors: 4.5:1 for body text, 3:1 for meaningful non-text marks. */
+const TEXT_MIN = 4.5;
+const MARK_MIN = 3;
+
+async function useTheme(page: Page, theme: Theme) {
+  await page.addInitScript((t) => {
+    localStorage.setItem("mtrack-theme", t as string);
+  }, theme);
+  await page.emulateMedia({ colorScheme: theme });
+}
+
+interface Probe {
+  /** Contrast of the element's text against what is behind it. */
+  text: number;
+  /** Contrast of its own background fill against what is behind it. */
+  fill: number | null;
+  /** Contrast of its border against what is behind it. */
+  border: number | null;
+}
+
+/**
+ * Measures an element in the page: composites its colour, background and
+ * border over the accumulated background of every ancestor (so a
+ * half-transparent fill on a card is judged against the card, not against
+ * an assumed white) and returns WCAG contrast ratios.
+ */
+async function probe(
+  page: Page,
+  selector: string,
+  pseudo?: string,
+): Promise<Probe> {
+  const result = await page.evaluate(
+    ([sel, pseudoEl]) => {
+      const toLinear = (c: number) => {
+        const v = c / 255;
+        return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      };
+      const luminance = (rgb: number[]) =>
+        0.2126 * toLinear(rgb[0]) +
+        0.7152 * toLinear(rgb[1]) +
+        0.0722 * toLinear(rgb[2]);
+      const parse = (c: string): number[] | null => {
+        // color-mix() computes to `color(srgb r g b / a)` with 0–1 channels,
+        // everything else to `rgb()` / `rgba()` with 0–255 channels.
+        const srgb = c.match(/color\(srgb\s+([^)]+)\)/);
+        if (srgb) {
+          const [rgb, alpha] = srgb[1].split("/");
+          const parts = rgb
+            .trim()
+            .split(/\s+/)
+            .map((n) => parseFloat(n) * 255);
+          return [
+            parts[0],
+            parts[1],
+            parts[2],
+            alpha === undefined ? 1 : parseFloat(alpha),
+          ];
+        }
+        const m = c.match(/rgba?\(([^)]+)\)/);
+        if (!m) return null;
+        const parts = m[1].split(",").map((n) => parseFloat(n));
+        return [parts[0], parts[1], parts[2], parts.length > 3 ? parts[3] : 1];
+      };
+      const composite = (fg: number[], bg: number[]): number[] => {
+        const a = fg[3];
+        return [
+          fg[0] * a + bg[0] * (1 - a),
+          fg[1] * a + bg[1] * (1 - a),
+          fg[2] * a + bg[2] * (1 - a),
+          1,
+        ];
+      };
+      const ratio = (a: number[], b: number[]) => {
+        const [l1, l2] = [luminance(a), luminance(b)];
+        const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1];
+        return (hi + 0.05) / (lo + 0.05);
+      };
+
+      const el = document.querySelector(sel);
+      if (!el) return null;
+
+      // Everything the element is painted on top of, outermost first. A
+      // pseudo-element also sits on top of its own host's background.
+      const ancestors: Element[] = [];
+      const from = pseudoEl ? (el as Element) : el.parentElement;
+      for (let n: Element | null = from; n; n = n.parentElement) {
+        ancestors.push(n);
+      }
+      ancestors.reverse();
+      let behind = [255, 255, 255, 1];
+      for (const n of ancestors) {
+        const c = parse(getComputedStyle(n).backgroundColor);
+        if (c && c[3] > 0) behind = composite(c, behind);
+      }
+
+      const cs = getComputedStyle(el, pseudoEl || null);
+      const own = parse(cs.backgroundColor);
+      const border = parse(cs.borderTopColor);
+      const hasBorder = parseFloat(cs.borderTopWidth) > 0;
+      // Text sits on the element's own fill when it has one.
+      const textBg = own && own[3] > 0 ? composite(own, behind) : behind;
+      const text = parse(cs.color);
+
+      return {
+        text: text ? ratio(composite(text, textBg), textBg) : 0,
+        fill: own && own[3] > 0 ? ratio(composite(own, behind), behind) : null,
+        border:
+          hasBorder && border && border[3] > 0
+            ? ratio(composite(border, behind), behind)
+            : null,
+      };
+    },
+    [selector, pseudo] as [string, string | undefined],
+  );
+
+  if (!result) throw new Error(`no element matched ${selector}`);
+  return {
+    text: Number(result.text.toFixed(2)),
+    fill: result.fill === null ? null : Number(result.fill.toFixed(2)),
+    border: result.border === null ? null : Number(result.border.toFixed(2)),
+  };
+}
+
+const SONG = "Test Song Beta";
+const SONG_ENC = encodeURIComponent(SONG);
+
+const SONG_YAML = `name: ${SONG}
+tracks:
+  - name: guitar
+    file: guitar.wav
+sections:
+  - name: verse
+    start_measure: 1
+    end_measure: 4
+  - name: chorus
+    start_measure: 5
+    end_measure: 8
+tempo:
+  bpm: 120
+  time_signature: 4/4
+  start: 0
+pilot:
+  track: pilot
+  hints:
+    - at: { measure: 3 }
+      label: verse
+`;
+
+const PLAYBACK = {
+  type: "playback",
+  is_playing: true,
+  elapsed_ms: 0,
+  song_name: SONG,
+  song_duration_ms: 34000,
+  playlist_name: "setlist",
+  playlist_position: 1,
+  playlist_songs: ["Test Song Alpha", SONG],
+  tracks: [],
+  available_playlists: ["all_songs", "setlist"],
+  persisted_playlist_name: "setlist",
+  locked: false,
+};
+
+// A label-only hint immediately followed by its countdown: their display
+// windows overlap, so at 55.5s "bridge" is live while "3..2..1" is not —
+// which is what lets the test compare the highlight against its sibling.
+const HINTS = [
+  {
+    label: "bridge",
+    at_ms: 55000,
+    start_ms: 55000,
+    end_ms: 55000,
+    has_audio: false,
+  },
+  {
+    label: "3..2..1",
+    at_ms: 60000,
+    start_ms: 57000,
+    end_ms: 60000,
+    has_audio: true,
+  },
+];
+
+async function openTimeline(page: Page, yaml: string, wsId?: string) {
+  await page.route(`**/api/songs/${SONG_ENC}`, async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({ status: 200, contentType: "text/yaml", body: yaml });
+  });
+  await page.route("**/api/songs", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    const res = await route.fetch();
+    const data = await res.json();
+    for (const song of data.songs ?? []) {
+      if (song.name === SONG) {
+        song.has_tempo_map = true;
+        song.duration_ms = 34000;
+        song.duration_display = "0:34";
+      }
+    }
+    await route.fulfill({ response: res, json: data });
+  });
+  await page.goto(
+    wsId
+      ? `/?wsId=${wsId}#/songs/${SONG_ENC}/sections`
+      : `/#/songs/${SONG_ENC}/sections`,
+  );
+  await expect(page.locator(".section-timeline-editor")).toBeVisible();
+}
+
+for (const theme of THEMES) {
+  test.describe(`${theme} theme`, () => {
+    test.beforeEach(async ({ page }) => {
+      await useTheme(page, theme);
+    });
+
+    test("the live pilot cue is the most legible label on the card", async ({
+      page,
+    }) => {
+      const wsId = freshWsId("pilot");
+      await page.goto(`/?wsId=${wsId}#/`);
+      await expect(page.locator(".playback-card__title")).toBeVisible();
+      await sendWsMessage(page, wsId, {
+        ...PLAYBACK,
+        song_duration_ms: 240000,
+        elapsed_ms: 55500,
+        pilot_hints: HINTS,
+      });
+      await expect(
+        page.locator(".playback-card__hint-label--live"),
+      ).toHaveCount(1);
+
+      const live = await probe(page, ".playback-card__hint-label--live");
+      expect(live.text).toBeGreaterThanOrEqual(TEXT_MIN);
+
+      // The highlight has to beat the un-highlighted state, not just clear
+      // the floor: amber-400 on a white card scored 1.83 against a 5.15
+      // grey sibling, which read as the live cue being *de*-emphasised.
+      const idle = await probe(
+        page,
+        ".playback-card__hint-label:not(.playback-card__hint-label--live)",
+      );
+      expect(live.text).toBeGreaterThan(idle.text);
+    });
+
+    test("pilot hint ticks are visible on the scrub bar", async ({ page }) => {
+      const wsId = freshWsId("ticks");
+      await page.goto(`/?wsId=${wsId}#/`);
+      await expect(page.locator(".playback-card__title")).toBeVisible();
+      await sendWsMessage(page, wsId, {
+        ...PLAYBACK,
+        song_duration_ms: 240000,
+        elapsed_ms: 1000,
+        pilot_hints: HINTS,
+      });
+      await expect(page.locator(".scrub__hint").first()).toBeVisible();
+
+      const tick = await probe(page, ".scrub__hint");
+      expect(tick.fill).toBeGreaterThanOrEqual(MARK_MIN);
+    });
+
+    test("the timeline playhead and its readout stand out", async ({
+      page,
+    }) => {
+      const wsId = freshWsId("playhead");
+      await openTimeline(page, SONG_YAML, wsId);
+      await sendWsMessage(page, wsId, { ...PLAYBACK, elapsed_ms: 12000 });
+      await expect(page.locator(".playhead-info")).toBeVisible();
+
+      const readout = await probe(page, ".playhead-info__pos");
+      expect(readout.text).toBeGreaterThanOrEqual(TEXT_MIN);
+
+      // The playhead line is drawn as a ::before, so it has to be probed
+      // as one — reading the host element would measure nothing.
+      const line = await probe(page, ".playhead", "::before");
+      expect(line.fill).toBeGreaterThanOrEqual(MARK_MIN);
+
+      // The time pill only exists mid-drag.
+      const playhead = page.locator(".playhead");
+      const box = await playhead.boundingBox();
+      if (!box) throw new Error("playhead has no bounding box");
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + 40, box.y + box.height / 2, { steps: 6 });
+      await expect(page.locator(".playhead__time")).toBeVisible();
+
+      const badge = await probe(page, ".playhead__time");
+      expect(badge.text).toBeGreaterThanOrEqual(TEXT_MIN);
+      expect(badge.fill).toBeGreaterThanOrEqual(MARK_MIN);
+
+      await page.mouse.up();
+    });
+
+    test("the drag-to-create ghost is visible while dragging", async ({
+      page,
+    }) => {
+      // Only the first section, so the rest of the bar is empty and a drag
+      // there creates a new one.
+      const oneSection = SONG_YAML.replace(
+        `  - name: chorus
+    start_measure: 5
+    end_measure: 8
+`,
+        "",
+      );
+      await openTimeline(page, oneSection);
+
+      const bar = page.locator(".section-bar .bar-content");
+      const box = await bar.boundingBox();
+      if (!box) throw new Error("section bar has no bounding box");
+      await page.mouse.move(box.x + box.width * 0.65, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + box.width * 0.9, box.y + box.height / 2, {
+        steps: 12,
+      });
+
+      const ghost = page.locator(".section-block.creating");
+      await expect(ghost).toBeVisible();
+      // `toBeVisible` passed on white-on-white too — the ghost was in the
+      // DOM at full opacity and simply the same colour as the bar behind it.
+      const measured = await probe(page, ".section-block.creating");
+      expect(measured.border).toBeGreaterThanOrEqual(MARK_MIN);
+      expect(measured.fill).toBeGreaterThan(1);
+
+      await page.mouse.up();
+    });
+  });
+}
+
+test("no component pins a colour through an undefined custom property", async ({
+  page,
+}) => {
+  // `var(--token, #literal)` on a token that was never defined resolves to
+  // the literal in both themes — the theme switch cannot reach it. Assert
+  // the tokens these components name actually exist.
+  await page.goto("/#/");
+  const tokens = [
+    "--nc-amber-400",
+    "--nc-amber-fg",
+    "--nc-ink",
+    "--nc-error",
+    "--accent",
+    "--nc-fg-1",
+    "--nc-bg-1",
+  ];
+  const missing = await page.evaluate((names) => {
+    const root = getComputedStyle(document.documentElement);
+    return names.filter((n) => !root.getPropertyValue(n).trim());
+  }, tokens);
+  expect(missing).toEqual([]);
+});

--- a/src/webui/svelte/e2e/tests/theme-contrast.spec.ts
+++ b/src/webui/svelte/e2e/tests/theme-contrast.spec.ts
@@ -28,6 +28,11 @@
 // hint ticks) are held to the 3:1 non-text floor.
 
 import { test, expect, type Page } from "@playwright/test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let testCounter = 0;
 
@@ -375,25 +380,61 @@ for (const theme of THEMES) {
   });
 }
 
-test("no component pins a colour through an undefined custom property", async ({
-  page,
-}) => {
+test("every custom property referenced with a fallback is defined", () => {
   // `var(--token, #literal)` on a token that was never defined resolves to
-  // the literal in both themes — the theme switch cannot reach it. Assert
-  // the tokens these components name actually exist.
-  await page.goto("/#/");
-  const tokens = [
-    "--nc-amber-400",
-    "--nc-amber-fg",
-    "--nc-ink",
-    "--nc-error",
-    "--accent",
-    "--nc-fg-1",
-    "--nc-bg-1",
-  ];
-  const missing = await page.evaluate((names) => {
-    const root = getComputedStyle(document.documentElement);
-    return names.filter((n) => !root.getPropertyValue(n).trim());
-  }, tokens);
-  expect(missing).toEqual([]);
+  // the literal in *both* themes, so the theme switch cannot reach it. That
+  // is how the amber, warning and error colours above came to be pinned to
+  // one theme, and nothing in the toolchain says a word about it: it is
+  // valid CSS that renders.
+  //
+  // This walks the source rather than the rendered page, because the page
+  // only proves the tokens on screen at that moment; a component nobody
+  // navigated to can carry the same bug indefinitely.
+  const root = path.resolve(__dirname, "..", "..", "src");
+
+  function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) return walk(p);
+      return /\.(svelte|css|ts)$/.test(e.name) ? [p] : [];
+    });
+  }
+
+  const defined = new Set<string>();
+  const referenced = new Map<string, Set<string>>();
+
+  for (const file of walk(root)) {
+    const text = readFileSync(file, "utf8");
+    // Declared in a stylesheet: `--token: value`.
+    for (const m of text.matchAll(/(--[A-Za-z0-9_-]+)\s*:/g)) {
+      defined.add(m[1]);
+    }
+    // Declared on an element by Svelte (`style:--token={…}`) or set
+    // imperatively (`el.style.setProperty("--token", …)`). Both are as real
+    // as a stylesheet declaration; the value just arrives at runtime.
+    for (const m of text.matchAll(/style:(--[A-Za-z0-9_-]+)/g)) {
+      defined.add(m[1]);
+    }
+    for (const m of text.matchAll(/setProperty\(\s*["'`](--[A-Za-z0-9_-]+)/g)) {
+      defined.add(m[1]);
+    }
+    // Referenced *with a fallback* — the only form that can fail silently.
+    for (const m of text.matchAll(/var\(\s*(--[A-Za-z0-9_-]+)\s*,/g)) {
+      const rel = path.relative(root, file);
+      referenced.set(m[1], (referenced.get(m[1]) ?? new Set()).add(rel));
+    }
+  }
+
+  // Pre-existing offenders in the calibration wizard, which this change does
+  // not touch. `--bg-base` pins that panel to a dark navy in both themes and
+  // wants fixing on its own; listing them here keeps this test a guard
+  // against new ones rather than a permanently red check.
+  const known = new Set(["--bg-base", "--danger"]);
+
+  const undefinedTokens = [...referenced.entries()]
+    .filter(([token]) => !defined.has(token) && !known.has(token))
+    .map(([token, files]) => `${token} (${[...files].sort().join(", ")})`)
+    .sort();
+
+  expect(undefinedTokens).toEqual([]);
 });

--- a/src/webui/svelte/src/app.css
+++ b/src/webui/svelte/src/app.css
@@ -57,6 +57,18 @@
   --nc-cyan-600: #1f8faf;
   --nc-cyan-700: #166a82;
 
+  /* Amber ramp — the "live / attention" hue. The 400 is the brand amber
+     that --nc-warn has always been; the darker steps exist so amber can be
+     used as *text* on a light surface, where the 400 is only 1.8:1. */
+  --nc-amber-50: #fef7e9;
+  --nc-amber-100: #fdedcd;
+  --nc-amber-200: #fadb9c;
+  --nc-amber-300: #f6c86e;
+  --nc-amber-400: #f2b544;
+  --nc-amber-500: #c98d1c;
+  --nc-amber-600: #8a5f0e;
+  --nc-amber-700: #6f4c0a;
+
   /* Warm neutral ramp (UI grays — keyed off ink) */
   --nc-gray-50: #f7f6f6;
   --nc-gray-100: #efeeee;
@@ -70,7 +82,7 @@
   --nc-gray-900: #141112;
 
   --nc-success: #4dc08a;
-  --nc-warn: #f2b544;
+  --nc-warn: var(--nc-amber-400);
   --nc-error: #e84b4b;
 
   /* ---- Semantic (light, default) ---- */
@@ -83,6 +95,10 @@
   --nc-fg-4: var(--nc-gray-400);
   --nc-border-1: var(--nc-gray-200);
   --nc-border-2: var(--nc-gray-300);
+
+  /* Amber that stays legible as text/hairlines on the current surface.
+     Fills that carry --nc-ink on top (badges) keep using --nc-amber-400. */
+  --nc-amber-fg: var(--nc-amber-600);
 
   --card-bg: #ffffff;
   --card-border: var(--nc-border-1);
@@ -202,6 +218,8 @@
   --nc-fg-4: #5c5453;
   --nc-border-1: #3a3334;
   --nc-border-2: #4a4243;
+
+  --nc-amber-fg: var(--nc-amber-400);
 
   --card-bg: #231f20;
   --card-border: #3a3334;

--- a/src/webui/svelte/src/components/cards/BeatIndicator.svelte
+++ b/src/webui/svelte/src/components/cards/BeatIndicator.svelte
@@ -157,7 +157,7 @@
     background: var(--nc-pink-400);
   }
   .beat-flash--half {
-    background: var(--nc-amber-400, #f2b544);
+    background: var(--nc-amber-400);
   }
   .beat-flash--off {
     animation: none;
@@ -204,7 +204,7 @@
     background: var(--nc-pink-400);
   }
   .beat-dot--half.beat-dot--active {
-    background: var(--nc-amber-400, #f2b544);
+    background: var(--nc-amber-400);
   }
   .beat-dot--silent.beat-dot--active {
     background: transparent;

--- a/src/webui/svelte/src/components/cards/PlaybackCard.svelte
+++ b/src/webui/svelte/src/components/cards/PlaybackCard.svelte
@@ -824,7 +824,7 @@
     width: 2px;
     height: 6px;
     margin-left: -1px;
-    background: var(--nc-amber-400, #f2b544);
+    background: var(--nc-amber-fg);
     border-radius: 1px;
     z-index: 3;
     pointer-events: none;
@@ -847,7 +847,7 @@
     transition: color var(--nc-dur-fast) var(--nc-ease);
   }
   .playback-card__hint-label--live {
-    color: var(--nc-amber-400, #f2b544);
+    color: var(--nc-amber-fg);
     font-weight: 600;
   }
 

--- a/src/webui/svelte/src/components/songs/PositionPicker.svelte
+++ b/src/webui/svelte/src/components/songs/PositionPicker.svelte
@@ -702,7 +702,7 @@
     background: var(--bg-input);
     border: 1px solid var(--border);
     border-radius: 8px;
-    font-family: var(--font-mono, ui-monospace, monospace);
+    font-family: var(--mono);
     font-variant-numeric: tabular-nums;
     font-size: 15px;
     cursor: text;

--- a/src/webui/svelte/src/components/songs/SectionBar.svelte
+++ b/src/webui/svelte/src/components/songs/SectionBar.svelte
@@ -405,7 +405,7 @@
     flex: 1;
     position: relative;
     overflow: hidden;
-    background: rgba(255, 255, 255, 0.02);
+    background: color-mix(in srgb, var(--nc-fg-1) 2%, transparent);
   }
   .section-block {
     position: absolute;
@@ -422,8 +422,8 @@
     pointer-events: none;
   }
   .section-block.creating {
-    background: rgba(255, 255, 255, 0.1) !important;
-    border: 1px dashed rgba(255, 255, 255, 0.3) !important;
+    background: color-mix(in srgb, var(--nc-fg-1) 10%, transparent) !important;
+    border: 1px dashed color-mix(in srgb, var(--nc-fg-1) 55%, transparent) !important;
   }
   .bar-empty-hint {
     position: absolute;

--- a/src/webui/svelte/src/components/songs/SectionTimelineEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SectionTimelineEditor.svelte
@@ -1004,7 +1004,7 @@
     font-variant-numeric: tabular-nums;
   }
   .playhead-info__pos {
-    color: var(--nc-amber-400, #f2b544);
+    color: var(--nc-amber-fg);
     font-weight: 600;
   }
   .toolbar-controls {
@@ -1045,14 +1045,14 @@
     bottom: 0;
     left: 6px;
     width: 2px;
-    background: var(--nc-amber-400, #f2b544);
-    box-shadow: 0 0 6px rgba(242, 181, 68, 0.5);
+    background: var(--nc-amber-fg);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--nc-amber-fg) 50%, transparent);
   }
   .playhead--dragging::before,
   .playhead:focus-visible::before {
     width: 3px;
     left: 5.5px;
-    box-shadow: 0 0 10px rgba(242, 181, 68, 0.8);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--nc-amber-fg) 80%, transparent);
   }
   .playhead:focus-visible {
     outline: none;
@@ -1064,13 +1064,13 @@
     font-size: 10px;
     padding: 1px 6px;
     border-radius: 6px;
-    background: var(--nc-amber-400, #f2b544);
-    color: var(--nc-ink, #111);
+    background: var(--nc-amber-fg);
+    color: var(--nc-bg-1);
     font-weight: 600;
     white-space: nowrap;
   }
   .preview-btn--live {
-    color: var(--nc-amber-400, #f2b544);
+    color: var(--nc-amber-fg);
   }
   .scroll-spacer {
     height: 0;

--- a/src/webui/svelte/src/components/songs/SongMetronomeEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongMetronomeEditor.svelte
@@ -370,7 +370,7 @@
     font-weight: 600;
   }
   .no-grid-warning {
-    color: var(--warning, #e8a54b);
+    color: var(--nc-amber-fg);
     font-size: 12px;
   }
   .metronome-body {

--- a/src/webui/svelte/src/components/songs/SongPilotEditor.svelte
+++ b/src/webui/svelte/src/components/songs/SongPilotEditor.svelte
@@ -351,7 +351,7 @@
     cursor: pointer;
   }
   .delete-btn:hover {
-    color: var(--error, #e84b4b);
+    color: var(--nc-error);
   }
   .hint-text {
     font-size: 12px;

--- a/src/webui/svelte/src/components/songs/TimelineMarkerLane.svelte
+++ b/src/webui/svelte/src/components/songs/TimelineMarkerLane.svelte
@@ -112,7 +112,7 @@
     flex: 1;
     position: relative;
     overflow: hidden;
-    background: rgba(255, 255, 255, 0.02);
+    background: color-mix(in srgb, var(--nc-fg-1) 2%, transparent);
     cursor: copy;
   }
   .lane-empty-hint {


### PR DESCRIPTION
Audited every UI surface added by this release's timeline, metronome and pilot work (#327, #329, #363, #364, #365, #366, #367, #381, #382) in both themes. Most of it is theme-clean. Four places were styled dark-first and degrade in light mode, one of them to the point of invisibility.

## Root cause

Custom properties referenced but never defined: `--nc-amber-400`, `--warning` and `--error`. A `var(--token, #fallback)` naming a token that does not exist resolves to the fallback in *both* themes, so the theme switch can never reach it. Nothing catches this — the element still renders, still carries its class, still passes a visibility check. It is only wrong to look at.

## What was broken

Measured in the running page, compositing each colour over its real ancestor background chain:

| Element | Light before | Light after | Dark before | Dark after | Floor |
|---|---|---|---|---|---|
| Drag-create ghost, border (`SectionBar.svelte`) | **1.00** | 3.68 | 2.71 | 5.44 | 3:1 |
| Live pilot cue, text (`PlaybackCard.svelte`) | **1.83** | 5.64 | 8.90 | 8.90 | 4.5:1 |
| Playhead readout, text (`SectionTimelineEditor.svelte`) | **1.83** | 5.64 | 9.72 | 9.72 | 4.5:1 |
| Pilot hint ticks, fill (`PlaybackCard.svelte`) | **1.58** | 4.87 | 7.93 | 7.93 | 3:1 |

The drag-to-create ghost was a white fill and a white dashed border on a white bar — contrast 1.00, literally the same colour as what sat behind it. Dragging out a new section in light mode drew nothing at all.

The live pilot cue is the one that matters on stage: highlighting it in amber made it *less* legible than the un-highlighted grey cues beside it, which sit at 5.15:1, so the emphasis ran backwards on the element a musician reads from across a stage.

Also fixed, same cause: the metronome's missing-beat-grid warning (~2.1:1 on white), and two lane tints written as `rgba(255,255,255,0.02)`, which paint nothing on a light ground.

## The fix

An amber ramp whose darker steps can carry text on a light surface, plus a semantic `--nc-amber-fg` that resolves to a dark step in light mode and the bright brand amber in dark. This follows the pattern already used for the lighting badge in `SongDetail.svelte`.

Deliberately unchanged:

- Fills that carry `--nc-ink` text on top of them keep `--nc-amber-400` — they work on both grounds.
- The beat-dot row keeps the bright amber. Its siblings are cyan-400 and pink-400, equally light on a white card; the row is hue-coded, not contrast-coded, so darkening only the amber dot would break the set.
- The drag ghost stays an empty outline. The section has no name until the drag ends and the edit dialog opens, and its snapped edges already align with the ruler's measure gridlines.

## Test

`e2e/tests/theme-contrast.spec.ts` has two halves.

The contrast tests read the *computed* colour of each element above in both themes — after the cascade, after `var()`, after `color-mix()` — composite it over the real ancestor background chain, and hold text to 4.5:1 and meaningful marks to 3:1. Verified to catch the original bugs: reverting the CSS fails every light-mode case and the dark drag ghost (2.71:1, borderline there too), while the dark pilot and playhead cases keep passing.

Their limit is worth stating: they read declared colour, not sampled pixels, so an `opacity`, occlusion or z-index mistake would still pass. They cover the elements listed above, not the whole UI.

The second half scans the source for every custom property referenced with a fallback and fails if nothing defines it — in a stylesheet, through Svelte's `style:--token={…}`, or imperatively via `setProperty`. That is the actual bug class, and it caught one more that no hand-written list would have: the timeline's position picker asked for `--font-mono`, which does not exist (the token is `--mono`), so its numerals had been rendering in the browser's generic monospace rather than JetBrains Mono, in both themes. Fixed here. Verified by reintroducing the typo — the scan fails and names both the token and its file.

## Verification

`npm run lint`, `npm run check` (416 files, 0 errors) and `prettier --check` are clean. Every affected surface was rendered and inspected in both themes.

The full mock Playwright suite was **not** run to completion locally — each test carries a large fixed browser start-up cost in this sandbox that does not reflect CI. The 9 tests in this file pass; the rest is left to the `playwright` job here.

## Follow-ups, not in this PR

**`TriggerSection.svelte:1038`** — `background: var(--bg-base, #1a1a2e)`, and `--bg-base` is not defined anywhere, so the calibration wizard panel is pinned to a dark navy in *both* themes. In light mode that is a dark navy box carrying dark ink text. Same bug class as everything above, but it belongs to a feature this change does not otherwise touch, so it and `--danger` beside it are listed as known in the scan rather than fixed here.

**Docs screenshots** under `docs/src/images/` are stale, and by more than this change:

- `virtual-track-waveforms.png` — header still reads "Sections" rather than "Timeline", and the ruler is missing the clock band added in #382.
- `dashboard.png` — track rows predate the per-track mute and gain controls.
- `section-preview-transport.png` — playhead line and readout still show the old amber.

`npm run screenshots:mock` covers all of them. I regenerated them here and backed it out: this container cannot reach `fonts.googleapis.com`, so captures fall back to the wrong typography, and working around that still leaves a 1–3% rasterisation delta against the previous run's machine. Better done on a dev machine where the diff is clean.