### PR TITLE
dmx: loud reporting for venue universes the profile can't drive

### DIFF
--- a/design/venue_exchange_design.md
+++ b/design/venue_exchange_design.md
@@ -243,6 +243,12 @@ layer:
    (44 Hz is ample; 8-bit quantization was the real smoothness problem). Configured
    `max_pan_speed` clamps output; lint flags cues that demand more than the fixture can do.
 
+Positions also give chase *direction* real meaning: today `left_to_right`
+orders fixtures by their position in the resolved group list, which has no
+spatial (or cross-universe) significance. Once venues carry positions, chase
+ordering resolves from them, with list order as the fallback for
+position-less venues.
+
 **Pointing math (tier 2, not tier 3):** fixture position + mounting rotation + pan/tilt
 ranges → spherical solve for "aim at (x,y,z)". No geometry-tree kinematics; a page of
 trigonometry, property-tested (§12). Fixtures with unattainable targets (out of range) clamp
@@ -298,6 +304,9 @@ existing group-resolution lint:
 - Movement feasibility: cue requires more than `max_*_speed`, or target outside pan/tilt
   range from a fixture's position.
 - Positional effects against a venue without positions.
+- Universe coverage: the venue patches fixtures on universes the active
+  profile configures no output for (today this is reported loudly at venue
+  registration and on first drop; lint makes it a pre-show answer).
 - Import hygiene: fixture_types whose source GDTF has a newer revision in the library.
 
 ## 12. Testing

