### PR TITLE
Harden playback paths against panic-aborts and control-surface wedges

### DIFF
--- a/examples/audio_stress.rs
+++ b/examples/audio_stress.rs
@@ -28,7 +28,7 @@ extern crate mtrack;
 
 use clap::Parser;
 use mtrack::audio;
-use mtrack::audio::mixer::ActiveSource;
+use mtrack::audio::mixer::{ActiveSource, AudioMixer, PreparedSource};
 use mtrack::audio::sample_source::{ChannelMappedSource, LoopingSampleSource};
 use mtrack::config;
 use mtrack::playsync::CancelHandle;
@@ -36,6 +36,13 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::atomic::AtomicBool;
+
+/// Mirrors the production producer path: prepare on this thread so the audio
+/// callback only inserts.
+fn prepare_for_send(mixer: &AudioMixer, mut source: ActiveSource) -> PreparedSource {
+    mixer.prepare_source(&mut source);
+    std::sync::Arc::new(Mutex::new(source))
+}
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::Subscriber;
@@ -438,6 +445,7 @@ fn run_scenario(
     let source_tx = device
         .source_sender()
         .ok_or("Device does not support source_sender")?;
+    let mixer = device.mixer().ok_or("Device does not support mixer")?;
 
     // Use 2 channels (stereo)
     let channels = 2u16;
@@ -450,7 +458,7 @@ fn run_scenario(
         let sine_buffer = generate_sine_buffer(freq, sample_rate, channels);
         let (active_source, _is_finished, cancel_handle) =
             create_looping_source(&sine_buffer, channels, sample_rate, volume);
-        source_tx.send(active_source)?;
+        source_tx.send(prepare_for_send(&mixer, active_source))?;
         cancel_handles.push(cancel_handle);
     }
 
@@ -523,6 +531,7 @@ fn run_ramp_scenario(
     let source_tx = device
         .source_sender()
         .ok_or("Device does not support source_sender")?;
+    let mixer = device.mixer().ok_or("Device does not support mixer")?;
 
     let channels = 2u16;
     let budget_us = compute_budget_us(buffer_size, sample_rate);
@@ -539,7 +548,7 @@ fn run_ramp_scenario(
             let sine_buffer = generate_sine_buffer(freq, sample_rate, channels);
             let (active_source, _is_finished, cancel_handle) =
                 create_looping_source(&sine_buffer, channels, sample_rate, volume);
-            source_tx.send(active_source)?;
+            source_tx.send(prepare_for_send(&mixer, active_source))?;
             cancel_handles.push(cancel_handle);
         }
         current_sources += to_add;
@@ -619,6 +628,7 @@ fn run_churn_scenario(
     let source_tx = device
         .source_sender()
         .ok_or("Device does not support source_sender")?;
+    let mixer = device.mixer().ok_or("Device does not support mixer")?;
 
     let channels = 2u16;
     let budget_us = compute_budget_us(buffer_size, sample_rate);
@@ -638,7 +648,7 @@ fn run_churn_scenario(
             let sine_buffer = generate_sine_buffer(freq, sample_rate, channels);
             let (active_source, _is_finished, cancel_handle) =
                 create_looping_source(&sine_buffer, channels, sample_rate, 0.05);
-            if source_tx.send(active_source).is_ok() {
+            if source_tx.send(prepare_for_send(&mixer, active_source)).is_ok() {
                 cancel_handles.push((cancel_handle, now));
                 sources_created += 1;
             }

--- a/examples/audio_stress.rs
+++ b/examples/audio_stress.rs
@@ -648,7 +648,10 @@ fn run_churn_scenario(
             let sine_buffer = generate_sine_buffer(freq, sample_rate, channels);
             let (active_source, _is_finished, cancel_handle) =
                 create_looping_source(&sine_buffer, channels, sample_rate, 0.05);
-            if source_tx.send(prepare_for_send(&mixer, active_source)).is_ok() {
+            if source_tx
+                .send(prepare_for_send(&mixer, active_source))
+                .is_ok()
+            {
                 cancel_handles.push((cancel_handle, now));
                 sources_created += 1;
             }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -51,7 +51,7 @@ pub fn next_source_id() -> u64 {
 }
 
 /// Type alias for the channel sender used to add sources to the mixer.
-pub type SourceSender = crossbeam_channel::Sender<mixer::ActiveSource>;
+pub type SourceSender = crossbeam_channel::Sender<mixer::PreparedSource>;
 
 /// Typed errors for the audio subsystem.
 #[derive(Debug, thiserror::Error)]

--- a/src/audio/cpal/manager.rs
+++ b/src/audio/cpal/manager.rs
@@ -33,7 +33,7 @@ const STREAM_FLAPPING_UNDER: Duration = Duration::from_secs(1);
 /// second, and the point is to tell the operator once, not to fill the journal.
 const FLAP_WARN_INTERVAL: Duration = Duration::from_secs(10);
 
-use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
+use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer, PreparedSource};
 
 use crate::audio::health::{OutputHealth, OutputHealthSnapshot};
 
@@ -45,9 +45,9 @@ pub(super) struct OutputManager {
     /// The core audio mixer
     pub(super) mixer: AudioMixer,
     /// Channel for receiving new audio sources to play.
-    pub(super) source_tx: crossbeam_channel::Sender<MixerActiveSource>,
+    pub(super) source_tx: crossbeam_channel::Sender<PreparedSource>,
     /// Channel receiver for processing new sources.
-    source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+    source_rx: crossbeam_channel::Receiver<PreparedSource>,
     /// Handle to the output thread (keeps it alive).
     output_thread: Option<thread::JoinHandle<()>>,
     /// Shared shutdown signal: set to true and notify condvar to stop the output thread.
@@ -120,9 +120,13 @@ impl OutputManager {
         Ok(manager)
     }
 
-    /// Adds a new audio source to be played.
-    pub(super) fn add_source(&self, source: MixerActiveSource) -> Result<(), Box<dyn Error>> {
-        self.source_tx.send(source)?;
+    /// Adds a new audio source to be played. The allocation-heavy preparation
+    /// (channel-mapping precompute) happens here on the caller's thread; the
+    /// audio callback receives a ready-to-insert source and only pushes it.
+    pub(super) fn add_source(&self, mut source: MixerActiveSource) -> Result<(), Box<dyn Error>> {
+        self.mixer.prepare_source(&mut source);
+        self.source_tx
+            .send(std::sync::Arc::new(parking_lot::Mutex::new(source)))?;
         Ok(())
     }
 

--- a/src/audio/cpal/stream.rs
+++ b/src/audio/cpal/stream.rs
@@ -20,7 +20,7 @@ use tracing::{error, info};
 
 use crate::audio::format::{SampleFormat, TargetFormat};
 use crate::audio::health::{has_output_signal, OutputHealth};
-use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
+use crate::audio::mixer::{AudioMixer, PreparedSource};
 use crate::thread_priority::{
     callback_thread_priority, env_flag, promote_to_realtime, rt_audio_enabled,
 };
@@ -47,7 +47,7 @@ pub(crate) trait OutputStreamFactory: Send + 'static {
     fn build_stream(
         &self,
         mixer: AudioMixer,
-        source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+        source_rx: crossbeam_channel::Receiver<PreparedSource>,
         num_channels: u16,
         error_notify: CondvarNotify,
         health: Arc<OutputHealth>,
@@ -132,7 +132,7 @@ impl OutputStreamFactory for CpalOutputStreamFactory {
     fn build_stream(
         &self,
         mixer: AudioMixer,
-        source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+        source_rx: crossbeam_channel::Receiver<PreparedSource>,
         num_channels: u16,
         error_notify: CondvarNotify,
         health: Arc<OutputHealth>,
@@ -200,7 +200,7 @@ impl CpalOutputStreamFactory {
         &self,
         device: &cpal::Device,
         mixer: AudioMixer,
-        source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+        source_rx: crossbeam_channel::Receiver<PreparedSource>,
         num_channels: u16,
         error_notify: CondvarNotify,
         health: Arc<OutputHealth>,
@@ -331,10 +331,10 @@ fn error_handler(
 /// Drains pending sources from the channel and adds them to the mixer.
 pub(super) fn drain_pending_sources(
     mixer: &AudioMixer,
-    source_rx: &crossbeam_channel::Receiver<MixerActiveSource>,
+    source_rx: &crossbeam_channel::Receiver<PreparedSource>,
 ) {
     while let Ok(new_source) = source_rx.try_recv() {
-        mixer.add_source(new_source);
+        mixer.push_prepared(new_source);
     }
 }
 
@@ -353,7 +353,7 @@ pub(super) struct CallbackInstruments<'a> {
 pub(super) fn process_f32_callback(
     data: &mut [f32],
     mixer: &AudioMixer,
-    source_rx: &crossbeam_channel::Receiver<MixerActiveSource>,
+    source_rx: &crossbeam_channel::Receiver<PreparedSource>,
     num_channels: u16,
     instruments: CallbackInstruments<'_>,
 ) {
@@ -375,7 +375,7 @@ pub(super) fn process_f32_callback(
 pub(super) fn process_int_callback<T: cpal::Sample + cpal::FromSample<f32>>(
     data: &mut [T],
     mixer: &AudioMixer,
-    source_rx: &crossbeam_channel::Receiver<MixerActiveSource>,
+    source_rx: &crossbeam_channel::Receiver<PreparedSource>,
     num_channels: u16,
     temp_buffer: &mut [f32],
     instruments: CallbackInstruments<'_>,
@@ -410,7 +410,7 @@ pub(super) fn process_int_callback<T: cpal::Sample + cpal::FromSample<f32>>(
 /// Direct mixer callback for f32 output - no intermediate ring buffer
 fn create_direct_f32_callback(
     mixer: AudioMixer,
-    source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+    source_rx: crossbeam_channel::Receiver<PreparedSource>,
     num_channels: u16,
     health: Arc<OutputHealth>,
 ) -> impl FnMut(&mut [f32], &cpal::OutputCallbackInfo) + Send + 'static {
@@ -440,7 +440,7 @@ fn create_direct_f32_callback(
 /// so the temp buffer is pre-allocated and never resized in the callback.
 fn create_direct_int_callback<T: cpal::Sample + cpal::FromSample<f32> + std::fmt::Debug>(
     mixer: AudioMixer,
-    source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+    source_rx: crossbeam_channel::Receiver<PreparedSource>,
     num_channels: u16,
     max_samples: usize,
     health: Arc<OutputHealth>,
@@ -477,7 +477,7 @@ pub(super) mod test {
 
     use super::super::CondvarNotify;
     use super::*;
-    use crate::audio::mixer::AudioMixer;
+    use crate::audio::mixer::{ActiveSource as MixerActiveSource, AudioMixer};
     use crate::playsync::CancelHandle;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -550,7 +550,7 @@ pub(super) mod test {
         fn build_stream(
             &self,
             _mixer: AudioMixer,
-            _source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+            _source_rx: crossbeam_channel::Receiver<PreparedSource>,
             _num_channels: u16,
             _error_notify: CondvarNotify,
             _health: Arc<OutputHealth>,
@@ -569,7 +569,7 @@ pub(super) mod test {
         fn build_stream(
             &self,
             _mixer: AudioMixer,
-            _source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+            _source_rx: crossbeam_channel::Receiver<PreparedSource>,
             _num_channels: u16,
             _error_notify: CondvarNotify,
             _health: Arc<OutputHealth>,
@@ -643,7 +643,7 @@ pub(super) mod test {
         fn build_stream(
             &self,
             _mixer: AudioMixer,
-            _source_rx: crossbeam_channel::Receiver<MixerActiveSource>,
+            _source_rx: crossbeam_channel::Receiver<PreparedSource>,
             _num_channels: u16,
             error_notify: CondvarNotify,
             _health: Arc<OutputHealth>,
@@ -668,7 +668,7 @@ pub(super) mod test {
     mod process_callbacks {
         use super::*;
 
-        fn setup(channels: u16) -> (AudioMixer, crossbeam_channel::Receiver<MixerActiveSource>) {
+        fn setup(channels: u16) -> (AudioMixer, crossbeam_channel::Receiver<PreparedSource>) {
             let (tx, rx) = crossbeam_channel::bounded(64);
             let mixer = AudioMixer::new(channels, 44100);
 
@@ -685,9 +685,11 @@ pub(super) mod test {
             let samples: Vec<f32> = (0..4 * channels as usize)
                 .map(|i| (i + 1) as f32 * 0.1)
                 .collect();
-            let source =
+            let mut source =
                 make_active_source(make_test_source(samples, channels, labels), track_mappings);
-            tx.send(source).unwrap();
+            mixer.prepare_source(&mut source);
+            tx.send(std::sync::Arc::new(parking_lot::Mutex::new(source)))
+                .unwrap();
 
             (mixer, rx)
         }
@@ -751,7 +753,7 @@ pub(super) mod test {
         /// facts and leaves the verdict to a caller that knows the playback state.
         #[test]
         fn f32_callback_idle_is_alive_but_silent() {
-            let (_tx, rx) = crossbeam_channel::bounded::<MixerActiveSource>(64);
+            let (_tx, rx) = crossbeam_channel::bounded::<PreparedSource>(64);
             let mixer = AudioMixer::new(2, 44100);
             let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut output = vec![1.0f32; 8];
@@ -797,7 +799,7 @@ pub(super) mod test {
 
         #[test]
         fn f32_callback_produces_silence_with_no_sources() {
-            let (_tx, rx) = crossbeam_channel::bounded::<MixerActiveSource>(64);
+            let (_tx, rx) = crossbeam_channel::bounded::<PreparedSource>(64);
             let mixer = AudioMixer::new(2, 44100);
             let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());
             let mut output = vec![1.0f32; 8];
@@ -890,11 +892,13 @@ pub(super) mod test {
             for _ in 0..2 {
                 let mut mappings = HashMap::new();
                 mappings.insert("ch0".to_string(), vec![1]);
-                let source = make_active_source(
+                let mut source = make_active_source(
                     make_test_source(vec![0.5; 4], 1, vec![vec!["ch0".to_string()]]),
                     mappings,
                 );
-                tx.send(source).unwrap();
+                mixer.prepare_source(&mut source);
+                tx.send(std::sync::Arc::new(parking_lot::Mutex::new(source)))
+                    .unwrap();
             }
 
             let (mut profiler, health) = (CallbackProfiler::new(false), OutputHealth::new());

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -33,6 +33,10 @@ thread_local! {
     static SOURCES_SCRATCH: RefCell<Vec<Arc<Mutex<ActiveSource>>>> = const { RefCell::new(Vec::new()) };
 }
 
+/// A source that has been through `prepare_source` and can be inserted by the
+/// audio callback without further allocation-heavy work.
+pub type PreparedSource = Arc<Mutex<ActiveSource>>;
+
 /// Core audio mixing logic that's independent of any audio backend
 #[derive(Clone)]
 pub struct AudioMixer {
@@ -218,8 +222,10 @@ impl AudioMixer {
         (channel_mappings, gain)
     }
 
-    /// Adds a new audio source to the mixer
-    pub fn add_source(&self, mut source: ActiveSource) {
+    /// Prepares a source for mixing: caches its channel count and precomputes
+    /// its channel mappings. Allocation-heavy — call this on the producer
+    /// thread, never in the audio callback.
+    pub fn prepare_source(&self, source: &mut ActiveSource) {
         // Cache source channel count (avoids repeated trait calls)
         if source.cached_source_channel_count == 0 {
             source.cached_source_channel_count = source.source.source_channel_count();
@@ -233,9 +239,19 @@ impl AudioMixer {
         );
         source.channel_mappings = channel_mappings;
         source.gain = gain;
+    }
 
-        let mut sources = self.active_sources.write();
-        sources.push(Arc::new(Mutex::new(source)));
+    /// Inserts an already-prepared source. The one Vec push is the only
+    /// allocation, so this is what the audio callback's drain uses.
+    pub fn push_prepared(&self, source: Arc<Mutex<ActiveSource>>) {
+        self.active_sources.write().push(source);
+    }
+
+    /// Adds a new audio source to the mixer. Prepare + insert in one call,
+    /// for callers not on the audio callback (tests, direct use).
+    pub fn add_source(&self, mut source: ActiveSource) {
+        self.prepare_source(&mut source);
+        self.push_prepared(Arc::new(Mutex::new(source)));
     }
 
     /// Removes sources by ID.

--- a/src/audio/sample_source/buffered.rs
+++ b/src/audio/sample_source/buffered.rs
@@ -38,9 +38,18 @@ impl BufferFillPool {
     /// Creates a new pool with the given number of worker threads.
     pub fn new(num_threads: usize) -> Result<Self, String> {
         let threads = num_threads.max(1);
+        // Without a panic handler, rayon aborts the whole process when a job
+        // panics. Fill tasks catch their own unwinds; this is the backstop
+        // that keeps a panic from ever ending playback of the rest of the mix.
         let pool = ThreadPoolBuilder::new()
             .num_threads(threads)
             .thread_name(|i| format!("mtrack-buffer-fill-{i}"))
+            .panic_handler(|payload| {
+                tracing::error!(
+                    "Panic in audio buffer fill pool: {}",
+                    crate::util::panic_message(payload.as_ref())
+                );
+            })
             .build()
             .map_err(|e| e.to_string())?;
         Ok(Self { pool })
@@ -228,87 +237,130 @@ impl BufferedSampleSource {
         warmup_signal: Option<Arc<WarmupSignal>>,
     ) {
         pool.spawn(move || {
-            let mut producer = match producer_slot.lock().unwrap().take() {
-                Some(p) => p,
-                None => {
-                    // The debounce on `refill_in_progress` should make this
-                    // unreachable. Bail safely if we ever hit it.
-                    refill_in_progress.store(false, Ordering::Release);
-                    if let Some(sig) = warmup_signal {
-                        sig.signal();
-                    }
-                    return;
-                }
-            };
-
-            let mut local_frame = vec![0.0f32; channels];
-            let mut samples_written: usize = 0;
-            let mut warmup_signalled = warmup_signal.is_none();
-
-            loop {
-                // Need at least one frame's worth of free slots to write.
-                if producer.slots() < channels {
-                    break;
-                }
-
-                // Decode one frame outside the producer's critical path.
-                let done = {
-                    let mut g = inner.lock().unwrap();
-                    match g.next_frame(&mut local_frame[..]) {
-                        Ok(Some(_)) => false,
-                        Ok(None) => true,
-                        Err(e) => {
-                            // A decode error permanently ends just this source
-                            // while the rest of the mix continues — make sure
-                            // that leaves a trace in the logs.
-                            tracing::warn!("Audio source ended early due to decode error: {}", e);
-                            true
-                        }
-                    }
-                };
-
-                if done {
-                    finished_flag.store(true, Ordering::Release);
-                    break;
-                }
-
-                // Push one frame into the ring. `push` is the simple safe
-                // single‑item API; for typical channel counts (1–8) the
-                // per‑push atomic overhead is negligible relative to decode
-                // work.
-                let mut pushed_full_frame = true;
-                for &sample in &local_frame[..channels] {
-                    if producer.push(sample).is_err() {
-                        // Ring filled mid‑frame; should not happen because we
-                        // checked slots() >= channels above, but be defensive.
-                        pushed_full_frame = false;
-                        break;
-                    }
-                }
-                if !pushed_full_frame {
-                    break;
-                }
-                samples_written += channels;
-
-                if !warmup_signalled && samples_written >= warmup_min_samples {
-                    if let Some(sig) = warmup_signal.as_ref() {
-                        sig.signal();
-                    }
-                    warmup_signalled = true;
-                }
-            }
-
-            *producer_slot.lock().unwrap() = Some(producer);
-            refill_in_progress.store(false, Ordering::Release);
-
-            // If the source ended before we hit the warmup threshold, unblock
-            // the constructor anyway.
-            if !warmup_signalled {
-                if let Some(sig) = warmup_signal {
+            // A decoder panic (symphonia/rubato on a malformed file) must end
+            // only this source, not the process: catch the unwind, mark the
+            // source finished so no further fill task is spawned for it, and
+            // release `refill_in_progress` so the flag can never latch. The
+            // producer is lost on that path, which is fine — the source is
+            // finished.
+            let refill_flag = refill_in_progress.clone();
+            let finished = finished_flag.clone();
+            let warmup = warmup_signal.clone();
+            let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                Self::run_fill_task(
+                    inner,
+                    producer_slot,
+                    refill_in_progress,
+                    finished_flag,
+                    channels,
+                    warmup_min_samples,
+                    warmup_signal,
+                );
+            }));
+            if let Err(payload) = unwound {
+                tracing::error!(
+                    "Audio fill task panicked ({}); ending this source early while the rest of the mix continues",
+                    crate::util::panic_message(payload.as_ref())
+                );
+                finished.store(true, Ordering::Release);
+                refill_flag.store(false, Ordering::Release);
+                if let Some(sig) = warmup {
                     sig.signal();
                 }
             }
         });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_fill_task(
+        inner: Arc<Mutex<Box<dyn ChannelMappedSampleSource + Send + Sync>>>,
+        producer_slot: Arc<Mutex<Option<Producer<f32>>>>,
+        refill_in_progress: Arc<AtomicBool>,
+        finished_flag: Arc<AtomicBool>,
+        channels: usize,
+        warmup_min_samples: usize,
+        warmup_signal: Option<Arc<WarmupSignal>>,
+    ) {
+        let mut producer = match producer_slot.lock().unwrap().take() {
+            Some(p) => p,
+            None => {
+                // The debounce on `refill_in_progress` should make this
+                // unreachable. Bail safely if we ever hit it.
+                refill_in_progress.store(false, Ordering::Release);
+                if let Some(sig) = warmup_signal {
+                    sig.signal();
+                }
+                return;
+            }
+        };
+
+        let mut local_frame = vec![0.0f32; channels];
+        let mut samples_written: usize = 0;
+        let mut warmup_signalled = warmup_signal.is_none();
+
+        loop {
+            // Need at least one frame's worth of free slots to write.
+            if producer.slots() < channels {
+                break;
+            }
+
+            // Decode one frame outside the producer's critical path.
+            let done = {
+                let mut g = inner.lock().unwrap();
+                match g.next_frame(&mut local_frame[..]) {
+                    Ok(Some(_)) => false,
+                    Ok(None) => true,
+                    Err(e) => {
+                        // A decode error permanently ends just this source
+                        // while the rest of the mix continues — make sure
+                        // that leaves a trace in the logs.
+                        tracing::warn!("Audio source ended early due to decode error: {}", e);
+                        true
+                    }
+                }
+            };
+
+            if done {
+                finished_flag.store(true, Ordering::Release);
+                break;
+            }
+
+            // Push one frame into the ring. `push` is the simple safe
+            // single‑item API; for typical channel counts (1–8) the
+            // per‑push atomic overhead is negligible relative to decode
+            // work.
+            let mut pushed_full_frame = true;
+            for &sample in &local_frame[..channels] {
+                if producer.push(sample).is_err() {
+                    // Ring filled mid‑frame; should not happen because we
+                    // checked slots() >= channels above, but be defensive.
+                    pushed_full_frame = false;
+                    break;
+                }
+            }
+            if !pushed_full_frame {
+                break;
+            }
+            samples_written += channels;
+
+            if !warmup_signalled && samples_written >= warmup_min_samples {
+                if let Some(sig) = warmup_signal.as_ref() {
+                    sig.signal();
+                }
+                warmup_signalled = true;
+            }
+        }
+
+        *producer_slot.lock().unwrap() = Some(producer);
+        refill_in_progress.store(false, Ordering::Release);
+
+        // If the source ended before we hit the warmup threshold, unblock
+        // the constructor anyway.
+        if !warmup_signalled {
+            if let Some(sig) = warmup_signal {
+                sig.signal();
+            }
+        }
     }
 }
 

--- a/src/controller/midi.rs
+++ b/src/controller/midi.rs
@@ -114,7 +114,10 @@ impl Driver {
 
 impl super::Driver for Driver {
     fn monitor_events(&self) -> JoinHandle<Result<(), io::Error>> {
-        let (midi_events_tx, mut midi_events_rx) = mpsc::channel::<Vec<u8>>(10);
+        // Deep enough to absorb a footswitch burst or an unfiltered clock
+        // stream while the consumer awaits player calls; the producer side
+        // drops (never blocks) when this fills.
+        let (midi_events_tx, mut midi_events_rx) = mpsc::channel::<Vec<u8>>(256);
         let player = self.player.clone();
         let device = self.midi_device.clone();
         let events = MidiEvents {

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -448,11 +448,16 @@ impl Engine {
         let mut effect_engine = match self.effect_engine.try_lock_for(Duration::from_secs(2)) {
             Some(guard) => guard,
             None => {
+                // Skip this tick rather than falling back to a blocking
+                // acquire: blocking here wedges the whole 44Hz loop behind
+                // the stuck holder, freezing lighting entirely. Skipping
+                // keeps the loop alive so output resumes the moment the
+                // lock frees up.
                 error!(
                     "effect_engine lock blocked for >2s in update_effects — \
-                     another holder is not releasing it"
+                     another holder is not releasing it; skipping this tick"
                 );
-                self.effect_engine.lock()
+                return Ok(());
             }
         };
         let commands = effect_engine.update(dt, Some(song_time))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,32 @@ async fn main() {
             .init();
     }
 
+    // A panicking background task otherwise dies with output only on stderr —
+    // invisible headless under systemd journal filtering and in the web UI log
+    // stream. Log it through tracing first, then let the default hook (or the
+    // TUI's terminal-restoring hook, which chains onto this one) run.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        tracing::error!("Thread panicked: {panic_info}");
+        default_hook(panic_info);
+    }));
+
+    // Rayon's global pool (waveform generation) aborts the process if a job
+    // panics and no handler is installed. Install one before first use so a
+    // panic there logs and ends that job instead of ending playback.
+    if let Err(e) = rayon::ThreadPoolBuilder::new()
+        .panic_handler(|payload| {
+            tracing::error!(
+                "Panic in rayon global thread pool: {}",
+                mtrack::util::panic_message(payload.as_ref())
+            )
+        })
+        .build_global()
+    {
+        // Already initialized elsewhere; nothing to do.
+        tracing::debug!("Global rayon pool already initialized: {e}");
+    }
+
     if let Err(e) = cli::run(tui_mode).await {
         eprintln!("Error: {}", e);
         std::process::exit(1);

--- a/src/midi/midir.rs
+++ b/src/midi/midir.rs
@@ -25,7 +25,7 @@ use std::{
 
 use midir::{MidiInput, MidiInputConnection, MidiInputPort, MidiOutput, MidiOutputPort};
 use midly::live::LiveEvent;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{error::TrySendError, Sender};
 use tracing::{debug, error, info, span, warn, Level};
 
 use crate::{
@@ -154,11 +154,22 @@ impl super::Device for Device {
                         );
                     }
                 }
-                if let Err(e) = sender.blocking_send(Vec::from(raw_event)) {
-                    error!(
-                        err = format!("{:?}", e),
-                        "Error sending MIDI event to receiver."
-                    );
+                // This closure runs on the MIDI driver's input thread: it must
+                // never block. If the consumer stalls (it awaits player calls),
+                // a blocking send here would wedge the driver thread and with
+                // it all incoming MIDI. Dropping an event under backpressure is
+                // the lesser harm.
+                match sender.try_send(Vec::from(raw_event)) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        warn!("MIDI control channel full; dropping incoming event");
+                    }
+                    Err(e @ TrySendError::Closed(_)) => {
+                        error!(
+                            err = format!("{:?}", e),
+                            "Error sending MIDI event to receiver."
+                        );
+                    }
                 }
             },
             (),

--- a/src/player/seek.rs
+++ b/src/player/seek.rs
@@ -19,6 +19,11 @@ use tracing::{info, warn};
 
 use super::{Player, ReactiveLoopState};
 
+/// How long a seek waits for the previous playback to wind down before
+/// abandoning it. Normal wind-down is well under a second; this only fires
+/// when a playback thread failed to observe cancellation.
+const SEEK_WINDDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
 impl Player {
     /// Seeks to an absolute position within the current song.
     ///
@@ -76,9 +81,30 @@ impl Player {
 
         // Wait for all subsystems to wind down (play_files joins its audio/
         // MIDI/DMX threads before completing) so the restart can't race
-        // shutdown of the previous playback.
-        if let Err(e) = handles.join.await {
-            warn!(err = %e, "Error waiting for playback to wind down during seek");
+        // shutdown of the previous playback. The wait is bounded: this runs
+        // with the join lock held, and an unbounded await here would wedge
+        // every control call (play/stop/next/is_playing and the web UI
+        // poller) behind a playback thread that failed to observe
+        // cancellation. On timeout the handle is dropped — detaching the
+        // wind-down like stop() does — and the seek reports failure rather
+        // than restarting on top of a device that may still be held.
+        match tokio::time::timeout(SEEK_WINDDOWN_TIMEOUT, handles.join).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(err = %e, "Error waiting for playback to wind down during seek");
+            }
+            Err(_) => {
+                warn!(
+                    timeout = ?SEEK_WINDDOWN_TIMEOUT,
+                    "Playback did not wind down in time during seek; abandoning it"
+                );
+                return Err(format!(
+                    "Seek aborted: previous playback did not wind down within {:?}. \
+                     Stop and play to recover.",
+                    SEEK_WINDDOWN_TIMEOUT
+                )
+                .into());
+            }
         }
 
         // Restart at the target position under the same join lock.

--- a/src/samples/engine.rs
+++ b/src/samples/engine.rs
@@ -341,7 +341,13 @@ impl SampleEngine {
             gain_envelope: None,
         };
 
-        if let Err(e) = self.source_tx.send(active_source) {
+        // Prepare on this thread so the audio callback's drain only inserts.
+        let mut active_source = active_source;
+        self.mixer.prepare_source(&mut active_source);
+        if let Err(e) = self
+            .source_tx
+            .send(std::sync::Arc::new(parking_lot::Mutex::new(active_source)))
+        {
             error!(error = %e, "Failed to send sample to mixer");
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,18 @@ use serde::Serialize;
 use yaml_rust2::{Yaml, YamlEmitter};
 
 /// Extracts a displayable file name from a path, returning a fallback if the name is unreadable.
+/// Extracts the human-readable message from a panic payload, as delivered to
+/// `std::panic::set_hook` callbacks and rayon `panic_handler`s. Panic payloads
+/// are `&str` for `panic!("literal")` and `String` for `panic!("{x}")`;
+/// anything else has no portable message.
+pub fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<non-string panic payload>")
+}
+
 pub fn filename_display(path: &Path) -> &str {
     path.file_name()
         .and_then(|f| f.to_str())


### PR DESCRIPTION
Five fixes from a pre-0.16 reliability audit of the realtime paths. Theme: a fault mid-song must degrade, never end the show.

1. **Panic in the audio prefetch pool no longer aborts the process.** Rayon aborts on job panic when no `panic_handler` is installed; the fill jobs run symphonia decode + rubato resample, the most panic-prone stack in the player. Fill tasks now `catch_unwind` and end just their own source — finished flag set so no refill respawns, `refill_in_progress` released so it can't latch, warmup signalled so a constructor can't hang — while the rest of the mix continues. The pool's new `panic_handler` (and one on the global rayon pool used for waveforms) logs the payload as a backstop, and `main` installs a tracing panic hook so background-thread panics are visible headless and in the web UI log stream.
2. **`seek_to` can no longer wedge the control surface.** It held the join lock across an unbounded wind-down await; one stuck playback thread froze play/stop/next/`is_playing` and the web UI poller forever while audio kept playing. The wait is bounded (10s), and on timeout the handle is dropped — the same detach semantics `stop()` already uses — with the seek reporting failure rather than restarting over a device the old playback may still hold.
3. **MIDI input callback never blocks.** `blocking_send` into a 10-slot channel (whose consumer awaits player calls) becomes `try_send` into 256 slots; under backpressure an event is dropped with a warning instead of wedging the driver's input thread.
4. **DMX effects loop skips a tick instead of freezing.** The 2s `try_lock_for` fallback previously logged the stuck lock and then blocked on it anyway.
5. **No allocation-heavy work in the audio callback at song start.** Channel-mapping precompute moves to the producer side (`OutputManager::add_source` / `SampleEngine`); the callback drain now only pushes an already-prepared `Arc<Mutex<ActiveSource>>` (new `PreparedSource` alias).

Verified: `cargo test` 3,382 passed / 0 failed; `cargo clippy --all-targets` clean; `examples/audio_stress.rs` updated for the new producer-side prepare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153MsUL34wD3EEY7KsjAWnL