### PR TITLE
design: Venue Exchange draft 5 — extension-as-version, syntax ships with its consumer

### DIFF
--- a/design/venue_exchange_design.md
+++ b/design/venue_exchange_design.md
@@ -2,7 +2,7 @@
 
 *Design doc, draft 5 — 2026-08-19. Draft 5 revises the file-format story
 after implementation review: the extension identifies the DSL generation (v1
-`.light` files are never renamed or migrated), the intermediary model is
+`.light` files are not renamed or migrated), the intermediary model is
 machine-only, the DSL is scoped to the datasheet-typable subset, and every
 DSL construct ships in the same phase as its consumer.*
 
@@ -42,7 +42,7 @@ OFL import (possible later addition for hobbyist gear; not in scope here).
 | MVR parser | Own implementation | No Rust crate exists. Simpler format; reuses our GDTF machinery for embedded fixtures. |
 | Fixture sourcing | GDTF-sourced fixtures are *referential*: a thin `.fixture` file names the GDTF + mode (+ overrides); the expanded channel table is an ephemeral cache, never committed | Fixture data is a manufacturer fact — a fat distilled copy can only drift from its source. The cache pattern (hash-keyed, regenerated on change) is the waveform-cache model mtrack already has. |
 | Venue sourcing | MVR import *seeds* an owned `.venue` file | Venues are authored, not derived: tags, focus points, and position tweaks are human judgment layered on the import. |
-| File extensions | `.fixture`/`.venue` identify the **v2 DSL**; v1 fixture/venue definitions stay in `.light` files, valid forever beside them | The extension *is* the version marker (versions mark breakages, not expansions). Nothing renames, migrates, or deprecates v1 files, and there is no in-file version field. |
+| File extensions | `.fixture`/`.venue` identify the **v2 DSL**; v1 fixture/venue definitions stay in `.light` files, valid beside them | The extension *is* the version marker (versions mark breakages, not expansions). This design renames, migrates, and deprecates nothing, and there is no in-file version field. No v1 removal is scheduled — retiring v1 someday is a legitimate future decision, but it would be its own design, with its own migration story. |
 | GDTF/MVR export | Deferred (phase 2+) | Nothing in v1 depends on it; model stays exportable. |
 | Visualizer | 2D top-down in phase 1; real 3D simulation in phase 2 | Positions/orientations/beam data and glTF assets are retained from import day one so 3D is additive, not a re-import. |
 | Position abstraction | Named focus points, bound per-venue | The positional analog of tags: shows say `focus "drummer"`; venues supply coordinates. |
@@ -342,7 +342,9 @@ Open in draft 2; all resolved by draft 4.
    *millimeters*, author-chosen origin) is converted at import with a re-origin step (§6).
 2. **v2 DSL grammar** — hybrid: name-keyed channel one-liners, optional block only where a
    channel has structure (§4.1). Simple fixtures stay as terse as v1. The v1 grammar is
