### PR TITLE
lighting: GDTF import — .fixture references, loader expansion, CLI + MCP

### DIFF
--- a/docs/src/lighting/configuration.md
+++ b/docs/src/lighting/configuration.md
@@ -108,6 +108,43 @@ fixture_type "MovingHead" {
 }
 ```
 
+### GDTF-referential fixture types (`*.fixture`)
+
+Instead of hand-transcribing a channel map from a manual, a fixture type can
+reference a manufacturer [GDTF](https://gdtf-share.com/) file — most
+manufacturers publish them — and mtrack distills the chosen DMX mode into the
+same model a hand-written definition produces:
+
+```light
+# lighting/fixture_types/pb15_pixelbrick.fixture
+fixture_type "PB15 PixelBrick"
+  from gdtf("lighting/library/pb15.gdtf", mode "8: RGBS")
+{
+  # Optional overrides — data not in GDTF, e.g. measured movement limits:
+  # movement { max_pan_speed: 240deg/s }
+}
+```
+
+The easiest way to create one is the import command, which lists an
+archive's modes, copies it into `lighting/library/`, writes the `.fixture`
+file, and verifies it loads:
+
+```sh
+mtrack import-gdtf downloaded.gdtf                 # list the modes
+mtrack import-gdtf downloaded.gdtf --mode "8: RGBS"
+```
+
+Notes:
+
+- The GDTF archive is part of your project (`lighting/library/`) — commit
+  it. Expansions live in `lighting/.cache/`, which is rebuildable and should
+  be gitignored.
+- A referential fixture's channels come from the GDTF; the `.fixture` body
+  carries only overrides. Anything the distiller can't represent (wheels,
+  pixel/matrix modes) is skipped or refused with a clear message.
+- `.fixture` and `.light` fixture files load side by side; nothing renames
+  or migrates.
+
 **Strobe frequency range:**
 
 Fixtures with a dedicated strobe channel can specify their supported frequency range and DMX

--- a/docs/src/lighting/configuration.md
+++ b/docs/src/lighting/configuration.md
@@ -144,6 +144,11 @@ Notes:
   pixel/matrix modes) is skipped or refused with a clear message.
 - `.fixture` and `.light` fixture files load side by side; nothing renames
   or migrates.
+- On a hardened deployment (`mtrack systemd` with `ProtectSystem=strict`),
+  `lighting/.cache/` must be writable — pass your project directory (or at
+  least the cache path) to `mtrack systemd` so it lands in
+  `ReadWritePaths=`. Referential fixtures cannot expand on a fully
+  read-only filesystem, since the cache is rebuilt rather than committed.
 
 **Strobe frequency range:**
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,6 +226,25 @@ enum Commands {
         /// ProtectSystem=strict and excepts exactly these paths.
         paths: Vec<String>,
     },
+    /// Imports a GDTF fixture file: lists its modes, or (with --mode)
+    /// copies the archive into the project library and writes a
+    /// GDTF-referential .fixture definition.
+    ImportGdtf {
+        /// Path to the .gdtf archive to import.
+        gdtf_path: String,
+        /// The DMX mode to distill. Omit to list the archive's modes.
+        #[arg(short, long)]
+        mode: Option<String>,
+        /// Name for the fixture type (defaults to the GDTF's fixture name).
+        #[arg(short, long)]
+        name: Option<String>,
+        /// Project directory the import writes into.
+        #[arg(short, long, default_value = ".")]
+        project: String,
+        /// Fixture types directory, relative to the project.
+        #[arg(long, default_value = "lighting/fixture_types")]
+        fixture_types_dir: String,
+    },
     /// Verifies the syntax of a light show file.
     VerifyLightShow {
         /// The path to the light show file to verify.
@@ -460,6 +479,19 @@ pub async fn run(tui_mode: bool) -> Result<(), Box<dyn Error>> {
             duration,
             sample_format,
             bits_per_sample,
+        )?,
+        Commands::ImportGdtf {
+            gdtf_path,
+            mode,
+            name,
+            project,
+            fixture_types_dir,
+        } => local::import_gdtf(
+            &gdtf_path,
+            mode.as_deref(),
+            name.as_deref(),
+            &project,
+            &fixture_types_dir,
         )?,
         Commands::VerifyLightShow { show_path, config } => {
             local::verify_light_show(&show_path, config.as_deref())?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -222,8 +222,10 @@ enum Commands {
     Systemd {
         /// Directories the service must be able to write — your library, plus
         /// any songs, playlists, profiles or samples directory configured
-        /// outside it. Given at least one, the unit is hardened with
-        /// ProtectSystem=strict and excepts exactly these paths.
+        /// outside it (and lighting/.cache if you use GDTF-referential
+        /// fixtures — the expansion cache is rebuilt, not committed). Given
+        /// at least one, the unit is hardened with ProtectSystem=strict and
+        /// excepts exactly these paths.
         paths: Vec<String>,
     },
     /// Imports a GDTF fixture file: lists its modes, or (with --mode)

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -262,11 +262,16 @@ pub async fn start(
             .join("playlist.yaml")
     });
 
+    // `.parent()` answers `Some("")` for a bare config filename, which is
+    // harmless for plain joins but fails the first consumer that
+    // canonicalizes it (GDTF-referential fixture expansion). Normalize to a
+    // real directory the same way the bootstrap path above does.
+    let project_dir = crate::util::project_dir_of(player_path);
     let player = crate::player::Player::new(
         playlists,
         active_playlist,
         &player_config,
-        player_path.parent(),
+        Some(project_dir.as_path()),
     )?;
     player.set_config_store(config_store);
     player.set_default_metronome(default_metronome);

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -599,6 +599,135 @@ pub fn verify(
     Ok(())
 }
 
+/// Imports a GDTF archive: with no mode, lists the archive's modes; with a
+/// mode, delegates to the shared importer (also behind the MCP tool), which
+/// copies the archive into the project library, writes a GDTF-referential
+/// `.fixture` definition, and warms the expansion cache through the same
+/// code path the player's loader takes.
+pub fn import_gdtf(
+    gdtf_path: &str,
+    mode: Option<&str>,
+    name: Option<&str>,
+    project: &str,
+    fixture_types_dir: &str,
+) -> Result<(), Box<dyn Error>> {
+    use crate::lighting::gdtf;
+
+    let Some(mode) = mode else {
+        // Mode selection is human input: list what the archive offers.
+        let bytes = std::fs::read(gdtf_path)
+            .map_err(|e| format!("cannot read GDTF archive {gdtf_path}: {e}"))?;
+        let description = gdtf::parse_archive(&bytes)?;
+        println!(
+            "\"{}\" by {} — {} modes:",
+            description.name,
+            description.manufacturer,
+            description.modes.len()
+        );
+        for summary in gdtf::mode_summaries(&description) {
+            println!(
+                "  {:40} {:>3} channels, footprint {}",
+                format!("\"{}\"", summary.name),
+                summary.channel_count,
+                summary.footprint
+            );
+        }
+        println!("\nRe-run with --mode <name> to import one.");
+        return Ok(());
+    };
+
+    let report = crate::lighting::import::import_gdtf(
+        Path::new(gdtf_path),
+        mode,
+        name,
+        Path::new(project),
+        fixture_types_dir,
+    )?;
+
+    println!(
+        "Imported \"{}\" (mode \"{}\"):",
+        report.type_name, report.mode
+    );
+    println!(
+        "  archive: {}{}",
+        report.archive,
+        if report.replaced_archive {
+            " (replaced existing)"
+        } else {
+            ""
+        }
+    );
+    println!("  fixture: {}", report.fixture_file);
+    for (offset, channel) in &report.channels {
+        println!("  channel {offset}: {channel}");
+    }
+    if report.warnings.is_empty() {
+        println!("  no distillation warnings");
+    } else {
+        println!("  {} warning(s):", report.warnings.len());
+        for warning in &report.warnings {
+            println!("    {warning}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod import_gdtf_tests {
+    use super::*;
+
+    fn write_synthetic_gdtf(dir: &Path) -> PathBuf {
+        let path = dir.join("synth.gdtf");
+        std::fs::write(
+            &path,
+            crate::lighting::gdtf::build_zip(&[(
+                "description.xml",
+                crate::lighting::gdtf::SYNTHETIC_DESCRIPTION.as_bytes(),
+            )]),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn listing_modes_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let gdtf = write_synthetic_gdtf(dir.path());
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        import_gdtf(
+            gdtf.to_str().unwrap(),
+            None,
+            None,
+            project.to_str().unwrap(),
+            "lighting/fixture_types",
+        )
+        .unwrap();
+        assert!(!project.join("lighting").exists(), "listing must not write");
+    }
+
+    #[test]
+    fn importing_delegates_to_the_shared_importer() {
+        let dir = tempfile::tempdir().unwrap();
+        let gdtf = write_synthetic_gdtf(dir.path());
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        import_gdtf(
+            gdtf.to_str().unwrap(),
+            Some("8: RGBS"),
+            Some("Brick"),
+            project.to_str().unwrap(),
+            "lighting/fixture_types",
+        )
+        .unwrap();
+        assert!(project
+            .join("lighting/fixture_types/brick.fixture")
+            .exists());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/controller/mcp/dsl_reference.md
+++ b/src/controller/mcp/dsl_reference.md
@@ -227,6 +227,22 @@ fixture_type "RGBW_Par" {
 }
 ```
 