--- a/docs/src/lighting/configuration.md
+++ b/docs/src/lighting/configuration.md
@@ -159,6 +159,23 @@ venue "small_club" {
 }
 ```
 
+**Multiple universes:**
+
+Fixtures may be patched on any universe (`@ universe:address`), and a single
+venue may span several. Shows never reference universes — they target logical
+groups — so the same show drives a one-universe rig and a four-universe house
+patch alike. Every universe a venue references must have an output configured
+under `dmx.universes` in the active profile; fixtures patched on an
+unconfigured universe are reported at venue registration (and again, once, if
+a show drives them) and will not light.
+
+```light
+venue "warehouse" {
+  fixture "Wash1" RGBW_Par @ 1:1 tags ["wash", "front"]
+  fixture "Wash3" RGBW_Par @ 2:1 tags ["wash", "back"]
+}
+```
+
 ## Song Lighting Definitions
 
 Lighting shows are defined in separate `.light` files using the DSL format. Songs reference these files:

--- a/examples/lighting/venues/warehouse.light
+++ b/examples/lighting/venues/warehouse.light
@@ -1,0 +1,20 @@
+# Warehouse venue definition — a patch that spans two DMX universes.
+#
+# Fixtures may be patched on any universe; shows never mention universes
+# (they target logical groups), so the same show drives this venue and the
+# single-universe ones. Every universe referenced here must have an output
+# configured under dmx.universes in the active profile — fixtures on an
+# unconfigured universe are reported at venue registration and will not
+# light.
+
+venue "warehouse" {
+  # Front-of-house truss on universe 1
+  fixture "Wash1" RGBW_Par @ 1:1 tags ["wash", "front", "rgb"]
+  fixture "Wash2" RGBW_Par @ 1:7 tags ["wash", "front", "rgb"]
+  fixture "Mover1" MovingHead @ 1:37 tags ["moving_head", "spot"]
+
+  # Back-wall run on universe 2
+  fixture "Wash3" RGBW_Par @ 2:1 tags ["wash", "back", "rgb"]
+  fixture "Wash4" RGBW_Par @ 2:7 tags ["wash", "back", "rgb"]
+  fixture "Strobe1" Strobe @ 2:100 tags ["strobe", "back"]
+}

--- a/src/dmx/engine.rs
+++ b/src/dmx/engine.rs
@@ -92,6 +92,10 @@ pub struct Engine {
     pub(super) playback_delay: Duration,
     pub(super) universes: HashMap<u16, Universe>,
     pub(super) universe_name_to_id: HashMap<String, u16>,
+    /// Universe IDs already warned about for having no configured output —
+    /// the effects loop runs at 44Hz, so the drop warning fires once per
+    /// universe, not once per tick.
+    warned_missing_universes: Mutex<HashSet<u16>>,
     pub(super) cancel_handle: CancelHandle,
     pub(super) client_handle: Option<JoinHandle<()>>,
     pub(super) join_handles: Vec<JoinHandle<()>>,
@@ -212,6 +216,7 @@ impl Engine {
             playback_delay: config.playback_delay()?,
             universes: universes.into_iter().collect(),
             universe_name_to_id,
+            warned_missing_universes: Mutex::new(HashSet::new()),
             cancel_handle,
             client_handle: Some(client_handle),
             join_handles,
@@ -479,6 +484,15 @@ impl Engine {
             // Direct lookup by universe ID - no name mapping needed
             if let Some(universe) = self.universes.get(&universe_id) {
                 universe.update_effect_commands(commands);
+            } else if self.warned_missing_universes.lock().insert(universe_id) {
+                // A venue can patch fixtures on a universe this profile has
+                // no output for; dropping their light silently is how a rig
+                // stays dark at a gig with no clue why. Once per universe.
+                error!(
+                    universe = universe_id,
+                    dropped_commands = commands.len(),
+                    "Dropping DMX for universe {universe_id}: the venue patches fixtures                      there, but this profile configures no such universe under dmx.universes"
+                );
             }
         }
 
@@ -500,6 +514,19 @@ impl Engine {
         if let Some(lighting_system) = &self.lighting_system {
             let lighting_system = lighting_system.lock();
             let fixture_infos = lighting_system.get_current_venue_fixtures()?;
+
+            // Say up front — once, at registration — which parts of the venue
+            // this profile cannot drive, naming the fixtures. The per-tick
+            // drop warning in update_effects is the backstop, not the report.
+            self.warned_missing_universes.lock().clear();
+            for (universe, fixtures) in unconfigured_universes(&fixture_infos, &self.universes) {
+                warn!(
+                    universe,
+                    fixtures = fixtures.join(", "),
+                    "Venue fixtures are patched on universe {universe}, but this profile                      configures no such universe under dmx.universes — they will not light"
+                );
+            }
+
             let mut effect_engine = self.effect_engine.lock();
             let mut midi_dmx_store = self.midi_dmx_store.write();
 
@@ -635,6 +662,78 @@ impl Drop for Engine {
         {
             error!("Error joining handle");
         }
+    }
+}
+
+/// Groups fixtures by the universes `configured` has no entry for:
+/// universe → fixture names, both sorted for stable reporting. Generic over
+/// the map's value so tests don't need to construct output threads.
+fn unconfigured_universes<V>(
+    fixture_infos: &[crate::lighting::effects::FixtureInfo],
+    configured: &HashMap<u16, V>,
+) -> std::collections::BTreeMap<u16, Vec<String>> {
+    let mut gaps: std::collections::BTreeMap<u16, Vec<String>> = Default::default();
+    for fixture_info in fixture_infos {
+        if !configured.contains_key(&fixture_info.universe) {
+            gaps.entry(fixture_info.universe)
+                .or_default()
+                .push(fixture_info.name.clone());
+        }
+    }
+    for fixtures in gaps.values_mut() {
+        fixtures.sort();
+    }
+    gaps
+}
+
+#[cfg(test)]
+mod universe_gap_tests {
+    use std::collections::HashMap;
+
+    use super::unconfigured_universes;
+    use crate::lighting::effects::FixtureInfo;
+
+    fn fixture(name: &str, universe: u16) -> FixtureInfo {
+        let mut channels = HashMap::new();
+        channels.insert("dimmer".to_string(), 1);
+        FixtureInfo::new(
+            name.to_string(),
+            universe,
+            1,
+            "Par".to_string(),
+            channels,
+            None,
+        )
+    }
+
+    #[test]
+    fn reports_only_unconfigured_universes_with_sorted_fixtures() {
+        let fixtures = vec![
+            fixture("Wash1", 1),
+            fixture("Truss2", 9),
+            fixture("Truss1", 9),
+            fixture("Side1", 4),
+        ];
+        let mut configured = HashMap::new();
+        configured.insert(1u16, ());
+
+        let gaps = unconfigured_universes(&fixtures, &configured);
+        assert_eq!(gaps.len(), 2);
+        assert_eq!(gaps[&4], vec!["Side1".to_string()]);
+        assert_eq!(
+            gaps[&9],
+            vec!["Truss1".to_string(), "Truss2".to_string()],
+            "fixture names sort for stable reports"
+        );
+        assert!(!gaps.contains_key(&1));
+    }
+
+    #[test]
+    fn a_fully_configured_venue_reports_nothing() {
+        let fixtures = vec![fixture("Wash1", 1)];
+        let mut configured = HashMap::new();
+        configured.insert(1u16, ());
+        assert!(unconfigured_universes(&fixtures, &configured).is_empty());
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up from a venue-portability review: the DMX render path is already multi-universe end to end (per-fixture universes in the venue DSL and model, per-universe command routing, per-universe output threads via OLA) — but a venue patching universes the active profile doesn't configure **failed silently**: `update_effects` dropped those commands with no warning anywhere. At an unfamiliar venue with a multi-universe patch, most of the rig would simply stay dark.

- **Venue registration** now reports each unconfigured universe once, naming the fixtures patched there ("Venue fixtures are patched on universe 2 ... they will not light").
- **The effects loop** warns once per universe (not per 44Hz tick) if commands are dropped anyway — backstop, not report. The warned-set resets on re-registration.
- **Example + docs**: a multi-universe `warehouse` venue and a docs section stating the rule — shows never mention universes (they target groups), and every universe a venue references needs an output under `dmx.universes`.
- **Design doc**: universe coverage joins the P1b pre-show lint list, and chase direction is recorded as position-resolved once venues carry positions (today's `left_to_right` is group-list order, spatially meaningless on any number of universes).

## Test plan

- `cargo test` — 3422 pass; fmt/clippy/licensure clean.
- New unit tests for the gap-report helper (unconfigured universes grouped and sorted, fully-configured venues report nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKzGqZbcZtMR5ZqtDJoDzz