-   frozen, not deprecated: `.light` fixture/venue files remain valid indefinitely.
+   frozen, not deprecated: `.light` fixture/venue files remain valid, and no removal is
+   scheduled. Retiring v1 is out of scope here — if it ever happens, it arrives as its
+   own design with its own migration story.
 3. **Corpus licensing** — sidestepped via the two-tier corpus (§12): committed synthetic
    files we author are the CI backbone; real manufacturer files are a bring-your-own local
    corpus, never fetched by CI (vendor URLs rot and block non-browser clients — brittle by

--- a/design/venue_exchange_design.md
+++ b/design/venue_exchange_design.md
@@ -1,10 +1,16 @@
-# Venue Exchange: GDTF/MVR Import, Fixture Model v2, and Physical-Unit Movement
+# Venue Exchange: GDTF/MVR Import, the Rich Fixture Model, and Physical-Unit Movement
 
 *Design doc, draft 5 — 2026-08-19. Draft 5 revises the file-format story
 after implementation review: the extension identifies the DSL generation (v1
 `.light` files are not renamed or migrated), the intermediary model is
 machine-only, the DSL is scoped to the datasheet-typable subset, and every
 DSL construct ships in the same phase as its consumer.*
+
+> **Terminology:** "v1 DSL" and "v2 DSL" refer to exactly one thing in this
+> document — the two generations of *fixture/venue definition syntax*,
+> identified by file extension (`.light` vs `.fixture`/`.venue`). Show files
+> are neither versioned nor touched by this design. Feature scope is named by
+> phase (P0–P2), never by version number.
 
 mtrack shows already target roles — tags and logical groups — rather than fixtures, and a
 show plays across multiple venues today. What doesn't scale is everything underneath: every
@@ -29,7 +35,7 @@ that answers "will my show work there?" before the van leaves.
 - Lint that reports capability gaps, unresolvable groups/focus points, and infeasible moves
   per venue.
 
-**Non-goals (v1).** GDTF/MVR *writing* (deferred; the model is designed to be exportable).
+**Non-goals (initial scope).** GDTF/MVR *writing* (deferred; the model is designed to be exportable).
 Wheels, gobos, matrix/pixel modes, RDM (skipped loudly on import). Full geometry-tree
 kinematics (tier-3 fidelity visualizers need; simple spherical pointing math suffices — §8).
 OFL import (possible later addition for hobbyist gear; not in scope here).
@@ -43,7 +49,7 @@ OFL import (possible later addition for hobbyist gear; not in scope here).
 | Fixture sourcing | GDTF-sourced fixtures are *referential*: a thin `.fixture` file names the GDTF + mode (+ overrides); the expanded channel table is an ephemeral cache, never committed | Fixture data is a manufacturer fact — a fat distilled copy can only drift from its source. The cache pattern (hash-keyed, regenerated on change) is the waveform-cache model mtrack already has. |
 | Venue sourcing | MVR import *seeds* an owned `.venue` file | Venues are authored, not derived: tags, focus points, and position tweaks are human judgment layered on the import. |
 | File extensions | `.fixture`/`.venue` identify the **v2 DSL**; v1 fixture/venue definitions stay in `.light` files, valid beside them | The extension *is* the version marker (versions mark breakages, not expansions). This design renames, migrates, and deprecates nothing, and there is no in-file version field. No v1 removal is scheduled — retiring v1 someday is a legitimate future decision, but it would be its own design, with its own migration story. |
-| GDTF/MVR export | Deferred (phase 2+) | Nothing in v1 depends on it; model stays exportable. |
+| GDTF/MVR export | Deferred (phase 2+) | Nothing in the initial phases depends on it; model stays exportable. |
 | Visualizer | 2D top-down in phase 1; real 3D simulation in phase 2 | Positions/orientations/beam data and glTF assets are retained from import day one so 3D is additive, not a re-import. |
 | Position abstraction | Named focus points, bound per-venue | The positional analog of tags: shows say `focus "drummer"`; venues supply coordinates. |
 | Legacy path | MIDI-to-DMX layer untouched | It's the working fallback while this lands. |
@@ -80,7 +86,7 @@ Trust boundary: everything above the `.fixture`/`.venue` + cache line is **parse
 (import / prewarm — the only place untrusted input is touched); everything below is **show
 time** (native files + warm cache only).
 
-## 4. Data model v2
+## 4. Data model
 
 ### 4.1 Fixture types: `.fixture` files
 
@@ -213,7 +219,7 @@ the patched channel count; warn) → hard error listing candidate modes.
   silently reshapes a working rig on gig day.
 - **Editing:** the webui shows referential fixtures as a read-only resolved view (provenance
   banner: archive, mode, revision) plus an editable overrides pane; native fixtures get the
-  full v2 editor (fine bytes, ranges, functions, movement speeds). "Detach to native" copies
+  full editor (fine bytes, ranges, functions, movement speeds). "Detach to native" copies
   the expansion into an editable file for the rare full-tweak case.
 
 ## 8. Engine: the physical-value pipeline
@@ -223,7 +229,7 @@ layer:
 
 1. **Effects emit physical intents** — pan/tilt in degrees (or a focus-point target), strobe
    in Hz, color as today. Color/dimmer effects keep their existing semantics; nothing about
-   the lighting-v2 duration model changes.
+   the explicit-durations effect model changes.
 2. **Per-fixture resolution** maps intents through the resolved fixture model: degrees →
    channel-function DMX range interpolation; focus targets → pan/tilt via pointing math
    (below); one logical value → coarse+fine bytes (16-bit fanout) in `to_dmx_commands`.