+Fixture types can also reference a manufacturer GDTF archive (`.fixture`
+files) instead of hand-written channel maps:
+
+```
+fixture_type "PB15 PixelBrick"
+  from gdtf("lighting/library/pb15.gdtf", mode "8: RGBS")
+{
+}
+```
+
+Prefer the MCP import flow over writing these by hand: download the GDTF
+into the project, call `list_gdtf_modes` to pick the mode against the
+venue's patch sheet, then `import_gdtf` — it copies the archive into
+`lighting/library/`, writes the `.fixture` file, and returns the resolved
+channels plus every distillation warning.
+
 ## Venue (rarely written from MCP)
 
 ```

--- a/src/controller/mcp/integration_test.rs
+++ b/src/controller/mcp/integration_test.rs
@@ -636,6 +636,114 @@ async fn build_standalone_player(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn mcp_gdtf_import_flow() -> Result<(), Box<dyn Error>> {
+    let fixture = setup_standalone_fixture()?;
+
+    // An agent downloads the archive into the project first; simulate that.
+    std::fs::create_dir_all(fixture.root.join("incoming"))?;
+    std::fs::write(
+        fixture.root.join("incoming/synth.gdtf"),
+        crate::lighting::gdtf::build_zip(&[(
+            "description.xml",
+            crate::lighting::gdtf::SYNTHETIC_DESCRIPTION.as_bytes(),
+        )]),
+    )?;
+
+    let player = build_standalone_player(&fixture).await?;
+    let port = pick_free_port();
+    let controller = Controller::new(
+        vec![config::Controller::Mcp(config::McpController::new(port))],
+        player,
+    );
+    assert!(controller.statuses().iter().all(|s| s.status == "running"));
+
+    let url = format!("http://127.0.0.1:{port}/mcp");
+    let client = Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .expect("client");
+    wait_until_listening(&client, &url).await;
+    let session = initialize_session(&client, &url).await;
+
+    // --- list_gdtf_modes surfaces the mode-picking input.
+    let modes = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            10,
+            "list_gdtf_modes",
+            json!({"path": "incoming/synth.gdtf"}),
+        )
+        .await,
+    );
+    assert_eq!(modes["fixture"], "Synth Brick");
+    let mode_names: Vec<&str> = modes["modes"]
+        .as_array()
+        .expect("modes array")
+        .iter()
+        .filter_map(|m| m["name"].as_str())
+        .collect();
+    assert!(mode_names.contains(&"8: RGBS"), "{mode_names:?}");
+
+    // --- a path escaping the project is refused.
+    let escape = call_tool(
+        &client,
+        &url,
+        &session,
+        11,
+        "list_gdtf_modes",
+        json!({"path": "../x.gdtf"}),
+    )
+    .await;
+    assert!(
+        escape["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("escapes")
+            || escape["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("cannot resolve"),
+        "{escape}"
+    );
+
+    // --- import_gdtf writes the library archive, the .fixture ref, and the
+    // cache, and reports channels + warnings.
+    let report = tool_json(
+        &call_tool(
+            &client,
+            &url,
+            &session,
+            12,
+            "import_gdtf",
+            json!({"path": "incoming/synth.gdtf", "mode": "8: RGBS", "name": "Brick"}),
+        )
+        .await,
+    );
+    assert_eq!(report["type_name"], "Brick");
+    assert_eq!(
+        report["fixture_file"],
+        "lighting/fixture_types/brick.fixture"
+    );
+    assert!(fixture.root.join("lighting/library/synth.gdtf").exists());
+    assert!(fixture
+        .root
+        .join("lighting/fixture_types/brick.fixture")
+        .exists());
+    assert!(fixture.root.join("lighting/.cache").is_dir());
+    let warnings = report["warnings"].as_array().expect("warnings");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or_default().contains("virtual channel")),
+        "{warnings:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn mcp_config_store_round_trip() -> Result<(), Box<dyn Error>> {
     let fixture = setup_standalone_fixture()?;
     let player = build_standalone_player(&fixture).await?;

--- a/src/controller/mcp/service.rs
+++ b/src/controller/mcp/service.rs
@@ -320,6 +320,22 @@ pub struct SongLightingArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListGdtfModesArgs {
+    /// Path to a .gdtf archive, relative to the project directory.
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ImportGdtfArgs {
+    /// Path to a .gdtf archive, relative to the project directory.
+    pub path: String,
+    /// The DMX mode to distill (see list_gdtf_modes).
+    pub mode: String,
+    /// Name for the fixture type; defaults to the GDTF's fixture name.
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct WriteSongLightingArgs {
     /// Song name as listed by `list_songs`.
     pub song: String,
@@ -1718,6 +1734,86 @@ impl McpServer {
             })
             .collect();
         Ok(ok_json(json!({ "fixture_types": types })))
+    }
+
+    /// Resolves a caller-supplied project-relative path, refusing anything
+    /// that escapes the project directory.
+    fn resolve_in_project(&self, relative: &str) -> Result<std::path::PathBuf, McpError> {
+        let project = crate::util::project_dir_of(self.config_store()?.path());
+        let candidate = project.join(relative);
+        let canonical = candidate.canonicalize().map_err(|e| {
+            McpError::invalid_params(format!("cannot resolve {relative}: {e}"), None)
+        })?;
+        let canonical_project = project.canonicalize().map_err(|e| {
+            McpError::internal_error(format!("cannot resolve project dir: {e}"), None)
+        })?;
+        if !canonical.starts_with(&canonical_project) {
+            return Err(McpError::invalid_params(
+                format!("{relative} escapes the project directory"),
+                None,
+            ));
+        }
+        Ok(canonical)
+    }
+
+    #[tool(description = "List the DMX modes of a GDTF fixture archive, with \
+        channel counts and DMX footprints. Mode selection is the one human \
+        input a GDTF import needs; pick against the venue's patch sheet.")]
+    async fn list_gdtf_modes(
+        &self,
+        Parameters(args): Parameters<ListGdtfModesArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let path = self.resolve_in_project(&args.path)?;
+        let bytes = tokio::fs::read(&path).await.map_err(|e| {
+            McpError::invalid_params(format!("cannot read {}: {e}", args.path), None)
+        })?;
+        let description = crate::lighting::gdtf::parse_archive(&bytes)
+            .map_err(|e| McpError::invalid_params(format!("not a parseable GDTF: {e}"), None))?;
+        let modes: Vec<Value> = crate::lighting::gdtf::mode_summaries(&description)
+            .into_iter()
+            .map(|summary| {
+                json!({
+                    "name": summary.name,
+                    "channel_count": summary.channel_count,
+                    "footprint": summary.footprint,
+                })
+            })
+            .collect();
+        Ok(ok_json(json!({
+            "fixture": description.name,
+            "manufacturer": description.manufacturer,
+            "modes": modes,
+        })))
+    }
+
+    #[tool(description = "Import one mode of a GDTF fixture archive: copies \
+        the archive into lighting/library/, writes a GDTF-referential \
+        .fixture definition, and warms the expansion cache through the same \
+        path the player loads with. Returns the resolved channels and every \
+        distillation warning. The archive must already be inside the \
+        project directory (download it there first).")]
+    async fn import_gdtf(
+        &self,
+        Parameters(args): Parameters<ImportGdtfArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let path = self.resolve_in_project(&args.path)?;
+        let project = crate::util::project_dir_of(self.config_store()?.path());
+        let report = tokio::task::spawn_blocking(move || {
+            crate::lighting::import::import_gdtf(
+                &path,
+                &args.mode,
+                args.name.as_deref(),
+                &project,
+                "lighting/fixture_types",
+            )
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("import task failed: {e}"), None))?
+        .map_err(|e| McpError::invalid_params(e, None))?;
+        Ok(ok_json(serde_json::to_value(&report).map_err(|e| {
+            McpError::internal_error(format!("report serialization failed: {e}"), None)
+        })?))
     }
 
     #[tool(description = "Read a lighting `.light` file referenced by a song. \

--- a/src/lighting.rs
+++ b/src/lighting.rs
@@ -21,6 +21,7 @@ pub mod effects;
 pub mod engine;
 pub mod evaluate;
 pub mod gdtf;
+pub mod import;
 #[cfg(test)]
 mod layering_tests;
 pub mod lint;

--- a/src/lighting/gdtf.rs
+++ b/src/lighting/gdtf.rs
@@ -35,6 +35,11 @@ mod archive;
 mod description;
 mod distiller;
 
+#[cfg(test)]
+pub(crate) use archive::tests::build_zip;
+#[cfg(test)]
+pub(crate) use description::tests::SYNTHETIC_DESCRIPTION;
+
 pub use archive::read_description_xml;
 pub use description::{parse_description, Description};
 pub use distiller::{distill, mode_summaries, Distilled, ModeSummary};

--- a/src/lighting/gdtf/archive.rs
+++ b/src/lighting/gdtf/archive.rs
@@ -105,7 +105,7 @@ pub(super) mod tests {
     use super::*;
 
     /// Builds an in-memory zip with the given entries.
-    pub(in super::super) fn build_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    pub(crate) fn build_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
         let mut cursor = Cursor::new(Vec::new());
         {
             let mut writer = zip::ZipWriter::new(&mut cursor);

--- a/src/lighting/gdtf/description.rs
+++ b/src/lighting/gdtf/description.rs
@@ -365,7 +365,7 @@ pub(super) mod tests {
     /// A PixelBrick-shaped synthetic description: two modes, a virtual
     /// dimmer, a strobe channel with function ranges, and a 16-bit mover
     /// mode. Structure mirrors the real Astera PB15 file.
-    pub(in super::super) const SYNTHETIC_DESCRIPTION: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+    pub(crate) const SYNTHETIC_DESCRIPTION: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <GDTF DataVersion="1.2">
   <FixtureType Name="Synth Brick" ShortName="Brick" Manufacturer="mtrack synthetic">
     <AttributeDefinitions/>

--- a/src/lighting/grammar.pest
+++ b/src/lighting/grammar.pest
@@ -227,13 +227,26 @@ tempo_transition_snap = { "snap" }
 COMMENT = _{ ("//" | "#") ~ (!"\n" ~ ANY)* }
 
 // Fixture type rules
-fixture_type = { "fixture_type" ~ fixture_type_name ~ "{" ~ fixture_type_content ~ "}" }
+fixture_type = { "fixture_type" ~ fixture_type_name ~ gdtf_source? ~ "{" ~ fixture_type_content ~ "}" }
 
 fixture_type_name = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
+// Referential fixture types pin the GDTF archive + mode they are distilled
+// from; the file body carries only human additions (movement limits).
+gdtf_source = { "from" ~ "gdtf" ~ "(" ~ string ~ "," ~ "mode" ~ string ~ ")" }
+
 fixture_type_content = {
-    (channels | channel_map | max_strobe_frequency | min_strobe_frequency | strobe_dmx_offset | special_cases)*
+    (channels | channel_map | movement_block | max_strobe_frequency | min_strobe_frequency | strobe_dmx_offset | special_cases)*
 }
+
+// Movement limits — not in GDTF; measured or taken from the datasheet.
+movement_block = { "movement" ~ "{" ~ movement_param* ~ "}" }
+
+movement_param = { movement_param_name ~ ":" ~ speed_value }
+
+movement_param_name = { "max_pan_speed" | "max_tilt_speed" }
+
+speed_value = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? ~ "deg/s" }
 
 channels = { "channels" ~ ":" ~ number_value }
 

--- a/src/lighting/import.rs
+++ b/src/lighting/import.rs
@@ -66,8 +66,32 @@ fn fixture_filename_stem(name: &str) -> String {
     }
 }
 
-/// Imports one mode of a GDTF archive into a project. Nothing is written
-/// until the mode has distilled successfully.
+/// [`crate::util::write_file`] with the path and any deploy hint in the
+/// error — a bare "Read-only file system (os error 30)" names no file and
+/// no fix.
+fn write(path: &Path, contents: &[u8]) -> Result<(), Box<dyn Error>> {
+    crate::util::write_file(path, contents)
+        .map_err(|e| annotate(crate::util::WriteTarget::File(path), e))
+}
+
+/// [`crate::util::create_dir_all`] with the same annotation.
+fn create_dir(path: &Path) -> Result<(), Box<dyn Error>> {
+    crate::util::create_dir_all(path)
+        .map_err(|e| annotate(crate::util::WriteTarget::Directory(path), e))
+}
+
+fn annotate(target: crate::util::WriteTarget<'_>, error: std::io::Error) -> Box<dyn Error> {
+    let mut message = format!("could not write {}: {error}", target.path().display());
+    if let Some(hint) = crate::util::write_failure_hint(target, &error) {
+        message.push_str("\n\n");
+        message.push_str(&hint);
+    }
+    message.into()
+}
+
+/// Imports one mode of a GDTF archive into a project. All validation runs
+/// before anything is written; a refused import leaves the project
+/// untouched.
 pub fn import_gdtf(
     gdtf_path: &Path,
     mode: &str,
@@ -84,19 +108,17 @@ pub fn import_gdtf(
     // before anything lands on disk.
     let distilled = gdtf::distill(&description, mode, &type_name)?;
 
-    let library_dir = project.join("lighting/library");
-    std::fs::create_dir_all(&library_dir)?;
+    // Every check runs before anything is written: a refused import must
+    // leave the project exactly as it found it.
     let archive_file_name: PathBuf = gdtf_path
         .file_name()
         .ok_or("GDTF path has no file name")?
         .into();
+    let library_dir = project.join("lighting/library");
     let library_path = library_dir.join(&archive_file_name);
     let library_rel = format!("lighting/library/{}", archive_file_name.display());
-    let replaced_archive = library_path.exists();
-    std::fs::write(&library_path, &bytes)?;
 
     let fixture_dir = project.join(fixture_types_dir);
-    std::fs::create_dir_all(&fixture_dir)?;
     let fixture_path = fixture_dir.join(format!("{}.fixture", fixture_filename_stem(&type_name)));
     if fixture_path.exists() {
         return Err(format!(
@@ -105,6 +127,30 @@ pub fn import_gdtf(
         )
         .into());
     }
+
+    // A same-named archive with the same bytes is a harmless re-import; one
+    // with different bytes would silently re-source every .fixture that
+    // already points at it. Refuse rather than corrupt.
+    let mut replaced_archive = false;
+    if library_path.exists() {
+        let existing = std::fs::read(&library_path)
+            .map_err(|e| format!("cannot read existing {}: {e}", library_path.display()))?;
+        if existing != bytes {
+            return Err(format!(
+                "{library_rel} already exists with different content — other fixture \
+                 types may reference it; rename the source file (the library filename \
+                 follows it) or remove the existing archive deliberately",
+            )
+            .into());
+        }
+        replaced_archive = true;
+    }
+
+    create_dir(&library_dir)?;
+    if !replaced_archive {
+        write(&library_path, &bytes)?;
+    }
+    create_dir(&fixture_dir)?;
     let definition = format!(
         "# Imported from {} (\"{}\" by {}).\n\
          # Channels come from the GDTF; this file carries only overrides.\n\
@@ -113,7 +159,7 @@ pub fn import_gdtf(
         description.name,
         description.manufacturer,
     );
-    std::fs::write(&fixture_path, &definition)?;
+    write(&fixture_path, definition.as_bytes())?;
 
     // Warm the cache and prove the written definition loads, through the
     // exact expansion path the player takes at startup.
@@ -213,6 +259,108 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(err.contains("already exists"), "{err}");
+    }
+
+    #[test]
+    fn a_conflicting_archive_is_refused_before_any_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        // First import from archive A.
+        let a = write_synthetic_gdtf(dir.path());
+        import_gdtf(
+            &a,
+            "8: RGBS",
+            Some("Brick"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap();
+        let original = std::fs::read(project.join("lighting/library/synth.gdtf")).unwrap();
+
+        // A different archive under the same basename must refuse — Brick's
+        // .fixture points at that library path.
+        let other_dir = dir.path().join("elsewhere");
+        std::fs::create_dir_all(&other_dir).unwrap();
+        let b = other_dir.join("synth.gdtf");
+        std::fs::write(
+            &b,
+            crate::lighting::gdtf::build_zip(&[(
+                "description.xml",
+                // Same shape, different bytes.
+                crate::lighting::gdtf::SYNTHETIC_DESCRIPTION
+                    .replace("Synth Brick", "Other Brick")
+                    .as_bytes(),
+            )]),
+        )
+        .unwrap();
+        let err = import_gdtf(
+            &b,
+            "8: RGBS",
+            Some("Other"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("different content"), "{err}");
+        assert_eq!(
+            std::fs::read(project.join("lighting/library/synth.gdtf")).unwrap(),
+            original,
+            "a refused import must not touch the library archive"
+        );
+        assert!(!project
+            .join("lighting/fixture_types/other.fixture")
+            .exists());
+
+        // The same bytes under a new type name are a harmless re-import.
+        let report = import_gdtf(
+            &a,
+            "8: RGBS",
+            Some("Twin"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap();
+        assert!(report.replaced_archive);
+    }
+
+    #[test]
+    fn a_name_collision_leaves_the_archive_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let gdtf = write_synthetic_gdtf(dir.path());
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        import_gdtf(
+            &gdtf,
+            "8: RGBS",
+            Some("Brick"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap();
+
+        // Clobber the library copy so any rewrite would be visible.
+        let library = project.join("lighting/library/synth.gdtf");
+        let before = b"sentinel".to_vec();
+        std::fs::write(&library, &before).unwrap();
+
+        let err = import_gdtf(
+            &gdtf,
+            "8: RGBS",
+            Some("Brick"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("already exists"), "{err}");
+        assert_eq!(
+            std::fs::read(&library).unwrap(),
+            before,
+            "the name-collision check must run before any write"
+        );
     }
 
     #[test]

--- a/src/lighting/import.rs
+++ b/src/lighting/import.rs
@@ -1,0 +1,244 @@
+// Copyright (C) 2026 Michael Wilson <mike@mdwn.dev>
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+//! GDTF import: the one implementation behind the CLI command and the MCP
+//! tool.
+//!
+//! An import copies the archive into `<project>/lighting/library/`, writes a
+//! GDTF-referential `.fixture` definition, and warms the expansion cache
+//! through the same code path the player's loader takes — so a successful
+//! import is, by construction, a fixture type that will load.
+
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use super::gdtf;
+use super::system::LightingSystem;
+
+/// What an import did, for reporting: files written, the channels the
+/// fixture ended up with, and everything the distiller skipped or guessed.
+#[derive(Debug, Serialize)]
+pub struct GdtfImport {
+    /// The imported fixture type's name.
+    pub type_name: String,
+    /// The distilled mode.
+    pub mode: String,
+    /// Where the archive landed, project-relative.
+    pub archive: String,
+    /// Whether an existing library archive of the same name was replaced.
+    pub replaced_archive: bool,
+    /// The written `.fixture` definition, project-relative.
+    pub fixture_file: String,
+    /// The resolved channels: offset → name, sorted by offset.
+    pub channels: Vec<(u16, String)>,
+    /// Distillation warnings — what was skipped or approximated.
+    pub warnings: Vec<String>,
+}
+
+/// A fixture-type name reduced to a safe filename stem.
+fn fixture_filename_stem(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+        } else if !out.ends_with('_') && !out.is_empty() {
+            out.push('_');
+        }
+    }
+    let out = out.trim_end_matches('_').to_string();
+    if out.is_empty() {
+        "fixture".to_string()
+    } else {
+        out
+    }
+}
+
+/// Imports one mode of a GDTF archive into a project. Nothing is written
+/// until the mode has distilled successfully.
+pub fn import_gdtf(
+    gdtf_path: &Path,
+    mode: &str,
+    name: Option<&str>,
+    project: &Path,
+    fixture_types_dir: &str,
+) -> Result<GdtfImport, Box<dyn Error>> {
+    let bytes = std::fs::read(gdtf_path)
+        .map_err(|e| format!("cannot read GDTF archive {}: {e}", gdtf_path.display()))?;
+    let description = gdtf::parse_archive(&bytes)?;
+    let type_name = name.unwrap_or(&description.name).to_string();
+
+    // Distill up front so a bad mode or an unsupported (pixel) mode fails
+    // before anything lands on disk.
+    let distilled = gdtf::distill(&description, mode, &type_name)?;
+
+    let library_dir = project.join("lighting/library");
+    std::fs::create_dir_all(&library_dir)?;
+    let archive_file_name: PathBuf = gdtf_path
+        .file_name()
+        .ok_or("GDTF path has no file name")?
+        .into();
+    let library_path = library_dir.join(&archive_file_name);
+    let library_rel = format!("lighting/library/{}", archive_file_name.display());
+    let replaced_archive = library_path.exists();
+    std::fs::write(&library_path, &bytes)?;
+
+    let fixture_dir = project.join(fixture_types_dir);
+    std::fs::create_dir_all(&fixture_dir)?;
+    let fixture_path = fixture_dir.join(format!("{}.fixture", fixture_filename_stem(&type_name)));
+    if fixture_path.exists() {
+        return Err(format!(
+            "{} already exists; remove it or import with a different name",
+            fixture_path.display()
+        )
+        .into());
+    }
+    let definition = format!(
+        "# Imported from {} (\"{}\" by {}).\n\
+         # Channels come from the GDTF; this file carries only overrides.\n\
+         fixture_type \"{type_name}\"\n  from gdtf(\"{library_rel}\", mode \"{mode}\")\n{{\n}}\n",
+        archive_file_name.display(),
+        description.name,
+        description.manufacturer,
+    );
+    std::fs::write(&fixture_path, &definition)?;
+
+    // Warm the cache and prove the written definition loads, through the
+    // exact expansion path the player takes at startup.
+    let written = super::parser::parse_fixture_types(&definition)?;
+    let fixture_type = written
+        .get(&type_name)
+        .ok_or("written definition did not parse back")?;
+    let expanded = LightingSystem::expand_referential(&type_name, fixture_type, project)?;
+
+    let mut channels: Vec<(u16, String)> = expanded
+        .channels()
+        .iter()
+        .map(|(name, offset)| (*offset, name.clone()))
+        .collect();
+    channels.sort();
+
+    Ok(GdtfImport {
+        type_name,
+        mode: mode.to_string(),
+        archive: library_rel,
+        replaced_archive,
+        fixture_file: format!(
+            "{}/{}",
+            fixture_types_dir.trim_end_matches('/'),
+            fixture_path.file_name().unwrap_or_default().display()
+        ),
+        channels,
+        warnings: distilled.warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_synthetic_gdtf(dir: &Path) -> PathBuf {
+        let path = dir.join("synth.gdtf");
+        std::fs::write(
+            &path,
+            crate::lighting::gdtf::build_zip(&[(
+                "description.xml",
+                crate::lighting::gdtf::SYNTHETIC_DESCRIPTION.as_bytes(),
+            )]),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn imports_write_archive_fixture_and_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let gdtf = write_synthetic_gdtf(dir.path());
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let report = import_gdtf(
+            &gdtf,
+            "8: RGBS",
+            Some("Brick"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap();
+
+        assert_eq!(report.type_name, "Brick");
+        assert!(!report.replaced_archive);
+        assert_eq!(report.fixture_file, "lighting/fixture_types/brick.fixture");
+        assert_eq!(
+            report.channels,
+            vec![
+                (1, "red".to_string()),
+                (2, "green".to_string()),
+                (3, "blue".to_string()),
+                (4, "strobe".to_string()),
+            ]
+        );
+        assert!(project.join("lighting/library/synth.gdtf").exists());
+        assert!(project
+            .join("lighting/fixture_types/brick.fixture")
+            .exists());
+        assert_eq!(
+            std::fs::read_dir(project.join("lighting/.cache"))
+                .unwrap()
+                .count(),
+            1,
+            "import warms the expansion cache"
+        );
+
+        // Same name again refuses rather than clobbering.
+        let err = import_gdtf(
+            &gdtf,
+            "8: RGBS",
+            Some("Brick"),
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("already exists"), "{err}");
+    }
+
+    #[test]
+    fn a_bad_mode_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let gdtf = write_synthetic_gdtf(dir.path());
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let err = import_gdtf(
+            &gdtf,
+            "No Such Mode",
+            None,
+            &project,
+            "lighting/fixture_types",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("no mode named"), "{err}");
+        assert!(!project.join("lighting").exists());
+    }
+
+    #[test]
+    fn filename_stems() {
+        assert_eq!(fixture_filename_stem("PB15 PixelBrick"), "pb15_pixelbrick");
+        assert_eq!(fixture_filename_stem("Robe-Esprite"), "robe_esprite");
+        assert_eq!(fixture_filename_stem("///"), "fixture");
+    }
+}

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::error::Error;
 
-use super::super::types::{Fixture, FixtureType, FixtureTypeV1, Venue};
+use super::super::types::{Fixture, FixtureType, FixtureTypeV1, GdtfSource, MovementLimits, Venue};
 use super::error::get_error_context;
 use super::grammar::{LightingParser, Rule};
 use pest::iterators::Pair;
@@ -105,16 +105,22 @@ fn parse_fixture_type_definition(pair: Pair<Rule>) -> Result<FixtureType, Box<dy
     let mut max_strobe_frequency = None;
     let mut min_strobe_frequency = None;
     let mut strobe_dmx_offset = None;
+    let mut source = None;
+    let mut movement = MovementLimits::default();
 
     for pair in pair.into_inner() {
         match pair.as_rule() {
             Rule::fixture_type_name => {
                 name = extract_string(pair);
             }
+            Rule::gdtf_source => {
+                source = Some(parse_gdtf_source(pair)?);
+            }
             Rule::fixture_type_content => {
                 parse_fixture_content(
                     pair,
                     &mut channels,
+                    &mut movement,
                     &mut special_cases,
                     &mut max_strobe_frequency,
                     &mut min_strobe_frequency,
@@ -125,22 +131,86 @@ fn parse_fixture_type_definition(pair: Pair<Rule>) -> Result<FixtureType, Box<dy
         }
     }
 
+    // A referential fixture type carries only human additions; its channels
+    // come from the GDTF. Letting a channel_map ride along would silently
+    // lose whichever side the loader didn't pick.
+    if source.is_some() && !channels.is_empty() {
+        return Err(format!(
+            "fixture type \"{name}\" declares `from gdtf(...)` and a channel map; \
+             a referential fixture's channels come from the GDTF — remove the \
+             channel_map (or drop the gdtf reference to define it natively)"
+        )
+        .into());
+    }
+
     // The parser produces the v1 surface; From<FixtureTypeV1> is the single
     // normalization point into the internal model — no field pokes, no
     // manual step to forget.
-    Ok(FixtureTypeV1 {
+    let mut fixture_type: FixtureType = FixtureTypeV1 {
         name,
         channels,
         max_strobe_frequency,
         min_strobe_frequency,
         strobe_dmx_offset,
     }
-    .into())
+    .into();
+    if let Some(source) = source {
+        fixture_type.set_source(source);
+    }
+    fixture_type.set_movement(movement);
+    Ok(fixture_type)
+}
+
+fn parse_gdtf_source(pair: Pair<Rule>) -> Result<GdtfSource, Box<dyn Error>> {
+    let mut strings = pair
+        .into_inner()
+        .filter(|p| p.as_rule() == Rule::string)
+        .map(extract_string);
+    let path = strings
+        .next()
+        .ok_or("gdtf reference requires an archive path")?;
+    let mode = strings.next().ok_or("gdtf reference requires a mode")?;
+    Ok(GdtfSource { path, mode })
+}
+
+fn parse_movement_block(pair: Pair<Rule>) -> Result<MovementLimits, Box<dyn Error>> {
+    let mut movement = MovementLimits::default();
+    for param in pair
+        .into_inner()
+        .filter(|p| p.as_rule() == Rule::movement_param)
+    {
+        let mut name = String::new();
+        let mut value = None;
+        for inner in param.into_inner() {
+            match inner.as_rule() {
+                Rule::movement_param_name => name = inner.as_str().to_string(),
+                Rule::speed_value => {
+                    let text = inner.as_str().trim();
+                    let number = text
+                        .strip_suffix("deg/s")
+                        .ok_or_else(|| format!("speed \"{text}\" must end in deg/s"))?;
+                    value = Some(
+                        number
+                            .parse::<f64>()
+                            .map_err(|e| format!("Invalid speed \"{text}\": {e}"))?,
+                    );
+                }
+                _ => {}
+            }
+        }
+        match name.as_str() {
+            "max_pan_speed" => movement.max_pan_speed = value,
+            "max_tilt_speed" => movement.max_tilt_speed = value,
+            _ => {}
+        }
+    }
+    Ok(movement)
 }
 
 fn parse_fixture_content(
     pair: Pair<Rule>,
     channels: &mut HashMap<String, u16>,
+    movement: &mut MovementLimits,
     special_cases: &mut Vec<String>,
     max_strobe_frequency: &mut Option<f64>,
     min_strobe_frequency: &mut Option<f64>,
@@ -150,6 +220,9 @@ fn parse_fixture_content(
         match content_pair.as_rule() {
             Rule::channel_map => {
                 *channels = parse_channel_mappings(content_pair);
+            }
+            Rule::movement_block => {
+                *movement = parse_movement_block(content_pair)?;
             }
             Rule::max_strobe_frequency => {
                 for inner in content_pair.into_inner() {

--- a/src/lighting/parser/fixture_venue.rs
+++ b/src/lighting/parser/fixture_venue.rs
@@ -131,16 +131,30 @@ fn parse_fixture_type_definition(pair: Pair<Rule>) -> Result<FixtureType, Box<dy
         }
     }
 
-    // A referential fixture type carries only human additions; its channels
-    // come from the GDTF. Letting a channel_map ride along would silently
-    // lose whichever side the loader didn't pick.
-    if source.is_some() && !channels.is_empty() {
-        return Err(format!(
-            "fixture type \"{name}\" declares `from gdtf(...)` and a channel map; \
-             a referential fixture's channels come from the GDTF — remove the \
-             channel_map (or drop the gdtf reference to define it natively)"
-        )
-        .into());
+    // A referential fixture type carries only human additions (movement);
+    // its channels and strobe parameters come from the GDTF. Letting either
+    // ride along would silently lose whichever side the loader didn't pick.
+    if source.is_some() {
+        if !channels.is_empty() {
+            return Err(format!(
+                "fixture type \"{name}\" declares `from gdtf(...)` and a channel map; \
+                 a referential fixture's channels come from the GDTF — remove the \
+                 channel_map (or drop the gdtf reference to define it natively)"
+            )
+            .into());
+        }
+        if max_strobe_frequency.is_some()
+            || min_strobe_frequency.is_some()
+            || strobe_dmx_offset.is_some()
+        {
+            return Err(format!(
+                "fixture type \"{name}\" declares `from gdtf(...)` and strobe fields; \
+                 a referential fixture's strobe parameters come from the GDTF's \
+                 strobe function — remove the strobe fields (or drop the gdtf \
+                 reference to define the fixture natively)"
+            )
+            .into());
+        }
     }
 
     // The parser produces the v1 surface; From<FixtureTypeV1> is the single
@@ -175,6 +189,7 @@ fn parse_gdtf_source(pair: Pair<Rule>) -> Result<GdtfSource, Box<dyn Error>> {
 
 fn parse_movement_block(pair: Pair<Rule>) -> Result<MovementLimits, Box<dyn Error>> {
     let mut movement = MovementLimits::default();
+    let mut seen: Vec<String> = Vec::new();
     for param in pair
         .into_inner()
         .filter(|p| p.as_rule() == Rule::movement_param)
@@ -198,6 +213,10 @@ fn parse_movement_block(pair: Pair<Rule>) -> Result<MovementLimits, Box<dyn Erro
                 _ => {}
             }
         }
+        if seen.contains(&name) {
+            return Err(format!("movement declares \"{name}\" more than once").into());
+        }
+        seen.push(name.clone());
         match name.as_str() {
             "max_pan_speed" => movement.max_pan_speed = value,
             "max_tilt_speed" => movement.max_tilt_speed = value,
@@ -579,6 +598,78 @@ fixture_type "TypeB" {
     #[test]
     fn fixture_type_invalid_syntax() {
         let content = "fixture_type {";
+        assert!(parse_fixture_types(content).is_err());
+    }
+
+    // ── referential fixture types ────────────────────────────────
+
+    #[test]
+    fn referential_fixture_type_parses_with_movement() {
+        let content = r#"fixture_type "Brick"
+  from gdtf("lighting/library/pb15.gdtf", mode "8: RGBS")
+{
+  movement { max_pan_speed: 240.0deg/s max_tilt_speed: 200deg/s }
+}"#;
+        let result = parse_fixture_types(content).unwrap();
+        let ft = result.get("Brick").unwrap();
+        let source = ft.source().unwrap();
+        assert_eq!(source.path, "lighting/library/pb15.gdtf");
+        assert_eq!(source.mode, "8: RGBS");
+        assert_eq!(ft.movement().max_pan_speed, Some(240.0));
+        assert_eq!(ft.movement().max_tilt_speed, Some(200.0));
+        assert!(ft.channels().is_empty());
+    }
+
+    #[test]
+    fn referential_with_channel_map_is_rejected() {
+        let content = r#"fixture_type "Brick"
+  from gdtf("x.gdtf", mode "M")
+{
+  channel_map: { "red": 1 }
+}"#;
+        let err = parse_fixture_types(content).unwrap_err().to_string();
+        assert!(err.contains("channels come from the GDTF"), "{err}");
+    }
+
+    #[test]
+    fn referential_with_strobe_fields_is_rejected() {
+        // Silently dropping these was worse than refusing: the file looked
+        // configured while the override never applied.
+        let content = r#"fixture_type "Brick"
+  from gdtf("x.gdtf", mode "M")
+{
+  max_strobe_frequency: 999.0
+}"#;
+        let err = parse_fixture_types(content).unwrap_err().to_string();
+        assert!(
+            err.contains("strobe parameters come from the GDTF"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_movement_params_are_rejected() {
+        let content = r#"fixture_type "M" {
+  movement { max_pan_speed: 100deg/s max_pan_speed: 200deg/s }
+}"#;
+        let err = parse_fixture_types(content).unwrap_err().to_string();
+        assert!(err.contains("more than once"), "{err}");
+    }
+
+    #[test]
+    fn empty_movement_block_is_fine() {
+        let content = r#"fixture_type "M" {
+  movement { }
+}"#;
+        let ft = parse_fixture_types(content).unwrap();
+        assert!(ft.get("M").unwrap().movement().is_empty());
+    }
+
+    #[test]
+    fn speed_without_unit_is_a_parse_error() {
+        let content = r#"fixture_type "M" {
+  movement { max_pan_speed: 240 }
+}"#;
         assert!(parse_fixture_types(content).is_err());
     }
 

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -226,6 +226,15 @@ impl LightingSystem {
     ) -> Result<FixtureType, Box<dyn Error>> {
         let source = fixture_type.source().expect("caller checked source");
 
+        // A bare-filename config path can yield an empty base_path; plain
+        // joins tolerate it but canonicalize() does not. Defense in depth —
+        // the call sites normalize too.
+        let base_path = if base_path.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            base_path
+        };
+
         // The archive must live inside the project: a .fixture file is
         // config, but keeping references project-relative means a rig
         // directory stays self-contained (and a stray absolute path can't

--- a/src/lighting/system.rs
+++ b/src/lighting/system.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 
 use tracing::{info, warn};
 
+use super::distill::DistillCache;
+use super::gdtf;
 use super::parser::{parse_fixture_types, parse_venues};
 use super::types::{Fixture, FixtureType, Venue};
 use crate::config::lighting::{GroupConstraint, LogicalGroup};
@@ -100,7 +102,7 @@ impl LightingSystem {
         if let Some(dirs) = config.directories() {
             if let Some(fixture_types_dir) = dirs.fixture_types() {
                 let path = base_path.join(fixture_types_dir);
-                self.load_fixture_types_directory(&path)?;
+                self.load_fixture_types_directory(&path, base_path)?;
             }
 
             if let Some(venues_dir) = dirs.venues() {
@@ -113,7 +115,11 @@ impl LightingSystem {
     }
 
     /// Loads fixture types from a directory.
-    fn load_fixture_types_directory(&mut self, dir: &Path) -> Result<(), Box<dyn Error>> {
+    fn load_fixture_types_directory(
+        &mut self,
+        dir: &Path,
+        base_path: &Path,
+    ) -> Result<(), Box<dyn Error>> {
         if !dir.exists() {
             return Ok(()); // Directory doesn't exist, skip
         }
@@ -124,10 +130,14 @@ impl LightingSystem {
 
             if path.is_dir() {
                 // Recursively load subdirectories
-                self.load_fixture_types_directory(&path)?;
-            } else if path.extension().is_some_and(|ext| ext == "light") {
-                // Load .light files
-                self.load_fixture_types_file(&path)?;
+                self.load_fixture_types_directory(&path, base_path)?;
+            } else if path
+                .extension()
+                .is_some_and(|ext| ext == "fixture" || ext == "light")
+            {
+                // .fixture files carry GDTF-referential definitions; .light
+                // files are the existing DSL. Peers, not a migration.
+                self.load_fixture_types_file(&path, base_path)?;
             }
         }
         Ok(())
@@ -155,14 +165,45 @@ impl LightingSystem {
     }
 
     /// Loads fixture types from a file.
-    fn load_fixture_types_file(&mut self, path: &Path) -> Result<(), Box<dyn Error>> {
+    fn load_fixture_types_file(
+        &mut self,
+        path: &Path,
+        base_path: &Path,
+    ) -> Result<(), Box<dyn Error>> {
         let content = std::fs::read_to_string(path)?;
 
         // Parse fixture types from DSL content
         match parse_fixture_types(&content) {
             Ok(types) => {
                 for (name, fixture_type) in types {
-                    info!(fixture_type = name, "Loading fixture type");
+                    let fixture_type = if fixture_type.source().is_some() {
+                        // Referential: expand through the distill cache. A
+                        // failure skips the type loudly — registering an
+                        // empty shell would patch fixtures that emit nothing.
+                        match Self::expand_referential(&name, &fixture_type, base_path) {
+                            Ok(expanded) => {
+                                info!(
+                                    fixture_type = name,
+                                    channels = expanded.channels().len(),
+                                    "Loaded GDTF-referential fixture type"
+                                );
+                                expanded
+                            }
+                            Err(e) => {
+                                warn!(
+                                    fixture_type = name,
+                                    file = %path.display(),
+                                    error = %e,
+                                    "Failed to expand GDTF-referential fixture type; \
+                                     skipping — fixtures of this type will not light"
+                                );
+                                continue;
+                            }
+                        }
+                    } else {
+                        info!(fixture_type = name, "Loading fixture type");
+                        fixture_type
+                    };
                     self.fixture_types.insert(name, fixture_type);
                 }
             }
@@ -172,6 +213,62 @@ impl LightingSystem {
         }
 
         Ok(())
+    }
+
+    /// Expands a GDTF-referential fixture type through the per-project
+    /// distill cache (`lighting/.cache/`, hash-keyed, rebuildable). Parsing
+    /// the archive happens only on a cold cache — at load time, never
+    /// mid-show — and the fill is logged loudly.
+    pub(crate) fn expand_referential(
+        name: &str,
+        fixture_type: &FixtureType,
+        base_path: &Path,
+    ) -> Result<FixtureType, Box<dyn Error>> {
+        let source = fixture_type.source().expect("caller checked source");
+
+        // The archive must live inside the project: a .fixture file is
+        // config, but keeping references project-relative means a rig
+        // directory stays self-contained (and a stray absolute path can't
+        // wander the filesystem).
+        let archive_path = base_path.join(&source.path);
+        let canonical = archive_path
+            .canonicalize()
+            .map_err(|e| format!("cannot read GDTF archive {}: {e}", archive_path.display()))?;
+        let canonical_base = base_path.canonicalize()?;
+        if !canonical.starts_with(&canonical_base) {
+            return Err(format!(
+                "GDTF archive path {} escapes the project directory",
+                source.path
+            )
+            .into());
+        }
+
+        let bytes = std::fs::read(&canonical)
+            .map_err(|e| format!("cannot read GDTF archive {}: {e}", canonical.display()))?;
+        // Everything that can change the expansion participates in the key;
+        // movement is the only override today, so it is the fingerprint.
+        let fingerprint = format!("{:?}", fixture_type.movement());
+        let key = DistillCache::key(name, &bytes, &source.mode, &fingerprint);
+        let cache = DistillCache::new(base_path.join("lighting").join(".cache"));
+        cache.get_or_fill(&key, || {
+            info!(
+                fixture_type = name,
+                gdtf = %source.path,
+                mode = %source.mode,
+                "Expansion cache is cold — distilling GDTF"
+            );
+            let description = gdtf::parse_archive(&bytes)?;
+            let distilled = gdtf::distill(&description, &source.mode, name)?;
+            // Distillation warnings surface on the cold fill; the import
+            // command is the place they're reported interactively.
+            for warning in &distilled.warnings {
+                warn!(fixture_type = name, "GDTF distillation: {warning}");
+            }
+            let mut expanded = distilled.fixture_type;
+            expanded.set_source(source.clone());
+            expanded.set_movement(*fixture_type.movement());
+            Ok(expanded)
+        })
     }
 
     /// Loads venues from a file.
@@ -520,6 +617,110 @@ mod tests {
             !system.venues.contains_key("old"),
             "the legacy file genuinely does not parse"
         );
+    }
+
+    #[test]
+    fn referential_fixture_types_expand_through_the_cache() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path();
+        let library = base.join("lighting/library");
+        let ft_dir = base.join("lighting/fixture_types");
+        std::fs::create_dir_all(&library).expect("mkdir");
+        std::fs::create_dir_all(&ft_dir).expect("mkdir");
+        std::fs::write(
+            library.join("synth.gdtf"),
+            crate::lighting::gdtf::build_zip(&[(
+                "description.xml",
+                crate::lighting::gdtf::SYNTHETIC_DESCRIPTION.as_bytes(),
+            )]),
+        )
+        .expect("write gdtf");
+        std::fs::write(
+            ft_dir.join("brick.fixture"),
+            "fixture_type \"Brick\"\n  from gdtf(\"lighting/library/synth.gdtf\", mode \"8: RGBS\")\n{\n  movement { max_pan_speed: 240.0deg/s }\n}\n",
+        )
+        .expect("write fixture");
+
+        let mut system = LightingSystem::new();
+        system
+            .load_fixture_types_directory(&ft_dir, base)
+            .expect("loads");
+
+        let brick = system.fixture_types.get("Brick").expect("expanded");
+        assert_eq!(brick.channels().get("red"), Some(&1));
+        assert_eq!(brick.channels().get("strobe"), Some(&4));
+        assert_eq!(brick.strobe_dmx_offset(), Some(7));
+        assert_eq!(brick.max_strobe_frequency(), Some(25.0));
+        assert_eq!(brick.movement().max_pan_speed, Some(240.0));
+        assert_eq!(
+            brick.source().map(|s| s.mode.as_str()),
+            Some("8: RGBS"),
+            "the expansion keeps its provenance"
+        );
+
+        // The expansion landed in the per-project cache (hit/miss/corruption
+        // mechanics are unit-tested on DistillCache itself; the key covers
+        // the archive bytes, so a changed archive is a fresh distillation
+        // by design).
+        let cache_entries = std::fs::read_dir(base.join("lighting/.cache"))
+            .expect("cache dir")
+            .count();
+        assert_eq!(cache_entries, 1);
+
+        // A reload with the same inputs resolves to the same single entry.
+        let mut reloaded = LightingSystem::new();
+        reloaded
+            .load_fixture_types_directory(&ft_dir, base)
+            .expect("loads");
+        assert!(reloaded.fixture_types.contains_key("Brick"));
+        let cache_entries = std::fs::read_dir(base.join("lighting/.cache"))
+            .expect("cache dir")
+            .count();
+        assert_eq!(cache_entries, 1);
+    }
+
+    #[test]
+    fn referential_failures_skip_loudly_and_natives_still_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path();
+        let ft_dir = base.join("lighting/fixture_types");
+        std::fs::create_dir_all(&ft_dir).expect("mkdir");
+        std::fs::write(
+            ft_dir.join("mixed.fixture"),
+            "fixture_type \"Ghost\"\n  from gdtf(\"lighting/library/missing.gdtf\", mode \"X\")\n{ }\n\nfixture_type \"Par\" {\n  channels: 1\n  channel_map: { \"dimmer\": 1 }\n}\n",
+        )
+        .expect("write");
+
+        let mut system = LightingSystem::new();
+        system
+            .load_fixture_types_directory(&ft_dir, base)
+            .expect("loads");
+        assert!(
+            !system.fixture_types.contains_key("Ghost"),
+            "a failed expansion must not register an empty shell"
+        );
+        assert!(system.fixture_types.contains_key("Par"));
+    }
+
+    #[test]
+    fn referential_archive_paths_cannot_escape_the_project() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path().join("project");
+        let ft_dir = base.join("lighting/fixture_types");
+        std::fs::create_dir_all(&ft_dir).expect("mkdir");
+        // A real file outside the project the reference tries to reach.
+        std::fs::write(dir.path().join("outside.gdtf"), b"whatever").expect("write");
+        std::fs::write(
+            ft_dir.join("evil.fixture"),
+            "fixture_type \"Evil\"\n  from gdtf(\"../outside.gdtf\", mode \"X\")\n{ }\n",
+        )
+        .expect("write");
+
+        let mut system = LightingSystem::new();
+        system
+            .load_fixture_types_directory(&ft_dir, &base)
+            .expect("loads");
+        assert!(!system.fixture_types.contains_key("Evil"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The user-visible half of P1a (`design/venue_exchange_design.md` §7, §13), born working end to end — this PR introduces the `.fixture` extension and referential syntax *together with* every consumer:

- **DSL**: `fixture_type "X" from gdtf("lighting/library/x.gdtf", mode "...") { ... }` with an overrides-only body (`movement { max_pan_speed: 240deg/s }`). Referential purity is enforced: a channel map or strobe fields alongside `from gdtf(...)` is a parse error — those come from the GDTF, and silently losing either side was the alternative.
- **Loader**: `.fixture` loads beside `.light` as peers (nothing renames or migrates). Referential types expand through the per-project distill cache (`lighting/.cache/`, keyed on archive bytes + mode + distiller version + overrides). Cold fills happen loudly at load time, never mid-show; failures skip the type loudly; archive paths are contained to the project.
- **CLI**: `mtrack import-gdtf <file>` lists modes; with `--mode` it copies the archive into `lighting/library/`, writes the `.fixture` definition, and warms the cache *through the loader's own expansion path* — a successful import is by construction a fixture that loads. All validation runs before any write; a refused import leaves the project untouched (name collisions, and same-basename archives with different content — which would silently re-source other fixtures — both refuse with clear errors).
- **MCP**: `list_gdtf_modes` + `import_gdtf` expose the same flow to agents, paths strictly contained to the project directory (symlink-escape verified in review), one shared importer implementation behind both surfaces. Covered by a full integration test through the real MCP server.
- **Docs**: the `.fixture` syntax, the import flow, commit-the-archive / gitignore-the-cache, and the `ReadWritePaths=` requirement for hardened systemd deploys.

Reviewed by code-ripper (all findings reproduced by the reviewer before fixing): archive-collision corruption, write-before-validation ordering, silently-discarded strobe overrides, and a `base_path=""` shape (`mtrack local mtrack.yaml` from inside the project) that silently killed every referential fixture — all fixed with regression tests.

## Test plan

- `cargo test` — 3439 pass; fmt/clippy/licensure clean.
- New coverage: referential parsing + both purity refusals, duplicate/malformed movement params, loader expansion through the cache (incl. path escape and failure-skips-loudly), importer conflict/ordering/idempotence, and the MCP flow end to end.
- Manually verified against Astera's real PB15 GDTF via `mtrack import-gdtf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKzGqZbcZtMR5ZqtDJoDzz