@@ -267,7 +273,7 @@ rendering project, not a data-model project.
 ## 10. Surfaces
 
 - **webui API:** upload endpoints for `.gdtf`/`.mvr` (import report as the response), mode
-  listing, focus-point CRUD, fixture_type v2 CRUD.
+  listing, focus-point CRUD, fixture-type editing CRUD.
 - **MCP:** `list_fixture_types` gains capabilities/ranges/provenance; venue tools gain
   positions and focus points; `evaluate_show` gains the new lint classes. The import flow
   gets first-class tools — `list_gdtf_modes`, `import_gdtf`, `import_mvr`, import-report
@@ -306,9 +312,10 @@ existing group-resolution lint:
 - **Property tests:** pointing math round-trips (aim → pan/tilt → direction), 16-bit fanout
   monotonicity (no coarse-byte jumps across fine rollover), physical-range interpolation
   against channel-function tables.
-- **Equivalence:** a v1 definition and its v2 rendering produce identical channel maps
-  and strobe parameters — existing v1 configs produce byte-identical DMX. A referential
-  PixelBrick (`from gdtf(...)`) resolves identically to its native-form equivalent.
+- **Equivalence:** parsing a v1-DSL definition into the internal model is lossless —
+  identical channel maps and strobe parameters — and existing configs produce
+  byte-identical DMX. A referential PixelBrick (`from gdtf(...)`) resolves identically
+  to its native-form equivalent.
 - **Cache correctness:** expansion regenerates on archive hash, mode, distiller-version, or
   override change — and only then; cold-cache startup fills loudly and deterministically.
 - **Harness:** a DMX frame-capture sink joins the audio loopback — hardware e2e checks
@@ -321,7 +328,7 @@ existing group-resolution lint:
 
 | Phase | Scope | Exit criterion | Size |
 |---|---|---|---|
-| P0 | Internal only: rich fixture model (v1 view derived, `From<FixtureTypeV1>` conversion) + expansion cache plumbing; no grammar, no new extensions, no user-facing surface | Existing v1 configs produce byte-identical DMX; cache fill/hit/corruption covered | S |
+| P0 | Internal only: rich fixture model (the v1-DSL view derived, `From<FixtureTypeV1>` conversion) + expansion cache plumbing; no grammar, no new extensions, no user-facing surface | Existing configs produce byte-identical DMX; cache fill/hit/corruption covered | S |
 | P1a | GDTF parser + distiller, CLI + webui import, corpus + fuzzing, security hardening. **Introduces** the `.fixture` extension and referential syntax (`from gdtf(...)`, `movement`) — born working | PixelBrick distills byte-identical; a 16-ch+ mover distills with only expected warnings | M |
 | P1b | MVR import, positions, focus points, positional 2D StageView, lint expansion. **Introduces** the `.venue` extension and `position`/`rotation`/`focus` syntax | A real venue MVR imports to a playable venue; show lint runs against it | M |
 | P1c | Physical-value pipeline, 16-bit fanout, movement effects, slew model, harness DMX sink. **Introduces** rich channel syntax (`fine`, `range:`, function tables) for hand-authored fixtures | A movement show authored on one venue plays correctly on a second imported venue | L |
@@ -357,7 +364,7 @@ Open in draft 2; all resolved by draft 4.
    (`540deg / 2.2s`). Calibration is a *guided webui flow* first, CLI second: pick fixture →
    it sweeps full travel → tap when it stops → value written to the override; no extra
    hardware.
-5. **Color model scope** — CCT/white handling enters v1 in the resolution layer only; show
+5. **Color model scope** — CCT/white handling enters the initial engine work (P1c) in the resolution layer only; show
    DSL parameters unchanged (RGB-first as today), physical color params additive (§8).
    Spectral/calibrated cross-fixture matching deferred to P2.
 6. **Mode identity in MVR** — fallback chain: exact → normalized (warn) → unique-footprint

--- a/design/venue_exchange_design.md
+++ b/design/venue_exchange_design.md
@@ -1,6 +1,10 @@
 # Venue Exchange: GDTF/MVR Import, Fixture Model v2, and Physical-Unit Movement
 
-*Design doc, draft 4 — 2026-08-19.*
+*Design doc, draft 5 — 2026-08-19. Draft 5 revises the file-format story
+after implementation review: the extension identifies the DSL generation (v1
+`.light` files are never renamed or migrated), the intermediary model is
+machine-only, the DSL is scoped to the datasheet-typable subset, and every
+DSL construct ships in the same phase as its consumer.*
 
 mtrack shows already target roles — tags and logical groups — rather than fixtures, and a
 show plays across multiple venues today. What doesn't scale is everything underneath: every
@@ -38,11 +42,14 @@ OFL import (possible later addition for hobbyist gear; not in scope here).
 | MVR parser | Own implementation | No Rust crate exists. Simpler format; reuses our GDTF machinery for embedded fixtures. |
 | Fixture sourcing | GDTF-sourced fixtures are *referential*: a thin `.fixture` file names the GDTF + mode (+ overrides); the expanded channel table is an ephemeral cache, never committed | Fixture data is a manufacturer fact — a fat distilled copy can only drift from its source. The cache pattern (hash-keyed, regenerated on change) is the waveform-cache model mtrack already has. |
 | Venue sourcing | MVR import *seeds* an owned `.venue` file | Venues are authored, not derived: tags, focus points, and position tweaks are human judgment layered on the import. |
-| File extensions | `.fixture` for fixture types, `.venue` for venues; `.light` remains for shows | Extension encodes content type; editors and the webui route on it. Loader accepts legacy `.light` fixture/venue files during migration, then support is removed. |
+| File extensions | `.fixture`/`.venue` identify the **v2 DSL**; v1 fixture/venue definitions stay in `.light` files, valid forever beside them | The extension *is* the version marker (versions mark breakages, not expansions). Nothing renames, migrates, or deprecates v1 files, and there is no in-file version field. |
 | GDTF/MVR export | Deferred (phase 2+) | Nothing in v1 depends on it; model stays exportable. |
 | Visualizer | 2D top-down in phase 1; real 3D simulation in phase 2 | Positions/orientations/beam data and glTF assets are retained from import day one so 3D is additive, not a re-import. |
 | Position abstraction | Named focus points, bound per-venue | The positional analog of tags: shows say `focus "drummer"`; venues supply coordinates. |
-| Legacy path | MIDI-to-DMX layer untouched | It's the working fallback while this lands; v1 fixture_type syntax migrates then gets removed (shed-legacy policy). |
+| Legacy path | MIDI-to-DMX layer untouched | It's the working fallback while this lands. |
+| Intermediary | The serde model and its cache are **machine-only** — never hand-edited, never a user-facing format | GDTF and the DSL are the two sources; both compile into the intermediary. Letting users hand-craft a compilation target forfeits its derived/rebuildable property. |
+| DSL scope | The DSL models the **datasheet-typable** subset of what the engine consumes | Asset-class data — 3D meshes, geometry trees, gobo images, spectral/emitter data — is GDTF-only; no text format can carry it, and everything downstream degrades gracefully without it (generic body, cone from beam angle, sRGB-ish color). |
+| Syntax delivery | Every DSL construct ships in the same phase as its engine consumer | Defined-but-inert syntax invites files that look configured but aren't, and freezes grammar shape before a consumer exists to pressure-test it. |
 
 ## 3. Architecture
 
@@ -116,8 +123,12 @@ GDTF's standardized attributes (`ColorAdd_R`, `Dimmer`, `Pan`, `CTC`), making th
 the normalizer — multi-user configs stop diverging on spelling. Debuggability:
 `mtrack lighting expand <fixture>` (and the webui detail view) dumps the resolved model,
 since a referential fixture's runtime truth isn't otherwise a text file you can read. v1
-`.light` fixture files (`channel_map` + three strobe fields) migrate to native-form
-`.fixture` with a one-time rewrite; v1 syntax and extension support are then removed.
+`.light` fixture files (`channel_map` + three strobe fields) stay valid, unrenamed and
+unmigrated, loading beside v2 files; internally both normalize through one conversion
+point (`From<FixtureTypeV1>`). "Detach to native" renders control data as DSL and is
+lossy w.r.t. GDTF asset data (which has no textual form) — it says so loudly. The
+syntax shown in this section is the v2 target across phases; each construct lands
+with its consumer (§13), never ahead of it.
 
 ### 4.2 Venues: `.venue` files and focus points
 
@@ -295,9 +306,9 @@ existing group-resolution lint:
 - **Property tests:** pointing math round-trips (aim → pan/tilt → direction), 16-bit fanout
   monotonicity (no coarse-byte jumps across fine rollover), physical-range interpolation
   against channel-function tables.
-- **Migration:** v1 `.light` → `.fixture`/`.venue` migration produces byte-identical DMX for
-  all existing example shows (phase-0 exit criterion). A referential PixelBrick
-  (`from gdtf(...)`) resolves identically to its native-form equivalent.
+- **Equivalence:** a v1 definition and its v2 rendering produce identical channel maps
+  and strobe parameters — existing v1 configs produce byte-identical DMX. A referential
+  PixelBrick (`from gdtf(...)`) resolves identically to its native-form equivalent.
 - **Cache correctness:** expansion regenerates on archive hash, mode, distiller-version, or
   override change — and only then; cold-cache startup fills loudly and deterministically.
 - **Harness:** a DMX frame-capture sink joins the audio loopback — hardware e2e checks
@@ -310,15 +321,17 @@ existing group-resolution lint:
 
 | Phase | Scope | Exit criterion | Size |
 |---|---|---|---|
-| P0 | `.fixture`/`.venue` v2 DSL + loader + expansion cache plumbing + v1 `.light` migration; no engine behavior change | Existing shows produce byte-identical DMX from migrated files | S–M |
-| P1a | GDTF parser + distiller, CLI + webui import, corpus + fuzzing, security hardening | PixelBrick distills byte-identical; a 16-ch+ mover distills with only expected warnings | M |
-| P1b | MVR import, positions, focus points, positional 2D StageView, lint expansion | A real venue MVR imports to a playable venue; show lint runs against it | M |
-| P1c | Physical-value pipeline, 16-bit fanout, movement effects, slew model, harness DMX sink | A movement show authored on one venue plays correctly on a second imported venue | L |
+| P0 | Internal only: rich fixture model (v1 view derived, `From<FixtureTypeV1>` conversion) + expansion cache plumbing; no grammar, no new extensions, no user-facing surface | Existing v1 configs produce byte-identical DMX; cache fill/hit/corruption covered | S |
+| P1a | GDTF parser + distiller, CLI + webui import, corpus + fuzzing, security hardening. **Introduces** the `.fixture` extension and referential syntax (`from gdtf(...)`, `movement`) — born working | PixelBrick distills byte-identical; a 16-ch+ mover distills with only expected warnings | M |
+| P1b | MVR import, positions, focus points, positional 2D StageView, lint expansion. **Introduces** the `.venue` extension and `position`/`rotation`/`focus` syntax | A real venue MVR imports to a playable venue; show lint runs against it | M |
+| P1c | Physical-value pipeline, 16-bit fanout, movement effects, slew model, harness DMX sink. **Introduces** rich channel syntax (`fine`, `range:`, function tables) for hand-authored fixtures | A movement show authored on one venue plays correctly on a second imported venue | L |
 | P2 | 3D simulation (glTF, beam rendering); GDTF/MVR export; optionally OFL import | Show playable against a 3D venue never visited | L–XL |
 
 Each phase ships independently; P1a is already useful alone (import replaces hand
-transcription). The legacy MIDI-to-DMX path stays untouched throughout as the working
-fallback.
+transcription). Grammar follows the same rule as everything else here: a DSL construct
+is introduced by the phase whose engine work consumes it, never earlier — so at no
+point does syntax exist that parses but does nothing. The legacy MIDI-to-DMX path
+stays untouched throughout as the working fallback.
 
 ## 14. Resolved questions
 
@@ -328,7 +341,8 @@ Open in draft 2; all resolved by draft 4.
    downstage-center on the deck, +x stage-left, +y upstage. MVR (right-handed Z-up,
    *millimeters*, author-chosen origin) is converted at import with a re-origin step (§6).
 2. **v2 DSL grammar** — hybrid: name-keyed channel one-liners, optional block only where a
-   channel has structure (§4.1). Simple fixtures stay as terse as v1.
+   channel has structure (§4.1). Simple fixtures stay as terse as v1. The v1 grammar is
+   frozen, not deprecated: `.light` fixture/venue files remain valid indefinitely.
 3. **Corpus licensing** — sidestepped via the two-tier corpus (§12): committed synthetic
    files we author are the CI backbone; real manufacturer files are a bring-your-own local
    corpus, never fetched by CI (vendor URLs rot and block non-browser clients — brittle by
@@ -347,3 +361,7 @@ Open in draft 2; all resolved by draft 4.
 6. **Mode identity in MVR** — fallback chain: exact → normalized (warn) → unique-footprint
    (warn) → error with candidates (§6).
 7. **Cache scope** — per-project `lighting/.cache/`.
+8. **Format versioning** — no in-file version field. The extension is the version marker,
+   and versions mark breakages, not expansions: additive syntax never mints a new
+   generation, and changing the meaning of existing syntax is forbidden (new meaning
+   requires new syntax). A v3 would arrive as a new extension, if it ever exists.

--- a/design/venue_exchange_design.md
+++ b/design/venue_exchange_design.md
@@ -6,11 +6,13 @@ after implementation review: the extension identifies the DSL generation (v1
 machine-only, the DSL is scoped to the datasheet-typable subset, and every
 DSL construct ships in the same phase as its consumer.*
 
-> **Terminology:** "v1 DSL" and "v2 DSL" refer to exactly one thing in this
-> document — the two generations of *fixture/venue definition syntax*,
-> identified by file extension (`.light` vs `.fixture`/`.venue`). Show files
-> are neither versioned nor touched by this design. Feature scope is named by
-> phase (P0–P2), never by version number.
+> **Terminology:** today there is exactly one fixture/venue definition
+> syntax — the `.light` DSL. This document calls it "v1" only to contrast it
+> with the **planned** extended syntax ("v2") that phases P1a–P1c will
+> introduce under the `.fixture`/`.venue` extensions; until those phases
+> ship, no v2 DSL exists. Show files are neither versioned nor touched by
+> this design. Feature scope is named by phase (P0–P2), never by version
+> number.
 
 mtrack shows already target roles — tags and logical groups — rather than fixtures, and a
 show plays across multiple venues today. What doesn't scale is everything underneath: every
@@ -48,7 +50,7 @@ OFL import (possible later addition for hobbyist gear; not in scope here).
 | MVR parser | Own implementation | No Rust crate exists. Simpler format; reuses our GDTF machinery for embedded fixtures. |
 | Fixture sourcing | GDTF-sourced fixtures are *referential*: a thin `.fixture` file names the GDTF + mode (+ overrides); the expanded channel table is an ephemeral cache, never committed | Fixture data is a manufacturer fact — a fat distilled copy can only drift from its source. The cache pattern (hash-keyed, regenerated on change) is the waveform-cache model mtrack already has. |
 | Venue sourcing | MVR import *seeds* an owned `.venue` file | Venues are authored, not derived: tags, focus points, and position tweaks are human judgment layered on the import. |
-| File extensions | `.fixture`/`.venue` identify the **v2 DSL**; v1 fixture/venue definitions stay in `.light` files, valid beside them | The extension *is* the version marker (versions mark breakages, not expansions). This design renames, migrates, and deprecates nothing, and there is no in-file version field. No v1 removal is scheduled — retiring v1 someday is a legitimate future decision, but it would be its own design, with its own migration story. |
+| File extensions | `.fixture`/`.venue` will identify the planned v2 DSL as P1a–P1c introduce its constructs; existing definitions stay in `.light` files, valid beside them | The extension *is* the version marker (versions mark breakages, not expansions). This design renames, migrates, and deprecates nothing, and there is no in-file version field. No v1 removal is scheduled — retiring v1 someday is a legitimate future decision, but it would be its own design, with its own migration story. |
 | GDTF/MVR export | Deferred (phase 2+) | Nothing in the initial phases depends on it; model stays exportable. |
 | Visualizer | 2D top-down in phase 1; real 3D simulation in phase 2 | Positions/orientations/beam data and glTF assets are retained from import day one so 3D is additive, not a re-import. |
 | Position abstraction | Named focus points, bound per-venue | The positional analog of tags: shows say `focus "drummer"`; venues supply coordinates. |
@@ -128,13 +130,14 @@ Canonical channel names (`red`, `dimmer`, `pan`, `ct`, …) are produced by the 
 GDTF's standardized attributes (`ColorAdd_R`, `Dimmer`, `Pan`, `CTC`), making the distiller
 the normalizer — multi-user configs stop diverging on spelling. Debuggability:
 `mtrack lighting expand <fixture>` (and the webui detail view) dumps the resolved model,
-since a referential fixture's runtime truth isn't otherwise a text file you can read. v1
-`.light` fixture files (`channel_map` + three strobe fields) stay valid, unrenamed and
-unmigrated, loading beside v2 files; internally both normalize through one conversion
-point (`From<FixtureTypeV1>`). "Detach to native" renders control data as DSL and is
-lossy w.r.t. GDTF asset data (which has no textual form) — it says so loudly. The
-syntax shown in this section is the v2 target across phases; each construct lands
-with its consumer (§13), never ahead of it.
+since a referential fixture's runtime truth isn't otherwise a text file you can read.
+Existing `.light` fixture files (`channel_map` + three strobe fields) stay valid,
+unrenamed and unmigrated, and will load beside v2 files once those exist; internally
+both normalize through one conversion point (`From<FixtureTypeV1>`). "Detach to
+native" renders control data as DSL and is lossy w.r.t. GDTF asset data (which has no
+textual form) — it says so loudly. **None of the syntax shown in this section exists
+yet**: it is the v2 target, and each construct lands with its consumer (§13), never
+ahead of it.
 
 ### 4.2 Venues: `.venue` files and focus points
 
@@ -347,9 +350,10 @@ Open in draft 2; all resolved by draft 4.
 1. **Coordinate convention** — stage-relative: meters, right-handed Z-up, origin at
    downstage-center on the deck, +x stage-left, +y upstage. MVR (right-handed Z-up,
    *millimeters*, author-chosen origin) is converted at import with a re-origin step (§6).
-2. **v2 DSL grammar** — hybrid: name-keyed channel one-liners, optional block only where a
-   channel has structure (§4.1). Simple fixtures stay as terse as v1. The v1 grammar is
-   frozen, not deprecated: `.light` fixture/venue files remain valid, and no removal is
+2. **v2 DSL grammar (planned, not shipped)** — hybrid: name-keyed channel one-liners,
+   optional block only where a channel has structure (§4.1); constructs ship with their
+   consumers (P1a–P1c). Simple fixtures stay as terse as v1. The v1 grammar is frozen,
+   not deprecated: `.light` fixture/venue files remain valid, and no removal is
    scheduled. Retiring v1 is out of scope here — if it ever happens, it arrives as its
    own design with its own migration story.
 3. **Corpus licensing** — sidestepped via the two-tier corpus (§12): committed synthetic


### PR DESCRIPTION
## Summary

Updates `design/venue_exchange_design.md` to draft 5, recording the decisions from implementation review of the (now superseded) P0 branch:

- **Extension is the version marker.** v1 `.light` fixture/venue files stay valid — this design renames, migrates, and deprecates nothing, and there is no in-file version field. No v1 removal is scheduled; retiring v1 someday is a legitimate future decision that would arrive as its own design with its own migration story. Versions mark breakages, not expansions, and changing the meaning of existing syntax is forbidden.
- **The intermediary is machine-only.** GDTF and the DSL are the two authoring sources; both compile into the serde model. Users never hand-edit the compilation target.
- **The DSL models the datasheet-typable subset** of what the engine consumes. Asset-class data (3D meshes, geometry trees, gobo images, spectral/emitter data) is GDTF-only, with graceful degradation when absent (generic body, cone from beam angle, sRGB-ish color).
- **Every DSL construct ships with its consumer.** P0 shrinks to internal-only work (rich model + distill cache); P1a introduces `.fixture` + referential syntax with the distiller; P1b introduces `.venue` + position/focus syntax with StageView; P1c introduces rich channel syntax with the physical pipeline. At no point does syntax exist that parses but does nothing.

Doc-only change. PR #420 was closed as superseded by this scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKzGqZbcZtMR5ZqtDJoDzz